### PR TITLE
[FRONTEND] Add check for axis of reduction op

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1133,6 +1133,10 @@ def reduce_impl(input: tl.tensor, axis: int, builder: ir.builder, name: str,
 
     # get result type
     shape = input.type.shape
+    
+    rank = len(shape)
+    assert axis >= 0 and axis < rank, f"axis (v={axis}) is out of range, should be within [0, {rank})"
+    
     ret_shape = []
     for i, s in enumerate(shape):
         if i != axis:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1133,10 +1133,10 @@ def reduce_impl(input: tl.tensor, axis: int, builder: ir.builder, name: str,
 
     # get result type
     shape = input.type.shape
-    
+
     rank = len(shape)
     assert axis >= 0 and axis < rank, f"axis (v={axis}) is out of range, should be within [0, {rank})"
-    
+
     ret_shape = []
     for i, s in enumerate(shape):
         if i != axis:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1135,7 +1135,7 @@ def reduce_impl(input: tl.tensor, axis: int, builder: ir.builder, name: str,
     shape = input.type.shape
 
     rank = len(shape)
-    assert axis >= 0 and axis < rank, f"axis (v={axis}) is out of range, should be within [0, {rank})"
+    assert 0 <= axis < rank, f"axis (v={axis}) is out of range, should be within [0, {rank})"
 
     ret_shape = []
     for i, s in enumerate(shape):


### PR DESCRIPTION
For reduction ops, `Max/Min/Sum`, we have a param axis. Ideally, it should be in the range of (-rank,rank) where rank = len(shape(tensor)).

For now, Triton didn't check it and just compile into a tl.Tensor with probaly error axis.  If axis is not correct, triton will be crashed in line `pm.run(mod)` within function `optimize_ttgir`. It's unfriendly for users to know where is error from.

With this check, we can hanle negtive axis, and checked if it's valid.