### PR TITLE
enable unary and most binary operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.6)
 include(ExternalProject)
 
+set(TRITON_USE_ROCM "$ENV{TRITON_USE_ROCM}")
+
 if(NOT TRITON_LLVM_BUILD_DIR)
     set(TRITON_LLVM_BUILD_DIR ${CMAKE_BINARY_DIR})
 endif()
@@ -102,6 +104,9 @@ if(BUILD_PYTHON_MODULE)
     endif()
     include_directories("." ${PYTHON_SRC_PATH} ${PYTHON_INCLUDE_DIRS} ${CUTLASS_INCLUDE_DIR})
     link_directories(${PYTHON_LINK_DIRS} ${CUTLASS_LIBRARY_DIR})
+    if (TRITON_USE_ROCM)
+        add_definitions(-D__HIP_PLATFORM_AMD__)
+    endif()
     set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc  ${PYTHON_SRC_PATH}/superblock.cc ${CUTLASS_SRC})
 endif()
 

--- a/lib/driver/llvm.cc
+++ b/lib/driver/llvm.cc
@@ -308,7 +308,7 @@ std::string llir_to_amdgpu(llvm::Module* module, const std::string& _proc) {
   machine->addPassesToEmitFile(pass, *isabin_fs, nullptr, llvm::CGFT_ObjectFile);
   pass.run(*module);
   // Save GCN ISA.
-  std::string amdgcn_path = std::string("/tmp/") + module_name + std::string(".gcn");
+  std::string amdgcn_path = std::string("/tmp/") + module_name + std::string(".isa");
   std::string result(buffer.begin(), buffer.end());
   std::ofstream amdgcn(amdgcn_path);
   amdgcn << result;


### PR DESCRIPTION
This pr adds functionality for a basic load operator which allows us to execute unary and binary opreators. The only binary operator that doesnot work is the remainder(%) operator.

To check this pr

  0. enter a rocm docker container 
  ``` alias drun='sudo docker run -it --rm --network=host --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --ipc=host --shm-size 16G --device=/dev/kfd --device=/dev/dri' ```
  ``` drun rocm/pytorch ```

1. clone and check out this branch
```git clone -b rocm_bin_op_pr_2 https://github.com/micmelesse/triton```
2. build triton with the following steps 
```cd python ```
```pip install --verbose -e .```

3. test with 
```
pytest --capture=tee-sys --verbose python/test/test_language.py::test_empty_kernel
pytest --verbose python/test/unit/language/test_core.py::test_load_and_store_op
pytest --verbose python/test/unit/language/test_core.py::test_unary_op
pytest --verbose python/test/unit/language/test_core.py::test_bin_op
```
