### PR TITLE
[minor][v2.0] Hotfix for gcc compilation

### DIFF
--- a/include/triton/ir/type.h
+++ b/include/triton/ir/type.h
@@ -6,6 +6,7 @@
 #include <cassert>
 #include <vector>
 #include <string>
+#include <stdexcept>
 
 namespace triton{
 namespace ir{


### PR DESCRIPTION
Not sure what compiler you  typically use, but I cannot get triton v2.0 to `pip install -e .` with GCC 9 or 10 without this, std::logic_error cannot be resolved (which does look like a legit error, see [cppreference](https://en.cppreference.com/w/cpp/error/logic_error))