### PR TITLE
Add binding for create_int_to_ptr

### DIFF
--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -840,6 +840,7 @@ void init_triton_ir(py::module &&m) {
       .def("create_fp_trunc", &ir::builder::create_fp_trunc, ret::reference)
       .def("create_int_cast", &ir::builder::create_int_cast, ret::reference)
       .def("create_downcast", &ir::builder::create_downcast, ret::reference)
+      .def("create_int_to_ptr", &ir::builder::create_int_to_ptr, ret::reference)
       // phi
       .def("create_phi", &ir::builder::create_phi, ret::reference)
       // Binary instructions


### PR DESCRIPTION
Without this binding, the following test fails
```
import torch
import triton
import triton.language as tl

@triton.jit
def lookup_directly(input_ptr_ptr, output_ptr):
    input_ptr = tl.load(input_ptr_ptr)
    input_ptr = input_ptr.to(output_ptr.dtype, bitcast=True)
    input = tl.load(input_ptr)
    tl.store(output_ptr, input)

def test_lookup_directly():
    input_tensor = torch.ones((1), dtype=torch.float32, device="cuda")
    input_ptr = input_tensor.data_ptr()
    input_ptr_tensor = torch.full(
        (1,), fill_value=input_ptr, device="cuda", dtype=torch.long
    )
    output_tensor = torch.empty_like(input_tensor)
    grid = (1,)
    lookup_directly[grid](
        input_ptr_ptr=input_ptr_tensor, output_ptr=output_tensor, num_warps=1
    )
    print(output_tensor)

if __name__ == "__main__":
    test_lookup_directly()
```

with the error:
```
... snip ...
  File "/fsx/users/bertrand/triton/python/triton/language/core.py", line 561, in to
    return semantic.bitcast(self, dtype, _builder)
  File "/fsx/users/bertrand/triton/python/triton/language/semantic.py", line 547, in bitcast
    return cast(input, dst_ty, builder)
  File "/fsx/users/bertrand/triton/python/triton/language/semantic.py", line 635, in cast
    return tl.tensor(builder.create_int_to_ptr(input.handle, dst_ty.to_ir(builder)), dst_ty)
AttributeError: 'triton._C.libtriton.triton.ir.builder' object has no attribute 'create_int_to_ptr'
```