### PR TITLE
[Triton-MLIR][RUNTIME] Add /usr/bin/ptxas as a search path

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -977,7 +977,12 @@ def ptx_get_version(cuda_version) -> int:
 
 
 def path_to_ptxas():
-    prefixes = [os.environ.get("TRITON_PTXAS_PATH", ""), "", os.environ.get('CUDA_PATH', default_cuda_dir())]
+    prefixes = [
+        os.environ.get("TRITON_PTXAS_PATH", ""),
+        "",
+        "/usr",
+        os.environ.get('CUDA_PATH', default_cuda_dir())
+    ]
     for prefix in prefixes:
         ptxas = os.path.join(prefix, "bin", "ptxas")
         if os.path.exists(ptxas):


### PR DESCRIPTION
Make `ptxas` search a bit broader to include `/usr/bin/ptxas`, installed by the lambda stack repo versions:
https://lambdalabs.com/lambda-stack-deep-learning-software

```
$ lsb_release -d
Description:	Ubuntu 22.04.1 LTS

$ dpkg-query -S /usr/bin/ptxas 
nvidia-cuda-toolkit: /usr/bin/ptxas

$ apt info nvidia-cuda-toolkit
Package: nvidia-cuda-toolkit
Version: 11.6.2-0lambda3
```