### PR TITLE
Better bf16 support

### DIFF
--- a/lib/codegen/selection/generator.cc
+++ b/lib/codegen/selection/generator.cc
@@ -86,7 +86,7 @@ Value* geper::operator()(Value *ptr, Value* off, const std::string& name){
 // types
 #define void_ty              builder_->getVoidTy()
 #define f16_ty               builder_->getHalfTy()
-#define bf16_ty              builder_->getBFloatTy()
+#define bf16_ty              builder_->getInt16Ty()
 #define f32_ty               builder_->getFloatTy()
 #define i1_ty                builder_->getInt1Ty()
 #define i8_ty                builder_->getInt8Ty()
@@ -178,7 +178,7 @@ Type *generator::cvt(ir::type *ty) {
     case ir::type::VoidTyID:      return Type::getVoidTy(*ctx_);
     case ir::type::FP8TyID:       return Type::getInt8Ty(*ctx_);
     case ir::type::FP16TyID:      return Type::getHalfTy(*ctx_);
-    case ir::type::BF16TyID:      return Type::getBFloatTy(*ctx_);
+    case ir::type::BF16TyID:      return Type::getInt16Ty(*ctx_); // use int16 as storage type
     case ir::type::FP32TyID:      return Type::getFloatTy(*ctx_);
     case ir::type::FP64TyID:      return Type::getDoubleTy(*ctx_);
     case ir::type::LabelTyID:     return Type::getLabelTy(*ctx_);
@@ -970,8 +970,6 @@ void generator::visit_store_inst(ir::store_inst * x){
   has_l2_evict_policy = false;
   auto idxs    = idxs_.at(val_op);
   Type *ty = cvt(val_op->get_type()->get_scalar_ty());
-  if (ty->isBFloatTy()) // llvm11-nvptx cannot select bf16 store
-    ty = f16_ty;
   if(ty->isIntegerTy(1))
     ty = builder_->getInt8Ty();
   for(size_t i = 0; i < idxs.size(); i += vec){
@@ -2829,9 +2827,6 @@ void generator::visit_layout_convert(ir::value *out, ir::value *in){
   ir::block_type::block_shapes_t shape = out->get_type()->get_block_shapes();
   // pointer to temporary shared memory
   Type *ty = cvt(out->get_type()->get_scalar_ty());
-
-  if (ty->isBFloatTy()) // llvm11-nvptx cannot select bf16 store
-    ty = f16_ty;
 
   // Orders
   analysis::distributed_layout* in_layout = dynamic_cast<analysis::distributed_layout*>(layouts_->get(in));

--- a/lib/ir/constant.cc
+++ b/lib/ir/constant.cc
@@ -18,6 +18,8 @@ constant *constant::get_null_value(type *ty) {
     return constant_int::get(ty, 0);
   case type::FP16TyID:
     return constant_fp::get(type::get_fp16_ty(ctx), 0);
+  case type::BF16TyID:
+    return constant_fp::get(type::get_bf16_ty(ctx), 0);
   case type::FP32TyID:
     return constant_fp::get(type::get_fp32_ty(ctx), 0);
   case type::FP64TyID:

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -101,7 +101,7 @@ def check_type_supported(dtype):
     skip test if dtype is not supported on the current device
     '''
     cc = _triton.runtime.cc(_triton.runtime.backend.CUDA, torch.cuda.current_device())
-    if cc < 80 and (dtype is tl.bfloat16 or dtype == "bfloat16"):
+    if cc < 80 and (dtype is tl.bfloat16 or dtype == "bfloat16" or dtype is torch.bfloat16):
         pytest.skip("bfloat16 is only supported on NVGPU with cc >= 80")
 
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -84,7 +84,7 @@ def patch_kernel(template, to_replace):
     return kernel
 
 
-@pytest.mark.parametrize("dtype_x", [dtype_x for dtype_x in dtypes])
+@pytest.mark.parametrize("dtype_x", [dtype_x for dtype_x in dtypes] + ["bfloat16"])
 def test_empty_kernel(dtype_x, device='cuda'):
     SIZE = 128
 
@@ -211,7 +211,7 @@ def _mod_operation_ill_conditioned(dtype_x, dtype_y) -> bool:
 # test binary ops
 # ---------------
 
-
+# TODO: bf16
 @pytest.mark.parametrize("dtype_x, dtype_y, op", [
     (dtype_x, dtype_y, op)
     for op in ['+', '-', '*', '/', '%']
@@ -223,7 +223,7 @@ def test_bin_op(dtype_x, dtype_y, op, device='cuda'):
     if op == '%' and dtype_x in int_dtypes + uint_dtypes and dtype_y in int_dtypes + uint_dtypes:
         # LLVM has 'numpy.fmod', not 'numpy.remainder', semantics on integer remainders.
         numpy_expr = 'np.fmod(x, y)'
-    elif op in ('/', '%') and dtype_x in ('int16', 'float16') and dtype_y in ('int16', 'float16'):
+    elif op in ('/', '%') and dtype_x in ('int16', 'float16', 'bfloat16') and dtype_y in ('int16', 'float16', 'bfloat16'):
         # Triton promotes 16-bit floating-point / and % to 32-bit because there
         # are no native div or FRem operations on float16. Since we have to
         # convert anyway, we may as well take the accuracy bump.
@@ -263,6 +263,7 @@ def test_floordiv(dtype_x, dtype_y, device='cuda'):
 # ---------------
 # test bitwise ops
 # ---------------
+# TODO: bf16
 @pytest.mark.parametrize("dtype_x, dtype_y, op", [
     (dtype_x, dtype_y, op)
     for op in ['&', '|', '^']
@@ -305,7 +306,7 @@ def test_shift_op(dtype_x, dtype_y, op, device='cuda'):
 # ---------------
 ops = ['==', '!=', '>', '<', '>=', '<=']
 
-
+# TODO: bf16, but cast to fp16 (?)
 @pytest.mark.parametrize("dtype_x, dtype_y, op, mode_x, mode_y",
                          # real
                          [
@@ -336,6 +337,7 @@ def test_compare_op(dtype_x, dtype_y, op, mode_x, mode_y, device='cuda'):
 # ---------------
 # test unary ops
 # ---------------
+# TODO: bf16
 @pytest.mark.parametrize("dtype_x, expr", [
     (dtype_x, ' -x') for dtype_x in dtypes
 ] + [
@@ -350,7 +352,6 @@ def test_unary_op(dtype_x, expr, device='cuda'):
 # @pytest.mark.paramterize("expr", [
 #     'exp', 'log', 'cos', 'sin'
 # ])
-
 
 @pytest.mark.parametrize("expr", [
     'exp', 'log', 'cos', 'sin'
@@ -728,7 +729,7 @@ def test_f16_to_f8_rounding():
 # test reduce
 # ---------------
 
-
+# TODO: bfloat16
 @pytest.mark.parametrize("op, dtype_str, shape",
                          [(op, dtype, shape)
                           for op in ['min', 'max', 'argmin', 'argmax', 'sum']
@@ -768,7 +769,7 @@ def test_reduce1d(op, dtype_str, shape, device='cuda'):
         else:
             np.testing.assert_equal(z_ref, z_tri)
 
-
+# TODO: bfloat16
 reduce_configs1 = [
     (op, dtype, (1, 1024), axis) for dtype in dtypes
     for op in ['min', 'max', 'argmin', 'argmax', 'sum']
@@ -831,7 +832,7 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
 # test permute
 # ---------------
 
-
+# TODO: bfloat16
 @pytest.mark.parametrize("dtype_str, shape, perm",
                          [(dtype, shape, perm)
                           for dtype in ['float16', 'float32']
@@ -1037,6 +1038,7 @@ def test_arange(start, device='cuda'):
 # 'bfloat16': torch.bfloat16,
 # Testing masked loads with an intermate copy to shared memory run.
 
+# TODO: test bfloat16 masked load
 
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 def test_masked_load_shared_memory(dtype, device='cuda'):

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -766,6 +766,7 @@ def test_f16_to_f8_rounding():
                           for shape in [32, 64, 128, 512]])
 def test_reduce1d(op, dtype_str, shape, device='cuda'):
     check_type_supported(dtype_str)  # bfloat16 on cc < 80 will not be tested
+
     # triton kernel
     @triton.jit
     def kernel(X, Z, BLOCK: tl.constexpr):
@@ -886,6 +887,7 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
                              for perm in [(1, 0)]])
 def test_permute(dtype_str, shape, perm, device='cuda'):
     check_type_supported(dtype_str)  # bfloat16 on cc < 80 will not be tested
+
     # triton kernel
     @triton.jit
     def kernel(X, stride_xm, stride_xn,

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -207,7 +207,6 @@ def _test_binary(dtype_x, dtype_y, expr, numpy_expr=None, mode_x='real', mode_y=
     # triton result
     x_tri = to_triton(x, device=device, dst_type=dtype_x)
     y_tri = to_triton(y, device=device, dst_type=dtype_y)
-    # TODO: check dst_type
     z_tri = to_triton(np.empty(SIZE, dtype=z_ref.dtype), device=device)
     kernel[(1, )](z_tri, x_tri, y_tri, SIZE=SIZE, num_warps=4)
     np.testing.assert_allclose(z_ref, to_numpy(z_tri), err_msg=expr, rtol=0.01)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -44,7 +44,7 @@ def numpy_random(shape, dtype_str, rs: Optional[RandomState] = None, low=None, h
     elif dtype_str in float_dtypes:
         return rs.normal(0, 1, shape).astype(dtype_str)
     elif dtype_str == 'bfloat16':
-        return (rs.normal(0, 1, shape).astype('float32').view('uint32') \
+        return (rs.normal(0, 1, shape).astype('float32').view('uint32')
                 & np.uint32(0xffff0000)).view('float32')
     else:
         raise RuntimeError(f'Unknown dtype {dtype_str}')
@@ -242,6 +242,7 @@ def _mod_operation_ill_conditioned(dtype_x, dtype_y) -> bool:
 # test binary ops
 # ---------------
 
+
 @pytest.mark.parametrize("dtype_x, dtype_y, op", [
     (dtype_x, dtype_y, op)
     for op in ['+', '-', '*', '/', '%']
@@ -335,6 +336,7 @@ def test_shift_op(dtype_x, dtype_y, op, device='cuda'):
 # ---------------
 ops = ['==', '!=', '>', '<', '>=', '<=']
 
+
 @pytest.mark.parametrize("dtype_x, dtype_y, op, mode_x, mode_y",
                          # real
                          [
@@ -379,6 +381,7 @@ def test_unary_op(dtype_x, expr, device='cuda'):
 # @pytest.mark.paramterize("expr", [
 #     'exp', 'log', 'cos', 'sin'
 # ])
+
 
 @pytest.mark.parametrize("expr", [
     'exp', 'log', 'cos', 'sin'
@@ -779,6 +782,7 @@ def test_where(dtype):
 # test reduce
 # ---------------
 
+
 @pytest.mark.parametrize("op, dtype_str, shape",
                          [(op, dtype, shape)
                           for op in ['min', 'max', 'argmin', 'argmax', 'sum']
@@ -826,6 +830,7 @@ def test_reduce1d(op, dtype_str, shape, device='cuda'):
             np.testing.assert_equal(x[z_ref], x[z_tri])
         else:
             np.testing.assert_equal(z_ref, z_tri)
+
 
 reduce_configs1 = [
     (op, dtype, (1, 1024), axis) for dtype in dtypes + ['bfloat16']
@@ -896,6 +901,7 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
 # ---------------
 # test permute
 # ---------------
+
 
 @pytest.mark.parametrize("dtype_str, shape, perm",
                          [(dtype, shape, perm)
@@ -1101,6 +1107,7 @@ def test_arange(start, device='cuda'):
 # ---------------
 # 'bfloat16': torch.bfloat16,
 # Testing masked loads with an intermate copy to shared memory run.
+
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 def test_masked_load_shared_memory(dtype, device='cuda'):

--- a/python/test/unit/operators/test_cross_entropy.py
+++ b/python/test/unit/operators/test_cross_entropy.py
@@ -15,7 +15,7 @@ import triton._C.libtriton.triton as _triton
                          )
 def test_op(M, N, dtype, mode):
     cc = _triton.runtime.cc(_triton.runtime.backend.CUDA, torch.cuda.current_device())
-    if cc < 80 and DTYPE == "bfloat16":
+    if cc < 80 and dtype == "bfloat16":
         pytest.skip("Only test bfloat16 on devices with sm >= 80")
     dtype = {'bfloat16': torch.bfloat16, 'float16': torch.float16, 'float32': torch.float32}[dtype]
     # create inputs

--- a/python/test/unit/operators/test_cross_entropy.py
+++ b/python/test/unit/operators/test_cross_entropy.py
@@ -2,18 +2,22 @@ import pytest
 import torch
 
 import triton
+import triton._C.libtriton.triton as _triton
 
 
 @pytest.mark.parametrize("M, N, dtype, mode",
                          [
                              (M, N, dtype, mode) for M in [1024, 821]
                              for N in [512, 857, 1871, 2089, 8573, 31000]
-                             for dtype in ['float16', 'float32']
+                             for dtype in ['bfloat16', 'float16', 'float32']
                              for mode in ['forward', 'backward']
                          ]
                          )
 def test_op(M, N, dtype, mode):
-    dtype = {'float16': torch.float16, 'float32': torch.float32}[dtype]
+    cc = _triton.runtime.cc(_triton.runtime.backend.CUDA, torch.cuda.current_device())
+    if cc < 80 and DTYPE == "bfloat16":
+        pytest.skip("Only test bfloat16 on devices with sm >= 80")
+    dtype = {'bfloat16': torch.bfloat16, 'float16': torch.float16, 'float32': torch.float32}[dtype]
     # create inputs
     x = torch.randn(M, N, dtype=dtype, device='cuda', requires_grad=True)
     idx = 4 + torch.ones(M, dtype=torch.int64, device='cuda')

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -775,6 +775,7 @@ def atomic_cas(ptr: tl.tensor,
                val: tl.tensor,
                builder: ir.builder) -> tl.tensor:
     # TODO: type checking
+    # supported bit width: 16, 32, 64
     return tl.tensor(builder.create_atomic_cas(ptr.handle, cmp.handle, val.handle), val.type)
 
 
@@ -784,6 +785,9 @@ def atom_red_typechecking_impl(ptr: tl.tensor,
                                builder: ir.builder) -> Tuple[tl.tensor, tl.tensor, tl.tensor]:
     if not ptr.type.scalar.is_ptr():
         raise ValueError("Pointer argument of store instruction is " + ptr.type.__repr__())
+    # TODO: type checking
+    # supported type: f32, f64, i32, i64, u32, u64, (f16, atomic_add only)
+    # not supported type: i1, i8, i16, bf16
     if ptr.type.is_block():
         if mask:
             mask = broadcast_impl_shape(mask, ptr.type.get_block_shapes(), builder)

--- a/python/triton/ops/cross_entropy.py
+++ b/python/triton/ops/cross_entropy.py
@@ -65,7 +65,7 @@ def _backward(PROBS, IDX, DPROBS, N, BLOCK: tl.constexpr):
     # write result in-place in PROBS
     dout = tl.load(DPROBS + row)
     din = (probs - delta) * dout
-    tl.store(PROBS, din.to(tl.float16), mask=cols < N)
+    tl.store(PROBS, din.to(PROBS.dtype.element_ty), mask=cols < N)
 
 
 class _cross_entropy(torch.autograd.Function):

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -1,7 +1,7 @@
 """
 Fused Attention
 ===============
-This is a Triton implementation of the Flash Attention algorithm 
+This is a Triton implementation of the Flash Attention algorithm
 (see: Dao et al., https://arxiv.org/pdf/2205.14135v2.pdf; Rabe and Staats https://arxiv.org/pdf/2112.05682v2.pdf)
 """
 


### PR DESCRIPTION
* [FRONTEND] Check if bf16 is supported. If it's not supported, cast value to fp32.
* [CODEGEN] Use int16 as the storage type for bf16. Manually select add, mul, sub for bf16. Manually select bf16 constant.
* [OP] Fix type casting for cross_entropy's bwd kernel.

---
Thanks to @samsamoa for the original proposal and @tomconerlyanth for providing bf16 tests.