### PR TITLE
Revert "Minor fix to support sm_90 (#1125)"

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Combine.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Combine.cpp
@@ -866,11 +866,8 @@ int computeCapabilityToMMAVersion(int computeCapability) {
     return 1;
   } else if (computeCapability < 90) {
     return 2;
-  } else if (computeCapability < 100) {
-    // FIXME: temporarily add this to pass unis tests
-    return 2;
   } else {
-    assert(false && "computeCapability > 100 not supported");
+    assert(false && "computeCapability > 90 not supported");
     return 3;
   }
 }

--- a/lib/Target/PTX/PTXTranslation.cpp
+++ b/lib/Target/PTX/PTXTranslation.cpp
@@ -34,15 +34,15 @@ std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version) {
   // LLVM version in use may not officially support target hardware.
   // Supported versions for LLVM 14 are here:
   // https://github.com/llvm/llvm-project/blob/f28c006a5895fc0e329fe15fead81e37457cb1d1/clang/include/clang/Basic/BuiltinsNVPTX.def
-  int maxPTX = std::min(80, version);
-  int maxCC = std::min(90, cc);
+  int maxPTX = std::min(75, version);
+  int maxCC = std::min(86, cc);
   // options
   auto options = llvm::cl::getRegisteredOptions();
   auto *shortPtr =
       static_cast<llvm::cl::opt<bool> *>(options["nvptx-short-ptr"]);
   assert(shortPtr);
   shortPtr->setValue(true);
-  std::string sm = cc == 90 ? "sm_90a" : "sm_" + std::to_string(cc);
+  std::string sm = "sm_" + std::to_string(maxCC);
   // max PTX version
   int ptxMajor = maxPTX / 10;
   int ptxMinor = maxPTX % 10;

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -1495,9 +1495,7 @@ void init_triton_translation(py::module &m) {
           std::string cmd;
           int err;
           cmd = ptxasPath + " -v --gpu-name=sm_" + std::to_string(capability) +
-                (capability == 90 ? "a " : " ") + _fsrc + " -o " + _fsrc +
-                ".o 2> " + _flog;
-
+                " " + _fsrc + " -o " + _fsrc + ".o 2> " + _flog;
           err = system(cmd.c_str());
           if (err != 0) {
             std::ifstream _log(_flog);


### PR DESCRIPTION
To support sm_89 without warnings
Confirmed with @ptrblck that it works. 
This reverts commit 3e8d83b7cc11b1d26e7f1fb7f0022d03aa2377ae.