### PR TITLE
[FRONTEND] Fix bug when the `_SYSPATH` is set.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -79,9 +79,9 @@ def get_thirdparty_packages(triton_cache_path):
     for p in packages:
         package_root_dir = os.path.join(triton_cache_path, p.package)
         package_dir = os.path.join(package_root_dir, p.name)
-        test_file_path = os.path.join(package_dir, p.test_file)
         if p.syspath_var_name in os.environ:
             package_dir = os.environ[p.syspath_var_name]
+        test_file_path = os.path.join(package_dir, p.test_file)
         if not os.path.exists(test_file_path):
             try:
                 shutil.rmtree(package_root_dir)


### PR DESCRIPTION
When the user specifies third-party packages using system env like `PYBIND11_SYSPATH`,  the `test_file_path` should be set after `package_dir` is updated.

This happens when the user wants to use custom pybind11 or llvm by setting system env like:

```Bash
$export PYBIND11_SYSPATH=.../python3.10/site-packages/pybind11/
$export LLVM_SYSPATH=.../llvm/build/install/
$cd triton/python
$python setup.py develop
```