### PR TITLE
[FRONTEND] Now using symbol-dce in `optimize_triton_ir`

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -966,6 +966,7 @@ def optimize_triton_ir(mod):
     pm.add_canonicalizer_pass()
     pm.add_cse_pass()
     pm.add_licm_pass()
+    pm.add_symbol_dce_pass()
     pm.run(mod)
     return mod
 


### PR DESCRIPTION
This will removed unused private functions after we've inlined everything. That's important because TritonToTritonGPU doesn't know how to lower tensor arguments.