### PR TITLE
[Triton-MLIR][RUNTIME] Fix ir metadata lookup bug

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1416,7 +1416,8 @@ def compile(fn, **kwargs):
         path = fn_cache_manager._make_path(f"{name}.{ir}")
         if ir == ext:
             next_module = parse(fn)
-        elif os.path.exists(path) and\
+        elif os.path.exists(path) and \
+                ir in metadata["ctime"] and \
                 os.path.getctime(path) == metadata["ctime"][ir]:
             next_module = parse(path)
         else:


### PR DESCRIPTION
Fix lookup bug where a ctime may not yet be loaded for a given ir.
```
            if ir == ext:
                next_module = parse(fn)
            elif os.path.exists(path) and\
>                   os.path.getctime(path) == metadata["ctime"][ir]:
E                   KeyError: 'ttir'

triton/compiler.py:1425: KeyError
===== short test summary info =======
FAILED tests/test_reduce.py::test_reduce1d[max-int32-128] - KeyError: 'ttir'
```