### PR TITLE
[Frontend] Fix jit cache bug

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -243,7 +243,7 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
     sig_key =  {sig_keys},
     constexpr_key = {f'{constexpr_keys},' if len(constexpr_keys) > 0 else ()}
     spec_key = {f'{spec_keys},' if len(spec_keys) > 0 else ()}
-    key = (version_key, sig_key, constexpr_key, spec_key)
+    key = (version_key, sig_key, constexpr_key, spec_key, num_warps, num_stages)
     if not extern_libs is None:
       key = (key, tuple(extern_libs.items()))
     assert num_warps > 0 and (num_warps & (num_warps - 1)) == 0, "num_warps must be a power of 2"


### PR DESCRIPTION
## Issue

In the current JITFunction implementation, multiple Autotune Configs with the same settings but different `num_warps` or `num_stages` will map to the same kernel cache, sometimes bringing weird results (such as different autotuned performance after simply changing the Configs order).

Reference the code, a `key` is defined as https://github.com/openai/triton/blob/main/python/triton/runtime/jit.py#L246
`key = (version_key, sig_key, constexpr_key, spec_key)`, note that the `num_warps` and `num_stages` is not included in the key.
and this key is directly used to map to a compilation cache https://github.com/openai/triton/blob/main/python/triton/runtime/jit.py#L284
`self.cache[device][key] = bin`

## Phenomenon
A naive case to reproduce the issue:
```python
import triton
import torch
import triton
import triton.language as tl

@triton.autotune(
    configs=[
        triton.Config(dict(), num_warps=1),
        triton.Config(dict(), num_warps=4),
        triton.Config(dict(), num_warps=8),
    ], key=[])
@triton.jit
def vec_add(A, B, Out, N:tl.constexpr):
    a = tl.load(A + tl.arange(0, N))
    b = tl.load(B + tl.arange(0, N))
    tl.store(Out + tl.arange(0, N), a + b)


a = torch.randn(32, 32, dtype=torch.float32, device='cuda')
out = torch.empty_like(a)
grid = lambda meta: (1,)
vec_add[grid](a, a, out, 32)
```
Note that, the autotuner has three Configs, thus it should generate 3 kernels and evaluate their performance. While before this PR, it will generate a single cache
```
/home/X/.triton/cache/dda0e2e0e89ebeaa62fc23281ff0ca0c:
lock  vec_add.cubin  vec_add.json  vec_add.llir  vec_add.ptx  vec_add.ttgir  vec_add.ttir
```
with the `num_warps` (in `vec_add.ttgir`) looks like `module attributes {"triton_gpu.num-warps" = 1 : i32}`, which is due to the `num_warps=1` Config comes first.

## Effect

After this PR, it will generate 3 caches with different `num_warps`:

```
/home/X/.triton/cache/208cd9b942b957d56b2cfffa3304edef:
lock  vec_add.cubin  vec_add.json  vec_add.llir  vec_add.ptx  vec_add.ttgir  vec_add.ttir

/home/X/.triton/cache/de6d9812c3c693ae240b79e06d90ef6c:
lock  vec_add.cubin  vec_add.json  vec_add.llir  vec_add.ptx  vec_add.ttgir  vec_add.ttir

/home/X/.triton/cache/e0db42400e499d904997bc9963ebfe28:
lock  vec_add.cubin  vec_add.json  vec_add.llir  vec_add.ptx  vec_add.ttgir  vec_add.ttir
```

