### PR TITLE
Add dependency to TritonTableGen in TritonAnalysis

### DIFF
--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -6,5 +6,6 @@ add_mlir_library(TritonAnalysis
   Utility.cpp
 
   DEPENDS
+  TritonTableGen
   TritonGPUAttrDefsIncGen
 )


### PR DESCRIPTION
The `TritonAnalysis` target depends on `TritonTableGen` through including `Triton/IR/Dialect.h`, which itself includes `Triton/IR/Dialect.h.inc` generated by `TritonTableGen`.

Without it, the build might fail (seems to be happening inconsistently, due to multithreaded builds) with:

```
Building CXX object
    lib/Analysis/CMakeFiles/obj.TritonAnalysis.dir/AxisInfo.cpp.o
In file included from ./include/triton/Analysis/AxisInfo.h:8,
                 from ./lib/Analysis/AxisInfo.cpp:6:
.include/triton/Dialect/Triton/IR/Dialect.h:12:10: fatal error:
  triton/Dialect/Triton/IR/Dialect.h.inc: No such file or directory
   12 | #include "triton/Dialect/Triton/IR/Dialect.h.inc"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

I can reproduce it consistently if I use the "Unix Makefiles" build system generator, and build triton manually by just
running `make`, without specifying the `-j` flag (which is what IDEs will often do automatically).