### PR TITLE
Still build even if lit is not installed on user's system

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -144,8 +144,10 @@ class CMakeBuild(build_ext):
             "-DPython3_EXECUTABLE:FILEPATH=" + sys.executable,
             "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
             "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
-            "-DLLVM_EXTERNAL_LIT=" + lit_dir,
-        ] + thirdparty_cmake_args
+        ]
+        if lit_dir is not None:
+            cmake_args.append("-DLLVM_EXTERNAL_LIT=" + lit_dir)
+        cmake_args.extend(thirdparty_cmake_args)
 
         # configuration
         cfg = get_build_type()


### PR DESCRIPTION
Otherwise it fails with

```
File "/scratch/ezyang/work/c/triton/python/setup.py", line 147, in build_extension
    "-DLLVM_EXTERNAL_LIT=" + lit_dir,`
TypeError: can only concatenate str (not "NoneType") to str
```

Signed-off-by: Edward Z. Yang <ezyang@meta.com>
