### PR TITLE
Adding explicit version check in the github actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,13 +11,22 @@ on:
 jobs:
 
   Integration-Tests:
-    
+
     runs-on: self-hosted
+    strategy:
+      matrix:
+        python-version: '3.6 - 3.9'
 
     steps:
 
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+        run: python --version
 
       - name: Clear cache
         run: |

--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -956,7 +956,7 @@ class Kernel:
         return self.fn._warmup(key, arg_types=arg_types, device=device_idx, attributes=attributes, constants=constants, num_warps=num_warps, num_stages=num_stages, is_manual_warmup=False)
 
     def __call__(self, *wargs, grid, num_warps=4, num_stages=2, **kwargs):
-        assert num_warps != 0 and (num_warps & (num_warps - 1)) == 0, f"{num_warps=} must be a power of 2."
+        assert num_warps != 0 and (num_warps & (num_warps - 1)) == 0, f"num_warps={num_warps} must be a power of 2."
         # handle arguments passed by name
         kwargs = {self.fn.arg_names.index(name): value for name, value in kwargs.items()}
         wargs = list(wargs)


### PR DESCRIPTION
According to the documentation, the supported python (PyPy) versions
range from 3.6 to 3.9. However, some current changes were introduced in
the later versions of Python. Specifically, f-strings for
self-documenting expressions were introduced in
[3.8](https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging).

This PR only removes the new f-strings and does not check for ALL compatibilities.
There might be other issues with python versions that might be missed.

Current changes:

- [X] Add python-version to the github actions
- [X] Change the f-string in the code_gen.py to support python <3.8