### PR TITLE
[BACKEND] Remove duplicate def for create_get_program_id

### DIFF
--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -642,12 +642,6 @@ void init_triton_ir(py::module &&m) {
              return self.create<mlir::triton::MakeRangeOp>(loc, retType, start,
                                                            end);
            })
-      .def("create_get_program_id",
-           [](mlir::OpBuilder &self, int axis) -> mlir::Value {
-             auto loc = self.getUnknownLoc();
-             return self.create<mlir::triton::GetProgramIdOp>(
-                 loc, self.getI32Type(), axis);
-           })
 
       // Cast instructions
       // Conversions for custom FP types (FP8)


### PR DESCRIPTION
The same function is redefined in lines [645-650](https://github.com/openai/triton/blob/master/python/src/triton.cc#L645-L650) and [1174-1179](https://github.com/openai/triton/blob/master/python/src/triton.cc#L1174-L1179), compared these 2 definitions, looks like we should remove the code in lines 645-650.