### PR TITLE
Make triton.compile work without a cuda context

### DIFF
--- a/lib/driver/llvm.cc
+++ b/lib/driver/llvm.cc
@@ -239,14 +239,12 @@ std::string ptx_to_cubin(const std::string& ptx, const std::string& ptxas, int c
     unlink(_flog);
     throw std::runtime_error("Internal Triton PTX codegen error: \n" + log);
   }
-  CUmodule ret;
   std::ifstream _cubin(_fbin, std::ios::binary );
   std::string cubin(std::istreambuf_iterator<char>(_cubin), {});
   _cubin.close();
   unlink(_fsrc);
   unlink(_flog);
   unlink(_fbin);
-  dispatch::cuModuleLoadData(&ret, cubin.c_str());
   return cubin;
 }
 

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -1,7 +1,7 @@
+import multiprocessing
 import os
 import re
 import shutil
-import multiprocessing
 from collections import namedtuple
 
 import pytest

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -1,6 +1,8 @@
 import os
 import re
 import shutil
+import multiprocessing
+from collections import namedtuple
 
 import pytest
 import torch
@@ -172,3 +174,33 @@ def test_jit_warmup_cache() -> None:
     assert len(kernel_add.cache) == 1
     kernel_add.warmup(*args, grid=(1,))
     assert len(kernel_add.cache) == 1
+
+
+def test_compile_in_subproc() -> None:
+    @triton.jit
+    def kernel_sub(a, b, o, N: tl.constexpr):
+        idx = tl.arange(0, N)
+        tl.store(o + idx,
+                 tl.load(a + idx) - tl.load(b + idx) * 777)
+
+    major, minor = torch.cuda.get_device_capability(0)
+    cc = major * 10 + minor
+    config = namedtuple("instance_descriptor", [
+        "divisible_by_16", "equal_to_1"])(
+        tuple(range(4)),
+        ())
+
+    proc = multiprocessing.Process(
+        target=triton.compile,
+        kwargs=dict(
+            fn=kernel_sub,
+            signature={0: "*fp32", 1: "*fp32", 2: "*fp32"},
+            device=0,
+            constants={3: 32},
+            configs=[config],
+            warm_cache_only=True,
+            cc=cc,
+        ))
+    proc.start()
+    proc.join()
+    assert proc.exitcode == 0


### PR DESCRIPTION
This allows compiling in a subprocess.

I'm not seeing a ton of speedup from this, but figure it is a good change anyway.