### PR TITLE
Ensure __triton_launcher calls right _launch.

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1185,7 +1185,7 @@ static inline void gpuAssert(CUresult code, const char *file, int line)
 
 #define CUDA_CHECK(ans) {{ gpuAssert((ans), __FILE__, __LINE__); }}
 
-void _launch(int gridX, int gridY, int gridZ, int num_warps, int shared_memory, CUstream stream, CUfunction function, {arg_decls}) {{
+static void _launch(int gridX, int gridY, int gridZ, int num_warps, int shared_memory, CUstream stream, CUfunction function, {arg_decls}) {{
   void *params[] = {{ {', '.join(f"&arg{i}" for i in signature.keys() if i not in constants)} }};
   if(gridX*gridY*gridZ > 0){{
     CUDA_CHECK(cuLaunchKernel(function, gridX, gridY, gridZ, 32*num_warps, 1, 1, shared_memory, stream, params, 0));


### PR DESCRIPTION
Per issue https://github.com/openai/triton/issues/1228.  I believe we are potentially exposed when a Triton executor (Pytorch for example) links in two or more `triton_.so` shared objects and each has a stub for `_launch`.

This fix ensures the `_launch` function is tied locally to the calling `__triton_launcher` and can't be misused by another library.