### PR TITLE
Refresh cache when the source code of outlined functions are changed

### DIFF
--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -236,12 +236,13 @@ void parse_args(py::list& args, py::list do_not_specialize, const std::string& f
         continue;
       }
       // argument is `constexpr`
-      if(py::hasattr(arg, "value")){
+      if (py::hasattr(arg, "value")) {
         py::object value = arg.attr("value");
-        std::string ty_str = value.attr("__class__").attr("__name__").cast<std::string>();
-        if (ty_str == "JITFunction") {
+        // check if value is a callable object using PyCallable_Check
+        if (PyCallable_Check(value.ptr())) {
           throw std::runtime_error(
-              "JITFunction is not supported as a constexpr argument");
+              "constant argument cannot be a callable object: " +
+              std::string(py::str(arg)));
         }
         py::object name = arg_names[i];
         constants[name] = value;

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -238,6 +238,11 @@ void parse_args(py::list& args, py::list do_not_specialize, const std::string& f
       // argument is `constexpr`
       if(py::hasattr(arg, "value")){
         py::object value = arg.attr("value");
+        std::string ty_str = value.attr("__class__").attr("__name__").cast<std::string>();
+        if (ty_str == "JITFunction") {
+          throw std::runtime_error(
+              "JITFunction is not supported as a constexpr argument");
+        }
         py::object name = arg_names[i];
         constants[name] = value;
         py::object repr = py::repr(value);

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -143,10 +143,10 @@ def test_constexpr_not_callable() -> None:
         kernel[(1, )](x, c="str")
     except BaseException:
         error = True
-    assert error == False
+    assert error is False
     # try and catch
     try:
         kernel[(1, )](x, c=tl.abs)
     except BaseException:
         error = True
-    assert error == True
+    assert error is True

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -261,7 +261,7 @@ def leaky_relu(x):
 # and (1) checks any shape constraint; (2) allocates the output; (3) launches the above kernel
 
 
-def matmul(a, b, activation=None):
+def matmul(a, b, activation=""):
     # checks constraints
     assert a.shape[1] == b.shape[0], "incompatible dimensions"
     assert a.is_contiguous(), "matrix A must be contiguous"

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -236,8 +236,8 @@ def matmul_kernel(
         b_ptrs += BLOCK_SIZE_K * stride_bk
     # you can fuse arbitrary activation functions here
     # while the accumulator is still in FP32!
-    if ACTIVATION:
-        accumulator = ACTIVATION(accumulator)
+    if ACTIVATION == "leaky_relu":
+        accumulator = leaky_relu(accumulator)
     c = accumulator.to(tl.float16)
 
     # -----------------------------------------------------------
@@ -347,7 +347,7 @@ def benchmark(M, N, K, provider):
         )
     if provider == 'triton + relu':
         ms, min_ms, max_ms = triton.testing.do_bench(
-            lambda: matmul(a, b, activation=leaky_relu)
+            lambda: matmul(a, b, activation="leaky_relu")
         )
     perf = lambda ms: 2 * M * N * K * 1e-12 / (ms * 1e-3)
     return perf(ms), perf(max_ms), perf(min_ms)


### PR DESCRIPTION
Draft proposal to update the cache logic. 

Testing cases and document are incomplete.

By revisiting the caching logic, my understanding is that we should update a binary/kernel whenever the following characteristics are changes:

1. The signature of the kernel's source code.
2. The signatures of inlined JIT functions being called.
3. The signatures of outlined JIT functions being called.
4. The length of any non-constexpr variables.
5. The number of variables.
6. The value of constexpr variables.
7. The alignment, date type, and ptr length of tensors.
8. The number of warps and stages.

This patch tries to fix a corner case of characteristics 3 (C3). 