### PR TITLE
Search for `libdevice` relative to shared library

### DIFF
--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -24,7 +24,7 @@ void MembarAnalysis::dfsOperation(Operation *operation,
     // scf.if only: two regions
     // scf.for: one region
     RegionInfo curRegionInfo;
-    auto traverseRegions = [&]() -> auto {
+    auto traverseRegions = [&]() -> auto{
       for (auto &region : operation->getRegions()) {
         // Copy the parent info as the current info.
         RegionInfo regionInfo = *parentRegionInfo;

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -24,7 +24,7 @@ void MembarAnalysis::dfsOperation(Operation *operation,
     // scf.if only: two regions
     // scf.for: one region
     RegionInfo curRegionInfo;
-    auto traverseRegions = [&]() -> auto{
+    auto traverseRegions = [&]() -> auto {
       for (auto &region : operation->getRegions()) {
         // Copy the parent info as the current info.
         RegionInfo regionInfo = *parentRegionInfo;

--- a/lib/Target/LLVMIR/LLVMIRTranslation.cpp
+++ b/lib/Target/LLVMIR/LLVMIRTranslation.cpp
@@ -18,8 +18,8 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/Support/SourceMgr.h"
-#include <filesystem>
 #include <dlfcn.h>
+#include <filesystem>
 
 namespace mlir {
 namespace triton {
@@ -123,38 +123,34 @@ static std::map<std::string, std::string> getExternLibs(mlir::ModuleOp module) {
     // Then native code is in `triton/_C/libtriton.so` and libdevice in
     // `triton/third_party/cuda/lib/libdevice.10.bc`
     static const auto this_library_path = [] {
-        Dl_info fileinfo;
-        if (dladdr(reinterpret_cast<void*>(&getExternLibs), &fileinfo) == 0) {
-          return std::filesystem::path();
-        }
-        return std::filesystem::path(fileinfo.dli_fname);
+      Dl_info fileinfo;
+      if (dladdr(reinterpret_cast<void *>(&getExternLibs), &fileinfo) == 0) {
+        return std::filesystem::path();
+      }
+      return std::filesystem::path(fileinfo.dli_fname);
     }();
-    static const auto runtime_path = this_library_path
-                                         .parent_path()
-                                         .parent_path() /
-                                     "third_party" / "cuda" / "lib" /
-                                     "libdevice.10.bc";
+    static const auto runtime_path =
+        this_library_path.parent_path().parent_path() / "third_party" / "cuda" /
+        "lib" / "libdevice.10.bc";
     if (fs::exists(runtime_path)) {
-        externLibs.try_emplace(libdevice, runtime_path.string());
+      externLibs.try_emplace(libdevice, runtime_path.string());
     } else {
-      // When using the Math Dialect, it is possible that some ops (e.g., log) are
-      // lowered to a function call. In this case, we need to link libdevice
+      // When using the Math Dialect, it is possible that some ops (e.g., log)
+      // are lowered to a function call. In this case, we need to link libdevice
       // using its default path:
       // [triton root dir]/python/triton/language/libdevice.10.bc
       // TODO(Keren): handle external linkage other than libdevice?
       static const auto this_file_path = std::filesystem::path(__FILE__);
-      static const auto compiletime_path = this_file_path
-                                               .parent_path()
+      static const auto compiletime_path = this_file_path.parent_path()
                                                .parent_path()
                                                .parent_path()
                                                .parent_path() /
-                                           "python" / "triton" /
-                                           "third_party" / "cuda" / "lib" /
-                                           "libdevice.10.bc";
+                                           "python" / "triton" / "third_party" /
+                                           "cuda" / "lib" / "libdevice.10.bc";
       if (!fs::exists(compiletime_path)) {
         std::string error_msg = "Can't find libdevice at neither " +
-                                 runtime_path.string() + " nor " +
-                                 compiletime_path.string();
+                                runtime_path.string() + " nor " +
+                                compiletime_path.string();
         llvm::report_fatal_error(error_msg.c_str());
       }
       externLibs.try_emplace(libdevice, compiletime_path.string());


### PR DESCRIPTION
If Triton is shipped as shared library inside python package, search for `libdevice.10.bc` relative to this library installation path: Triton package installation looks as follows
```
triton/
       _C/libtriton.so
       third_party/cuda/lib/libdevice.10.bc
```

Test plan:
```sh
CXX=g++-9 pip install git+https://github.com/malfet/triton@5a0fe18751bc15c7035916de55e0892e63c3db77#subdirectory=python
```
And run following:
```python
import torch

def foo(x: torch.Tensor) -> torch.Tensor:
   return torch.sin(x) + torch.cos(x)

if __name__=="__main__":
    x = torch.rand(3, 3, device="cuda")
    x_eager = foo(x)
    x_pt2 = torch.compile(foo)(x)
    print(torch.allclose(x_eager, x_pt2))
```