### PR TITLE
[BACKEND] Hotfix to remove SameOperandsAndResultEncoding for the trans operation

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -294,8 +294,7 @@ def TT_CatOp : TT_Op<"cat", [NoSideEffect,
 
 def TT_TransOp : TT_Op<"trans", [NoSideEffect,
                                  DeclareOpInterfaceMethods<InferTypeOpInterface>,
-                                 SameOperandsAndResultElementType,
-                                 SameOperandsAndResultEncoding]> {
+                                 SameOperandsAndResultElementType]> {
 
     let summary = "transpose a tensor";
 


### PR DESCRIPTION
The order of the input encoding is permuted to form the output encoding.

For example:

```
#A_SHARED = #triton_gpu.shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
#A_SHARED_T = #triton_gpu.shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [0, 1]}>
%b = tt.trans %tensor : (tensor<16x32xf16, #A_SHARED>) -> tensor<32x16xf16, #A_SHARED_T>
```