### PR TITLE
Better IR printer

### DIFF
--- a/include/triton/ir/basic_block.h
+++ b/include/triton/ir/basic_block.h
@@ -67,6 +67,8 @@ public:
   // factory functions
   static basic_block* create(context &ctx, const std::string &name, function *parent);
 
+  void print(std::ostream &os);
+
   // visitor
   void accept(visitor *v) { v->visit_basic_block(this); }
 

--- a/include/triton/ir/basic_block.h
+++ b/include/triton/ir/basic_block.h
@@ -39,6 +39,7 @@ public:
 
   // get instruction list
   inst_list_t           &get_inst_list()       { return inst_list_; }
+  const inst_list_t     &get_inst_list() const { return inst_list_; }
   void  erase(instruction *i)                  {  inst_list_.remove(i); }
 
   // instruction iterator functions

--- a/include/triton/ir/function.h
+++ b/include/triton/ir/function.h
@@ -118,6 +118,8 @@ public:
   bool has_attr(unsigned arg_id) const { return  attrs_.find(arg_id) != attrs_.end(); }
   std::set<attribute> get_attributes(argument* arg) { return attrs_[arg->get_arg_no() + 1]; }
 
+  void print(std::ostream &os);
+
   // visitor
   void accept(visitor *v) { v->visit_function(this); }
 

--- a/include/triton/ir/function.h
+++ b/include/triton/ir/function.h
@@ -104,19 +104,23 @@ public:
   // accessors
   const args_t &args() const { return args_; }
   function_type* get_fn_type() { return fn_ty_; }
+  const function_type* get_fn_type() const { return fn_ty_; }
+  module *get_parent() { return parent_; }
+  const module *get_parent() const { return parent_; }
 
   // factory methods
   static function *create(function_type *ty, linkage_types_t linkage,
                           const std::string &name, module *mod);
   // blocks
   const blocks_t &blocks() { return blocks_; }
+  const blocks_t &blocks() const { return blocks_; }
   void insert_block(basic_block* block, basic_block *next = nullptr);
 
   // attributes
   void add_attr(unsigned arg_id, attribute attr) { attrs_[arg_id].insert(attr); }
   const attr_map_t &attrs() { return attrs_; }
   bool has_attr(unsigned arg_id) const { return  attrs_.find(arg_id) != attrs_.end(); }
-  std::set<attribute> get_attributes(argument* arg) { return attrs_[arg->get_arg_no() + 1]; }
+  std::set<attribute> get_attributes(const argument* arg) { return attrs_[arg->get_arg_no() + 1]; }
 
   void print(std::ostream &os);
 

--- a/include/triton/ir/instructions.h
+++ b/include/triton/ir/instructions.h
@@ -73,6 +73,8 @@ public:
   // instruction id
   value_id_t get_id() const { return id_; }
 
+  void print(std::ostream &os);
+
 private:
   basic_block *parent_;
   std::map<ir::metadata::kind_t, unsigned> metadatas_;

--- a/include/triton/ir/module.h
+++ b/include/triton/ir/module.h
@@ -87,6 +87,8 @@ public:
   // Metadata
   void add_metadata(const std::string &name, md_pair_t x)     { metadatas_[name] = x; }
 
+  void print(std::ostream &os);
+
 private:
   std::string name_;
   builder& builder_;

--- a/include/triton/ir/value.h
+++ b/include/triton/ir/value.h
@@ -35,6 +35,7 @@ public:
   // name
   void set_name(const std::string &name);
   const std::string &get_name() const { return name_; }
+  bool has_name() { return name_ == ""; }
   type* get_type() const { return ty_; }
   // visitor
   virtual void accept(visitor *v) = 0;

--- a/include/triton/ir/value.h
+++ b/include/triton/ir/value.h
@@ -35,7 +35,7 @@ public:
   // name
   void set_name(const std::string &name);
   const std::string &get_name() const { return name_; }
-  bool has_name() { return name_ == ""; }
+  bool has_name() const { return !name_.empty(); }
   type* get_type() const { return ty_; }
   // visitor
   virtual void accept(visitor *v) = 0;
@@ -71,6 +71,7 @@ public:
 
   // Operands
   const ops_t& ops() { return ops_; }
+  const ops_t& ops() const { return ops_; }
   op_iterator op_begin() { return ops_.begin(); }
   op_iterator op_end()   { return ops_.end(); }
   void     set_operand(unsigned i, value *x);

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -93,6 +93,7 @@ void add_passes_to_emit_bin(ir::module &ir, driver::device *dev, int num_warps, 
   allocation.run(ir);
   prefetch_s.run(ir);
   barriers.run(ir);
+  // ir.print(std::cout);
   isel.visit(ir, *llvm);
   mod = driver::module::create(dev, std::move(llvm));
   ker = driver::kernel::create(&*mod, name.c_str());


### PR DESCRIPTION
* SlotTracker-based IR printer for both `module`, `function`, `basic_block`, and `instruction`.
* Examples:
    * mod->print(std::cout)
    * func->print(std::cout)
    * bb->print(std::cout)
    * instr->print(std::cout) 
* Compared with the original `ir::print()`, the new IR printer can record indices of values. `instruction::print(std::ostream &os)` can be called directly without calling `ir::print(mod, std::cout)` first.
* Add `const` accessors in `module`, `function`, and `basic_block`