### PR TITLE
Add Back Test Target

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,3 +15,12 @@ set(TRITON_TEST_DEPENDS
   triton-opt
   FileCheck
 )
+
+add_lit_testsuite(check-triton-lit-tests "Running the triton regression tests"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  DEPENDS ${TRITON_TEST_DEPENDS}
+  )
+
+set_target_properties(check-triton-lit-tests PROPERTIES FOLDER "Tests")
+
+add_lit_testsuites(TRITON-LIT-TESTS ${CMAKE_CURRENT_SOURCE_DIR} DEPENDS ${TRITON_TEST_DEPENDS})


### PR DESCRIPTION
This change adds back in the Triton test target to cmake. i've renamed it to check-triton-lit-tests.

@ptillet , this shouldn't add the lit target to the default build target as per the llvm cmake files (see code snippet below from `AddLLVM.cmake`)

Please let me know if there's additional validation i can run (or you'd like to run) before merging.


```cmake
# A raw function to create a lit target. This is used to implement the testuite
# management functions.
function(add_lit_target target comment)

 <snip>

  # Tests should be excluded from "Build Solution".
  set_target_properties(${target} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD ON)
endfunction()
```