### PR TITLE
Add missing args to get_simd_tflops()

### DIFF
--- a/python/triton/ops/matmul_perf_model.py
+++ b/python/triton/ops/matmul_perf_model.py
@@ -26,7 +26,7 @@ def get_simd_tflops(backend, device, num_ctas, num_warps, dtype):
 def get_tflops(backend, device, num_ctas, num_warps, dtype):
     cc = _triton.runtime.cc(backend, device)
     if cc < 80 and dtype == torch.float32:
-        return get_simd_tflops()
+        return get_simd_tflops(backend, device, num_ctas, num_warps, dtype)
     return get_tensorcore_tflops(backend, device, num_ctas, num_warps, dtype)
 
 


### PR DESCRIPTION
On a V100 I was getting:
```
Traceback (most recent call last):
  File "/home/circleci/project/torchdynamo/output_graph.py", line 341, in call_user_compiler
    compiled_fn = self.compiler_fn(gm, self.example_inputs())
  File "/home/circleci/project/torchinductor/compile_fx.py", line 118, in compile_fx
    return compile_fx_inner(gm, example_inputs, wrap=wrap, cudagraphs=cudagraphs)
  File "/home/circleci/project/torchinductor/compile_fx.py", line 145, in compile_fx_inner
    return cudagraphify(
  File "/home/circleci/project/torchinductor/compile_fx.py", line 179, in cudagraphify
    model(*inputs)
  File "/home/circleci/project/torchdynamo/optimizations/python_key.py", line 168, in call_fn
    return inner(*params_flat, *args)
  File "/tmp/torchinductor_circleci/e3/ce32oubh7w7iwszqqbgpirjkej5ybhnhfufejzlzg3h5isfza3eo.py", line 23, in call
    triton_mm_out(arg0, arg1, out=buf0)
  File "/home/circleci/project/torchinductor/triton_ops/matmul.py", line 213, in matmul_out
    _kernel[grid](
  File "/home/circleci/project/env/lib/python3.8/site-packages/triton/code_gen.py", line 998, in __call__
    return self.kernel(*wargs, **kwargs, grid=self.grid)
  File "/home/circleci/project/env/lib/python3.8/site-packages/triton/code_gen.py", line 1069, in __call__
    est_timing = {config: self.perf_model(**self.nargs, **kwargs, **config.kwargs, num_stages=config.num_stages, num_warps=config.num_warps) for config in pruned_configs}
  File "/home/circleci/project/env/lib/python3.8/site-packages/triton/code_gen.py", line 1069, in <dictcomp>
    est_timing = {config: self.perf_model(**self.nargs, **kwargs, **config.kwargs, num_stages=config.num_stages, num_warps=config.num_warps) for config in pruned_configs}
  File "/home/circleci/project/env/lib/python3.8/site-packages/triton/ops/matmul_perf_model.py", line 58, in estimate_matmul_time
    tput = get_tflops(backend, device, num_ctas, num_warps, dtype)
  File "/home/circleci/project/env/lib/python3.8/site-packages/triton/ops/matmul_perf_model.py", line 29, in get_tflops
    return get_simd_tflops()
TypeError: get_simd_tflops() missing 5 required positional arguments: 'backend', 'device', 'num_ctas', 'num_warps', and 'dtype'
```