### PR TITLE
[FRONTEND] launcher module is now renamed from `launcher` to `__triton_launcher`

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1293,13 +1293,13 @@ static PyMethodDef ModuleMethods[] = {{
 
 static struct PyModuleDef ModuleDef = {{
   PyModuleDef_HEAD_INIT,
-  \"launcher\",
+  \"__triton_launcher\",
   NULL, //documentation
   -1, //size
   ModuleMethods
 }};
 
-PyMODINIT_FUNC PyInit_launcher(void) {{
+PyMODINIT_FUNC PyInit___triton_launcher(void) {{
   PyObject *m = PyModule_Create(&ModuleDef);
   if(m == NULL) {{
     return NULL;
@@ -1654,7 +1654,7 @@ class CompiledKernel:
     def __init__(self, so_path, metadata, asm):
         # initialize launcher
         import importlib.util
-        spec = importlib.util.spec_from_file_location("launcher", so_path)
+        spec = importlib.util.spec_from_file_location("__triton_launcher", so_path)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
         self.c_wrapper = getattr(mod, "launch")


### PR DESCRIPTION
creating dynamically a module named `launcher` may conflict with other modules named the same in the user's environment.