### PR TITLE
[Triton-MLIR][FRONTEND] Fix the implicit broadcasting rule

### DIFF
--- a/python/tests/test_cast.py
+++ b/python/tests/test_cast.py
@@ -1,0 +1,56 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def cast_check():
+    zero_0d = tl.zeros([], dtype=tl.float32)
+    zero_1d = tl.zeros([2], dtype=tl.float32)
+    zero_2d_21 = tl.zeros([2, 1], dtype=tl.float32)
+    zero_2d_22 = tl.zeros([2, 2], dtype=tl.float32)
+
+    # scalar + scalar -> scalar
+    a0 = 0.0 + 0.0
+    # scalar + 0D -> 0D
+    a1 = 0.0 + zero_0d
+    a2 = zero_0d + 0.0
+    # scalar + 1D -> 1D
+    a3 = 0.0 + zero_1d
+    a4 = zero_1d + 0.0
+    # scalar + 2D -> 2D
+    a5 = 0.0 + zero_2d_22
+    a6 = zero_2d_22 + 0.0
+
+    # 0D + 0D -> 0D
+    b1 = zero_0d + zero_0d
+    # 0D + 1D -> 1D
+    b2 = zero_0d + zero_1d
+    b3 = zero_1d + zero_0d
+    # 0D + 2D -> 2D
+    b4 = zero_0d + zero_2d_22
+    b5 = zero_2d_22 + zero_0d
+
+    # 1D + 1D -> 1D
+    c1 = zero_1d + zero_1d
+    # 1D + 2D -> 2D
+    c2 = zero_1d + zero_2d_21
+    c3 = zero_1d + zero_2d_22
+    c4 = zero_2d_21 + zero_1d
+    c5 = zero_2d_22 + zero_1d
+
+    # 2D + 2D -> 2D
+    d1 = zero_2d_21 + zero_2d_21
+    d2 = zero_2d_22 + zero_2d_22
+    d3 = zero_2d_21 + zero_2d_22
+    d4 = zero_2d_22 + zero_2d_21
+
+    return a0, a1, a2, a3, a4, a5, a6, b1, b2, b3, b4, b5, c1, c2, c3, c4, c5, d1, d2, d3, d4
+
+
+def test_cast_check():
+    kernel = triton.compile(cast_check,
+                            signature="",
+                            device=0,
+                            output="ttir")
+    assert (kernel)
+    # TODO: Check types of the results

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -752,8 +752,11 @@ def make_triton_ir(fn, signature, constants=dict(), attributes=dict()):
     # create kernel prototype
     constants = {fn.arg_names.index(name): value for name, value in constants.items()}
     attributes = {fn.arg_names.index(name): value for name, value in attributes.items()}
-    arg_types = signature.replace(' ', '').split(',')
-    arg_types = [str_to_ty(x) for x in arg_types]
+    if signature.replace(' ', '') != '':
+        arg_types = signature.replace(' ', '').split(',')
+        arg_types = [str_to_ty(x) for x in arg_types]
+    else:
+        arg_types = []
     prototype = triton.language.function_type([], arg_types)
     # visit kernel AST
     gscope = fn.__globals__.copy()

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -239,8 +239,9 @@ class block_type(dtype):
 
         # Note that block_type's shape is a list of int
         # while tensor's shape is a list of constexpr.
-        assert shape
-        if isinstance(shape[0], constexpr):
+
+        # shape can be empty ([]) when an input is a 0D tensor.
+        if shape and isinstance(shape[0], constexpr):
             shape = [s.value for s in shape]
 
         self.shape = shape


### PR DESCRIPTION
This PR solves the cast issue that appears in some tutorial code.

## Problem

The frontend cannot compile the following code because `tensor<f32>` returned by `tl.max(row, axis=0)` was not cast properly to `tensor<256xf32>`, which is the type of `row`.
```py
import triton
import triton.language as tl

@triton.jit
def softmax_kernel(
    output_ptr, input_ptr,
    BLOCK_SIZE: tl.constexpr
):
    col_offsets = tl.arange(0, BLOCK_SIZE)
    row = tl.load(input_ptr + col_offsets)
    row_minus_max = row - tl.max(row, axis=0) # <=================== This line
    tl.store(output_ptr + col_offsets, row_minus_max)

if __name__ == "__main__":
    output = triton.compile(softmax_kernel, "*fp32,*fp32", device=0, constants={'BLOCK_SIZE': 256}, output="ttir")
    print(output)
```

## Solution

This PR fixes this issue by fixing/extending the implicit broadcast semantics. As a result, the code above will be translated into the following (specifically,  `tt.expand_dims` is issued for the reduced value `%4`)

```llvm
module {
  func @softmax_kernel__Pfp32_Pfp32__2c256(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
    %0 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
    %1 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
    %2 = tt.addptr %1, %0 : tensor<256x!tt.ptr<f32>>
    %3 = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
    %4 = tt.reduce %3 {axis = 0 : i32, redOp = 5 : i32} : tensor<256xf32> -> tensor<f32>
    %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<f32>) -> tensor<1xf32>
    %6 = tt.broadcast %5 : (tensor<1xf32>) -> tensor<256xf32>
    %7 = arith.subf %3, %6 : tensor<256xf32>
    %8 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
    %9 = tt.addptr %8, %0 : tensor<256x!tt.ptr<f32>>
    tt.store %9, %7 : tensor<256xf32>
    return
  }
}
```

### Technical details

Previously, the following 3 cases are handled.
```
scalar [binop] tensor -> splat(scalar) + tensor   # note: scalar != 0D-tensor
tensor [binop] scalar -> tensor + splat(scalar).  # note: scalar != 0D-tensor
nD-tensor [binop] mD-tensor -> broadcast(...)     # only if n == m
```

This patch newly allows the following.
- 0D-tensor (e.g., `tensor<f32>`)
- `nD-tensor [binop] mD-tensor` where `n != m`, by adding axes to the smaller tensor, which will be broadcast before (for example) `[binop]`.
  - For example: 
    - `tensor<f32>` -> `tensor<1x1x1xf32>`
    - `tensor<128xf32>` -> `tensor<128x1xf32>`
