### PR TITLE
[Triton-MLIR] Fix a few minor issues

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Check cpp style
         if: ${{ matrix.runner != 'macos-latest' }}
         run: |
-          sudo apt-get install -y clang-format
+          pip install clang-format
           find . -regex '.*\.\(cpp\|hpp\|h\|cc\)' -not -path "./python/build/*" -not -path "./include/triton/external/*" -print0 | xargs -0 -n1 clang-format -style=file --dry-run -Werror -i ||
           (echo '::error title=Style issues:: Please run `find . -regex ".*\.\(cpp\|hpp\|h\|cc\)" -not -path "./python/build/*" -not -path "./include/triton/external/*" -print0 | xargs -0 -n1 clang-format -style=file -i`' ; exit 1)
 

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -71,7 +71,7 @@ public:
     mlir::Value falseValue = selectOp.getFalseValue();
 
     auto *loadOpCandidate = trueValue.getDefiningOp();
-    auto loadOp = llvm::dyn_cast<triton::LoadOp>(loadOpCandidate);
+    auto loadOp = llvm::dyn_cast_or_null<triton::LoadOp>(loadOpCandidate);
     if (!loadOp)
       return mlir::failure();
 
@@ -81,7 +81,7 @@ public:
 
     auto *broadcastOpCandidate = mask.getDefiningOp();
     auto broadcastOp =
-        llvm::dyn_cast<triton::BroadcastOp>(broadcastOpCandidate);
+        llvm::dyn_cast_or_null<triton::BroadcastOp>(broadcastOpCandidate);
     if (!broadcastOp)
       return mlir::failure();
 
@@ -106,7 +106,8 @@ struct CanonicalizeMaskedLoadPattern
     if (!mask)
       return mlir::failure();
 
-    auto constantMask = llvm::dyn_cast<arith::ConstantOp>(mask.getDefiningOp());
+    auto constantMask =
+        llvm::dyn_cast_or_null<arith::ConstantOp>(mask.getDefiningOp());
     if (!constantMask)
       return mlir::failure();
 
@@ -152,7 +153,8 @@ struct CanonicalizeMaskedStorePattern
     if (!mask)
       return mlir::failure();
 
-    auto constantMask = llvm::dyn_cast<arith::ConstantOp>(mask.getDefiningOp());
+    auto constantMask =
+        llvm::dyn_cast_or_null<arith::ConstantOp>(mask.getDefiningOp());
     if (!constantMask)
       return mlir::failure();
 


### PR DESCRIPTION
1. In Triton-MLIR's combine pass, I didn't check if `getDefiningOp()` returns `nullptr` or not. Unlike `dynamic_cast`, `llvm::dyn_cast` fails if `nullptr` is passed. The first two commits fix this issue and add tests to check the behavior.

2. `Pipeline` transformation in TritonGPU-MLIR uses a wrong index to access the `mask` argument of `insert_slice_async`. The last commit fixes this issue.

(Note that the these issues are found to try to compile the tutorial matmul code.)
