### PR TITLE
[FRONTEND] For __rshift__ operator, use arithmetic right shift if dtype is a signed int.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -330,7 +330,10 @@ def test_bitwise_op(dtype_x, dtype_y, op, device='cuda'):
 def test_shift_op(dtype_x, dtype_y, op, device='cuda'):
     expr = f'x {op} y'
     bw = max(_bitwidth(dtype_x), _bitwidth(dtype_y))
-    dtype_z = f'uint{bw}'
+    if dtype_x.startswith('int'):
+        dtype_z = f'int{bw}'
+    else:
+        dtype_z = f'uint{bw}'
     numpy_expr = f'x.astype(np.{dtype_z}) {op} y.astype(np.{dtype_z})'
     _test_binary(dtype_x, dtype_y, expr, numpy_expr, device=device, y_low=0, y_high=65)
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -549,7 +549,10 @@ class tensor:
     @builtin
     def __rshift__(self, other, _builder=None):
         other = _to_tensor(other, _builder)
-        return semantic.lshr(self, other, _builder)
+        if self.dtype.is_int_signed():
+            return semantic.ashr(self, other, _builder)
+        else:
+            return semantic.lshr(self, other, _builder)
 
     # comparison operators
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -324,11 +324,13 @@ def lshr(input: tl.tensor,
     input, other = bitwise_op_type_checking_impl(input, other, builder)
     return tl.tensor(builder.create_lshr(input.handle, other.handle), input.type)
 
+
 def ashr(input: tl.tensor,
          other: tl.tensor,
          builder: ir.builder) -> tl.tensor:
     input, other = bitwise_op_type_checking_impl(input, other, builder)
     return tl.tensor(builder.create_ashr(input.handle, other.handle), input.type)
+
 
 def shl(input: tl.tensor,
         other: tl.tensor,

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -324,6 +324,11 @@ def lshr(input: tl.tensor,
     input, other = bitwise_op_type_checking_impl(input, other, builder)
     return tl.tensor(builder.create_lshr(input.handle, other.handle), input.type)
 
+def ashr(input: tl.tensor,
+         other: tl.tensor,
+         builder: ir.builder) -> tl.tensor:
+    input, other = bitwise_op_type_checking_impl(input, other, builder)
+    return tl.tensor(builder.create_ashr(input.handle, other.handle), input.type)
 
 def shl(input: tl.tensor,
         other: tl.tensor,


### PR DESCRIPTION

Previously it was always using logical right shift, which gives wrong results for signed inputs.