### PR TITLE
Minimal changes to support llvm-15

### DIFF
--- a/lib/codegen/pass.cc
+++ b/lib/codegen/pass.cc
@@ -1,5 +1,6 @@
 #include "triton/codegen/pass.h"
 
+#include "llvm/Pass.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"

--- a/lib/driver/llvm.cc
+++ b/lib/driver/llvm.cc
@@ -40,7 +40,11 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
+#if LLVM_VERSION_MAJOR >= 15
+#include "llvm/MC/TargetRegistry.h"
+#else
 #include "llvm/Support/TargetRegistry.h"
+#endif
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -448,6 +448,9 @@ void init_triton_codegen(py::module &&m) {
             name = ir.get_function_list()[0]->get_name();
             ir.print(ttir);
             llvm::LLVMContext ctx;
+#if LLVM_VERSION_MAJOR >= 15
+	    ctx.setOpaquePointers(false);
+#endif
             // construct extern lib map
             triton::codegen::ExternLibMap extern_lib_map;
             for (auto item : extern_libs) {


### PR DESCRIPTION
Inside Meta we're pushing to support llvm-15, so need some minor API changes.

The biggest difference since 11 is the move to opaque, untyped pointers; I've applied `LLVMContext::setOpaquePointers(false)` to work around this for now, and hopefully the move to MLIR will obviate this by the time LLVM 16 comes around.