### PR TITLE
Run full triton pipeline in triton-translate

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ configure_lit_site_cfg(
 
 set(TRITON_TEST_DEPENDS
   triton-opt
+  triton-translate
   FileCheck
 )
 

--- a/test/bin/triton-translate.mlir
+++ b/test/bin/triton-translate.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-translate %s | FileCheck %s
+// RUN: triton-translate --num-warps=4 %s | FileCheck %s --check-prefix=NW4
+// RUN: triton-translate --target=ptx %s | FileCheck %s --check-prefix=PTX
+
+func @f(%arg: !tt.ptr<i32>) {
+  %barg = tt.splat %arg : (!tt.ptr<i32>) -> tensor<256x!tt.ptr<i32>>
+  %ofs = tt.make_range {start = 0 : i32, end = 256 : i32} : tensor<256xi32>
+  %ptrs = tt.addptr %barg, %ofs : tensor<256x!tt.ptr<i32>>, tensor<256xi32>
+  tt.store %ptrs, %ofs : tensor<256xi32>
+  return
+}
+
+// CHECK: asm sideeffect
+// CHECK-SAME: st.global.b32
+
+// If we have 4 warps, every thread should do 2 elements
+// NW4: st.global.b32
+// NW4: st.global.b32
+
+// PTX-NOT: asm sideeffect
+// PTX: st.global.b32


### PR DESCRIPTION
I updated `triton-translate` a bit to make my experimentation with Triton easier.
Not sure how you feel about merging this in the context of #648, but sending a patch in case you're interested anyway.

## Original commit message

At present, `triton-translate` only lowers optimized TritonGPU.

Add the same set of passes from `python/triton/compiler.py` to `triton-translate` so that it can lower high-level Triton dialect to PTX.

For now, we are duplicating the definition of the pipeline, but this can easily be unified by grouping passes into MLIR pipelines.

Compared to `triton-opt` and the python bindings, `triton-translate` has the advantage of being an easy entry point in exploring the Triton pipeline, as it can compile a program end-to-end, and print out all the intermediate steps along the way.