### PR TITLE
[Triton-MLIR][FRONTEND] Remove the dangling `check-triton` call in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -125,11 +125,6 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=self.build_temp, env=env)
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=self.build_temp)
 
-        # run tests. Note: this depends on llvm-lit
-        # -DLLVM_EXTERNAL_LIT=<path-to-lit.py>
-        # Note: get_llvm_lit_path(...) in llvm/cmake/modules/AddLLVM.cmake
-        subprocess.call(["cmake", "--build", ".", "--target", "check-triton"], cwd=self.build_temp, env=env)
-
 
 setup(
     name="triton",


### PR DESCRIPTION
I noticed the `check-triton` target has been remove in [PR#790](https://github.com/openai/triton/commit/bb0f9235d182c88851aab5e3d1819b8e17350769#diff-33394812ba204689144fd2f80832db83853ba1cb32403edb4e15fe4893e675fdL18).

But the `call` is still reserved in [setup.py](https://github.com/openai/triton/blob/triton-mlir/python/setup.py#L131), this will trigger a error `make: *** No rule to make target 'check-triton'.  Stop.`