### PR TITLE
Include triton/language/libdevice.10.bc in package data

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -141,7 +141,11 @@ setup(
         "filelock",
         "torch",
     ],
-    package_data={"triton/ops": ["*.c"], "triton/ops/blocksparse": ["*.c"]},
+    package_data={
+        "triton/ops": ["*.c"],
+        "triton/ops/blocksparse": ["*.c"],
+        "triton/language": ["*.bc"],
+    },
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={"build_ext": CMakeBuild},


### PR DESCRIPTION
This should make https://github.com/openai/triton/pull/562 work with `setup.py install` / `pip install` rather than just `setup.py develop`.

Our CI was failing with:
```
>       name, asm, shared_mem = _triton.code_gen.compile_ttir(backend, generator.module, device, num_warps, num_stages, extern_libs)
E       RuntimeError: Failed to load extern lib libdevice at /home/circleci/project/env/lib/python3.8/site-packages/triton/language/libdevice.10.bc

env/lib/python3.8/site-packages/triton/code_gen.py:1320: RuntimeError
```