### PR TITLE
Fix AutoTuner error when OutOfResources

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -62,9 +62,9 @@ class Autotuner(KernelInterface):
             self.hook(args)
             self.fn.run(*args, num_warps=config.num_warps, num_stages=config.num_stages, **current)
         try:
-            return do_bench(kernel_call)
+            return do_bench(kernel_call, percentiles=(0.5, 0.2, 0.8))
         except OutOfResources:
-            return float('inf')
+            return (float('inf'), float('inf'), float('inf'))
 
     def run(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))


### PR DESCRIPTION
Minor bug: AutoTuner currently throws the following error when certain configs go OutOfResources (e.g. the matmul example when testing on GPUs with less shared memory). 

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
[<ipython-input-7-e8822053f6d7>](https://localhost:8080/#) in <module>
      2 a = torch.randn((512, 512), device='cuda', dtype=torch.float16)
      3 b = torch.randn((512, 512), device='cuda', dtype=torch.float16)
----> 4 triton_output = matmul(a, b)
      5 torch_output = torch.matmul(a, b)
      6 print(f"triton_output={triton_output}")

1 frames
[/content/triton/python/triton/runtime/autotuner.py](https://localhost:8080/#) in run(self, *args, **kwargs)
     79                 bench_end = time.time()
     80                 self.bench_time = bench_end - bench_start
---> 81                 self.cache[key] = builtins.min(timings, key=timings.get)
     82                 self.hook(args)
     83                 self.configs_timings = timings

TypeError: '<' not supported between instances of 'tuple' and 'float'
```

This is due to inconsistent return types on the [_bench](https://github.com/openai/triton/blob/main/python/triton/runtime/autotuner.py#L47) method (returning float if OutOfResources and tuple if not). do_bench with default percentile args returns a tuple of 3 quantiles. Error thrown when [trying to compare different types](https://github.com/openai/triton/blob/main/python/triton/runtime/autotuner.py#L81) to find the best config.

I've just made made the percentiles explicit within the _bench method and changed the return type to be a tuple of 3 quantiles in all cases. Tested on Colab GPU.
