### PR TITLE
[Build] Strip the static libraries symbol from the triton shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,9 +238,7 @@ if(TRITON_BUILD_PYTHON_MODULE)
   target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
 endif()
 
-if (APPLE)
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-fvisibility=hidden")
-else()
+if (UNIX AND NOT APPLE)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,6 +238,12 @@ if(TRITON_BUILD_PYTHON_MODULE)
   target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
 endif()
 
+if (APPLE)
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-fvisibility=hidden")
+else()
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
+endif()
+
 if(TRITON_BUILD_PYTHON_MODULE AND NOT WIN32)
     set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
     # Check if the platform is MacOS


### PR DESCRIPTION
This is to solve https://github.com/openai/triton/issues/1236

This commit hides the symbols of the shared libraries for `libtriton.so`, so that when other object link against `libtriton.so`, it won't have confilct.

This PR didn't handle the case in MacOS, but there is a possible way to use `exported_symbols_lists` to export a whitelist symbols as [mxnet/CMakeLists.txt](https://github.com/apache/mxnet/blob/b84609d3fc73d20929c114eab95faaa56e6c5ede/CMakeLists.txt#L740). I put here in case anyone needs it.
