### PR TITLE
@heuristics decorator docs. 

### DIFF
--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -794,7 +794,7 @@ def heuristics(values):
     .. highlight:: python
     .. code-block:: python
 
-        @heuristics(values={'BLOCK_SIZE': lambda args: 2 ** int(math.ceil(math.log2(args[1])))})
+        @triton.heuristics(values={'BLOCK_SIZE': lambda args: 2 ** int(math.ceil(math.log2(args[1])))})
         @triton.jit
         def kernel(x_ptr, x_size, **META):
             BLOCK_SIZE = META['BLOCK_SIZE'] # smallest power-of-two >= x_size


### PR DESCRIPTION
Change: `@heuristics` decorator to `@triton.heuristics`. This code example shows up in the [documentation](https://triton-lang.org/python-api/generated/triton.heuristics.html) as well. 

Error when using just `@heuristics`:

```
NameError                             Traceback (most recent call last)
<ipython-input-7-1ac8acb536e2> in <module>
      7 #     key=['n_cols'],
      8 # )
----> 9 @heuristics(values={'BLOCK_SIZE': lambda args: 2 ** int(math.ceil(math.log2(args[4])))})
     10 @triton.jit
     11 def softmax_kernel(

NameError: name 'heuristics' is not defined
```