### PR TITLE
Fix stack-use-after-scope in translateLLVMIRToPTX.

### DIFF
--- a/lib/Target/PTX/PTXTranslation.cpp
+++ b/lib/Target/PTX/PTXTranslation.cpp
@@ -81,17 +81,18 @@ std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version) {
   else
     module.setDataLayout(layout);
   // emit machine code
-  std::string result;
-  llvm::raw_string_ostream stream(result);
-  llvm::buffer_ostream pstream(stream);
   for (llvm::Function &f : module.functions())
     f.addFnAttr(llvm::Attribute::AlwaysInline);
-  llvm::legacy::PassManager pass;
-  // emit
-  machine->addPassesToEmitFile(pass, pstream, nullptr,
-                               llvm::CodeGenFileType::CGFT_AssemblyFile);
-  pass.run(module);
-  stream.flush();
+  std::string result;
+  {
+    llvm::raw_string_ostream stream(result);
+    llvm::buffer_ostream pstream(stream);
+    llvm::legacy::PassManager pass;
+    // emit
+    machine->addPassesToEmitFile(pass, pstream, nullptr,
+                                 llvm::CodeGenFileType::CGFT_AssemblyFile);
+    pass.run(module);
+  }
 
   // post-process
   findAndReplace(result, ".version", "\n",

--- a/lib/Target/PTX/PTXTranslation.cpp
+++ b/lib/Target/PTX/PTXTranslation.cpp
@@ -50,7 +50,6 @@ std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version) {
   int ptxMajor = maxPTX / 10;
   int ptxMinor = maxPTX % 10;
   // create
-  llvm::SmallVector<char, 0> buffer;
   std::string triple = "nvptx64-nvidia-cuda";
   std::string proc = "sm_" + std::to_string(maxCC);
   std::string layout = "";
@@ -82,17 +81,19 @@ std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version) {
   else
     module.setDataLayout(layout);
   // emit machine code
+  std::string result;
+  llvm::raw_string_ostream stream(result);
+  llvm::buffer_ostream pstream(stream);
   for (llvm::Function &f : module.functions())
     f.addFnAttr(llvm::Attribute::AlwaysInline);
   llvm::legacy::PassManager pass;
-  llvm::raw_svector_ostream stream(buffer);
   // emit
-  machine->addPassesToEmitFile(pass, stream, nullptr,
+  machine->addPassesToEmitFile(pass, pstream, nullptr,
                                llvm::CodeGenFileType::CGFT_AssemblyFile);
   pass.run(module);
+  stream.flush();
 
   // post-process
-  std::string result(buffer.begin(), buffer.end());
   findAndReplace(result, ".version", "\n",
                  ".version " + std::to_string(ptxMajor) + "." +
                      std::to_string(ptxMinor) + "\n");


### PR DESCRIPTION
Stack-use-after-scope is reported by LLVM AddressSanitizer at stream flush happening in PassManager's destructor.