### PR TITLE
[Build] Prevent excessive hyphens from causing build errors.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -193,7 +193,7 @@ class CMakeBuild(build_ext):
         else:
             import multiprocessing
             cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
-            build_args += ["--", '-j' + str(2 * multiprocessing.cpu_count())]
+            build_args += ['-j' + str(2 * multiprocessing.cpu_count())]
 
         env = os.environ.copy()
         subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=self.build_temp, env=env)


### PR DESCRIPTION
Prevents excessive hyphens from causing build errors on non-Windows machines.