### PR TITLE
Raise an expection when pytorch tensor is not on a cuda device

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1449,6 +1449,20 @@ def test_noop(device='cuda'):
     kernel[(1, )](x)
 
 
+@pytest.mark.parametrize("device", ['cuda', 'cpu'])
+def test_pointer_arguments(device):
+    @triton.jit
+    def kernel(x):
+        pass
+    x = torch.empty(1024, device=device)
+    result = True
+    try:
+        kernel[(1,)](x)
+    except ValueError:
+        result = True if device == 'cpu' else False
+    assert result
+
+
 @pytest.mark.parametrize("value, value_type", [
     (-1, 'i32'), (0, 'i32'), (-2**31, 'i32'), (2**31 - 1, 'i32'),
     (2**31, 'u32'), (2**32 - 1, 'u32'), (2**32, 'i64'), (2**63 - 1, 'i64'),


### PR DESCRIPTION
Always raise an exception when JITFunction's argument is not on cuda.

For exampe:
`# raise exception`
`_kernel[grid](a, b.cpu())`