### PR TITLE
[RUNTIME] Dump llvm, ttir, and sass to help debugging

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -22,7 +22,6 @@ from filelock import FileLock
 
 import triton
 import triton._C.libtriton.triton as _triton
-
 from .tools.disasm import extract
 
 


### PR DESCRIPTION
`ttir` and `llir` seem to have similar size to `ptx` IR in text format, each taking 10-30KB per triton function. So I suppose it's not a big issue by loading them into memory?