### PR TITLE
WIP: Fixturize device 

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+import torch
+
+devices = ['cpu']
+
+if torch.cuda.is_available():
+    devices += ['cuda']
+
+
+@pytest.fixture(params=devices, scope="session")
+def device(request):
+    """
+    Fixture for CPU/GPU device in pytorch
+    """
+    return request.param

--- a/python/test/unit/language/test_random.py
+++ b/python/test/unit/language/test_random.py
@@ -115,7 +115,7 @@ BLOCK = 1024
                          [(size, seed) for size in ['10', '4,53', '10000']
                           for seed in [0, 42, 124, 54, 0xffffffff, 0xdeadbeefcafeb0ba]]
                          )
-def test_randint(size, seed, device='cuda'):
+def test_randint(size, seed, device):
     size = list(map(int, size.split(',')))
 
     @triton.jit
@@ -141,7 +141,7 @@ def test_randint(size, seed, device='cuda'):
                          [(size, seed) for size in [1000000]
                           for seed in [0, 42, 124, 54]]
                          )
-def test_rand(size, seed, device='cuda'):
+def test_rand(size, seed, device):
     @triton.jit
     def kernel(X, N, seed):
         offset = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
@@ -162,7 +162,7 @@ def test_rand(size, seed, device='cuda'):
                          [(size, seed) for size in [1000000]
                           for seed in [0, 42, 124, 54]]
                          )
-def test_randn(size, seed, device='cuda'):
+def test_randn(size, seed, device):
     @triton.jit
     def kernel(X, N, seed):
         offset = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)

--- a/python/test/unit/operators/test_blocksparse.py
+++ b/python/test/unit/operators/test_blocksparse.py
@@ -9,7 +9,7 @@ import triton
 @pytest.mark.parametrize("TRANS_B", [False, True])
 @pytest.mark.parametrize("BLOCK", [16, 32, 64])
 @pytest.mark.parametrize("DTYPE", [torch.float16])
-def test_matmul(MODE, TRANS_A, TRANS_B, BLOCK, DTYPE, Z=3, H=2, M=512, N=384, K=256):
+def test_matmul(MODE, TRANS_A, TRANS_B, BLOCK, DTYPE, device, Z=3, H=2, M=512, N=384, K=256):
     seed = 0
     torch.manual_seed(seed)
     is_sdd = MODE == "sdd"
@@ -52,7 +52,7 @@ def test_matmul(MODE, TRANS_A, TRANS_B, BLOCK, DTYPE, Z=3, H=2, M=512, N=384, K=
     b_tri = do_sparsify(b_tri) if is_dds else b_tri
     a_tri.retain_grad()
     b_tri.retain_grad()
-    op = triton.ops.blocksparse.matmul(layout, BLOCK, MODE, trans_a=TRANS_A, trans_b=TRANS_B, device="cuda")
+    op = triton.ops.blocksparse.matmul(layout, BLOCK, MODE, trans_a=TRANS_A, trans_b=TRANS_B, device=device)
     c_tri = triton.testing.catch_oor(lambda: op(a_tri, b_tri), pytest)
     triton.testing.catch_oor(lambda: c_tri.backward(dc_tri), pytest)
     da_tri = a_tri.grad
@@ -73,7 +73,7 @@ configs = [
 
 @pytest.mark.parametrize("is_dense", [False, True])
 @pytest.mark.parametrize("BLOCK, WIDTH", configs)
-def test_softmax(BLOCK, WIDTH, is_dense, Z=2, H=2, is_causal=True, scale=0.4):
+def test_softmax(BLOCK, WIDTH, is_dense, device, Z=2, H=2, is_causal=True, scale=0.4):
     # set seed
     torch.random.manual_seed(0)
     Z, H, M, N = 2, 3, WIDTH, WIDTH
@@ -92,7 +92,7 @@ def test_softmax(BLOCK, WIDTH, is_dense, Z=2, H=2, is_causal=True, scale=0.4):
     # compute [torch]
     a_ref = triton.testing.mask_tensor(a_ref, layout, BLOCK, value=float("-inf"))
     a_ref.retain_grad()
-    at_mask = torch.ones((M, N), device="cuda")
+    at_mask = torch.ones((M, N), device=device)
     if is_causal:
         at_mask = torch.tril(at_mask)
     M = at_mask[None, None, :, :] + torch.zeros_like(a_ref)
@@ -105,7 +105,7 @@ def test_softmax(BLOCK, WIDTH, is_dense, Z=2, H=2, is_causal=True, scale=0.4):
     a_tri = triton.testing.sparsify_tensor(a_tri, layout, BLOCK)
     a_tri.retain_grad()
     dout_tri = triton.testing.sparsify_tensor(dout_tri, layout, BLOCK)
-    op = triton.ops.blocksparse.softmax(layout, BLOCK, device="cuda", is_dense=is_dense)
+    op = triton.ops.blocksparse.softmax(layout, BLOCK, device=device, is_dense=is_dense)
     out_tri = op(a_tri, scale=scale, is_causal=is_causal)
     out_tri.backward(dout_tri)
     da_tri = a_tri.grad
@@ -119,6 +119,7 @@ def test_softmax(BLOCK, WIDTH, is_dense, Z=2, H=2, is_causal=True, scale=0.4):
 def test_attention_fwd_bwd(
     block,
     dtype,
+    device,
     input_scale=1.0,
     scale=1 / 8.0,
     n_ctx=256,
@@ -128,7 +129,7 @@ def test_attention_fwd_bwd(
     # inputs
     qkv_shape = (batch_size, n_heads, n_ctx, 64)
     qkvs = [
-        torch.nn.Parameter(input_scale * torch.randn(qkv_shape), requires_grad=True).to(dtype).cuda() for _ in range(3)
+        torch.nn.Parameter(input_scale * torch.randn(qkv_shape), requires_grad=True).to(dtype, device=device) for _ in range(3)
     ]
 
     # Triton:
@@ -146,9 +147,9 @@ def test_attention_fwd_bwd(
 
     # Torch version:
     torch_q, torch_k, torch_v = [x.clone() for x in qkvs]
-    attn_mask = torch.ones([n_ctx, n_ctx], device="cuda", dtype=dtype)
+    attn_mask = torch.ones([n_ctx, n_ctx], device=device, dtype=dtype)
     attn_mask = torch.tril(attn_mask, diagonal=0)
-    attn_mask = 1e6 * (-1 + (attn_mask.reshape((1, 1, n_ctx, n_ctx)).cuda()))
+    attn_mask = 1e6 * (-1 + (attn_mask.reshape((1, 1, n_ctx, n_ctx)).to(device=device)))
     torch_q.retain_grad()
     torch_k.retain_grad()
     torch_v.retain_grad()

--- a/python/test/unit/operators/test_cross_entropy.py
+++ b/python/test/unit/operators/test_cross_entropy.py
@@ -12,11 +12,11 @@ import triton
                              for mode in ['forward', 'backward']
                          ]
                          )
-def test_op(M, N, dtype, mode):
+def test_op(M, N, dtype, mode, device):
     dtype = {'float16': torch.float16, 'float32': torch.float32}[dtype]
     # create inputs
-    x = torch.randn(M, N, dtype=dtype, device='cuda', requires_grad=True)
-    idx = 4 + torch.ones(M, dtype=torch.int64, device='cuda')
+    x = torch.randn(M, N, dtype=dtype, device=device, requires_grad=True)
+    idx = 4 + torch.ones(M, dtype=torch.int64, device=device)
     # forward pass
     tt_y = triton.ops.cross_entropy(x, idx)
     th_y = torch.nn.CrossEntropyLoss(reduction="none")(x, idx)

--- a/python/test/unit/operators/test_matmul.py
+++ b/python/test/unit/operators/test_matmul.py
@@ -66,8 +66,8 @@ import triton._C.libtriton.triton as _triton
         ]
     ),
 )
-def test_op(BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, NWARP, NSTAGE, M, N, K, AT, BT, DTYPE):
-    cc = _triton.runtime.cc(_triton.runtime.backend.CUDA, torch.cuda.current_device())
+def test_op(BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, NWARP, NSTAGE, M, N, K, AT, BT, DTYPE, device):
+    cc = _triton.runtime.cc(_triton.runtime.backend.CUDA, device)
     if cc < 80 and DTYPE == "bfloat16":
         pytest.skip("Only test bfloat16 on devices with sm >= 80")
     if DTYPE == "bfloat16" and SPLIT_K != 1:
@@ -88,8 +88,8 @@ def test_op(BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, NWARP, NSTAGE, M, N, K, AT, BT, 
     K = BLOCK_K * SPLIT_K if K is None else K
     # allocate/transpose inputs
     DTYPE = {"float16": torch.float16, "bfloat16": torch.bfloat16, "float32": torch.float32}[DTYPE]
-    a = .1 * torch.randn((K, M) if AT else (M, K), device="cuda", dtype=DTYPE)
-    b = .1 * torch.randn((N, K) if BT else (K, N), device="cuda", dtype=DTYPE)
+    a = .1 * torch.randn((K, M) if AT else (M, K), device=device, dtype=DTYPE)
+    b = .1 * torch.randn((N, K) if BT else (K, N), device=device, dtype=DTYPE)
     a = a.t() if AT else a
     b = b.t() if BT else b
     # run test

--- a/python/test/unit/runtime/test_comm.py
+++ b/python/test/unit/runtime/test_comm.py
@@ -11,7 +11,7 @@ import triton.language as tl
 def get_p2p_matrix():
     try:
         stdout = subprocess.check_output(["nvidia-smi", "topo", "-p2p", "n"]).decode("ascii")
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, FileNotFoundError):
         return pytest.skip("No multi-GPU topology", allow_module_level=True)
 
     lines = stdout.split("Legend")[0].split('\n')[1:]


### PR DESCRIPTION
This is inspired by the discussion in #466 (which has moved on from what the title suggests).

It comes from trying to run the test suite without a physically present GPU, i.e. trying to test against both `torch.device('cpu')` as well as `torch.device('cuda')`, and the latter only based on availability of a physical GPU.

This is very much a draft just to facilitate discussion because things like [`Kernel.__call__`](https://github.com/openai/triton/blob/v1.1.2/python/triton/code_gen.py#L569-L667) will complain loudly if the device is not a GPU:
```
        if invalid_args:
>           raise ValueError("Arguments at index {invalid_args} are on the wrong device.".format(invalid_args=invalid_args) +
                             " Only CUDA is supported at the moment")
E           ValueError: Arguments at index [0, 1, 2, 12] are on the wrong device. Only CUDA is supported at the moment
```