### PR TITLE
Correctly propagate address spaces through GEP

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
@@ -110,10 +110,10 @@ Value DotOpMmaV1ConversionHelper::loadA(
   }
 
   Type elemX2Ty = vec_ty(f16_ty, 2);
-  Type elemPtrTy = ptr_ty(f16_ty);
+  Type elemPtrTy = ptr_ty(f16_ty, 3);
   if (tensorTy.getElementType().isBF16()) {
     elemX2Ty = vec_ty(i16_ty, 2);
-    elemPtrTy = ptr_ty(i16_ty);
+    elemPtrTy = ptr_ty(i16_ty, 3);
   }
 
   // prepare arguments
@@ -121,7 +121,7 @@ Value DotOpMmaV1ConversionHelper::loadA(
 
   std::map<std::pair<int, int>, std::pair<Value, Value>> has;
   for (int i = 0; i < numPtrA; i++)
-    ptrA[i] = gep(ptr_ty(f16_ty), smemBase, offA[i]);
+    ptrA[i] = gep(ptr_ty(f16_ty, 3), smemBase, offA[i]);
 
   auto ld = [&](decltype(has) &vals, int m, int k, Value val0, Value val1) {
     vals[{m, k}] = {val0, val1};
@@ -224,17 +224,17 @@ Value DotOpMmaV1ConversionHelper::loadB(
     offB[i] = add(mul(offB0I, strideB0), mul(offB1, strideB1));
   }
 
-  Type elemPtrTy = ptr_ty(f16_ty);
+  Type elemPtrTy = ptr_ty(f16_ty, 3);
   Type elemX2Ty = vec_ty(f16_ty, 2);
   if (tensorTy.getElementType().isBF16()) {
-    elemPtrTy = ptr_ty(i16_ty);
+    elemPtrTy = ptr_ty(i16_ty, 3);
     elemX2Ty = vec_ty(i16_ty, 2);
   }
 
   SmallVector<Value> ptrB(numPtrB);
   ValueTable hbs;
   for (int i = 0; i < numPtrB; ++i)
-    ptrB[i] = gep(ptr_ty(f16_ty), smem, offB[i]);
+    ptrB[i] = gep(ptr_ty(f16_ty, 3), smem, offB[i]);
 
   auto ld = [&](decltype(hbs) &vals, int m, int k, Value val0, Value val1) {
     vals[{m, k}] = {val0, val1};
@@ -1292,7 +1292,7 @@ Value DotOpFMAConversionHelper::loadA(
   }
   auto elemTy = A.getType().cast<RankedTensorType>().getElementType();
 
-  Type ptrTy = ptr_ty(elemTy);
+  Type ptrTy = ptr_ty(elemTy, 3);
   SmallVector<Value> aPtrs(aNumPtr);
   for (int i = 0; i < aNumPtr; ++i)
     aPtrs[i] = gep(ptrTy, aSmem.base, aOff[i]);
@@ -1355,7 +1355,7 @@ Value DotOpFMAConversionHelper::loadB(
   }
   auto elemTy = B.getType().cast<RankedTensorType>().getElementType();
 
-  Type ptrTy = ptr_ty(elemTy);
+  Type ptrTy = ptr_ty(elemTy, 3);
   SmallVector<Value> bPtrs(bNumPtr);
   for (int i = 0; i < bNumPtr; ++i)
     bPtrs[i] = gep(ptrTy, bSmem.base, bOff[i]);


### PR DESCRIPTION
While doing it incorrectly works at the moment, this will cause a validation error once we rebase Triton closer to LLVM head, since validation for some LLVM Dialect ops got stricter.

Specifically, if we remove the shared memory space attribute, a subsequent bitcast tries to add it back, which is illegal.