### PR TITLE
`tl.cdiv` and `triton.cdiv` both used

### DIFF
--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -108,9 +108,9 @@ You will specifically learn about:
 #    # program ID
 #    pid = tl.program_id(axis=0)
 #    # number of program ids along the M axis
-#    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+#    num_pid_m = triton.cdiv(M, BLOCK_SIZE_M)
 #    # number of programs ids along the N axis
-#    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+#    num_pid_n = triton.cdiv(N, BLOCK_SIZE_N)
 #    # number of programs in group
 #    num_pid_in_group = GROUP_SIZE_M * num_pid_n 
 #    # id of the group this program is in


### PR DESCRIPTION
- `tl.cdiv` is used in two places
- `triton.cdiv` is used in two places
- Should probably be `triton.cdiv` everywhere, since `tl.cdiv` throws an error.
- Changed two occurrences of `tl.cdiv` -> `triton.cdiv`.