### PR TITLE
Support environments with multiple cudalibs

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -666,7 +666,7 @@ def test_atomic_cas():
     Lock = torch.zeros((1,), device='cuda', dtype=torch.int32)
     change_value[(1,)](Lock)
 
-    assert(Lock[0] == 1)
+    assert (Lock[0] == 1)
 
     # 2. only one block enters the critical section
     @triton.jit

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1102,9 +1102,9 @@ class CacheManager:
 
 
 @functools.lru_cache()
-def libcuda_dir():
-    loc = subprocess.check_output(["whereis", "libcuda.so"]).decode().strip().split()[-1]
-    return os.path.dirname(loc)
+def libcuda_dirs():
+    locs = subprocess.check_output(["whereis", "libcuda.so"]).decode().strip().split()[1:]
+    return [ os.path.dirname(loc) for loc in locs ]
 
 
 @contextlib.contextmanager
@@ -1118,7 +1118,7 @@ def quiet():
 
 
 def _build(name, src, srcdir):
-    cuda_lib_dir = libcuda_dir()
+    cuda_lib_dirs = libcuda_dirs()
     cu_include_dir = "/usr/local/cuda/include"
     suffix = sysconfig.get_config_var('EXT_SUFFIX')
     so = os.path.join(srcdir, '{name}{suffix}'.format(name=name, suffix=suffix))
@@ -1130,7 +1130,9 @@ def _build(name, src, srcdir):
         gcc = shutil.which("gcc")
         cc = gcc if gcc is not None else clang
     py_include_dir = get_paths()["include"]
-    ret = subprocess.check_call([cc, src, "-O3", f"-I{cu_include_dir}", f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", f"-L{cuda_lib_dir}", "-lcuda", "-o", so])
+    cc_cmd = [cc, src, "-O3", f"-I{cu_include_dir}", f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", "-lcuda", "-o", so]
+    cc_cmd += [ f"-L{dir}" for dir in cuda_lib_dirs ]
+    ret = subprocess.check_call(cc_cmd)
     if ret == 0:
         return so
     # fallback on setuptools

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1137,7 +1137,7 @@ def _build(name, src, srcdir):
         return so
     # fallback on setuptools
     extra_compile_args = []
-    library_dirs = [cuda_lib_dir]
+    library_dirs = cuda_lib_dirs
     include_dirs = [srcdir, cu_include_dir]
     libraries = ['cuda']
     # extra arguments

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1104,7 +1104,7 @@ class CacheManager:
 @functools.lru_cache()
 def libcuda_dirs():
     locs = subprocess.check_output(["whereis", "libcuda.so"]).decode().strip().split()[1:]
-    return [ os.path.dirname(loc) for loc in locs ]
+    return [os.path.dirname(loc) for loc in locs]
 
 
 @contextlib.contextmanager
@@ -1131,7 +1131,7 @@ def _build(name, src, srcdir):
         cc = gcc if gcc is not None else clang
     py_include_dir = get_paths()["include"]
     cc_cmd = [cc, src, "-O3", f"-I{cu_include_dir}", f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", "-lcuda", "-o", so]
-    cc_cmd += [ f"-L{dir}" for dir in cuda_lib_dirs ]
+    cc_cmd += [f"-L{dir}" for dir in cuda_lib_dirs]
     ret = subprocess.check_call(cc_cmd)
     if ret == 0:
         return so


### PR DESCRIPTION
On my system `whereis libcuda.so` (which is used in `libcuda_dir()` in `compiler.py`) returns multiple locations (one is for 32 bit version of library, the other for 64 bit).

`libcuda_dir()` currently only uses the last location returned, and this leads to linker errors when running triton if the last location is not the one needed.

This updates the compiler command to use all locations and makes triton work again in my system.
