### PR TITLE
Fix restoration of llir IR from cache to give a string.

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1545,7 +1545,7 @@ def compile(fn, **kwargs):
                  lambda src: ast_to_ttir(src, signature, configs[0], constants)),
         "ttgir": (lambda path: _triton.ir.parse_mlir_module(path, context),
                   lambda src: ttir_to_ttgir(src, num_warps, num_stages, capability)),
-        "llir": (lambda path: Path(path).read_bytes(),
+        "llir": (lambda path: Path(path).read_text(),
                  lambda src: ttgir_to_llir(src, extern_libs, capability)),
         "ptx": (lambda path: Path(path).read_text(),
                 lambda src: llir_to_ptx(src, capability)),


### PR DESCRIPTION
Since the llir IR is a string when it is first generated, it should also be a string when we fetch it from the cache.

The original read_bytes() implementation is causing a pytorch 2.0/inductor unit test failure:

`python3 -bb test/inductor/test_torchinductor.py -v CudaTests.test_elu_cuda`

When the test is run with the -bb flag, attempts to convert a byte array to a string result in an error.