### PR TITLE
Fix: replaced comparison operator with in 

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -885,7 +885,7 @@ def test_f16_to_f8_rounding():
 
 
 def get_reduced_dtype(dtype_str, op):
-    if op == 'argmin' or op == 'argmax':
+    if op in ('argmin', 'argmax'):
         return 'int32'
     if dtype_str in ['int8', 'uint8', 'int16', 'uint16']:
         return 'int32'
@@ -917,7 +917,7 @@ def test_reduce1d(op, dtype_str, shape, device='cuda'):
     numpy_op = {'sum': np.sum, 'max': np.max, 'min': np.min,
                 'argmin': np.argmin, 'argmax': np.argmax}[op]
     # numpy result
-    z_dtype_str = 'int32' if op == 'argmin' or op == 'argmax' else dtype_str
+    z_dtype_str = 'int32' if op in ('argmin', 'argmax') else dtype_str
     z_tri_dtype_str = z_dtype_str
     if op not in ['argmin', 'argmax'] and dtype_str == 'bfloat16':
         z_dtype_str = 'float32'
@@ -936,7 +936,7 @@ def test_reduce1d(op, dtype_str, shape, device='cuda'):
     if op == 'sum':
         np.testing.assert_allclose(z_ref, z_tri, rtol=0.01)
     else:
-        if op == 'argmin' or op == 'argmax':
+        if op in ('argmin', 'argmax'):
             # argmin and argmax can have multiple valid indices.
             # so instead we compare the values pointed by indices
             np.testing.assert_equal(x[z_ref], x[z_tri])
@@ -1013,7 +1013,7 @@ def test_reduce2d(op, dtype_str, shape, axis, device='cuda'):
     if op == 'sum':
         np.testing.assert_allclose(z_ref, z_tri, rtol=0.01)
     else:
-        if op == 'argmin' or op == 'argmax':
+        if op in ('argmin', 'argmax'):
             # argmin and argmax can have multiple valid indices.
             # so instead we compare the values pointed by indices
             z_ref_index = np.expand_dims(z_ref, axis=axis)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -168,13 +168,13 @@ class dtype:
             return builder.get_void_ty()
         elif self.name == 'int1':
             return builder.get_int1_ty()
-        elif self.name == 'int8' or self.name == 'uint8':
+        elif self.name in ('int8', 'uint8'):
             return builder.get_int8_ty()
-        elif self.name == 'int16' or self.name == 'uint16':
+        elif self.name in ('int16', 'uint16'):
             return builder.get_int16_ty()
-        elif self.name == 'int32' or self.name == 'uint32':
+        elif self.name in ('int32', 'uint32'):
             return builder.get_int32_ty()
-        elif self.name == 'int64' or self.name == 'uint64':
+        elif self.name in ('int64', 'uint64'):
             return builder.get_int64_ty()
         elif self.name == 'fp8':
             return builder.get_fp8_ty()


### PR DESCRIPTION
To check if a variable is equal to one of many values, combine the values into a tuple and check if the variable is contained in it instead of checking for equality against each of the values. This is faster, less verbose, and more readable.