### PR TITLE
[FRONTEND] fix implicit broadcasting semantics

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -377,25 +377,26 @@ def test_compare_op(dtype_x, dtype_y, op, mode_x, mode_y, device='cuda'):
 @pytest.mark.parametrize("dtype", dtypes_with_bfloat16 + ["*int32"])
 def test_broadcast(dtype):
     @triton.jit
-    def broadcast_kernel(x_ptr, y_ptr, y_broadcasted_ptr, BLOCK_SIZE: tl.constexpr):
-        offset1 = tl.arange(0, BLOCK_SIZE)
-        offset2 = tl.arange(0, BLOCK_SIZE)
-        x = tl.load(x_ptr + BLOCK_SIZE * offset1[:, None] + offset2[None, :])
+    def broadcast_kernel(x_ptr, y_ptr, y_broadcasted_ptr, M: tl.constexpr, N: tl.constexpr):
+        offset1 = tl.arange(0, M)
+        offset2 = tl.arange(0, N)
+        x = tl.load(x_ptr + N * offset1[:, None] + offset2[None, :])
         y = tl.load(y_ptr + offset2)
         _, y_broadcasted = tl.broadcast(x, y)
-        tl.store(y_broadcasted_ptr + BLOCK_SIZE * offset1[:, None] + offset2[None, :], y_broadcasted)
+        tl.store(y_broadcasted_ptr + N * offset1[:, None] + offset2[None, :], y_broadcasted)
 
-    SIZE = 32
+    M = 32
+    N = 64
     rs = RandomState(17)
-    x = numpy_random((SIZE, SIZE), dtype_str=dtype, rs=rs)
-    y = numpy_random(SIZE, dtype_str=dtype, rs=rs)
+    x = numpy_random((M, N), dtype_str=dtype, rs=rs)
+    y = numpy_random(N, dtype_str=dtype, rs=rs)
     _, y_broadcasted_np = np.broadcast_arrays(x, y)
 
     x_tri = to_triton(x, device='cuda', dst_type=dtype)
     y_tri = to_triton(y, device='cuda', dst_type=dtype)
-    y_broadcasted_tri = to_triton(np.empty((SIZE, SIZE), dtype=y_broadcasted_np.dtype), device='cuda', dst_type=dtype)
+    y_broadcasted_tri = to_triton(np.empty((M, N), dtype=y_broadcasted_np.dtype), device='cuda', dst_type=dtype)
 
-    broadcast_kernel[(1,)](x_tri, y_tri, y_broadcasted_tri, BLOCK_SIZE=SIZE)
+    broadcast_kernel[(1,)](x_tri, y_tri, y_broadcasted_tri, M=M, N=N)
     assert (y_broadcasted_np == to_numpy(y_broadcasted_tri)).all()
 
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -372,6 +372,34 @@ def test_compare_op(dtype_x, dtype_y, op, mode_x, mode_y, device='cuda'):
 
 
 # ---------------
+# test broadcast
+# ---------------
+@pytest.mark.parametrize("dtype", dtypes_with_bfloat16 + ["*int32"])
+def test_broadcast(dtype):
+    @triton.jit
+    def broadcast_kernel(x_ptr, y_ptr, y_broadcasted_ptr, BLOCK_SIZE: tl.constexpr):
+        offset1 = tl.arange(0, BLOCK_SIZE)
+        offset2 = tl.arange(0, BLOCK_SIZE)
+        x = tl.load(x_ptr + BLOCK_SIZE * offset1[:, None] + offset2[None, :])
+        y = tl.load(y_ptr + offset2)
+        _, y_broadcasted = tl.broadcast(x, y)
+        tl.store(y_broadcasted_ptr + BLOCK_SIZE * offset1[:, None] + offset2[None, :], y_broadcasted)
+
+    SIZE = 32
+    rs = RandomState(17)
+    x = numpy_random((SIZE, SIZE), dtype_str=dtype, rs=rs)
+    y = numpy_random(SIZE, dtype_str=dtype, rs=rs)
+    _, y_broadcasted_np = np.broadcast_arrays(x, y)
+
+    x_tri = to_triton(x, device='cuda', dst_type=dtype)
+    y_tri = to_triton(y, device='cuda', dst_type=dtype)
+    y_broadcasted_tri = to_triton(np.empty((SIZE, SIZE), dtype=y_broadcasted_np.dtype), device='cuda', dst_type=dtype)
+
+    broadcast_kernel[(1,)](x_tri, y_tri, y_broadcasted_tri, BLOCK_SIZE=SIZE)
+    assert (y_broadcasted_np == to_numpy(y_broadcasted_tri)).all()
+
+
+# ---------------
 # test where
 # ---------------
 @pytest.mark.parametrize("dtype", dtypes_with_bfloat16 + ["*int32"])

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -577,13 +577,13 @@ def broadcast_impl_value(lhs: tl.tensor,
         if len(lhs_shape) < len(rhs_shape):
             # Add new axes to lhs
             for dim in range(len(lhs_shape), len(rhs_shape)):
-                lhs = tl.tensor(builder.create_expand_dims(lhs.handle, dim), tl.block_type(lhs_ty.scalar, lhs_shape + [1]))
+                lhs = tl.tensor(builder.create_expand_dims(lhs.handle, 0), tl.block_type(lhs_ty.scalar, [1] + lhs_shape))
                 lhs_ty = lhs.type
                 lhs_shape = lhs_ty.get_block_shapes()
         elif len(rhs_shape) < len(lhs_shape):
             # Add new axes to rhs
             for dim in range(len(rhs_shape), len(lhs_shape)):
-                rhs = tl.tensor(builder.create_expand_dims(rhs.handle, dim), tl.block_type(rhs_ty.scalar, rhs_shape + [1]))
+                rhs = tl.tensor(builder.create_expand_dims(rhs.handle, 0), tl.block_type(rhs_ty.scalar, [1] + rhs_shape))
                 rhs_ty = rhs.type
                 rhs_shape = rhs_ty.get_block_shapes()
         assert len(rhs_shape) == len(lhs_shape)


### PR DESCRIPTION
Based on #1175, shapes are supposed to be left-padded with ones when there is a rank mismatch. A test is added to ensure the behavior aligns with NumPy's `broadcast_arrays`.

