### PR TITLE
Fixed p2p tests failing when there are no supported p2p devices

### DIFF
--- a/python/test/unit/runtime/test_comm.py
+++ b/python/test/unit/runtime/test_comm.py
@@ -23,13 +23,13 @@ def get_p2p_matrix():
 def get_p2p_devices():
     matrix = get_p2p_matrix()
     idx = np.where(matrix == "OK")
-    return f"cuda:{idx[0][0]}", f"cuda:{idx[1][0]}"
+    return [f"cuda:{idx[0][0]}", f"cuda:{idx[1][0]}"] if len(idx[0]) > 0 else []
 
 
 def get_non_p2p_devices():
     matrix = get_p2p_matrix()
     idx = np.where(matrix == "NS")
-    return f"cuda:{idx[0][0]}", f"cuda:{idx[1][0]}"
+    return [f"cuda:{idx[0][0]}", f"cuda:{idx[1][0]}"] if len(idx[0]) > 0 else []
 
 
 p2p_devices = get_p2p_devices()


### PR DESCRIPTION
My p2p matrix looks like this, and it seems like it was not handled correctly:
```
 	GPU0	GPU1	
 GPU0	X	NS	
 GPU1	NS	X
```

`skipif` does check for empty device lists, but the `get_*_devices` functions never used to return them.