### PR TITLE
signed-integer math fixes and testing

### DIFF
--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -482,7 +482,8 @@ class CodeGenerator(ast.NodeVisitor):
         with warnings.catch_warnings():
             # The ast library added visit_Constant and deprecated some other
             # methods but we can't move to that without breaking Python 3.6 and 3.7.
-            warnings.simplefilter("ignore", DeprecationWarning)
+            warnings.simplefilter("ignore", DeprecationWarning)  # python 3.9
+            warnings.simplefilter("ignore", PendingDeprecationWarning)  # python 3.8
             return super().visit(node)
 
     def generic_visit(self, node):
@@ -905,7 +906,7 @@ class JITFunction:
             node = generator.last_node
             if node is None or isinstance(e, (NotImplementedError, CompilationError)):
                 raise e
-            raise CompilationError(self.src, node, e)
+            raise CompilationError(self.src, node) from e
 
     # - when `.src` attribute is set, cache path needs
     #   to be reinitialized


### PR DESCRIPTION
- Promote 16-bit floating-point `/` and `%` to 32-bit; we have to anyway.
- Do not force result of integer binary operations to be the LHS type. There used to be a bug in pytorch that did this, which Triton matched, but that bug is fixed now.
- When testing signed integer operations, use random numbers from the full range of the type.
- Add an optional `seed` argument to `triton.testing.random` so binary operations are not tested with both sides equal when the LHS and RHS have the same type.
- Fix a bad `CompilationError` invocation.
- Fix a warning suppression that causes tests to fail if you run them with `-W error` on python 3.8.