### PR TITLE
Windows and cmake compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,66 +202,36 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
 if(TRITON_BUILD_PYTHON_MODULE)
   add_library(triton SHARED ${PYTHON_SRC})
-
+  set(TRITON_LIBRARIES
+    TritonAnalysis
+    TritonTransforms
+    TritonGPUTransforms
+    TritonLLVMIR
+    TritonPTX
+    ${dialect_libs}
+    ${conversion_libs}
+    # optimizations
+    MLIRPass
+    MLIRTransforms
+    MLIRLLVMDialect
+    MLIRSupport
+    MLIRTargetLLVMIRExport
+    MLIRExecutionEngine
+    MLIRMathToLLVM
+    MLIRNVVMToLLVMIRTranslation
+    MLIRIR
+  )
   if(WIN32)
     target_link_libraries(triton PRIVATE ${LLVM_LIBRARIES} ${CMAKE_DL_LIBS}
-      TritonAnalysis
-      TritonTransforms
-      TritonGPUTransforms
-      TritonLLVMIR
-      TritonPTX
-      ${dialect_libs}
-      ${conversion_libs}
-      # optimizations
-      MLIRPass
-      MLIRTransforms
-      MLIRLLVMDialect
-      MLIRSupport
-      MLIRTargetLLVMIRExport
-      MLIRExecutionEngine
-      MLIRMathToLLVM
-      MLIRNVVMToLLVMIRTranslation
-      MLIRIR
+      ${TRITON_LIBRARIES}
     )
   elseif(APPLE)
     target_link_libraries(triton ${LLVM_LIBRARIES} z
-      TritonAnalysis
-      TritonTransforms
-      TritonGPUTransforms
-      TritonLLVMIR
-      TritonPTX
-      ${dialect_libs}
-      ${conversion_libs}
-      # optimizations
-      MLIRPass
-      MLIRTransforms
-      MLIRLLVMDialect
-      MLIRSupport
-      MLIRTargetLLVMIRExport
-      MLIRExecutionEngine
-      MLIRMathToLLVM
-      MLIRNVVMToLLVMIRTranslation
-      MLIRIR
+      ${TRITON_LIBRARIES}
     )
   else()
     target_link_libraries(triton ${LLVM_LIBRARIES} z stdc++fs
-      TritonAnalysis
-      TritonTransforms
-      TritonGPUTransforms
-      TritonLLVMIR
-      TritonPTX
-      ${dialect_libs}
-      ${conversion_libs}
-      # optimizations
-      MLIRPass
-      MLIRTransforms
-      MLIRLLVMDialect
-      MLIRSupport
-      MLIRTargetLLVMIRExport
-      MLIRExecutionEngine
-      MLIRMathToLLVM
-      MLIRNVVMToLLVMIRTranslation
-      MLIRIR
+      ${TRITON_LIBRARIES}
     )
   endif()
   

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ include_directories(${PYBIND11_INCLUDE_DIR})
 
 if(WIN32)
     SET(BUILD_SHARED_LIBS OFF)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR}/deps/dlfcn-win32/src)
-    add_subdirectory(deps/dlfcn-win32/src ${CMAKE_BINARY_DIR}/dlfcn-win32)
+    find_package(dlfcn-win32 REQUIRED)
+    set(CMAKE_DL_LIBS dlfcn-win32::dl)
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden")
@@ -203,35 +203,69 @@ get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 if(TRITON_BUILD_PYTHON_MODULE)
   add_library(triton SHARED ${PYTHON_SRC})
 
-  target_link_libraries(triton
-    TritonAnalysis
-    TritonTransforms
-    TritonGPUTransforms
-    TritonLLVMIR
-    TritonPTX
-    ${dialect_libs}
-    ${conversion_libs}
-    # optimizations
-    MLIRPass
-    MLIRTransforms
-    MLIRLLVMDialect
-    MLIRSupport
-    MLIRTargetLLVMIRExport
-    MLIRExecutionEngine
-    MLIRMathToLLVM
-    MLIRNVVMToLLVMIRTranslation
-    MLIRIR
-  )
-
-  target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
-
   if(WIN32)
-      target_link_libraries(triton PRIVATE ${LLVM_LIBRARIES} dl) # dl is from dlfcn-win32
+    target_link_libraries(triton PRIVATE ${LLVM_LIBRARIES} ${CMAKE_DL_LIBS}
+      TritonAnalysis
+      TritonTransforms
+      TritonGPUTransforms
+      TritonLLVMIR
+      TritonPTX
+      ${dialect_libs}
+      ${conversion_libs}
+      # optimizations
+      MLIRPass
+      MLIRTransforms
+      MLIRLLVMDialect
+      MLIRSupport
+      MLIRTargetLLVMIRExport
+      MLIRExecutionEngine
+      MLIRMathToLLVM
+      MLIRNVVMToLLVMIRTranslation
+      MLIRIR
+    )
   elseif(APPLE)
-      target_link_libraries(triton ${LLVM_LIBRARIES} z)
+    target_link_libraries(triton ${LLVM_LIBRARIES} z
+      TritonAnalysis
+      TritonTransforms
+      TritonGPUTransforms
+      TritonLLVMIR
+      TritonPTX
+      ${dialect_libs}
+      ${conversion_libs}
+      # optimizations
+      MLIRPass
+      MLIRTransforms
+      MLIRLLVMDialect
+      MLIRSupport
+      MLIRTargetLLVMIRExport
+      MLIRExecutionEngine
+      MLIRMathToLLVM
+      MLIRNVVMToLLVMIRTranslation
+      MLIRIR
+    )
   else()
-      target_link_libraries(triton ${LLVM_LIBRARIES} z stdc++fs)
+    target_link_libraries(triton ${LLVM_LIBRARIES} z stdc++fs
+      TritonAnalysis
+      TritonTransforms
+      TritonGPUTransforms
+      TritonLLVMIR
+      TritonPTX
+      ${dialect_libs}
+      ${conversion_libs}
+      # optimizations
+      MLIRPass
+      MLIRTransforms
+      MLIRLLVMDialect
+      MLIRSupport
+      MLIRTargetLLVMIRExport
+      MLIRExecutionEngine
+      MLIRMathToLLVM
+      MLIRNVVMToLLVMIRTranslation
+      MLIRIR
+    )
   endif()
+  
+  target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
 endif()
 
 if(TRITON_BUILD_PYTHON_MODULE AND NOT WIN32)

--- a/python/setup.py
+++ b/python/setup.py
@@ -65,7 +65,7 @@ def get_llvm_package_info():
         linux_suffix = 'ubuntu-18.04' if vglibc > 217 else 'centos-7'
         system_suffix = f"linux-gnu-{linux_suffix}"
     else:
-        raise RuntimeError(f"unsupported system: {system}")
+        return Package("llvm", "LLVM-C.lib", "", "lib", "LLVM_INCLUDE_DIRS", "LLVM_LIBRARY_DIR", "LLVM_SYSPATH")
     use_assert_enabled_llvm = check_env_flag("TRITON_USE_ASSERT_ENABLED_LLVM", "False")
     release_suffix = "assert" if use_assert_enabled_llvm else "release"
     name = f'llvm+mlir-17.0.0-x86_64-{system_suffix}-{release_suffix}'

--- a/python/setup.py
+++ b/python/setup.py
@@ -159,7 +159,11 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         lit_dir = shutil.which('lit')
-        triton_cache_path = os.path.join(os.getenv("HOME", os.environ["HOMEPATH"]), ".triton")
+        user_home = os.getenv("HOME") or os.getenv("USERPROFILE") or \
+            os.getenv("HOMEPATH") or None
+        if not user_home:
+            raise RuntimeError("Could not find user home directory")
+        triton_cache_path = os.path.join(user_home, ".triton")
         # lit is used by the test suite
         thirdparty_cmake_args = get_thirdparty_packages(triton_cache_path)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.path)))

--- a/python/setup.py
+++ b/python/setup.py
@@ -159,7 +159,7 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         lit_dir = shutil.which('lit')
-        triton_cache_path = os.path.join(os.environ["HOME"], ".triton")
+        triton_cache_path = os.path.join(os.getenv("HOME", os.environ["HOMEPATH"]), ".triton")
         # lit is used by the test suite
         thirdparty_cmake_args = get_thirdparty_packages(triton_cache_path)
         extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.path)))


### PR DESCRIPTION
Make cmake happier, it doesn't like multiple target_link_library definitions for the same name.

Use find_package instead on Windows for dlfcn-win32. 
Set LLVM_SYS_PATH on Windows for python setup.

Debug build almost working, AlwaysCreate error thrown still.