### PR TITLE
faster jit function launch

### DIFF
--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -16,12 +16,11 @@ import time
 import warnings
 from typing import Dict, Set, Tuple, Union
 
+import torch
 from filelock import FileLock
 
-import torch
 import triton
 import triton._C.libtriton.triton as _triton
-
 from .tools.disasm import extract
 
 try:

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -15,17 +15,20 @@ import time
 import warnings
 from typing import Dict, Set, Tuple, Union
 
+from filelock import FileLock
+
 import torch
+import triton
+import triton._C.libtriton.triton as _triton
+
+from .tools.disasm import extract
+
 try:
     from torch._C import _cuda_getCurrentRawStream as get_cuda_stream
 except ImportError:
     get_cuda_stream = lambda dev_idx: torch.cuda.current_stream(dev_idx).cuda_stream
 
-from filelock import FileLock
 
-import triton
-import triton._C.libtriton.triton as _triton
-from .tools.disasm import extract
 
 
 def current_cuda_stream(device_idx=0):

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -16,6 +16,11 @@ import warnings
 from typing import Dict, Set, Tuple, Union
 
 import torch
+try:
+    from torch._C import _cuda_getCurrentRawStream as get_cuda_stream
+except ImportError:
+    get_cuda_stream = lambda dev_idx: torch.cuda.current_stream(dev_idx).cuda_stream
+
 from filelock import FileLock
 
 import triton
@@ -27,7 +32,7 @@ def current_cuda_stream(device_idx=0):
     # Torch's torch.cuda.current_stream() is slow. We provide this
     # function to give the user an opportunity to monkey-patch their
     # own faster current stream lookup.
-    return torch.cuda.current_stream().cuda_stream
+    return get_cuda_stream(device_idx)
 
 
 def mangle_ty(ty):
@@ -908,6 +913,8 @@ class Kernel:
 
     def __init__(self, fn):
         self.fn = fn
+        self.cache_key = {}
+
 
     def add_to_cache(self, key, wargs, device_idx, num_warps, num_stages):
         tensor_idxs = [i for i, arg in enumerate(wargs) if hasattr(arg, 'data_ptr')]
@@ -949,12 +956,11 @@ class Kernel:
         #         assert arg.is_cuda, "All tensors must be on GPU!"
         # set device (i.e., make sure torch has the context initialized)
         device = torch.cuda.current_device()
-        torch.cuda.set_device(device)
-        # query compute capability
-        cc = torch.cuda.get_device_capability(device)
-        cc = str(cc[0]) + '-' + str(cc[1])
-        cache_key = self.fn.cache_key + cc
-        # query current stream
+        if device not in self.cache_key:
+            cc = torch.cuda.get_device_capability(device)
+            cc = str(cc[0]) + '-' + str(cc[1])
+            self.cache_key[device] = self.fn.cache_key + cc
+        cache_key = self.cache_key[device]
         stream = current_cuda_stream(device)
         return _triton.runtime.launch(wargs, self.fn.do_not_specialize, cache_key, self.fn.arg_names,
                                       device, stream, self.fn.bin_cache, num_warps, num_stages, self.add_to_cache,

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -721,7 +721,7 @@ class CodeGenerator(ast.NodeVisitor):
         ast.NodeVisitor.generic_visit(self, node)
 
     def visit_NoneType(self, node):
-        return triton.language.constexpr(None)
+        return None
 
     def visit(self, node):
         if node is not None:

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -29,8 +29,6 @@ except ImportError:
     get_cuda_stream = lambda dev_idx: torch.cuda.current_stream(dev_idx).cuda_stream
 
 
-
-
 def current_cuda_stream(device_idx=0):
     # Torch's torch.cuda.current_stream() is slow. We provide this
     # function to give the user an opportunity to monkey-patch their
@@ -918,7 +916,6 @@ class Kernel:
     def __init__(self, fn):
         self.fn = fn
         self.cache_key = {}
-
 
     def add_to_cache(self, key, wargs, device_idx, num_warps, num_stages):
         tensor_idxs = [i for i, arg in enumerate(wargs) if hasattr(arg, 'data_ptr')]

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -27,6 +27,8 @@ def _to_tensor(x, builder):
     elif isinstance(x, float):
         return tensor(builder.get_float32(x), float32)
     elif isinstance(x, constexpr):
+        if x.value is None:
+            return None
         return _to_tensor(x.value, builder)
     elif isinstance(x, tensor):
         return x


### PR DESCRIPTION
With fast (200 ns) get_stream function soon to be available from pytorch this shaves off approx 25-30 us from function launch, but even without that function due to caching device properties we are saving ~15-20us. 