### PR TITLE
[Triton-MLIR][Backend] Fix convert_layout blocked->shared in non-default order

### DIFF
--- a/python/tests/test_gemm.py
+++ b/python/tests/test_gemm.py
@@ -30,18 +30,32 @@ def matmul_no_scf_kernel(
 # TODO: num_warps could only be 4 for now
 
 
-@pytest.mark.parametrize('SIZE_M,SIZE_N,SIZE_K,NUM_WARPS', [
-    [128, 256, 32, 4],
-    [256, 128, 16, 4],
-    [128, 16, 32, 4],
-    [32, 128, 64, 4],
-    [128, 128, 64, 4],
-    [64, 128, 128, 4],
-    [64, 128, 128, 2],
+@pytest.mark.parametrize('SHAPE,NUM_WARPS,TRANS_A,TRANS_B', [
+    (shape, num_warps, trans_a, trans_b)
+    for shape in [
+        [128, 256, 32],
+        [256, 128, 16],
+        [128, 16, 32],
+        [32, 128, 64],
+        [128, 128, 64],
+        [64, 128, 128],
+    ]
+    for num_warps in [2, 4]
+    for trans_a in [False, True]
+    for trans_b in [False, True]
 ])
-def test_gemm_no_scf(SIZE_M, SIZE_N, SIZE_K, NUM_WARPS):
-    a = torch.randn((SIZE_M, SIZE_K), device='cuda', dtype=torch.float16)
-    b = torch.randn((SIZE_K, SIZE_N), device='cuda', dtype=torch.float16)
+def test_gemm_no_scf(SHAPE, NUM_WARPS, TRANS_A, TRANS_B):
+    SIZE_M, SIZE_N, SIZE_K = SHAPE
+    if (TRANS_A):
+        a = torch.randn((SIZE_K, SIZE_M), device='cuda', dtype=torch.float16).T
+    else:
+        a = torch.randn((SIZE_M, SIZE_K), device='cuda', dtype=torch.float16)
+
+    if (TRANS_B):
+        b = torch.randn((SIZE_N, SIZE_K), device='cuda', dtype=torch.float16).T
+    else:
+        b = torch.randn((SIZE_K, SIZE_N), device='cuda', dtype=torch.float16)
+
     c = torch.empty((SIZE_M, SIZE_N), device=a.device, dtype=torch.float32)
     grid = lambda META: (1, )
     matmul_no_scf_kernel[grid](a_ptr=a, b_ptr=b, c_ptr=c,
@@ -55,16 +69,32 @@ def test_gemm_no_scf(SIZE_M, SIZE_N, SIZE_K, NUM_WARPS):
     assert_close(c, golden, rtol=1e-3, atol=1e-3, check_dtype=False)
 
 
-@pytest.mark.parametrize('SIZE_M,SIZE_N,SIZE_K,NUM_WARPS', [
-    [64, 128, 128, 1],
-    [128, 128, 128, 4],
-    [16, 8, 32, 1],
-    [32, 16, 64, 2],
-    [32, 16, 64, 4],
+@pytest.mark.parametrize('SHAPE,NUM_WARPS,TRANS_A,TRANS_B', [
+    (shape, num_warps, trans_a, trans_b)
+    for shape in [
+        [64, 128, 128],
+        [128, 128, 128],
+        [16, 8, 32],
+        [32, 16, 64],
+        [32, 16, 64],
+    ]
+    for num_warps in [1, 2, 4]
+    for trans_a in [False, True]
+    for trans_b in [False, True]
 ])
-def test_gemm_no_scf_int8(SIZE_M, SIZE_N, SIZE_K, NUM_WARPS):
-    a = torch.randint(-5, 5, (SIZE_M, SIZE_K), device='cuda', dtype=torch.int8)
-    b = torch.randint(-5, 5, (SIZE_K, SIZE_N), device='cuda', dtype=torch.int8)
+def test_gemm_no_scf_int8(SHAPE, NUM_WARPS, TRANS_A, TRANS_B):
+    SIZE_M, SIZE_N, SIZE_K = SHAPE
+
+    if (TRANS_A):
+        a = torch.randint(-5, 5, (SIZE_K, SIZE_M), device='cuda', dtype=torch.int8).T
+    else:
+        a = torch.randint(-5, 5, (SIZE_M, SIZE_K), device='cuda', dtype=torch.int8)
+
+    if (TRANS_B):
+        b = torch.randint(-5, 5, (SIZE_N, SIZE_K), device='cuda', dtype=torch.int8).T
+    else:
+        b = torch.randint(-5, 5, (SIZE_K, SIZE_N), device='cuda', dtype=torch.int8)
+
     c = torch.empty((SIZE_M, SIZE_N), device=a.device, dtype=torch.int32)
 
     grid = lambda META: (1, )
@@ -125,28 +155,39 @@ def get_variant_golden(a, b):
     return c_padded[:SIZE_M, :SIZE_N]
 
 
-@pytest.mark.parametrize('SIZE_M,SIZE_N,SIZE_K,NUM_WARPS,BLOCK_SIZE_M,BLOCK_SIZE_N,BLOCK_SIZE_K', [
+@pytest.mark.parametrize('SIZE_M,SIZE_N,SIZE_K,NUM_WARPS,BLOCK_SIZE_M,BLOCK_SIZE_N,BLOCK_SIZE_K,TRANS_A,TRANS_B', [
     # Non-forloop
-    [64, 32, 64, 4, 64, 32, 64],
-    [128, 64, 128, 4, 128, 64, 128],
+    [64, 32, 64, 4, 64, 32, 64, False, False],
+    [128, 64, 128, 4, 128, 64, 128, False, False],
     # K-Forloop
-    [64, 32, 128, 4, 64, 32, 64],
-    [128, 16, 128, 4, 128, 16, 32],
-    [32, 16, 128, 4, 32, 16, 32],
-    [32, 64, 128, 4, 32, 64, 32],
-    [32, 128, 256, 4, 32, 128, 64],
-    [64, 128, 64, 4, 64, 128, 32],
-    [64, 64, 128, 4, 64, 64, 32],
-    [128, 128, 64, 4, 128, 128, 32],
-    [128, 128, 128, 4, 128, 128, 32],
-    [128, 128, 256, 4, 128, 128, 64],
-    [128, 256, 128, 4, 128, 256, 32],
-    [256, 128, 64, 4, 256, 128, 16],
-    [128, 64, 128, 4, 128, 64, 32],
+    [64, 32, 128, 4, 64, 32, 64, False, False],
+    [128, 16, 128, 4, 128, 16, 32, False, False],
+    [32, 16, 128, 4, 32, 16, 32, False, False],
+    [32, 64, 128, 4, 32, 64, 32, False, False],
+    [32, 128, 256, 4, 32, 128, 64, False, False],
+    [64, 128, 64, 4, 64, 128, 32, False, False],
+    [64, 64, 128, 4, 64, 64, 32, False, False],
+    [128, 128, 64, 4, 128, 128, 32, False, False],
+    [128, 128, 128, 4, 128, 128, 32, False, False],
+    [128, 128, 256, 4, 128, 128, 64, False, False],
+    [128, 256, 128, 4, 128, 256, 32, False, False],
+    [256, 128, 64, 4, 256, 128, 16, False, False],
+    [128, 64, 128, 4, 128, 64, 32, False, False],
+    # TODO[goostavz]: fix these cases
+    #[128, 64, 128, 4, 128, 64, 32, True, False],
+    #[128, 64, 128, 4, 128, 64, 32, False, True],
 ])
-def test_gemm(SIZE_M, SIZE_N, SIZE_K, NUM_WARPS, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K):
-    a = torch.randn((SIZE_M, SIZE_K), device='cuda', dtype=torch.float16)
-    b = torch.randn((SIZE_K, SIZE_N), device='cuda', dtype=torch.float16)
+def test_gemm(SIZE_M, SIZE_N, SIZE_K, NUM_WARPS, BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, TRANS_A, TRANS_B):
+    if (TRANS_A):
+        a = torch.randn((SIZE_K, SIZE_M), device='cuda', dtype=torch.float16).T
+    else:
+        a = torch.randn((SIZE_M, SIZE_K), device='cuda', dtype=torch.float16)
+
+    if (TRANS_B):
+        b = torch.randn((SIZE_N, SIZE_K), device='cuda', dtype=torch.float16).T
+    else:
+        b = torch.randn((SIZE_K, SIZE_N), device='cuda', dtype=torch.float16)
+
     c = torch.empty((SIZE_M, SIZE_N), device=a.device, dtype=torch.float32)
     grid = lambda META: (1, )
     matmul_kernel[grid](a_ptr=a, b_ptr=b, c_ptr=c,


### PR DESCRIPTION
This PR fix the problem of TN/NT GEMM correctness when no SCF involved. I'll continue to clean up getLinearIndex/getMultiDimIndex in a uniformed way which should be benifical to avoid different kinds of order issues. This is not fully done yet, just merge to sync the code.