### PR TITLE
[FRONTEND] Better cache hook

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -71,8 +71,21 @@ def test_reuse():
     reset_tmp_dir()
     x = torch.empty(1, dtype=torch.int32, device='cuda')
     for i in range(10):
-        kernel[(1,)](x, 43, BLOCK=1024)
+        kernel[(1,)](x, 1, BLOCK=1024)
     assert counter == 1
+
+def test_hook():
+    ret = None
+    def cache_hook(key, binary, repr):
+        nonlocal ret
+        print('a')
+        ret = (key, binary, repr)
+    JITFunction.cache_hook = cache_hook
+    reset_tmp_dir()
+    x = torch.empty(1, dtype=torch.int32, device='cuda')
+    kernel[(1,)](x, 43, BLOCK=1024)
+    print(ret)
+    
 
 @pytest.mark.parametrize('mode', ['enable', 'disable'])
 def test_specialize(mode):

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -64,7 +64,7 @@ def reset_tmp_dir():
 
 def test_reuse():
     counter = 0
-    def inc_counter(key, binary):
+    def inc_counter(key, binary, repr):
         nonlocal counter
         counter += 1
     JITFunction.cache_hook = inc_counter
@@ -73,24 +73,12 @@ def test_reuse():
     for i in range(10):
         kernel[(1,)](x, 1, BLOCK=1024)
     assert counter == 1
-
-def test_hook():
-    ret = None
-    def cache_hook(key, binary, repr):
-        nonlocal ret
-        print('a')
-        ret = (key, binary, repr)
-    JITFunction.cache_hook = cache_hook
-    reset_tmp_dir()
-    x = torch.empty(1, dtype=torch.int32, device='cuda')
-    kernel[(1,)](x, 43, BLOCK=1024)
-    print(ret)
     
 
 @pytest.mark.parametrize('mode', ['enable', 'disable'])
 def test_specialize(mode):
     counter = 0
-    def inc_counter(key, binary):
+    def inc_counter(key, binary, repr):
         nonlocal counter
         counter += 1
     JITFunction.cache_hook = inc_counter

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -700,35 +700,16 @@ class Kernel:
                         pickle.dump({"binary": binary, "key": key}, f)
                     os.rename(bin_cache_path + ".tmp", bin_cache_path)
                     if JITFunction.cache_hook is not None:
-                        signatures = []
-                        for i, name in enumerate(self.fn.arg_names):
-                            arg = wargs[i]
-                            curr = f'{name}: '
-                            if i in constants:
-                                curr += f"constant({constants[i]})"
-                            else:
-                                if(hasattr(arg, 'data_ptr')):
-                                    curr += Kernel._type_name(arg) + '*'
-                                elif isinstance(arg, triton.language.constexpr):
-                                    curr += f'constexpr[{arg.value}]'
-                                elif isinstance(arg, int):
-                                    if abs(arg) <= 0xffffffff:
-                                        curr += 'i32'
-                                    else:
-                                        curr += 'i64'
-                                elif isinstance(arg, float):
-                                    curr += "f32"
-                                elif isinstance(arg, bool):
-                                    curr += "i1"
-                                if i in attributes:
-                                    curr += f"[multipleof({attributes[i]})]"
-                            
-
-
-                            
-                            signatures.append(curr)
-                        signature = ', '.join(signatures)
-                        repr = f'{self.fn.fn.__name__}({signature})'
+                        name = self.fn.fn.__name__
+                        info = key.split('-')[-3:]
+                        num_warps, num_stages, sig = info[0], info[1], info[2].split('_')[1:]
+                        # make signature human-readable
+                        arg_reprs = []
+                        for arg_name, arg_sig in zip(self.fn.arg_names, sig):
+                            arg_reprs.append(f'{arg_name}: {arg_sig}')
+                        # assemble the repr
+                        arg_reprs = ", ".join(arg_reprs)
+                        repr = f"{name}[num_warps={num_warps}, num_stages={num_stages}]({arg_reprs})"
                         JITFunction.cache_hook(key=key, binary=binary, repr=repr)
 
         self.fn.bin_cache[key] = LoadedBinary(device_idx, binary)


### PR DESCRIPTION
Added an additional `repr` argument to the cache hook, which represents a human-readable string representation of the signature and argument attributes associated with the compiled binary.