### PR TITLE
[ROCM] enable matmul(dot) and others

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ if(NOT TRITON_LLVM_BUILD_DIR)
     set(TRITON_LLVM_BUILD_DIR ${CMAKE_BINARY_DIR})
 endif()
 
+set(TRITON_USE_ROCM "$ENV{TRITON_USE_ROCM}")
+set(TRITON_ROCM_DEBUG "$ENV{TRITON_ROCM_DEBUG}")
 
 project(triton)
 include(CTest)
@@ -37,7 +39,11 @@ if(WIN32)
     add_subdirectory(deps/dlfcn-win32/src ${CMAKE_BINARY_DIR}/dlfcn-win32)
 endif()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -std=gnu++17")
+if (TRITON_USE_ROCM)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -std=gnu++17 -Wno-unused-result -Wno-attributes")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__STDC_FORMAT_MACROS  -std=gnu++17")
+endif()
 
 
 ##########
@@ -110,6 +116,15 @@ libLLVMBinaryFormat.a
 libLLVMAMDGPUInfo.a
 libLLVMSupport.a
 libLLVMDemangle.a
+libLLVMPasses.a
+libLLVMAnalysis.a
+libLLVMTransformUtils.a
+libLLVMScalarOpts.a
+libLLVMTransformUtils.a
+libLLVMipo.a
+libLLVMObjCARCOpts.a
+libLLVMCoroutines.a
+libLLVMAnalysis.a
 )
 endif()
 include_directories("${LLVM_INCLUDE_DIRS}")
@@ -128,6 +143,13 @@ if(BUILD_PYTHON_MODULE)
     endif()
     include_directories("." ${PYTHON_SRC_PATH} ${PYTHON_INCLUDE_DIRS} ${CUTLASS_INCLUDE_DIR})
     link_directories(${PYTHON_LINK_DIRS} ${CUTLASS_LIBRARY_DIR})
+    if (TRITON_USE_ROCM)
+        add_definitions(-DUSE_ROCM)
+    endif()
+    if (TRITON_ROCM_DEBUG)
+        add_definitions(-DDEBUG_ROCM)
+    endif()
+
     set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc  ${PYTHON_SRC_PATH}/superblock.cc ${CUTLASS_SRC})
 endif()
 

--- a/include/triton/driver/dispatch.h
+++ b/include/triton/driver/dispatch.h
@@ -11,7 +11,6 @@
 #include "triton/external/CUDA/nvml.h"
 
 //// HIP backend
-//#define __HIP_PLATFORM_AMD__
 #include "triton/external/hip.h"
 
 //Exceptions

--- a/include/triton/ir/builder.h
+++ b/include/triton/ir/builder.h
@@ -42,6 +42,7 @@ public:
   value *get_int64(int64_t val);
   value *get_float16(float val);
   value *get_float32(float val);
+  value *get_float64(float val);
   value *get_range(int32_t lo, int32_t hi);
   // Types
   type *get_void_ty();

--- a/lib/codegen/analysis/layout.cc
+++ b/lib/codegen/analysis/layout.cc
@@ -145,7 +145,7 @@ mma_layout::mma_layout(size_t num_warps,
                        shared_layout *layout_a, shared_layout *layout_b): distributed_layout(MMA, axes, shape, values, align) {
   /* fragments per warp */
   // try to make things as square as possible to maximize data re-use
-  if(tgt->as_nvidia()->sm() < 80){
+  if(tgt->as_nvidia() && tgt->as_nvidia()->sm() < 80){
     fpw_ = {2, 2, 1};
     auto ord_a = layout_a->get_order();
     auto ord_b = layout_b->get_order();

--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -26,6 +26,7 @@ namespace codegen {
 // There should be a proper pass manager there!
 std::unique_ptr<llvm::Module> add_passes_to_emit_bin(ir::module &ir, llvm::LLVMContext& ctx, codegen::target* target,
                                                      int cc, int num_warps, int num_stages, int& shared_static) {
+ 
   // generate llvm code
   std::string name = ir.get_function_list()[0]->get_name();
   std::unique_ptr<llvm::Module> llvm(new llvm::Module(name, ctx));

--- a/lib/codegen/target.cc
+++ b/lib/codegen/target.cc
@@ -41,7 +41,7 @@ Value* amd_cl_target::get_global_offset(Module *module, IRBuilder<>& builder, un
 }
 
 Instruction* amd_cl_target::add_memfence(Module *module, IRBuilder<>& builder) {
-  throw std::runtime_error("not implemented");
+  throw std::runtime_error("not implemented on AMD");
 }
 
 
@@ -156,7 +156,7 @@ Value* cpu_target::get_block_id(Module *module, llvm::IRBuilder<> &builder, unsi
 }
 
 Value* cpu_target::get_num_blocks(Module *module, IRBuilder<>& builder, unsigned ax) {
-  throw std::runtime_error("not implemented");
+  throw std::runtime_error("not implemented on CPU");
 }
 
 

--- a/lib/ir/builder.cc
+++ b/lib/ir/builder.cc
@@ -60,6 +60,9 @@ value *builder::get_float16(float val)
 value *builder::get_float32(float val)
 { return constant_fp::get(type::get_fp32_ty(ctx_), val); }
 
+value *builder::get_float64(float val)
+{ return constant_fp::get(type::get_fp64_ty(ctx_), val); }
+
 value *builder::get_range(int32_t _lo, int32_t _hi) {
   constant_int* lo = static_cast<constant_int*>(get_int32(_lo));
   constant_int* hi = static_cast<constant_int*>(get_int32(_hi));

--- a/scripts/amd/build.sh
+++ b/scripts/amd/build.sh
@@ -1,0 +1,7 @@
+set -e
+cd python
+pip uninstall -y triton
+# export TRITON_USE_ROCM=ON
+
+# export TRITON_ROCM_DEBUG=ON
+pip install --verbose -e .

--- a/scripts/amd/check_llvm_src.sh
+++ b/scripts/amd/check_llvm_src.sh
@@ -1,0 +1,3 @@
+shopt -s extglob
+/opt/rocm/llvm/bin/llc -mcpu=gfx908 triton_rocm_kernels/*+([0-9]).ll
+# /opt/rocm/llvm/bin/llc -mcpu=gfx908 triton_rocm_kernels/*_before_verify.ll

--- a/scripts/amd/clean.sh
+++ b/scripts/amd/clean.sh
@@ -1,0 +1,26 @@
+set -x
+rm -rf core
+rm -rf ptx.hip
+rm -rf python/build/
+rm -rf python/test/__pycache__/
+rm -rf python/triton.egg-info/
+rm -rf python/triton/_C/libtriton.so
+rm -rf python/triton/__pycache__/
+rm -rf python/triton/ops/__pycache__/
+rm -rf python/triton/ops/blocksparse/__pycache__/
+rm -rf *.isa
+rm -rf *.gcn
+rm -rf *.ptx
+rm -rf *.ll
+rm -rf *.s
+rm -rf *.o
+rm -rf *.hsaco
+rm -rf *.ttir
+sh scripts/amd/delete_hip_files.sh
+rm -rf triton_rocm_kernels
+rm -rf /tmp/*.ll
+rm -rf /tmp/*.gcn
+rm -rf /tmp/*.hsaco
+rm -rf /tmp/*.o
+rm -rf /tmp/*.ttir
+rm -rf /tmp/*.s

--- a/scripts/amd/collect_rocm_kernels.sh
+++ b/scripts/amd/collect_rocm_kernels.sh
@@ -1,0 +1,11 @@
+# COPY kernels
+DIRNAME=triton_rocm_kernels
+rm -rf $DIRNAME
+mkdir $DIRNAME
+mv /tmp/*.ttir $DIRNAME
+mv /tmp/*.ll $DIRNAME
+mv /tmp/*.gcn $DIRNAME
+mv /tmp/*.o $DIRNAME
+mv /tmp/*.hsaco $DIRNAME
+mv /tmp/*.s $DIRNAME
+chmod -R 777 $DIRNAME

--- a/scripts/amd/debug.sh
+++ b/scripts/amd/debug.sh
@@ -1,0 +1,7 @@
+gdb -ex "set pagination off" \
+    -ex "file python" \
+    -ex 'run -m pytest --capture=tee-sys --verbose "python/test/unit/language/test_core.py::test_load_and_store_op[float64]"' \
+    -ex "bt" \
+    -ex "set confirm off" \
+    -ex "q" \
+    2>&1 | tee /dockerx/pytorch/test_core_gdb.log

--- a/scripts/amd/delete_hip_files.sh
+++ b/scripts/amd/delete_hip_files.sh
@@ -1,0 +1,2 @@
+# find . -name '*hip.h' -delete
+find . -name '*_hip.*' -delete

--- a/scripts/amd/deps.sh
+++ b/scripts/amd/deps.sh
@@ -1,0 +1,3 @@
+sudo apt update
+sudo apt install libtinfo-dev gdb 
+# sudo apt install llvm-11 # install on cuda

--- a/scripts/amd/docker_build.sh
+++ b/scripts/amd/docker_build.sh
@@ -1,0 +1,14 @@
+# print every command
+# set -o xtrace
+
+# set path
+DOCKERFILE_PATH=scripts/docker/Dockerfile.triton_rocm
+# DOCKERFILE_PATH=scripts/docker/Dockerfile.triton_cuda
+
+# get tag
+DOCKERFILE_NAME=$(basename $DOCKERFILE_PATH)
+DOCKERIMAGE_NAME=$(echo "$DOCKERFILE_NAME" | cut -f 2- -d '.')
+echo $DOCKERIMAGE_NAME
+
+# build docker
+docker build -f $DOCKERFILE_PATH -t $DOCKERIMAGE_NAME .

--- a/scripts/amd/docker_run.sh
+++ b/scripts/amd/docker_run.sh
@@ -1,0 +1,27 @@
+set -o xtrace
+
+alias drun='sudo docker run -it --rm --network=host --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined'
+
+# DEVICES="--gpus all"
+DEVICES="--device=/dev/kfd --device=/dev/dri"
+
+MEMORY="--ipc=host --shm-size 16G"
+
+VOLUMES="-v $HOME/dockerx:/dockerx -v /data:/data"
+
+# WORK_DIR='/root/$(basename $(pwd))'
+WORK_DIR="/dockerx/$(basename $(pwd))"
+
+# IMAGE_NAME=nvcr.io/nvidia/pytorch:21.08-py3
+IMAGE_NAME=rocm/pytorch
+
+CONTAINER_NAME=triton
+
+# start new container
+CONTAINER_ID=$(drun -d -w $WORK_DIR --name $CONTAINER_NAME $MEMORY $VOLUMES $DEVICES $IMAGE_NAME)
+echo "CONTAINER_ID: $CONTAINER_ID"
+# docker cp . $CONTAINER_ID:$WORK_DIR
+# docker exec $CONTAINER_ID bash -c "bash scripts/amd/run.sh"
+docker attach $CONTAINER_ID
+docker stop $CONTAINER_ID
+docker rm $CONTAINER_ID

--- a/scripts/amd/find_lib.sh
+++ b/scripts/amd/find_lib.sh
@@ -1,0 +1,2 @@
+LIB_NAME=libtinfow
+ldconfig -p | grep $LIB_NAME

--- a/scripts/amd/git_config_user.sh
+++ b/scripts/amd/git_config_user.sh
@@ -1,0 +1,7 @@
+# use --global flag if you want to set it for whole machine
+git config user.name "Michael Melesse"
+git config user.email "micmelesse@gmail.com"
+
+# unset with
+# git config --global --unset-all user.name
+# git config --global --unset-all user.email

--- a/scripts/amd/git_submodule_add.sh
+++ b/scripts/amd/git_submodule_add.sh
@@ -1,0 +1,1 @@
+git submodule add https://github.com/ROCmSoftwarePlatform/hipify-torch third_party/hipify-torch

--- a/scripts/amd/git_submodule_rm.sh
+++ b/scripts/amd/git_submodule_rm.sh
@@ -1,0 +1,10 @@
+SUBMODULE=third_party/hipify-torch
+
+# Remove the submodule entry from .git/config
+git submodule deinit -f $SUBMODULE
+
+# Remove the submodule directory from the superproject's .git/modules directory
+rm -rf .git/modules/$SUBMODULE
+
+# Remove the entry in .gitmodules and remove the submodule directory located at path/to/submodule
+git rm -f $SUBMODULE

--- a/scripts/amd/git_submodule_update.sh
+++ b/scripts/amd/git_submodule_update.sh
@@ -1,0 +1,6 @@
+# if you are updating an existing checkout
+git submodule sync
+git submodule update --init --recursive
+
+# if you want to push every to tip
+# git submodule update --init --recursive --remote

--- a/scripts/amd/grep_for_symbol.sh
+++ b/scripts/amd/grep_for_symbol.sh
@@ -1,0 +1,18 @@
+# SYMBOL=_ZN4llvm11PassBuilder17OptimizationLevel2O0E
+# SYMBOL=_ZN4llvm11DDGAnalysis3KeyE
+# SYMBOL=_ZN4llvm26UnifyFunctionExitNodesPass3runERNS_8FunctionERNS_15AnalysisManagerIS1_JEEE
+# SYMBOL=_ZN4llvm12LoopFusePass3runERNS_8FunctionERNS_15AnalysisManagerIS1_JEEE
+# SYMBOL=_ZN4llvm30moveInstructionsToTheBeginningERNS_10BasicBlockES1_RNS_13DominatorTreeERKNS_17PostDominatorTreeERNS_14DependenceInfoE
+# SYMBOL=_ZN4llvm17LoopExtractorPass3runERNS_6ModuleERNS_15AnalysisManagerIS1_JEEE
+# SYMBOL=_ZN4llvm17ObjCARCExpandPass3runERNS_8FunctionERNS_15AnalysisManagerIS1_JEEE
+# SYMBOL=_ZN4llvm13CoroSplitPass3runERNS_13LazyCallGraph3SCCERNS_15AnalysisManagerIS2_JRS1_EEES5_RNS_17CGSCCUpdateResultE
+SYMBOL=_ZN4llvm20SyntheticCountsUtilsIPKNS_9CallGraphEE9propagateERKS3_NS_12function_refIFNS_8OptionalINS_12ScaledNumberImEEEEPKNS_13CallGraphNodeERKSt4pairINS8_INS_14WeakTrackingVHEEEPSC_EEEENS7_IFvSE_SA_EEE
+for lib in $(find /tmp/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04/ -name \*.a); do
+    symbols=$(nm $lib | grep $SYMBOL | grep -v " U ")
+    
+    if [ "${#symbols}" -gt "0" ]; then
+        echo $lib
+        echo $symbols
+    fi
+
+done

--- a/scripts/amd/hipify.sh
+++ b/scripts/amd/hipify.sh
@@ -1,0 +1,1 @@
+PYTHONDONTWRITEBYTECODE=1 python3 third_party/hipify-torch/hipify_cli.py --project-directory .

--- a/scripts/amd/lld.sh
+++ b/scripts/amd/lld.sh
@@ -1,0 +1,1 @@
+/opt/rocm/llvm/bin/ld.lld -flavor gnu -shared _empty.o -o _empty.hsaco

--- a/scripts/amd/run.sh
+++ b/scripts/amd/run.sh
@@ -1,0 +1,8 @@
+clear
+bash scripts/amd/clean.sh
+bash scripts/amd/deps.sh
+bash scripts/amd/build.sh
+bash scripts/amd/test.sh
+# bash scripts/amd/debug.sh
+bash scripts/amd/collect_rocm_kernels.sh
+bash scripts/amd/check_llvm_src.sh

--- a/scripts/amd/test.sh
+++ b/scripts/amd/test.sh
@@ -1,0 +1,112 @@
+# clear
+rm -rf triton_rocm_kernels
+
+export TRITON_LIBHIP=/opt/rocm/lib/libamdhip64.so
+
+# export AMD_OCL_WAIT_COMMAND=1
+# export AMD_LOG_LEVEL=3
+# export HIP_LAUNCH_BLOCKING=1
+
+# remove cache to avoid segfaults
+# TODO: inform triton dev the cache cause segfault
+rm -rf /tmp/triton
+
+# pytest python/test
+# pytest python/test/test_blocksparse.py
+
+# pytest --verbose python/test/test_conv.py
+# pytest --verbose python/test/test_blocksparse.py::test_matmul[sdd-False-False-16-float16]
+# pytest --verbose python/test/test_blocksparse.py::test_attention_fwd_bwd
+# python python/test/test_conv.py
+
+# gdb -ex "set breakpoint pending on" \
+#     -ex 'break add_passes_to_emit_bin' \
+#     --args python python/test/test_add.py
+
+# python python/test/test_empty.py
+# -ex 'ignore 1 472' \
+
+pytest --verbose python/test/unit/language/test_core.py |& tee /dockerx/triton/test_core.log
+
+# pytest --verbose python/test/unit/language/test_core.py::test_empty_kernel
+# pytest --verbose python/test/unit/language/test_core.py::test_load_and_store_op
+# pytest --verbose python/test/unit/language/test_core.py::test_unary_op
+# pytest --verbose python/test/unit/language/test_core.py::test_bin_op
+# pytest --verbose "python/test/unit/language/test_core.py::test_dot"
+# pytest --verbose python/test/unit/language/test_core.py::test_cast
+# pytest --verbose python/test/unit/language/test_core.py::test_reduce1d
+# pytest --verbose python/test/unit/language/test_core.py::test_reduce2d
+# pytest --verbose python/test/unit/language/test_core.py::test_math_op
+# pytest --verbose python/test/unit/language/test_core.py::test_atomic_rmw
+# pytest --verbose python/test/unit/operators/test_blocksparse.py::test_matmul
+# pytest --verbose "python/test/unit/operators/test_blocksparse.py::test_softmax" |& tee /dockerx/triton/test_softmax.log
+# pytest --verbose python/test/unit/language/test_core.py::test_permute
+# pytest --verbose python/test/unit/language/test_core.py::test_load_cache_modifier
+
+# pytest --verbose python/test/unit/language/test_core.py::test_math_op[log]
+# pytest --capture=tee-sys --verbose python/test/unit/language/test_core.py::test_load_and_store_op[float64]
+# pytest --verbose "python/test/unit/language/test_core.py::test_bin_op[int8-int64- x % y]"
+# pytest --verbose "python/test/unit/language/test_core.py::test_dot[none]" |& tee /dockerx/triton/test_dot_none.log
+# pytest --verbose "python/test/unit/language/test_core.py::test_dot[add-rows]"
+# pytest --verbose "python/test/unit/language/test_core.py::test_dot[add-cols]"
+# pytest --verbose "python/test/unit/language/test_core.py::test_cast[float32-float16-False]"
+
+# pytest --verbose python/test/unit/operators/test_blocksparse.py::test_matmul[DTYPE0-32-False-False-sdd]
+# pytest --capture=tee-sys --verbose python/test/unit/operators/test_blocksparse.py::test_softmax[DTYPE0-256-32]
+
+
+# pytest --verbose python/test/unit/operators/test_blocksparse.py
+# pytest --verbose python/test/unit/operators/test_blocksparse.py::test_matmul[DTYPE0-32-False-False-sdd]
+# pytest --verbose scripts/amd/test_fptrunc.py
+# pytest --verbose scripts/amd/test_fptrunc.py::test_fptrunc[float32-float32-False]
+# pytest --verbose "python/test/unit/language/test_core.py::test_cast"
+# pytest --verbose "python/test/unit/language/test_core.py::test_cast[float32-float16-False]"
+# pytest --verbose "python/test/unit/language/test_core.py::test_cast[float32-bfloat16-False]"
+# python python/test/unit/language/test_core.py
+
+# pytest --capture=tee-sys --verbose python/test/unit/language/test_core.py::test_empty_kernel
+
+# pytest --capture=tee-sys --verbose "python/test/unit/language/test_core.py::test_bin_op[int8-int64- x % y]"
+# pytest --capture=tee-sys --verbose "python/test/unit/language/test_core.py::test_bin_op[int8-float32- x % y]"
+# pytest --capture=tee-sys --verbose "python/test/unit/language/test_core.py::test_bin_op[int8-float16- x % y]"
+# pytest --capture=tee-sys --verbose "python/test/unit/language/test_core.py::test_bin_op[float32-float64- x % y]"
+# pytest --capture=tee-sys --verbose "python/test/unit/language/test_core.py::test_math_op[exp]"
+# pytest --verbose "python/test/unit/operators/test_blocksparse.py"
+# pytest --capture=tee-sys --verbose "python/test/unit/operators/test_blocksparse.py::test_matmul[sdd-False-False-16-float16]"
+
+# pytest --capture=tee-sys --verbose "python/test/unit/language/test_core.py::test_arange"
+
+# pytest --verbose "python/test/unit/language/test_core.py::test_masked_load_shared_memory"
+# pytest --verbose "python/test/unit/language/test_core.py::test_dot_without_load"
+# pytest --verbose "python/test/unit/language/test_core.py::test_fmadot"
+
+# FAILING TESTS
+# pytest --verbose "python/test/unit/language/test_core.py::test_bin_op[int8-float16- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int8-float32- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int8-float64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int16-float16- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int16-float32- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int16-float64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int32-float16- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int32-float32- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int32-float64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int64-float16- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int64-float32- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[int64-float64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float16-int8- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float16-int16- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float16-int32- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float16-int64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float16-float64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float32-int8- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float32-int16- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float32-int32- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float32-int64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float32-float64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float64-int8- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float64-int16- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float64-int32- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float64-int64- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float64-float16- x % y]" \
+#     "python/test/unit/language/test_core.py::test_bin_op[float64-float32- x % y]"
+

--- a/scripts/amd/test_fptrunc.py
+++ b/scripts/amd/test_fptrunc.py
@@ -1,0 +1,62 @@
+import torch
+import triton
+import triton.language as tl
+import pytest
+
+cvt = {
+    'bool': torch.bool,
+    'int8': torch.int8,
+    'int16': torch.int16,
+    'int32': torch.int32,
+    'int64': torch.int64,
+    'bfloat16': torch.bfloat16,
+    'float16': torch.float16,
+    'float32': torch.float32,
+    'float64': torch.float64,
+}
+
+int_dtypes = ['int8', 'int16', 'int32', 'int64']
+float_dtypes = ['float16', 'float32', 'float64']
+dtypes = int_dtypes + float_dtypes
+
+
+@pytest.mark.parametrize("dtype_x, dtype_z, bitcast", [
+    (dtype_x, dtype_z, False)
+    for dtype_x in dtypes
+    for dtype_z in dtypes
+])
+def test_fptrunc(dtype_x, dtype_z, bitcast, device='cuda'):
+    SIZE = 256
+    # define the kernel / launch-grid
+    @triton.jit
+    def kernel(Z, X, **meta):
+        off = tl.arange(0, meta['SIZE'])
+        x = tl.load(X + off)
+        tl.store(Z + off, x)
+    # inputs
+    x = triton.testing.random(SIZE, dtype=cvt[dtype_x], device=device)
+
+    # reference result
+    z_ref = x.type(dtype=cvt[dtype_z])
+
+    # triton result
+    z_tri = torch.zeros_like(x, dtype=cvt[dtype_z])
+
+    # triton.testing.assert_almost_equal(z_ref, z_tri)
+
+    print("before kernel")
+    # run load and store kernel
+    kernel[(1, )](z_tri, x, SIZE=SIZE, num_warps=1)
+    print("after kernel")
+
+    # print("x:", x)
+    # print("z_ref:", z_ref)
+    # print("z_tri:", z_tri)
+    # compare
+    print("before compare")
+    triton.testing.assert_almost_equal(z_ref, z_tri)
+    print("after compare")
+
+
+if __name__ == '__main__':
+    test_fptrunc()


### PR DESCRIPTION
# PR details
This pr adds functionality for a few operators. 
1. Matmul (dot)
2. exp, log, sin, cos
3. reduce1d
- > we use the reduce_nd op. It seems to work for most cases. 

It also updates the load and store operators on rocm such that they work along a mostly separate code path to the one used by cuda. This resolved multiple issues. We will revise this code path and add features and improve performance at a later date.

Finally we add and modify some test. 
1. add a test for the load and store operators(test_load_and_store_op) that test different combo of size and datatype.
2. expand the test_dot function to test fp32 data. 
3. expand the test_cast function to take data blocks
- > in addition to that we automatically fail 2 cases out of 52 on rocm that use bfloat. This will be resolved in a new pr

# PR testing
To check this pr

1. enter a rocm docker container
```
alias drun='sudo docker run -it --rm --network=host --group-add video --cap-add=SYS_PTRACE --security-opt seccomp=unconfined --ipc=host --shm-size 16G --device=/dev/kfd --device=/dev/dri'
drun rocm/pytorch 
``` 

2. clone and check out this branch
```
git clone -b rocm_matmul_pr https://github.com/micmelesse/triton
```
3. build triton with the following steps
```
cd python
pip install --verbose -e .
```

4. test with the whole test_core with 
```
pytest --verbose python/test/unit/language/test_core.py
```
We see that about 800 tests pass and 60 tests fail.
or relevant tests with 
```
pytest --verbose python/test/unit/language/test_core.py::test_load_and_store_op
pytest --verbose "python/test/unit/language/test_core.py::test_dot"
pytest --verbose python/test/unit/language/test_core.py::test_math_op
pytest --verbose python/test/unit/language/test_core.py::test_case
```