### PR TITLE
Replace the legacy print call in triton.cc with the SlotTracker-based one

### DIFF
--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -440,7 +440,7 @@ void init_triton_codegen(py::module &&m) {
         // record asm as we generate
         asm_map_t asm_map;
         std::ostringstream ttir;
-        ir::print(ir, ttir);
+        ir.print(ttir);
         asm_map["ttir"] = py::cast(ttir.str());
         llvm::LLVMContext ctx;
         if(backend == CUDA)


### PR DESCRIPTION
The legacy print call will assign names (e.g., %10) to values, which can be undesirable in some cases.