### PR TITLE
feat: Update PTX/SM support for LLVM14 (closes #950)

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -967,23 +967,12 @@ def ptx_get_version(cuda_version) -> int:
     '''
     assert isinstance(cuda_version, str)
     major, minor = map(int, cuda_version.split('.'))
-    version = major * 1000 + minor * 10
-    if version >= 11040:
-        return 74
-    if version >= 11030:
-        return 73
-    if version >= 11020:
-        return 72
-    if version >= 11010:
-        return 71
-    if version >= 11000:
-        return 70
-    if version >= 10020:
-        return 65
-    if version >= 10010:
-        return 64
-    if version >= 10000:
-        return 63
+    if major == 12:
+        return 80 + minor
+    if major == 11:
+        return 70 + minor
+    if major == 10:
+        return 63 + minor
     raise RuntimeError("Triton only support CUDA 10.0 or higher")
 
 


### PR DESCRIPTION
Summary:

LLVM 14 supports newer PTX and SM versions than LLVM 11 (the backend prior to the MLIR rewrite). This patch updates `PTXTranslation.cpp`and `compiler.py` to reflect that.

This should also close #950.

`PTXTranslation.cpp`:

- Makes a distinction between PTX version and Compute Capability
- Max PTX version is 7.5 (unchanged)
- Max Compute Capability is 8.6 (new, previously effectively limited by max PTX version)
- No longer limits the Compute Capability by the PTX version
    - Prior to this patch the PTX version was used (appended to `sm_`)
    - This should hopefully allow generation of better code for newer GPUs

`compiler.py`:

- Adds support for CUDA releases which provide PTX versions newer than 7.4
- PTX selection logic refactored to take advantage of the PTX versioning schemes used by CUDA 10, 11, and 12 (so far)