### PR TITLE
[CI] Enable assertions for CI

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Triton
         run: |
           cd python
-          DEBUG=TRUE TRITON_USE_ASSERT_ENABLED_LLVM=TRUE pip3 install -e '.[tests]'
+          TRITON_USE_ASSERT_ENABLED_LLVM=TRUE pip3 install -e '.[tests]'
 
       - name: Run lit tests
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Triton
         run: |
           cd python
-          TRITON_USE_ASSERT_ENABLED_LLVM=TRUE pip3 install -e '.[tests]'
+          DEBUG=TRUE TRITON_USE_ASSERT_ENABLED_LLVM=TRUE pip3 install -e '.[tests]'
 
       - name: Run lit tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,9 @@ option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 #  used conditionally in this file and by lit tests
 find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
 
-# Customized release build type with assertions
-set(CMAKE_C_FLAGS_RELWITHDEBINFOANDASSERTIONS "-O2 -g")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFOANDASSERTIONS "-O2 -g")
+# Customized release build type with assertions: TritonRelBuildWithAsserts
+set(CMAKE_C_FLAGS_TRITONRELBUILDWITHASSERTS "-O2 -g")
+set(CMAKE_CXX_FLAGS_TRITONRELBUILDWITHASSERTS "-O2 -g")
 
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
 #  used conditionally in this file and by lit tests
 find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
 
+# Customized release build type with assertions
+set(CMAKE_C_FLAGS_RELWITHDEBINFOANDASSERTIONS "-O2 -g")
+set(CMAKE_CXX_FLAGS_RELWITHDEBINFOANDASSERTIONS "-O2 -g")
+
 # Default build type
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "Default build type: Release")

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPU.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPU.cpp
@@ -223,7 +223,7 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
                   ConversionPatternRewriter &rewriter) const override {
     RankedTensorType origType = op.getType().cast<RankedTensorType>();
     auto origShape = origType.getShape();
-    auto typeConverter = static_cast<TritonGPUTypeConverter*>(getTypeConverter());
+    auto typeConverter = getTypeConverter<TritonGPUTypeConverter>();
     int numWarps = typeConverter->getNumWarps();
 
     SmallVector<unsigned> retSizePerThread = {1, 1};

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPU.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPU.cpp
@@ -223,7 +223,7 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
                   ConversionPatternRewriter &rewriter) const override {
     RankedTensorType origType = op.getType().cast<RankedTensorType>();
     auto origShape = origType.getShape();
-    auto typeConverter = cast<TritonGPUTypeConverter>(getTypeConverter());
+    auto typeConverter = static_cast<TritonGPUTypeConverter*>(getTypeConverter());
     int numWarps = typeConverter->getNumWarps();
 
     SmallVector<unsigned> retSizePerThread = {1, 1};

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,11 +24,11 @@ def get_build_type():
         return "Debug"
     elif check_env_flag("REL_WITH_DEB_INFO"):
         return "RelWithDebInfo"
-    elif check_env_flag("REL_WITH_DEB_INFO_AND_ASSERTIONS"):
-        return "RelWithDebInfoAndAssertions"
+    elif check_env_flag("TRITON_REL_BUILD_WITH_ASSERTS"):
+        return "TritonRelBuildWithAsserts"
     else:
         # TODO: change to release when stable enough
-        return "RelWithDebInfoAndAssertions"
+        return "TritonRelBuildWithAsserts"
 
 
 # --- third party packages -----

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,9 +24,11 @@ def get_build_type():
         return "Debug"
     elif check_env_flag("REL_WITH_DEB_INFO"):
         return "RelWithDebInfo"
+    elif check_env_flag("REL_WITH_DEB_INFO_AND_ASSERTIONS"):
+        return "RelWithDebInfoAndAssertions"
     else:
         # TODO: change to release when stable enough
-        return "RelWithDebInfo"
+        return "RelWithDebInfoAndAssertions"
 
 
 # --- third party packages -----


### PR DESCRIPTION
Enable assertions by a new CMake build type `TRITON_REL_BUILD_WITH_ASSERTS`.