### PR TITLE
[FRONTEND] fixed pinned memory exception behavior

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1463,18 +1463,18 @@ def test_noop(device='cuda'):
     kernel[(1, )](x)
 
 
-@pytest.mark.parametrize("device", ['cuda', 'cpu'])
+@pytest.mark.parametrize("device", ['cuda', 'cpu', 'cpu_pinned'])
 def test_pointer_arguments(device):
     @triton.jit
     def kernel(x):
         pass
-    x = torch.empty(1024, device=device)
-    result = True
-    try:
+    pin_memory = 'pinned' in device
+    x = torch.empty(1024, device=device.split('_')[0], pin_memory=pin_memory)
+    if device == "cpu":
+      with pytest.raises(ValueError):
         kernel[(1,)](x)
-    except ValueError:
-        result = True if device == 'cpu' else False
-    assert result
+    else:
+      kernel[(1, )](x)
 
 
 @pytest.mark.parametrize("value, value_type", [

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1471,10 +1471,10 @@ def test_pointer_arguments(device):
     pin_memory = 'pinned' in device
     x = torch.empty(1024, device=device.split('_')[0], pin_memory=pin_memory)
     if device == "cpu":
-      with pytest.raises(ValueError):
-        kernel[(1,)](x)
+        with pytest.raises(ValueError):
+            kernel[(1,)](x)
     else:
-      kernel[(1, )](x)
+        kernel[(1, )](x)
 
 
 @pytest.mark.parametrize("value, value_type", [

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1222,16 +1222,16 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
       return ptr_info;
     }}
     ptr_info.dev_ptr = PyLong_AsUnsignedLongLong(ret);
-    unsigned attr;
-    CUresult status =
-        cuPointerGetAttribute(&attr, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, ptr_info.dev_ptr);
-    if (ptr_info.dev_ptr &&
-        (!(attr == CU_MEMORYTYPE_DEVICE || attr == CU_MEMORYTYPE_UNIFIED) ||
-         !(status == CUDA_SUCCESS))) {{
+    if(!ptr_info.dev_ptr)
+      return ptr_info;
+    uint64_t dev_ptr;
+    int status = cuPointerGetAttribute(&dev_ptr, CU_POINTER_ATTRIBUTE_DEVICE_POINTER, ptr_info.dev_ptr);
+    if (status == CUDA_ERROR_INVALID_VALUE) {{
         PyErr_Format(PyExc_ValueError,
                      "Pointer argument (at %d) cannot be accessed from Triton (cpu tensor?)", idx);
         ptr_info.valid = false;
     }}
+    ptr_info.dev_ptr = dev_ptr;
     return ptr_info;
   }}
   PyErr_SetString(PyExc_TypeError, "Pointer argument must be either uint64 or have data_ptr method");


### PR DESCRIPTION
no longer raise exception when the pointer is on "cpu" but also accessible from within kernels (e.g., pinned memory)