### PR TITLE
[Frontend] fix crash on cast when dest is constexpr

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -647,6 +647,8 @@ def cast(input: tl.tensor,
          dst_ty: tl.dtype,
          builder: ir.builder) -> tl.tensor:
     src_ty = input.type
+    if isinstance(dst_ty, tl.constexpr):
+        dst_ty = dst_ty.value
     if src_ty.is_block():
         dst_ty = tl.block_type(dst_ty, input.type.get_block_shapes())
     if src_ty == dst_ty:


### PR DESCRIPTION
This pull request addresses a crash that occurs when casting to a tl.constexpr type in the frontend. 

More info and repro code available in: https://github.com/openai/triton/issues/1221