### PR TITLE
Fix layout convert for non-contiguous input

### DIFF
--- a/lib/codegen/selection/generator.cc
+++ b/lib/codegen/selection/generator.cc
@@ -2658,7 +2658,7 @@ void generator::visit_layout_convert(ir::value *out, ir::value *in){
       in_layout->to_mma() ? out_layout->get_order() : in_layout->get_order();
   auto out_ord =
       out_layout->to_mma() ? in_layout->get_order() : out_layout->get_order();
-  // out_ord[0] == 0 and in_order[0] == 0 means the first dimension is
+  // out_ord[0] == 0 or in_order[0] == 0 means the first dimension is
   // non-contiguous. in_vec can be greater than 0 only if both out_ord[0] and
   // and in_ord[0] are contiguous.
   int in_vec = out_ord[0] == 0  ? 1

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -815,8 +815,8 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
     z_tri_contiguous = to_triton(np.empty_like(x), device=device)
     x_tri = to_triton(x, device=device)
     pgm = kernel[(1, 1)](x_tri, x_tri.stride(0), x_tri.stride(1),
-                             z_tri, z_tri.stride(1), z_tri.stride(0),
-                             BLOCK_M=shape[0], BLOCK_N=shape[1])
+                         z_tri, z_tri.stride(1), z_tri.stride(0),
+                         BLOCK_M=shape[0], BLOCK_N=shape[1])
     pgm_contiguous = kernel[(1, 1)](x_tri, x_tri.stride(1), x_tri.stride(0),
                                     z_tri_contiguous, z_tri_contiguous.stride(0), z_tri_contiguous.stride(1),
                                     BLOCK_M=shape[0], BLOCK_N=shape[1])

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -793,8 +793,8 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
 
 @pytest.mark.parametrize("dtype_str, shape, perm",
                          [(dtype, shape, perm)
-                          for dtype in ['float32']
-                             for shape in [(128, 128)]
+                          for dtype in ['float16', 'float32']
+                             for shape in [(64, 64), (128, 128)]
                              for perm in [(1, 0)]])
 def test_permute(dtype_str, shape, perm, device='cuda'):
 
@@ -812,16 +812,24 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
     x = numpy_random(shape, dtype_str=dtype_str)
     # triton result
     z_tri = to_triton(np.empty_like(x), device=device)
+    z_tri_contiguous = to_triton(np.empty_like(x), device=device)
     x_tri = to_triton(x, device=device)
     pgm = kernel[(1, 1)](x_tri, x_tri.stride(0), x_tri.stride(1),
-                         z_tri, z_tri.stride(1), z_tri.stride(0),
-                         BLOCK_M=shape[0], BLOCK_N=shape[1])
+                             z_tri, z_tri.stride(1), z_tri.stride(0),
+                             BLOCK_M=shape[0], BLOCK_N=shape[1])
+    pgm_contiguous = kernel[(1, 1)](x_tri, x_tri.stride(1), x_tri.stride(0),
+                                    z_tri_contiguous, z_tri_contiguous.stride(0), z_tri_contiguous.stride(1),
+                                    BLOCK_M=shape[0], BLOCK_N=shape[1])
     # torch result
     z_ref = x.transpose(*perm)
     # compare
     triton.testing.assert_almost_equal(z_tri, z_ref)
+    triton.testing.assert_almost_equal(z_tri_contiguous, z_ref)
     # parse ptx to make sure ld/st are vectorized
     ptx = pgm.asm['ptx']
+    assert 'ld.global.v4' in ptx
+    assert 'st.global.v4' in ptx
+    ptx = pgm_contiguous.asm['ptx']
     assert 'ld.global.v4' in ptx
     assert 'st.global.v4' in ptx
 


### PR DESCRIPTION
There are two potential problems.

```
in_ord = in_layout->to_mma() ? out_ord : in_ord;
out_ord = out_layout->to_mma() ? in_ord : out_ord;
```

I'm not sure if the above line was written on purpose? If `in_layout->to_mma() == True`, `in_ord=out_ord`, then if `out_layout->to_mma() == True`, `out_ord = in_ord = out_ord`. So `out_ord` is unchanged.

The second problem is that we shouldn't use vectorized shared memory store if the input is in a transposed order, specifically for this [case](https://github.com/Jokeren/triton-samples/blob/main/transpose-2d.py).

Besides, I think probably we could tune the performance in the future with thread/layout reassociation. For instance, in layout convert, if we want as many vectorized shared memory loads as possible, we can adjust the thread/layout mapping for the output in a way that threads can read adjacent chunks. Just a very primitive thought anyway.