### PR TITLE
Fixed error when compiling in systems with multiple versions of python installed

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -141,8 +141,8 @@ class CMakeBuild(build_ext):
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DTRITON_BUILD_TUTORIALS=OFF",
             "-DTRITON_BUILD_PYTHON_MODULE=ON",
-            # '-DPYTHON_EXECUTABLE=' + sys.executable,
-            '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON',
+            "-DPython3_EXECUTABLE:FILEPATH=" + sys.executable,
+            "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
         ]
         if lit_dir:

--- a/python/setup.py
+++ b/python/setup.py
@@ -144,8 +144,10 @@ class CMakeBuild(build_ext):
             # '-DPYTHON_EXECUTABLE=' + sys.executable,
             '-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON',
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
-            "-DLLVM_EXTERNAL_LIT=" + lit_dir
-        ] + thirdparty_cmake_args
+        ]
+        if lit_dir:
+            cmake_args.append("-DLLVM_EXTERNAL_LIT=" + lit_dir)
+        cmake_args += thirdparty_cmake_args
 
         # configuration
         cfg = get_build_type()

--- a/python/setup.py
+++ b/python/setup.py
@@ -144,10 +144,8 @@ class CMakeBuild(build_ext):
             "-DPython3_EXECUTABLE:FILEPATH=" + sys.executable,
             "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
-        ]
-        if lit_dir:
-            cmake_args.append("-DLLVM_EXTERNAL_LIT=" + lit_dir)
-        cmake_args += thirdparty_cmake_args
+            "-DLLVM_EXTERNAL_LIT=" + lit_dir,
+        ] + thirdparty_cmake_args
 
         # configuration
         cfg = get_build_type()


### PR DESCRIPTION
This fixes an errors when trying to compile triton on some systems:

If your system has multiple versions of python3 installed, then previous CMake would fail when trying to verify Python3 is installed. Adding the `-DPython3_EXECUTABLE:FILEPATH` argument to CMake invocation fixes this. Note that you can't do this with an environment variable because you need the `:FILEPATH` part for it to work, and this can only be given with a `-D` argument to cmake.
