### PR TITLE
[FRONTEND] Added support for 'and' and 'or' operator

### DIFF
--- a/python/triton/code_gen.py
+++ b/python/triton/code_gen.py
@@ -438,6 +438,32 @@ class CodeGenerator(ast.NodeVisitor):
         else:
             return getattr(lhs, fn)(rhs)
 
+    def visit_BoolOp(self, node):
+        # visit operand
+        lhs = self.visit(node.values[0])
+        rhs = self.visit(node.values[1])
+        is_lhs_constexpr = isinstance(lhs, triton.language.constexpr)
+        is_rhs_constexpr = isinstance(rhs, triton.language.constexpr)
+        lhs = lhs.value if is_lhs_constexpr else lhs
+        rhs = rhs.value if is_rhs_constexpr else rhs
+        # get function name
+        fn = {
+            ast.And: '__and__',
+            ast.Or: '__or__',
+        }[type(node.op)]
+        # return a new constexpr if both arg are constexprs
+        if is_lhs_constexpr and is_rhs_constexpr:
+            return triton.language.constexpr(getattr(lhs, fn)(rhs))
+        # call operator
+        if is_triton_tensor(lhs):
+            return getattr(lhs, fn)(rhs, _builder=self.builder)
+        elif is_triton_tensor(rhs):
+            fn = fn[:2] + 'r' + fn[2:]
+            return getattr(rhs, fn)(lhs, _builder=self.builder)
+        else:
+            return getattr(lhs, fn)(rhs)
+
+
     def visit_If(self, node):
         cond = self.visit(node.test)
         if isinstance(cond, triton.language.tensor):


### PR DESCRIPTION
Currently `and` and `or` operator are not supported. Add some initial code to support that according to the discussion with @ptillet, but not totally sure if I am doing things correctly (like not sure if need and how to cast the operand to int type). Could you review when you get a chance? Thanks!