### PR TITLE
[Triton-MLIR][Backend]add atomic rmw without mask

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -5116,6 +5116,127 @@ struct FDivOpConversion
   }
 };
 
+/// ====================== atomic_rmw codegen begin ==========================
+struct AtomicRMWOpConversion
+    : public ConvertTritonGPUOpToLLVMPattern<triton::AtomicRMWOp>,
+      public LoadStoreConversionBase {
+  using ConvertTritonGPUOpToLLVMPattern<
+      triton::AtomicRMWOp>::ConvertTritonGPUOpToLLVMPattern;
+
+  AtomicRMWOpConversion(LLVMTypeConverter &converter,
+                        AxisInfoAnalysis &axisAnalysisPass,
+                        PatternBenefit benefit)
+      : ConvertTritonGPUOpToLLVMPattern<triton::AtomicRMWOp>(converter,
+                                                             benefit),
+        LoadStoreConversionBase(axisAnalysisPass) {}
+
+  LogicalResult
+  matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+
+    auto loc = op.getLoc();
+    MLIRContext *ctx = rewriter.getContext();
+
+    auto atomicRmwAttr = op.atomic_rmw_op();
+    Value ptr = op.ptr();
+    Value val = op.val();
+
+    Value llPtr = adaptor.ptr();
+    Value llVal = adaptor.val();
+
+    auto valElements = getElementsFromStruct(loc, llVal, rewriter);
+    auto ptrElements = getElementsFromStruct(loc, llPtr, rewriter);
+
+    // TODO[dongdongl]: Support mask and scalar
+
+    auto valueTy = op.getResult().getType().dyn_cast<RankedTensorType>();
+    if (!valueTy)
+      return failure();
+    Type valueElemTy =
+        getTypeConverter()->convertType(valueTy.getElementType());
+
+    auto valTy = val.getType().cast<RankedTensorType>();
+    const size_t valueElemNbits = valueElemTy.getIntOrFloatBitWidth();
+    auto vec = getVectorSize(ptr);
+    vec = std::min<unsigned>(vec, valTy.getElementType().isF16() ? 2 : 1);
+
+    auto vecTy = vec_ty(valueElemTy, vec);
+    auto elemsPerThread = getElemsPerThread(val.getType());
+    SmallVector<Value> resultVals(elemsPerThread);
+    for (size_t i = 0; i < elemsPerThread; i += vec) {
+      Value rmvVal = undef(vecTy);
+      for (int ii = 0; ii < vec; ++ii) {
+        Value iiVal = createIndexAttrConstant(
+            rewriter, loc, getTypeConverter()->getIndexType(), ii);
+        rmvVal = insert_element(vecTy, rmvVal, valElements[i], iiVal);
+      }
+      Value rmwPtr = bitcast(ptrElements[i], ptr_ty(valTy.getElementType()));
+      std::string sTy;
+      PTXBuilder ptxBuilder;
+
+      auto *dstOpr = ptxBuilder.newOperand("=r");
+      auto *ptrOpr = ptxBuilder.newAddrOperand(rmwPtr, "r");
+      auto *valOpr = ptxBuilder.newOperand(rmvVal, "r");
+
+      auto &atom = *ptxBuilder.create<>("atom");
+
+      atom.o("global").o("gpu");
+      auto rmwOp = stringifyRMWOp(atomicRmwAttr).str();
+      auto sBits = std::to_string(valueElemNbits);
+      switch (atomicRmwAttr) {
+      case RMWOp::AND:
+        sTy = "b" + sBits;
+        break;
+      case RMWOp::OR:
+        sTy = "b" + sBits;
+        break;
+      case RMWOp::XOR:
+        sTy = "b" + sBits;
+        break;
+      case RMWOp::ADD:
+        sTy = "s" + sBits;
+        break;
+      case RMWOp::FADD:
+        rmwOp = "add";
+        rmwOp += (valueElemNbits == 16 ? ".noftz" : "");
+        sTy = "f" + sBits;
+        sTy += (vec == 2 && valueElemNbits == 16) ? "x2" : "";
+        break;
+      case RMWOp::MAX:
+        sTy = "s" + sBits;
+        break;
+      case RMWOp::MIN:
+        sTy = "s" + sBits;
+        break;
+      case RMWOp::UMAX:
+        rmwOp = "max";
+        sTy = "u" + sBits;
+        break;
+      case RMWOp::UMIN:
+        rmwOp = "min";
+        sTy = "u" + sBits;
+        break;
+      default:
+        return failure();
+      }
+      atom.o(rmwOp).o(sTy);
+
+      atom(dstOpr, ptrOpr, valOpr);
+      auto ret = ptxBuilder.launch(rewriter, loc, valueElemTy, false);
+      for (int ii = 0; ii < vec; ++ii) {
+        resultVals[i * vec + ii] =
+            vec == 1 ? ret : extract_element(vecTy, ret, idx_val(ii));
+      }
+    }
+    Type structTy = getTypeConverter()->convertType(valueTy);
+    Value resultStruct =
+        getStructFromElements(loc, resultVals, rewriter, structTy);
+    rewriter.replaceOp(op, {resultStruct});
+    return success();
+  }
+};
+/// ====================== atomic_rmw codegen end ==========================
+
 void populateTritonToLLVMPatterns(mlir::LLVMTypeConverter &typeConverter,
                                   RewritePatternSet &patterns, int numWarps,
                                   AxisInfoAnalysis &axisInfoAnalysis,
@@ -5187,7 +5308,7 @@ void populateTritonToLLVMPatterns(mlir::LLVMTypeConverter &typeConverter,
   patterns.add<ReduceOpConversion>(typeConverter, allocation, smem, benefit);
   patterns.add<ConvertLayoutOpConversion>(typeConverter, allocation, smem,
                                           benefit);
-
+  patterns.add<AtomicRMWOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<ExtractSliceOpConversion>(typeConverter, allocation, smem,
                                          benefit);
   patterns.add<GetProgramIdOpConversion>(typeConverter, benefit);

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -830,3 +830,15 @@ module attributes {"triton_gpu.num-warps" = 4 : i32} {
     return
   }
 }
+
+// -----
+#blocked0 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
+module attributes {"triton_gpu.num-warps" = 4 : i32} {
+  // CHECK-LABEL: atomic_add_f32
+  func @atomic_add_f32(%arg0 : tensor<256x!tt.ptr<f32>, #blocked0>, %arg1 : tensor<256xi1, #blocked0>, %arg2 : tensor<256xf32, #blocked0>) {
+    // CHECK: llvm.inline_asm
+    // CHECK-SAME: atom.global.gpu.add.f32
+    %0 = "tt.atomic_rmw" (%arg0, %arg2, %arg1) {atomic_rmw_op = 5 : i32} : (tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xf32, #blocked0>, tensor<256xi1, #blocked0>) -> tensor<256xf32, #blocked0>
+    return
+  }
+}


### PR DESCRIPTION
add atomic without mask

TritonGPU
```
#blocked0 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
module attributes {"triton_gpu.num-warps" = 4 : i32} {
  func @atomic(%arg0 : tensor<256x!tt.ptr<f32>, #blocked0>, %arg1 : tensor<256xi1, #blocked0>, %arg2 : tensor<256xf32, #blocked0>) {
    %0 = "tt.atomic_rmw" (%arg0, %arg2, %arg1) {atomic_rmw_op = 5 : i32} : (tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xf32, #blocked0>, tensor<256xi1, #blocked0>) -> tensor<256xf32, #blocked0>
    return
  }
}
```
LLVM
```
#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
module attributes {"triton_gpu.num-warps" = 4 : i32, triton_gpu.shared = 0 : i32} {
  llvm.mlir.global external @global_smem() {addr_space = 3 : i32} : !llvm.array<0 x i8>
  llvm.func @atomic(%arg0: !llvm.struct<(ptr<f32, 1>, ptr<f32, 1>)>, %arg1: !llvm.struct<(i1, i1)>, %arg2: !llvm.struct<(f32, f32)>) attributes {nvvm.kernel = 1 : ui1, nvvm.maxntid = 128 : i32} {
    %0 = llvm.mlir.addressof @global_smem : !llvm.ptr<array<0 x i8>, 3>
    %1 = llvm.bitcast %0 : !llvm.ptr<array<0 x i8>, 3> to !llvm.ptr<i8, 3>
    %2 = builtin.unrealized_conversion_cast %arg2 : !llvm.struct<(f32, f32)> to tensor<256xf32, #blocked>
    %3 = builtin.unrealized_conversion_cast %arg1 : !llvm.struct<(i1, i1)> to tensor<256xi1, #blocked>
    %4 = builtin.unrealized_conversion_cast %arg0 : !llvm.struct<(ptr<f32, 1>, ptr<f32, 1>)> to tensor<256x!tt.ptr<f32>, #blocked>
    %5 = llvm.extractvalue %arg2[0] : !llvm.struct<(f32, f32)>
    %6 = llvm.extractvalue %arg2[1] : !llvm.struct<(f32, f32)>
    %7 = llvm.extractvalue %arg0[0] : !llvm.struct<(ptr<f32, 1>, ptr<f32, 1>)>
    %8 = llvm.extractvalue %arg0[1] : !llvm.struct<(ptr<f32, 1>, ptr<f32, 1>)>
    %9 = llvm.extractvalue %arg1[0] : !llvm.struct<(i1, i1)>
    %10 = llvm.extractvalue %arg1[1] : !llvm.struct<(i1, i1)>
    %11 = llvm.mlir.undef : vector<1xf32>
    %12 = llvm.mlir.constant(0 : index) : i32
    %13 = llvm.insertelement %5, %11[%12 : i32] : vector<1xf32>
    %14 = llvm.bitcast %7 : !llvm.ptr<f32, 1> to !llvm.ptr<f32>
    %15 = llvm.inline_asm asm_dialect = att operand_attrs = [] "atom.global.gpu.add.f32 $0, [ $1 + 0 ], $2;", "=r,r,r" %14, %13 : (!llvm.ptr<f32>, vector<1xf32>) -> f32
    %16 = llvm.mlir.undef : vector<1xf32>
    %17 = llvm.mlir.constant(0 : index) : i32
    %18 = llvm.insertelement %6, %16[%17 : i32] : vector<1xf32>
    %19 = llvm.bitcast %8 : !llvm.ptr<f32, 1> to !llvm.ptr<f32>
    %20 = llvm.inline_asm asm_dialect = att operand_attrs = [] "atom.global.gpu.add.f32 $0, [ $1 + 0 ], $2;", "=r,r,r" %19, %18 : (!llvm.ptr<f32>, vector<1xf32>) -> f32
    %21 = llvm.mlir.undef : !llvm.struct<(f32, f32)>
    %22 = llvm.insertvalue %15, %21[0] : !llvm.struct<(f32, f32)>
    %23 = llvm.insertvalue %20, %22[1] : !llvm.struct<(f32, f32)>
    llvm.return
  }
}
```
