### PR TITLE
Separate atomic cas from other atomic operations since operands are very different

### DIFF
--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -106,9 +106,13 @@ Atomic Ops
     :nosignatures:
 
     atomic_cas
+    atomic_xchg
     atomic_add
     atomic_max
     atomic_min
+    atomic_and
+    atomic_or
+    atomic_xor
 
 
 Comparison ops

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -825,7 +825,6 @@ def atomic_cas(pointer, cmp, val, _builder=None):
     return semantic.atomic_cas(pointer, cmp, val, _builder)
 
 
-@builtin
 def _add_atomic_docstr(name):
 
     def _decorator(func):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+
 from enum import Enum
 from functools import wraps
 from typing import List
@@ -806,6 +807,26 @@ def store(pointer, value, mask=None, _builder=None):
 # Atomic Memory Operations
 # -----------------------
 
+@builtin
+def atomic_cas(pointer, cmp, val, _builder=None):
+    """
+        Performs an atomic compare-and-swap at the memory location specified by :code:`pointer`.
+
+        Return the data stored at :code:`pointer` before the atomic operation.
+
+        :param pointer: The memory locations to compare-and-swap.
+        :type pointer: Block of dtype=triton.PointerDType
+        :param cmp: The values expected to be found in the atomic object
+        :type cmp: Block of dtype=`pointer.dtype.element_ty`
+        :param val: The values to copy in case the expected value matches the contained value.
+        :type val: Block of dtype=`pointer.dtype.element_ty`
+    """
+    cmp = _to_tensor(cmp, _builder)
+    val = _to_tensor(val, _builder)
+    return semantic.atomic_cas(pointer, cmp, val, _builder)
+
+
+@builtin
 def _add_atomic_docstr(name):
 
     def _decorator(func):
@@ -814,25 +835,17 @@ def _add_atomic_docstr(name):
 
     Return the data stored at :code:`pointer` before the atomic operation.
 
-    :param pointer: The memory locations to compare-and-swap.
+    :param pointer: The memory locations to apply {name}.
     :type pointer: Block of dtype=triton.PointerDType
-    :param cmp: The values expected to be found in the atomic object
-    :type cmp: Block of dtype=`pointer.dtype.element_ty`
-    :param val: The values to copy in case the expected value matches the contained value.
+    :param val: The values to {name} in the atomic object.
     :type val: Block of dtype=`pointer.dtype.element_ty`
+    :param mask: If mask[idx] is false, do not apply {name}.
+    :type mask: Block of triton.int1, optional
     """
         func.__doc__ = docstr.format(name=name)
         return func
 
     return _decorator
-
-
-@builtin
-@_add_atomic_docstr("compare-and-swap")
-def atomic_cas(pointer, cmp, val, _builder=None):
-    cmp = _to_tensor(cmp, _builder)
-    val = _to_tensor(val, _builder)
-    return semantic.atomic_cas(pointer, cmp, val, _builder)
 
 
 @builtin

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 from enum import Enum
 from functools import wraps
 from typing import List


### PR DESCRIPTION
I also found many some functions (e.g., `shl`) in `semantic.py` are not documented. May need to take another pass to fix the documentation later.