### PR TITLE
Fix: replaced unsafe exit with sys.exit

### DIFF
--- a/python/triton/tools/aot.py
+++ b/python/triton/tools/aot.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+
 import triton
 import triton._C.libtriton.triton as libtriton
 

--- a/python/triton/tools/aot.py
+++ b/python/triton/tools/aot.py
@@ -1,5 +1,5 @@
 import argparse
-
+import sys
 import triton
 import triton._C.libtriton.triton as libtriton
 
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     # check for validity of format arguments
     if args.target not in VALID_FORMATS:
         print("Invalid target format: " + args.target)
-        exit(0)
+        sys.exit(0)
 
     # parse source file to MLIR module
     context = libtriton.ir.context()
@@ -35,7 +35,7 @@ if __name__ == '__main__':
     module = triton.compiler.optimize_triton_ir(module)
     if args.target == 'triton-ir':
         print(module.str())
-        exit(0)
+        sys.exit(0)
 
     if not args.sm:
         raise argparse.ArgumentError(None, "Must specify --sm for PTX compilation")
@@ -44,13 +44,13 @@ if __name__ == '__main__':
     module = triton.compiler.ttir_to_ttgir(module, num_warps=4, num_stages=3, compute_capability=args.sm)
     if args.target == 'triton-gpu-ir':
         print(module.str())
-        exit(0)
+        sys.exit(0)
 
     # triton-gpu-ir -> llvm-ir
     module = triton.compiler.ttgir_to_llir(module, extern_libs=None, compute_capability=args.sm)
     if args.target == 'llvm-ir':
         print(module)
-        exit(0)
+        sys.exit(0)
 
     if not args.ptx_version:
         raise argparse.ArgumentError(None, "Must specify --ptx-version for PTX compilation")


### PR DESCRIPTION
The exit or quit functions don't exist at top-level if python is started with the **-S flag**, and will raise an error. Use **sys.exit()** instead.

**sys.exit()** is guaranteed to work, regardless of the interpreter options.