### PR TITLE
Update installation.rst to fix windows build error

### DIFF
--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -40,7 +40,7 @@ You can install the Python package from source by running the following commands
       pip install cmake; # build time dependency
       pip install -e .
 
-Note that, if llvm-11 is not present on your system, the setup.py script will download the official LLVM11 static libraries link against that.
+Note that, if llvm-11 is not present on your system and you are on linux, the setup.py script will download the official LLVM11 static libraries link against that. For windows users, LLVM must be installed and configured in PATH.
 
 You can then test your installation by running the unit tests:
 

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -34,7 +34,9 @@ You can install the Python package from source by running the following commands
 .. code-block:: bash
 
       git clone https://github.com/openai/triton.git;
-      cd triton/python;
+      cd triton;
+      git submodule update --init --recursive;
+      cd python;
       pip install cmake; # build time dependency
       pip install -e .
 


### PR DESCRIPTION
When building for windows, I got an error because a submodule dependency here wasn't initiliaized: https://github.com/openai/triton/tree/master/deps