### PR TITLE
[FRONTEND] Check if the data types of *A* and *B* in the dot op have the same data type

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -999,6 +999,7 @@ def dot(lhs: tl.tensor,
         allow_tf32: bool,
         builder: ir.builder) -> tl.tensor:
     assert lhs.type.is_block() and rhs.type.is_block()
+    assert lhs.dtype == rhs.dtype, "lhs and rhs must have the same dtype!"
     assert len(lhs.shape) == 2 and len(rhs.shape) == 2
     assert lhs.shape[1].value == rhs.shape[0].value
     assert lhs.shape[0].value >= 16 and lhs.shape[1].value >= 16 \


### PR DESCRIPTION
Check dot operands at early stage before lowering so that users can understand the errors.

We cannot enforce the `SameOperandsElementType` checks in the IR definition because *C* can have a different element type than *A* or *B*.

Example:

```Python
def _kernel(a, b, c, d, e, i0_shape: tl.constexpr, i1_shape: tl.constexpr, i2_shape: tl.constexpr, i3_shape: tl.constexpr, i0_BLOCK: tl.constexpr, i2_BLOCK: tl.constexpr, i1_BLOCK: tl.constexpr, i3_BLOCK: tl.constexpr):
    i0 = tl.program_id(0)
    d_ptrs = ((((d + ((i0 * i0_BLOCK) * i2_shape)) + (0 * i2_BLOCK)) + (tl.arange(0, i0_BLOCK) * i2_shape)[:, None]) + tl.arange(0, i2_BLOCK)[None, :])
    i3 = 0
    _shared0 = tl.zeros([i0_BLOCK, i3_BLOCK], tl.float32)
    for i2 in range((i2_shape // i2_BLOCK)):
        _shared1 = tl.zeros([i0_BLOCK, i2_BLOCK], tl.float32)
        for i1 in range((i1_shape // i1_BLOCK)):
            a_ptrs = (((a + (i1 * i1_BLOCK)) + (((i0 * i0_BLOCK) + tl.arange(0, i0_BLOCK))[:, None] * i1_shape)) + tl.arange(0, i1_BLOCK)[None, :])
            a_vals = tl.load(a_ptrs)
            b_ptrs = (((b + (i2 * i2_BLOCK)) + (((i1 * i1_BLOCK) + tl.arange(0, i1_BLOCK))[:, None] * i2_shape)) + tl.arange(0, i2_BLOCK)[None, :])
            b_vals = tl.load(b_ptrs)
            _shared1 += tl.dot(a_vals, b_vals)
        #tl.store(d_ptrs, _shared1)
        #_shared1 = tl.load(d_ptrs)
        #_shared1 = _shared1.to(tl.float16)
        i3 = 0
        c_ptrs = (((c + (i3 * i3_BLOCK)) + (((i2 * i2_BLOCK) + tl.arange(0, i2_BLOCK))[:, None] * i3_shape)) + tl.arange(0, i3_BLOCK)[None, :])
        c_vals = tl.load(c_ptrs)
        _shared0 += tl.dot(_shared1, c_vals) # <------------- _shared1 is float32, which doesn't match c_vals
    e_ptrs = (((e + (i3 * i3_BLOCK)) + (((i0 * i0_BLOCK) + tl.arange(0, i0_BLOCK))[:, None] * i3_shape)) + tl.arange(0, i3_BLOCK)[None, :])
    tl.store(e_ptrs, _shared0)
```

Without the PR, we may see very confusing error messages as shown below:

> SmallVector.h:273: T& llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::operator[](llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::size_type) [with T = mlir::Value; <template-parameter-1-2> = void; llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::reference = mlir::Value&; llvm::SmallVectorTemplateCommon<T, <template-parameter-1-2> >::size_type = long unsigned int]: Assertion `idx < size()' failed.