### PR TITLE
[FRONTEND] Add cache_version to triton.jit

### DIFF
--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,3 +1,6 @@
+# version
+__version__ = '1.0.0'
+
 # TODO: torch needs to be imported first
 # or pybind11 shows `munmap_chunk(): invalid pointer`
 import torch
@@ -8,5 +11,3 @@ from . import language
 from . import code_gen
 from . import testing
 from . import ops
-# version
-__version__ = '1.0.0'

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -715,8 +715,14 @@ def version_key():
     with open(triton._C.libtriton.__file__, "rb") as f:
         backend_contents = hashlib.md5(f.read()).hexdigest()
 
-    nvcc_version = hashlib.md5(subprocess.check_output(["nvcc", "--version"])).hexdigest()
-    ptxas_version = hashlib.md5(subprocess.check_output(["ptxas", "--version"])).hexdigest()
+    try:
+        nvcc_version = hashlib.md5(subprocess.check_output(["nvcc", "--version"])).hexdigest()
+    except subprocess.CalledProcessError:
+        nvcc_version = None
+    try:
+        ptxas_version = hashlib.md5(subprocess.check_output(["ptxas", "--version"])).hexdigest()
+    except subprocess.CalledProcessError:
+        ptxas_version = None
     compute_capability = tuple(torch.cuda.get_arch_list())
 
     return (

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -573,7 +573,6 @@ class Kernel:
                              " Only CUDA is supported at the moment")
 
         device = torch.device('cuda', torch.cuda.current_device())
-        device_ty  = device.type
         device_idx = device.index
         if len(set(device_ids)) != 1 or device_ids[0] != device_idx:
             # try to enable P2P communication

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -597,8 +597,9 @@ class Kernel:
         attr_key = tuple(attributes.items())
         meta_key = tuple(sorted(meta.items()))
         const_key = tuple(constants.items())
+        compute_capability = torch.cuda.get_device_capability(device)
 
-        key = (types_key, attr_key, num_warps, num_stages, meta_key, const_key)
+        key = (compute_capability, types_key, attr_key, num_warps, num_stages, meta_key, const_key)
         key = repr(key)
         # get cached binary
         drv_cache = self.fn.drv_cache
@@ -723,11 +724,10 @@ def version_key():
         ptxas_version = hashlib.md5(subprocess.check_output(["ptxas", "--version"])).hexdigest()
     except Exception:
         ptxas_version = None
-    compute_capability = tuple(torch.cuda.get_arch_list())
 
     return (
         triton.__version__, frontend_contents, backend_contents,
-        nvcc_version, ptxas_version, compute_capability
+        nvcc_version, ptxas_version
     )
 
 class JITFunction:

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -717,11 +717,11 @@ def version_key():
 
     try:
         nvcc_version = hashlib.md5(subprocess.check_output(["nvcc", "--version"])).hexdigest()
-    except subprocess.CalledProcessError:
+    except Exception:
         nvcc_version = None
     try:
         ptxas_version = hashlib.md5(subprocess.check_output(["ptxas", "--version"])).hexdigest()
-    except subprocess.CalledProcessError:
+    except Exception:
         ptxas_version = None
     compute_capability = tuple(torch.cuda.get_arch_list())
 

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -742,19 +742,19 @@ class JITFunction:
         # create cache directory
         if not os.path.exists(cache_dir):
             os.makedirs(cache_dir, exist_ok=True)
-        # load dbm file in cache_dir for md5_hash
-        cache_key = (self.cache_version, self.src) + version_key()
-        cache_key = hashlib.md5(repr(cache_key).encode("utf-8")).hexdigest()
-        self.bin_cache_path = os.path.join(cache_dir, cache_key)
+        # paths for dbm file in cache_dir
+        cache_key = (self.version, self.src) + version_key()
+        cache_key_str = hashlib.md5(repr(cache_key).encode("utf-8")).hexdigest()
+        self.bin_cache_path = os.path.join(cache_dir, cache_key_str)
         self.bin_lock_path  = self.bin_cache_path + '.lock'
         self.bin_mut_path = self.bin_cache_path + '.mutating'
 
-    def __init__(self, fn, cache_version=None):
+    def __init__(self, fn, version=None):
         # information of wrapped function
         self.fn = fn
         self.module = fn.__module__
         self.arg_names = inspect.getfullargspec(fn).args
-        self.cache_version = cache_version
+        self.version = version
         self.src = textwrap.dedent(inspect.getsource(fn))
         # cache for callable driver objects (e.g. CUkernel)
         self.drv_cache = dict()

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -917,7 +917,7 @@ def heuristics(values):
     return decorator
 
 
-def jit(fn_or_kwargs):
+def jit(*args, **kwargs):
     """
     Decorator for JIT-compiling a function using the Triton compiler.
 
@@ -933,11 +933,13 @@ def jit(fn_or_kwargs):
     :param fn: the function to be jit-compiled
     :type fn: Callable
     """
-    if callable(fn_or_kwargs):
-        return JITFunction(fn_or_kwargs)
+    if args:
+        assert len(args) == 1
+        assert callable(args[0])
+        return JITFunction(args[0], **kwargs)
     else:
         def decorator(fn):
-            return JITFunction(fn, **fn_or_kwargs)
+            return JITFunction(fn, **kwargs)
         return decorator
 
 

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -748,13 +748,13 @@ class JITFunction:
         self.fn = fn
         self.module = fn.__module__
         self.arg_names = inspect.getfullargspec(fn).args
+        self.cache_version = cache_version
         self.src = textwrap.dedent(inspect.getsource(fn))
         # cache for callable driver objects (e.g. CUkernel)
         self.drv_cache = dict()
 
         # on-disk paths for the binary cache and corresponding
         # file-lock
-        self.cache_version = cache_version
         self._init_cache_paths()
 
         # JITFunction can be instantiated as kernel


### PR DESCRIPTION
- Add a cache_version kwarg to triton.jit, so users can invalidate caches (for changes that do not affect the source of the function itself)
- Add a` __repr__` to JITFunction, so we don't include memory addresses in our cache key
- Include triton version, nvcc version, ptxas version in cache name, compute capability in cache key
- Don't rely on file mtimes for staleness
- Use tuples instead of frozensets for order guarantee
- Sort meta_key