### PR TITLE
[OPS][BLOCKSPARSE] Remove unnecessary loop and add CUDA bool layout support

### DIFF
--- a/python/triton/ops/blocksparse/matmul.py
+++ b/python/triton/ops/blocksparse/matmul.py
@@ -283,14 +283,14 @@ def dsd_lut(layout, block, step, trans, device):
     # -------------------------------
     # same as above, except that the increments are in the sparse memory layout
     if trans:
-        A_idx = torch.arange(num_blocks)
+        A_idx = torch.arange(num_blocks, device=layout.device)
     else:
         A_idx = torch.tensor([], dtype=torch.int64, device=layout.device)
         current_offset = 0
         for z in range(layout.size(0)):
-            layoutw = layout[z, :, :].clone()
+            layoutw = layout[z, :, :].clone().long()
             msum = layoutw.sum()
-            layoutw[layoutw > 0] = 1 + torch.arange(msum)
+            layoutw[layoutw > 0] = 1 + torch.arange(msum, device=layout.device)
             A_idx = torch.cat((A_idx, current_offset + layoutw.T[layoutw.T > 0] - 1))
             current_offset += msum
     A_incs = A_idx * block * block


### PR DESCRIPTION
Modifications:
- Remove unnecessary loop in make_lut functions for speedup.
- Add support for CUDA and torch.bool layout. CPU and torch.long layout remains supported.
  - CUDA layout gives better speed for large layout.
  - Boolean layout can help save memory, and users are free from manual bool-to-long transformation.

Code is tested.