### PR TITLE
Add ability to bundle CUDA dependencies

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -168,6 +168,22 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=self.build_temp)
 
 
+package_data = {
+    "triton/ops": ["*.c"],
+    "triton/ops/blocksparse": ["*.c"],
+    "triton/language": ["*.bc"],
+}
+
+if os.getenv("TRITION_PACKAGE_CUDA_DEPS"):
+    base_dir = os.path.dirname(__file__)
+    cuda_dir = os.getenv("CUDA_HOME", "/usr/local/cuda")
+    triton_dir = os.path.join(base_dir, "triton")
+    os.makedirs(os.path.join(triton_dir, "include"), exist_ok=True)
+    os.makedirs(os.path.join(triton_dir, "bin"), exist_ok=True)
+    shutil.copy(os.path.join(cuda_dir, "include", "cuda.h"), os.path.join(triton_dir, "include"))
+    shutil.copy(os.path.join(cuda_dir, "bin", "ptxas"), os.path.join(triton_dir, "bin"))
+    package_data["triton"] = ["include/cuda.h", "bin/ptxas"]
+
 setup(
     name="triton",
     version="2.0.0",
@@ -182,11 +198,7 @@ setup(
         "torch",
         "lit",
     ],
-    package_data={
-        "triton/ops": ["*.c"],
-        "triton/ops/blocksparse": ["*.c"],
-        "triton/language": ["*.bc"]
-    },
+    package_data=package_data,
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={"build_ext": CMakeBuild},

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -987,6 +987,9 @@ def path_to_ptxas():
         "/usr",
         os.environ.get('CUDA_PATH', default_cuda_dir())
     ]
+    if not os.getenv("TRITON_IGNORE_BUNDLED_PTXAS"):
+        prefixes.insert(0, os.path.dirname(__file__))
+
     for prefix in prefixes:
         ptxas = os.path.join(prefix, "bin", "ptxas")
         if os.path.exists(ptxas):
@@ -1287,6 +1290,11 @@ def _build(name, src, srcdir):
     cuda_lib_dirs = libcuda_dirs()
     cuda_path = os.environ.get('CUDA_PATH', default_cuda_dir())
     cu_include_dir = os.path.join(cuda_path, "include")
+    triton_include_dir = os.path.join(os.path.dirname(__file__), "include")
+    cuda_header = os.path.join(cu_include_dir, "cuda.h")
+    triton_cuda_header = os.path.join(triton_include_dir, "cuda.h")
+    if not os.path.exists(cuda_header) and os.path.exists(triton_cuda_header):
+        cu_include_dir = triton_include_dir
     suffix = sysconfig.get_config_var('EXT_SUFFIX')
     so = os.path.join(srcdir, '{name}{suffix}'.format(name=name, suffix=suffix))
     # try to avoid setuptools if possible


### PR DESCRIPTION
Define `TRITON_PACKAGE_CUDA_DEPS` to package `ptxas` and `cuda.h` into the wheel package. In that case bundled `cuda.h` will be used if one could not be found in the path.
Also bundled `ptxas` will be used unless one decides to opt out by defining `TRITON_IGNORE_BUNDLED_PTXAS`.