### PR TITLE
Add TRITON Prefixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ python/build/
 python/triton.egg-info/
 python/triton/_C/libtriton.pyd
 python/triton/_C/libtriton.so
+
+.vscode
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,8 @@ if(NOT WIN32)
 endif()
 
 # Options
-option(BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
-option(BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
+option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
+option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)
@@ -128,7 +128,7 @@ endif()
 include_directories(${LLVM_INCLUDE_DIRS})
 
 # Python module
-if(BUILD_PYTHON_MODULE)
+if(TRITON_BUILD_PYTHON_MODULE)
     message(STATUS "Adding Python module")
     set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/python/src)
     include_directories("." ${PYTHON_SRC_PATH} ${PYTHON_INCLUDE_DIRS})
@@ -139,7 +139,7 @@ endif()
 
 # # Triton
 # file(GLOB_RECURSE LIBTRITON_SRC lib/*.cc)
-# if (WIN32 AND BUILD_PYTHON_MODULE)
+# if (WIN32 AND TRITON_BUILD_PYTHON_MODULE)
 #     find_package(Python3 REQUIRED COMPONENTS Development)
 #     Python3_add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
 #     set_target_properties(triton PROPERTIES SUFFIX ".pyd")
@@ -209,7 +209,7 @@ else()
 endif()
 
 
-if(BUILD_PYTHON_MODULE AND NOT WIN32)
+if(TRITON_BUILD_PYTHON_MODULE AND NOT WIN32)
     set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
     # Check if the platform is MacOS
     if(APPLE)

--- a/python/setup.py
+++ b/python/setup.py
@@ -97,8 +97,8 @@ class CMakeBuild(build_ext):
         python_include_dirs = [distutils.sysconfig.get_python_inc()] + ['/usr/local/cuda/include']
         cmake_args = [
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
-            "-DBUILD_TUTORIALS=OFF",
-            "-DBUILD_PYTHON_MODULE=ON",
+            "-DTRITON_BUILD_TUTORIALS=OFF",
+            "-DTRITON_BUILD_PYTHON_MODULE=ON",
             "-DLLVM_INCLUDE_DIRS=" + llvm_include_dir,
             "-DLLVM_LIBRARY_DIR=" + llvm_library_dir,
             # '-DPYTHON_EXECUTABLE=' + sys.executable,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,7 @@ set(TRITON_TEST_DEPENDS
 
 add_lit_testsuite(check-triton "Running the triton regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
-  DEPENDS ${STANDALONE_TEST_DEPENDS}
+  DEPENDS ${TRITON_TEST_DEPENDS}
   )
 set_target_properties(check-triton PROPERTIES FOLDER "Tests")
 


### PR DESCRIPTION
Prefix Triton specific CMake options with `TRITON_`
Replace `STANDALONE_` prefix with `TRITON_` prefix in test dependencies
(also including my `.gitignore` fix from main)