### PR TITLE
Remove unused global var

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -216,7 +216,7 @@ setup(
         "torch",
         "lit",
     ],
-    package_data={"triton": ["third_party/*"]},
+    package_data={"triton": ["third_party/**/*"]},
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
     cmdclass={"build_ext": CMakeBuild},

--- a/python/setup.py
+++ b/python/setup.py
@@ -200,12 +200,6 @@ class CMakeBuild(build_ext):
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=self.build_temp)
 
 
-package_data = {
-    "triton/ops": ["*.c"],
-    "triton/ops/blocksparse": ["*.c"],
-    "triton/language": ["*.bc"],
-}
-
 download_and_copy_ptxas()
 
 setup(


### PR DESCRIPTION
`package_data` is no longer referenced from anywhere.

Use `third_party/**/*` wildcard to package contents of subfolders