### PR TITLE
[Build] Support GCC 8.x to build Triton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,8 +222,10 @@ target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
 
 if(WIN32)
     target_link_libraries(triton PRIVATE ${LLVM_LIBRARIES} dl) # dl is from dlfcn-win32
-else()
+elseif(APPLE)
     target_link_libraries(triton ${LLVM_LIBRARIES} z)
+else()
+    target_link_libraries(triton ${LLVM_LIBRARIES} z stdc++fs)
 endif()
 
 


### PR DESCRIPTION
## Problem
It seems that Triton compiled with GCC 8.x used on, for example, CentOS Stream 8, cannot be executed because of the following run-time error.

```sh 
$ lit build/$(ls build)/test
...
Traceback (most recent call last):
...
ImportError: /home/siwasaki/triton/python/triton/_C/libtriton.so: undefined symbol: _ZNKSt10filesystem7__cxx114path11parent_pathEv
```

This is because old GCC runtime library (in my case, GCC 8.x's `libstdc++`) does not contain `libstdc++fs`, according to https://github.com/mgbellemare/Arcade-Learning-Environment/issues/406.  Perhaps Ubuntu18 also uses old GCC (though its EOL is this April), so this might not be a CentOS Stream-specific issue.

## What this PR does

This PR fixes the issue by explicitly linking this `libstdc++fs` library.  This PR makes Triton buildable and executable in such an old environment as far as I checked it on CentOS Stream 8 + GCC 8.5. This change works on both Mac (GitHub Action's Mac 10.05 runner) and Ubuntu-latest (GitHub Action's Ubuntu 22 runner)

However, maybe we don't want to be bothered by an old GCC.  If so:
1. It'd be nice if we could write compiler requirement in `README.md`.
2. Otherwise, it'd be great if Triton by default uses the downloaded LLVM/Clang which should supposedly fix this issue.
