### PR TITLE
Fix bf16 i8 matmul performance

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
@@ -1134,7 +1134,8 @@ public:
       if (auto intTy = elemElemTy.dyn_cast<IntegerType>()) {
         if (intTy.getWidth() <= 16) {
           elemTy = rewriter.getI32Type();
-          resTy = LLVM::LLVMStructType::getLiteral(ctx, SmallVector<Type>(4, elemTy));
+          resTy = LLVM::LLVMStructType::getLiteral(
+              ctx, SmallVector<Type>(4, elemTy));
         }
       }
     }

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
@@ -1252,7 +1252,8 @@ public:
         }
       }
 
-      return {i8v4Elems[0], i8v4Elems[1], i8v4Elems[2], i8v4Elems[3]};
+      return {bitcast(i8v4Elems[0], i32_ty), bitcast(i8v4Elems[1], i32_ty),
+              bitcast(i8v4Elems[2], i32_ty), bitcast(i8v4Elems[3], i32_ty)};
     }
 
     assert(false && "Invalid smem load");

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.h
@@ -97,6 +97,15 @@ public:
           Type targetTy;
           if (targetTyMap.count(elemTy.getIntOrFloatBitWidth())) {
             targetTy = targetTyMap.lookup(elemTy.getIntOrFloatBitWidth());
+            // <2xi16>/<4xi8> => i32
+            // We are doing this because NVPTX inserts extra integer instrs to
+            // pack & unpack vectors of sub-word integers
+            // Note: this needs to be synced with
+            //       DotOpMmaV2ConversionHelper::loadX4
+            if (elemTy.isa<IntegerType>() &&
+                (elemTy.getIntOrFloatBitWidth() == 8 ||
+                 elemTy.getIntOrFloatBitWidth() == 16))
+              targetTy = IntegerType::get(ctx, 32);
           } else {
             assert(false && "Unsupported element type");
           }

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -161,7 +161,8 @@ LogicalResult Prefetcher::initialize() {
     auto kSize = dot.a().getType().cast<RankedTensorType>().getShape()[1];
 
     // works better with nvidia tensor cores
-    unsigned elementWidth = dot.a().getType().cast<RankedTensorType>().getElementTypeBitWidth();
+    unsigned elementWidth =
+        dot.a().getType().cast<RankedTensorType>().getElementTypeBitWidth();
     prefetchWidth = 256 / elementWidth;
 
     // Skip prefetching if kSize is less than prefetchWidth

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -159,6 +159,11 @@ LogicalResult Prefetcher::initialize() {
 
   for (triton::DotOp dot : dotsInFor) {
     auto kSize = dot.a().getType().cast<RankedTensorType>().getShape()[1];
+
+    // works better with nvidia tensor cores
+    unsigned elementWidth = dot.a().getType().cast<RankedTensorType>().getElementTypeBitWidth();
+    prefetchWidth = 256 / elementWidth;
+
     // Skip prefetching if kSize is less than prefetchWidth
     if (kSize < prefetchWidth)
       continue;


### PR DESCRIPTION
Use i32 as the storage type for <2xi16> and <4xi8>, as NVPTX inserts extra integer instructions for vector int types.

Performance before this PR: (8192x8192x8192-TN input)
bf16: 222 TFLOPS
i8:     339 TOPS

After this PR:
bf16: 272 TFLOPS
i8:      548 TOPS