### PR TITLE
Changed for loop to iterate by 1 in matmuls

### DIFF
--- a/python/triton/ops/matmul.py
+++ b/python/triton/ops/matmul.py
@@ -94,8 +94,9 @@ def _kernel(A, B, C, M, N, K,
             a = tl.load(A)
             b = tl.load(B)
         else:
-            a = tl.load(A, mask=rk[None, :] < k, other=0.)
-            b = tl.load(B, mask=rk[:, None] < k, other=0.)
+            k_remaining = K - k * (BLOCK_K * SPLIT_K)
+            a = tl.load(A, mask=rk[None, :] < k_remaining, other=0.)
+            b = tl.load(B, mask=rk[:, None] < k_remaining, other=0.)
         acc += tl.dot(a, b)
         A += BLOCK_K * SPLIT_K * stride_ak
         B += BLOCK_K * SPLIT_K * stride_bk

--- a/python/triton/ops/matmul.py
+++ b/python/triton/ops/matmul.py
@@ -71,8 +71,8 @@ def _kernel(A, B, C, M, N, K,
     # matrix multiplication
     pid = tl.program_id(0)
     pid_z = tl.program_id(1)
-    grid_m = (M + BLOCK_M - 1) // BLOCK_M
-    grid_n = (N + BLOCK_N - 1) // BLOCK_N
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
     # re-order program ID for better L2 performance
     width = GROUP_M * grid_n
     group_id = pid // width
@@ -89,7 +89,7 @@ def _kernel(A, B, C, M, N, K,
     A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
     B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=ACC_TYPE)
-    for k in range(K, 0, -BLOCK_K * SPLIT_K):
+    for k in range(0, tl.cdiv(K, BLOCK_K * SPLIT_K)):
         if EVEN_K:
             a = tl.load(A)
             b = tl.load(B)

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -187,6 +187,7 @@ def matmul_kernel(
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_k = tl.cdiv(K, BLOCK_SIZE_K)
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
     group_id = pid // num_pid_in_group
     first_pid_m = group_id * GROUP_SIZE_M
@@ -213,7 +214,7 @@ def matmul_kernel(
     # of fp32 values for higher accuracy.
     # `accumulator` will be converted back to fp16 after the loop
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, K, BLOCK_SIZE_K):
+    for k in range(0, num_pid_k):
         # Note that for simplicity, we don't apply a mask here.
         # This means that if K is not a multiple of BLOCK_SIZE_K,
         # this will access out-of-bounds memory and produce an


### PR DESCRIPTION
For the new MLIR backend, this appears to increase matmul perf significantly in many cases.

<img width="1091" alt="image" src="https://user-images.githubusercontent.com/6355099/219252937-47fcc7f7-f24d-43c5-8f54-bb61e308e8a8.png">

The TTIR changes:


<details closed>
<summary>Old</summary>
<br>

```
module {
  func public @matmul_kernel_0d1d2d3d4d5d6d7c8d9c10d11c(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) {
    %c32_i32 = arith.constant 32 : i32
    %cst = arith.constant dense<32> : tensor<128x32xi32>
    %c32 = arith.constant 32 : index
    %c0 = arith.constant 0 : index
    %c128_i32 = arith.constant 128 : i32
    %c127_i32 = arith.constant 127 : i32
    %c8_i32 = arith.constant 8 : i32
    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
    %0 = tt.get_program_id {axis = 0 : i32} : i32
    %1 = arith.addi %arg3, %c127_i32 : i32
    %2 = arith.divsi %1, %c128_i32 : i32
    %3 = arith.addi %arg4, %c127_i32 : i32
    %4 = arith.divsi %3, %c128_i32 : i32
    %5 = arith.muli %4, %c8_i32 : i32
    %6 = arith.divsi %0, %5 : i32
    %7 = arith.muli %6, %c8_i32 : i32
    %8 = arith.subi %2, %7 : i32
    %9 = arith.cmpi slt, %8, %c8_i32 : i32
    %10 = select %9, %8, %c8_i32 : i32
    %11 = arith.remsi %0, %10 : i32
    %12 = arith.addi %7, %11 : i32
    %13 = arith.remsi %0, %5 : i32
    %14 = arith.divsi %13, %10 : i32
    %15 = arith.muli %12, %c128_i32 : i32
    %16 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
    %17 = tt.splat %15 : (i32) -> tensor<128xi32>
    %18 = arith.addi %17, %16 : tensor<128xi32>
    %19 = arith.muli %14, %c128_i32 : i32
    %20 = tt.splat %19 : (i32) -> tensor<128xi32>
    %21 = arith.addi %20, %16 : tensor<128xi32>
    %22 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
    %23 = tt.expand_dims %18 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
    %24 = tt.splat %arg6 : (i32) -> tensor<128x1xi32>
    %25 = arith.muli %23, %24 : tensor<128x1xi32>
    %26 = tt.expand_dims %22 {axis = 0 : i32} : (tensor<32xi32>) -> tensor<1x32xi32>
    %27 = tt.broadcast %25 : (tensor<128x1xi32>) -> tensor<128x32xi32>
    %28 = tt.broadcast %26 : (tensor<1x32xi32>) -> tensor<128x32xi32>
    %29 = arith.addi %27, %28 : tensor<128x32xi32>
    %30 = tt.splat %arg0 : (!tt.ptr<f16>) -> tensor<128x32x!tt.ptr<f16>>
    %31 = tt.addptr %30, %29 : tensor<128x32x!tt.ptr<f16>>, tensor<128x32xi32>
    %32 = tt.expand_dims %22 {axis = 1 : i32} : (tensor<32xi32>) -> tensor<32x1xi32>
    %33 = tt.splat %arg7 : (i32) -> tensor<32x1xi32>
    %34 = arith.muli %32, %33 : tensor<32x1xi32>
    %35 = tt.expand_dims %21 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
    %36 = tt.broadcast %34 : (tensor<32x1xi32>) -> tensor<32x128xi32>
    %37 = tt.broadcast %35 : (tensor<1x128xi32>) -> tensor<32x128xi32>
    %38 = arith.addi %36, %37 : tensor<32x128xi32>
    %39 = tt.splat %arg1 : (!tt.ptr<f16>) -> tensor<32x128x!tt.ptr<f16>>
    %40 = tt.addptr %39, %38 : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
    %41 = arith.index_cast %arg5 : i32 to index
    %42 = arith.muli %arg7, %c32_i32 : i32
    %43 = tt.splat %42 : (i32) -> tensor<32x128xi32>
    %44:3 = scf.for %arg9 = %c0 to %41 step %c32 iter_args(%arg10 = %cst_0, %arg11 = %31, %arg12 = %40) -> (tensor<128x128xf32>, tensor<128x32x!tt.ptr<f16>>, tensor<32x128x!tt.ptr<f16>>) {
      %60 = tt.load %arg11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x32xf16>
      %61 = tt.load %arg12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x128xf16>
      %62 = tt.dot %60, %61, %arg10 {allowTF32 = true} : tensor<128x32xf16> * tensor<32x128xf16> -> tensor<128x128xf32>
      %63 = tt.addptr %arg11, %cst : tensor<128x32x!tt.ptr<f16>>, tensor<128x32xi32>
      %64 = tt.addptr %arg12, %43 : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
      scf.yield %62, %63, %64 : tensor<128x128xf32>, tensor<128x32x!tt.ptr<f16>>, tensor<32x128x!tt.ptr<f16>>
    }
    %45 = arith.truncf %44#0 : tensor<128x128xf32> to tensor<128x128xf16>
    %46 = tt.splat %arg8 : (i32) -> tensor<128x1xi32>
    %47 = arith.muli %46, %23 : tensor<128x1xi32>
    %48 = tt.splat %arg2 : (!tt.ptr<f16>) -> tensor<128x1x!tt.ptr<f16>>
    %49 = tt.addptr %48, %47 : tensor<128x1x!tt.ptr<f16>>, tensor<128x1xi32>
    %50 = tt.broadcast %49 : (tensor<128x1x!tt.ptr<f16>>) -> tensor<128x128x!tt.ptr<f16>>
    %51 = tt.broadcast %35 : (tensor<1x128xi32>) -> tensor<128x128xi32>
    %52 = tt.addptr %50, %51 : tensor<128x128x!tt.ptr<f16>>, tensor<128x128xi32>
    %53 = tt.splat %arg3 : (i32) -> tensor<128x1xi32>
    %54 = arith.cmpi slt, %23, %53 : tensor<128x1xi32>
    %55 = tt.splat %arg4 : (i32) -> tensor<1x128xi32>
    %56 = arith.cmpi slt, %35, %55 : tensor<1x128xi32>
    %57 = tt.broadcast %54 : (tensor<128x1xi1>) -> tensor<128x128xi1>
    %58 = tt.broadcast %56 : (tensor<1x128xi1>) -> tensor<128x128xi1>
    %59 = arith.andi %57, %58 : tensor<128x128xi1>
    tt.store %52, %45, %59 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf16>
    return
  }
}
```
</details>

<details closed>
<summary>New</summary>
<br>

```
module {
  func public @matmul_kernel_2_0d1d2d3d4d5d6d7c8d9c10d11c(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg3: i32 {tt.divisibility = 16 : i32}, %arg4: i32 {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}) {
    %cst = arith.constant dense<32> : tensor<128x32xi32>
    %c1 = arith.constant 1 : index
    %c0 = arith.constant 0 : index
    %c128_i32 = arith.constant 128 : i32
    %c127_i32 = arith.constant 127 : i32
    %c8_i32 = arith.constant 8 : i32
    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf32>
    %c32_i32 = arith.constant 32 : i32
    %c31_i32 = arith.constant 31 : i32
    %0 = tt.get_program_id {axis = 0 : i32} : i32
    %1 = arith.addi %arg3, %c127_i32 : i32
    %2 = arith.divsi %1, %c128_i32 : i32
    %3 = arith.addi %arg4, %c127_i32 : i32
    %4 = arith.divsi %3, %c128_i32 : i32
    %5 = arith.muli %4, %c8_i32 : i32
    %6 = arith.divsi %0, %5 : i32
    %7 = arith.muli %6, %c8_i32 : i32
    %8 = arith.subi %2, %7 : i32
    %9 = arith.cmpi slt, %8, %c8_i32 : i32
    %10 = select %9, %8, %c8_i32 : i32
    %11 = arith.remsi %0, %10 : i32
    %12 = arith.addi %7, %11 : i32
    %13 = arith.remsi %0, %5 : i32
    %14 = arith.divsi %13, %10 : i32
    %15 = arith.muli %12, %c128_i32 : i32
    %16 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
    %17 = tt.splat %15 : (i32) -> tensor<128xi32>
    %18 = arith.addi %17, %16 : tensor<128xi32>
    %19 = arith.muli %14, %c128_i32 : i32
    %20 = tt.splat %19 : (i32) -> tensor<128xi32>
    %21 = arith.addi %20, %16 : tensor<128xi32>
    %22 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
    %23 = tt.expand_dims %18 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
    %24 = tt.splat %arg6 : (i32) -> tensor<128x1xi32>
    %25 = arith.muli %23, %24 : tensor<128x1xi32>
    %26 = tt.expand_dims %22 {axis = 0 : i32} : (tensor<32xi32>) -> tensor<1x32xi32>
    %27 = tt.broadcast %25 : (tensor<128x1xi32>) -> tensor<128x32xi32>
    %28 = tt.broadcast %26 : (tensor<1x32xi32>) -> tensor<128x32xi32>
    %29 = arith.addi %27, %28 : tensor<128x32xi32>
    %30 = tt.splat %arg0 : (!tt.ptr<f16>) -> tensor<128x32x!tt.ptr<f16>>
    %31 = tt.addptr %30, %29 : tensor<128x32x!tt.ptr<f16>>, tensor<128x32xi32>
    %32 = tt.expand_dims %22 {axis = 1 : i32} : (tensor<32xi32>) -> tensor<32x1xi32>
    %33 = tt.splat %arg7 : (i32) -> tensor<32x1xi32>
    %34 = arith.muli %32, %33 : tensor<32x1xi32>
    %35 = tt.expand_dims %21 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
    %36 = tt.broadcast %34 : (tensor<32x1xi32>) -> tensor<32x128xi32>
    %37 = tt.broadcast %35 : (tensor<1x128xi32>) -> tensor<32x128xi32>
    %38 = arith.addi %36, %37 : tensor<32x128xi32>
    %39 = tt.splat %arg1 : (!tt.ptr<f16>) -> tensor<32x128x!tt.ptr<f16>>
    %40 = tt.addptr %39, %38 : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
    %41 = arith.addi %arg5, %c31_i32 : i32
    %42 = arith.divsi %41, %c32_i32 : i32
    %43 = arith.index_cast %42 : i32 to index
    %44 = arith.muli %arg7, %c32_i32 : i32
    %45 = tt.splat %44 : (i32) -> tensor<32x128xi32>
    %46:3 = scf.for %arg9 = %c0 to %43 step %c1 iter_args(%arg10 = %cst_0, %arg11 = %31, %arg12 = %40) -> (tensor<128x128xf32>, tensor<128x32x!tt.ptr<f16>>, tensor<32x128x!tt.ptr<f16>>) {
      %62 = tt.load %arg11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x32xf16>
      %63 = tt.load %arg12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x128xf16>
      %64 = tt.dot %62, %63, %arg10 {allowTF32 = true} : tensor<128x32xf16> * tensor<32x128xf16> -> tensor<128x128xf32>
      %65 = tt.addptr %arg11, %cst : tensor<128x32x!tt.ptr<f16>>, tensor<128x32xi32>
      %66 = tt.addptr %arg12, %45 : tensor<32x128x!tt.ptr<f16>>, tensor<32x128xi32>
      scf.yield %64, %65, %66 : tensor<128x128xf32>, tensor<128x32x!tt.ptr<f16>>, tensor<32x128x!tt.ptr<f16>>
    }
    %47 = arith.truncf %46#0 : tensor<128x128xf32> to tensor<128x128xf16>
    %48 = tt.splat %arg8 : (i32) -> tensor<128x1xi32>
    %49 = arith.muli %48, %23 : tensor<128x1xi32>
    %50 = tt.splat %arg2 : (!tt.ptr<f16>) -> tensor<128x1x!tt.ptr<f16>>
    %51 = tt.addptr %50, %49 : tensor<128x1x!tt.ptr<f16>>, tensor<128x1xi32>
    %52 = tt.broadcast %51 : (tensor<128x1x!tt.ptr<f16>>) -> tensor<128x128x!tt.ptr<f16>>
    %53 = tt.broadcast %35 : (tensor<1x128xi32>) -> tensor<128x128xi32>
    %54 = tt.addptr %52, %53 : tensor<128x128x!tt.ptr<f16>>, tensor<128x128xi32>
    %55 = tt.splat %arg3 : (i32) -> tensor<128x1xi32>
    %56 = arith.cmpi slt, %23, %55 : tensor<128x1xi32>
    %57 = tt.splat %arg4 : (i32) -> tensor<1x128xi32>
    %58 = arith.cmpi slt, %35, %57 : tensor<1x128xi32>
    %59 = tt.broadcast %56 : (tensor<128x1xi1>) -> tensor<128x128xi1>
    %60 = tt.broadcast %58 : (tensor<1x128xi1>) -> tensor<128x128xi1>
    %61 = arith.andi %59, %60 : tensor<128x128xi1>
    tt.store %54, %47, %61 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf16>
    return
  }
}
```
</detail>