### PR TITLE
[FRONTEND] Fixed inliner and got more tests to pass

### DIFF
--- a/include/triton/Dialect/Triton/Transforms/Passes.h
+++ b/include/triton/Dialect/Triton/Transforms/Passes.h
@@ -8,7 +8,7 @@ namespace triton {
 
 std::unique_ptr<Pass> createCombineOpsPass();
 
-}
+} // namespace triton
 
 #define GEN_PASS_REGISTRATION
 #include "triton/Dialect/Triton/Transforms/Passes.h.inc"

--- a/lib/Dialect/Triton/IR/Dialect.cpp
+++ b/lib/Dialect/Triton/IR/Dialect.cpp
@@ -8,10 +8,29 @@
 
 #include "mlir/IR/DialectImplementation.h"
 
+#include "mlir/Transforms/InliningUtils.h"
 #include "triton/Dialect/Triton/IR/Dialect.cpp.inc"
 
 using namespace mlir;
 using namespace mlir::triton;
+
+//===----------------------------------------------------------------------===//
+// TritonDialect Dialect Interfaces
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct TritonInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+  bool isLegalToInline(Region *dest, Region *src, bool wouldBeCloned,
+                       BlockAndValueMapping &valueMapping) const final {
+    return true;
+  }
+  bool isLegalToInline(Operation *, Region *, bool wouldBeCloned,
+                       BlockAndValueMapping &) const final {
+    return true;
+  }
+};
+} // namespace
 
 void TritonDialect::initialize() {
   registerTypes();
@@ -22,6 +41,7 @@ void TritonDialect::initialize() {
       >();
 
   // We can also add interface here.
+  addInterfaces<TritonInlinerInterface>();
 }
 
 Operation *TritonDialect::materializeConstant(OpBuilder &builder,

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,7 +3,6 @@ import os
 import platform
 import re
 import shutil
-from struct import pack
 import subprocess
 import sys
 import tarfile
@@ -68,9 +67,9 @@ def get_thirdparty_packages(triton_cache_path):
     for p in packages:
         package_root_dir = os.path.join(triton_cache_path, p.package)
         package_dir = os.path.join(package_root_dir, p.name)
-        if p.syspath_var_name in os.environ:
-          package_dir = os.environ[p.syspath_var_name]
         test_file_path = os.path.join(package_dir, p.test_file)
+        if p.syspath_var_name in os.environ:
+            package_dir = os.environ[p.syspath_var_name]
         if not os.path.exists(test_file_path):
             try:
                 shutil.rmtree(package_root_dir)

--- a/python/setup.py
+++ b/python/setup.py
@@ -3,6 +3,7 @@ import os
 import platform
 import re
 import shutil
+from struct import pack
 import subprocess
 import sys
 import tarfile
@@ -38,12 +39,13 @@ class Package(NamedTuple):
     test_file: str
     include_flag: str
     lib_flag: str
+    syspath_var_name: str
 
 
 def get_pybind11_package_info():
     name = "pybind11-2.10.0"
     url = "https://github.com/pybind/pybind11/archive/refs/tags/v2.10.0.tar.gz"
-    return Package("pybind11", name, url, "include/pybind11/pybind11.h", "PYBIND11_INCLUDE_DIR", "")
+    return Package("pybind11", name, url, "include/pybind11/pybind11.h", "PYBIND11_INCLUDE_DIR", "", "PYBIND11_SYSPATH")
 
 
 def get_llvm_package_info():
@@ -57,7 +59,7 @@ def get_llvm_package_info():
     else:
         name = 'clang+llvm-14.0.0-x86_64-{}'.format(system_suffix)
         url = "https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/{}.tar.xz".format(name)
-    return Package("llvm", name, url, "lib", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR")
+    return Package("llvm", name, url, "lib", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
 
 
 def get_thirdparty_packages(triton_cache_path):
@@ -66,6 +68,8 @@ def get_thirdparty_packages(triton_cache_path):
     for p in packages:
         package_root_dir = os.path.join(triton_cache_path, p.package)
         package_dir = os.path.join(package_root_dir, p.name)
+        if p.syspath_var_name in os.environ:
+          package_dir = os.environ[p.syspath_var_name]
         test_file_path = os.path.join(package_dir, p.test_file)
         if not os.path.exists(test_file_path):
             try:

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -422,7 +422,12 @@ void init_triton_ir(py::module &&m) {
       .def("get_int32_attr", &mlir::OpBuilder::getI32IntegerAttr)
       // Use arith.ConstantOp to create constants
       // // Constants
-      // .def("get_int1", &ir::builder::get_int1, ret::reference)
+      .def("get_int1",
+           [](mlir::OpBuilder &self, bool v) -> mlir::Value {
+             auto loc = self.getUnknownLoc();
+             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+                 loc, v, self.getI1Type()));
+           })
       .def("get_int32",
            [](mlir::OpBuilder &self, int64_t v) -> mlir::Value {
              auto loc = self.getUnknownLoc();

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -158,6 +158,7 @@ void init_triton_ir(py::module &&m) {
       .def("is_fp16", &mlir::Type::isF16);
 
   py::class_<mlir::Value>(m, "value")
+      .def(py::init<>())
       .def("set_attr",
            [](mlir::Value &self, std::string &name,
               mlir::Attribute &attr) -> void {
@@ -378,7 +379,10 @@ void init_triton_ir(py::module &&m) {
       .def("ret",
            [](mlir::OpBuilder &self, std::vector<mlir::Value> &vals) -> void {
              auto loc = self.getUnknownLoc();
-             self.create<mlir::ReturnOp>(loc, vals);
+             if (vals.empty()) {
+               self.create<mlir::ReturnOp>(loc);
+             } else
+               self.create<mlir::ReturnOp>(loc, vals);
            })
       .def("call",
            [](mlir::OpBuilder &self, mlir::FuncOp &func,

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -158,7 +158,6 @@ void init_triton_ir(py::module &&m) {
       .def("is_fp16", &mlir::Type::isF16);
 
   py::class_<mlir::Value>(m, "value")
-      .def(py::init<>())
       .def("set_attr",
            [](mlir::Value &self, std::string &name,
               mlir::Attribute &attr) -> void {
@@ -379,10 +378,7 @@ void init_triton_ir(py::module &&m) {
       .def("ret",
            [](mlir::OpBuilder &self, std::vector<mlir::Value> &vals) -> void {
              auto loc = self.getUnknownLoc();
-             if (vals.empty()) {
-               self.create<mlir::ReturnOp>(loc);
-             } else
-               self.create<mlir::ReturnOp>(loc, vals);
+             self.create<mlir::ReturnOp>(loc, vals);
            })
       .def("call",
            [](mlir::OpBuilder &self, mlir::FuncOp &func,

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -1447,36 +1447,36 @@ def test_constexpr_scalar_shape():
 # # -------------
 
 
-# @triton.jit
-# def val_multiplier(val, i):
-#     return val * i
+@triton.jit
+def val_multiplier(val, i):
+    return val * i
 
 
-# @triton.jit
-# def vecmul_kernel(ptr, n_elements, rep):
-#     pid = tl.program_id(axis=0)
-#     offsets = pid * 128 + tl.arange(0, 128)
-#     mask = offsets < n_elements
-#     vec = tl.load(ptr + offsets, mask=mask)
-#     for i in range(1, rep):
-#         vec = val_multiplier(vec, i)
-#     tl.store(ptr + offsets, vec, mask=mask)
+@triton.jit
+def vecmul_kernel(ptr, n_elements, rep):
+    pid = tl.program_id(axis=0)
+    offsets = pid * 128 + tl.arange(0, 128)
+    mask = offsets < n_elements
+    vec = tl.load(ptr + offsets, mask=mask)
+    for i in range(1, rep):
+        vec = val_multiplier(vec, i)
+    tl.store(ptr + offsets, vec, mask=mask)
 
 
-# def test_call():
+def test_call():
 
-#     @triton.jit
-#     def kernel(ptr, n_elements, num1, num2):
-#         vecmul_kernel(ptr, n_elements, num1)
-#         vecmul_kernel(ptr, n_elements, num2)
+    @triton.jit
+    def kernel(ptr, n_elements, num1, num2):
+        vecmul_kernel(ptr, n_elements, num1)
+        vecmul_kernel(ptr, n_elements, num2)
 
-#     size = 1024
-#     rand_val = numpy_random((size,), dtype_str="float32")
-#     rand_val_tri = to_triton(rand_val, device='cuda')
-#     kernel[(size // 128,)](rand_val_tri, size, 3, 5)
+    size = 1024
+    rand_val = numpy_random((size,), dtype_str="float32")
+    rand_val_tri = to_triton(rand_val, device='cuda')
+    kernel[(size // 128,)](rand_val_tri, size, 3, 5)
 
-#     ans = rand_val * 1 * 2 * 1 * 2 * 3 * 4
-#     np.testing.assert_equal(to_numpy(rand_val_tri), ans)
+    ans = rand_val * 1 * 2 * 1 * 2 * 3 * 4
+    np.testing.assert_equal(to_numpy(rand_val_tri), ans)
 
 # # -------------
 # # test if

--- a/python/tests/test_core.py
+++ b/python/tests/test_core.py
@@ -1370,6 +1370,7 @@ def test_value_specialization(value: int, value_type: str, device='cuda') -> Non
 # # value specialization
 # # --------------------
 
+
 @pytest.mark.parametrize(
     "value, overflow",
     [(2**64 - 1, False), (2**64, True), (-2**63, False), (-2**63 - 1, True)]

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -685,8 +685,7 @@ class CodeGenerator(ast.NodeVisitor):
             fn_name = mangle_fn(fn.__name__, arg_types, constants)
             # generate function def if necessary
             if not self.module.has_function(fn_name):
-                ret_type = triton.language.void
-                prototype = triton.language.function_type([ret_type], arg_types)
+                prototype = triton.language.function_type([], arg_types)
                 gscope = sys.modules[fn.fn.__module__].__dict__
                 generator = CodeGenerator(self.builder.context, prototype, gscope, attributes, constants, module=self.module, function_name=fn_name, function_types=self.function_ret_types)
                 generator.visit(fn.parse())
@@ -696,7 +695,7 @@ class CodeGenerator(ast.NodeVisitor):
                 callee_ret_type = self.function_ret_types[fn_name]
             symbol = self.module.get_function(fn_name)
             call_op = self.builder.call(symbol, arg_vals)
-            if call_op.get_num_results() == 0:
+            if call_op.get_num_results() == 0 or callee_ret_type is None:
                 return None
             elif call_op.get_num_results() == 1:
                 return triton.language.tensor(call_op.get_result(0), callee_ret_type)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -473,6 +473,11 @@ class tensor:
         other = _to_tensor(other, _builder)
         return semantic.mod(self, other, _builder)
 
+    @builtin
+    def __rmod__(self, other, _builder=None):
+        other = _to_tensor(other, _builder)
+        return semantic.mod(other, self, _builder)
+
     # unary operators
     @builtin
     def __neg__(self, _builder=None):
@@ -541,6 +546,7 @@ class tensor:
 
     @builtin
     def __rlt__(self, other, _builder=None):
+        other = _to_tensor(other, _builder)
         return semantic.less_than(other, self, _builder)
 
     # <=


### PR DESCRIPTION
This adds a `DialectInlinerInterface` to the Triton dialect. This, along with a few other minor semantic changes, fixes our tests on call instructions. Also added the option to provide use an "LLVM_SYSPATH" environment variable to link against locally build of LLVM; this was useful for debugging this issue.