### PR TITLE
Fix LLVM error for bfloat16

### DIFF
--- a/lib/codegen/selection/common.h
+++ b/lib/codegen/selection/common.h
@@ -26,7 +26,7 @@ namespace triton::codegen {
 // types
 #define void_ty              builder_->getVoidTy()
 #define f16_ty               builder_->getHalfTy()
-#define bf16_ty              builder_->getBFloatTy()
+#define bf16_ty              builder_->getInt16Ty()
 #define f32_ty               builder_->getFloatTy()
 #define i8_ty                builder_->getInt8Ty()
 #define i32_ty               builder_->getInt32Ty()

--- a/lib/ir/constant.cc
+++ b/lib/ir/constant.cc
@@ -18,6 +18,8 @@ constant *constant::get_null_value(type *ty) {
     return constant_int::get(ty, 0);
   case type::FP16TyID:
     return constant_fp::get(type::get_fp16_ty(ctx), 0);
+  case type::BF16TyID:
+    return constant_fp::get(type::get_bf16_ty(ctx), 0);
   case type::FP32TyID:
     return constant_fp::get(type::get_fp32_ty(ctx), 0);
   case type::FP64TyID:

--- a/lib/ir/dispatch.cc
+++ b/lib/ir/dispatch.cc
@@ -64,6 +64,13 @@ ir::type *computation_type(ir::type* a_ty, ir::type* b_ty, DivOrMod div_or_mod) 
       return type::get_fp16_ty(ctx);
     }
   }
+  if (a_ty->is_bf16_ty() || b_ty->is_bf16_ty()) {
+    if (div_or_mod == DivOrMod::YES) {
+      return type::get_fp32_ty(ctx);
+    } else {
+      return type::get_bf16_ty(ctx);
+    }
+  }
   if (!a_ty->is_integer_ty() || !b_ty->is_integer_ty())
     throw_unreachable("computation_type");
   // 4 ) both operands are integer and undergo

--- a/python/test/unit/operators/test_norm.py
+++ b/python/test/unit/operators/test_norm.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+import triton.language as tl
+from triton.code_gen import next_power_of_2
+
+import triton
+
+
+@triton.heuristics({"block_len": lambda args: next_power_of_2(args["N"])})
+@triton.jit
+def _normalized_op(inputs_ptr, normalized_out_ptr, N, eps, block_len: tl.constexpr):
+    row = tl.program_id(0)
+    cols = tl.arange(0, block_len)
+    inputs = inputs_ptr + row * N + cols
+    inputs = tl.load(inputs, mask=cols < N, other=0)
+    denom = tl.sum(inputs.to(tl.float32), 0) + eps
+    normalized_out = normalized_out_ptr + row * N + cols
+    tl.store(normalized_out, inputs / denom, mask=cols < N)
+
+
+def normalized(inputs, eps):
+    n_rows, n_cols = inputs.shape
+    grid = lambda opt: (n_rows,)
+    normalized = torch.empty_like(inputs)
+    _normalized_op[grid](inputs, normalized, n_cols, eps)
+    return normalized
+
+
+def torch_normalized(inputs, eps):
+    return inputs / (torch.sum(inputs, axis=1) + eps)[:, None]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
+def test_normalized(dtype):
+    eps = 1e-3
+    inputs = torch.ones((4, 23), dtype=torch.bfloat16, device="cuda")
+    triton_result = normalized(inputs, eps=eps)
+    torch_result = torch_normalized(inputs, eps=eps)
+    triton.testing.assert_almost_equal(triton_result, torch_result)


### PR DESCRIPTION
I was encountering some LLVM "Cannot select" issues when using bf16 with certain ops, even with the latest bf16 patch.  I've added a minimal reproducer as a test.

I don't fully understand the source of the issue here, but switching to representing bfloat16 types as int16 seems to solve the issue and still give correct results.  I also found that a couple other "Cannot select" errors were fixed by this as well, and removed those workarounds.

Without this patch, the new test fails with the following error:
```
triton/python/test/unit/operators/test_norm.py::test_normalized[dtype0] LLVM ERROR: Cannot select: 0x55b44dbdb690: bf16 = bitcast 0x55b44dbdea60
  0x55b44dbdea60: i16,ch,glue = CopyFromReg 0x55b44dbde9f8, Register:i16 %9, 0x55b44dbde9f8:1
    0x55b44dbde720: i16 = Register %9
    0x55b44dbde9f8: ch,glue = inlineasm 0x55b44dbde928, TargetExternalSymbol:i64'@$1 ld.global.b16 {$0}, [ $2 + 0];', MDNode:ch<null>, TargetConstant:i64<1>, TargetConstant:i32<196618>, Register:i16 %9, TargetConstant:i32<65545>, Register:i1 %10, TargetConstant:i32<851977>, Register:i64 %11, 0x55b44dbde928:1
      0x55b44dbde580: i64 = TargetExternalSymbol'@$1 ld.global.b16 {$0}, [ $2 + 0];'
      0x55b44dbde650: i64 = TargetConstant<1>
      0x55b44dbde6b8: i32 = TargetConstant<196618>
      0x55b44dbde720: i16 = Register %9
      0x55b44dbde858: i32 = TargetConstant<65545>
      0x55b44dbde788: i1 = Register %10
      0x55b44dbde990: i32 = TargetConstant<851977>
      0x55b44dbde8c0: i64 = Register %11
      0x55b44dbde928: ch,glue = CopyToReg 0x55b44dbde7f0, Register:i64 %11, 0x55b44dbde448, 0x55b44dbde7f0:1
        0x55b44dbde8c0: i64 = Register %11
        0x55b44dbde448: i64 = add 0x55b44dbdbbd8, 0x55b44dbe2b08
          0x55b44dbdbbd8: i64 = add 0x55b44dbdb830, 0x55b44dbde3e0
            0x55b44dbdb830: i64,ch = load<(dereferenceable invariant load 8 from `i64 addrspace(101)* null`, addrspace 101)> 0x55b44d28a958, TargetExternalSymbol:i64'_normalized_op_param_0', undef:i64
              0x55b44dbdacd0: i64 = TargetExternalSymbol'_normalized_op_param_0'
              0x55b44dbdada0: i64 = undef
            0x55b44dbde3e0: i64 = NVPTXISD::MUL_WIDE_SIGNED 0x55b44dbdb968, Constant:i32<2>
              0x55b44dbdb968: i32 = mul 0x55b44dbdb900, 0x55b44dbdbb70
                0x55b44dbdb900: i32 = llvm.nvvm.read.ptx.sreg.ctaid.x TargetConstant:i64<4999>
                  0x55b44dbdb898: i64 = TargetConstant<4999>
                0x55b44dbdbb70: i32,ch = load<(dereferenceable invariant load 4 from `i32 addrspace(101)* null`, addrspace 101)> 0x55b44d28a958, TargetExternalSymbol:i64'_normalized_op_param_2', undef:i64
                  0x55b44dbdb010: i64 = TargetExternalSymbol'_normalized_op_param_2'
                  0x55b44dbdada0: i64 = undef
              0x55b44dbe0f60: i32 = Constant<2>
          0x55b44dbe2b08: i64 = NVPTXISD::MUL_WIDE_SIGNED 0x55b44dbe29d0, Constant:i32<2>
            0x55b44dbe29d0: i32 = or 0x55b44dbe2e48, 0x55b44dbe2fe8
              0x55b44dbe2e48: i32 = shl 0x55b44dbdb7c8, Constant:i32<5>
                0x55b44dbdb7c8: i32 = srl 0x55b44dbdb558, Constant:i32<5>
                  0x55b44dbdb558: i32 = llvm.nvvm.read.ptx.sreg.tid.x TargetConstant:i64<5057>

                  0x55b44dbdee70: i32 = Constant<5>
                0x55b44dbdee70: i32 = Constant<5>
              0x55b44dbe2fe8: i32 = sub 0x55b44dbdb558, 0x55b44dbe2e48
                0x55b44dbdb558: i32 = llvm.nvvm.read.ptx.sreg.tid.x TargetConstant:i64<5057>
                  0x55b44dbdb4f0: i64 = TargetConstant<5057>
                0x55b44dbe2e48: i32 = shl 0x55b44dbdb7c8, Constant:i32<5>
                  0x55b44dbdb7c8: i32 = srl 0x55b44dbdb558, Constant:i32<5>


                  0x55b44dbdee70: i32 = Constant<5>
            0x55b44dbe0f60: i32 = Constant<2>
        0x55b44dbde7f0: ch,glue = CopyToReg 0x55b44d28a958, Register:i1 %10, 0x55b44dbde518
          0x55b44dbde788: i1 = Register %10
          0x55b44dbde518: i1 = setcc 0x55b44dbe29d0, 0x55b44dbdbb70, setlt:ch
            0x55b44dbe29d0: i32 = or 0x55b44dbe2e48, 0x55b44dbe2fe8
              0x55b44dbe2e48: i32 = shl 0x55b44dbdb7c8, Constant:i32<5>
                0x55b44dbdb7c8: i32 = srl 0x55b44dbdb558, Constant:i32<5>
                  0x55b44dbdb558: i32 = llvm.nvvm.read.ptx.sreg.tid.x TargetConstant:i64<5057>

                  0x55b44dbdee70: i32 = Constant<5>
                0x55b44dbdee70: i32 = Constant<5>
              0x55b44dbe2fe8: i32 = sub 0x55b44dbdb558, 0x55b44dbe2e48
                0x55b44dbdb558: i32 = llvm.nvvm.read.ptx.sreg.tid.x TargetConstant:i64<5057>
                  0x55b44dbdb4f0: i64 = TargetConstant<5057>
                0x55b44dbe2e48: i32 = shl 0x55b44dbdb7c8, Constant:i32<5>
                  0x55b44dbdb7c8: i32 = srl 0x55b44dbdb558, Constant:i32<5>


                  0x55b44dbdee70: i32 = Constant<5>
            0x55b44dbdbb70: i32,ch = load<(dereferenceable invariant load 4 from `i32 addrspace(101)* null`, addrspace 101)> 0x55b44d28a958, TargetExternalSymbol:i64'_normalized_op_param_2', undef:i64
              0x55b44dbdb010: i64 = TargetExternalSymbol'_normalized_op_param_2'
              0x55b44dbdada0: i64 = undef
In function: _normalized_op
Fatal Python error: Aborted
```