### PR TITLE
[PYTHON] Use 'd' to pack float in python

### DIFF
--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -495,6 +495,7 @@ class Kernel:
             'I': _triton.ir.type.get_int32,
             'L': _triton.ir.type.get_int64,
             'f': _triton.ir.type.get_fp32,
+            'd': _triton.ir.type.get_fp64,
             'B': _triton.ir.type.get_int1,
             'f8': _triton.ir.type.get_fp8,
             'f16': _triton.ir.type.get_fp16,


### PR DESCRIPTION
floats in python are of double-precision. We need to use 'd' to pack them