### PR TITLE
expose the register usage and spill information thru CompiledKernel

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1725,6 +1725,8 @@ class CompiledKernel:
         if self.shared > max_shared:
             raise OutOfResources(self.shared, max_shared, "shared memory")
         mod, func, n_regs, n_spills = cuda_utils.load_binary(self.metadata["name"], self.asm["cubin"], self.shared, device)
+        self.n_spills = n_spills
+        self.n_regs = n_regs
         self.cu_module = mod
         self.cu_function = func
 


### PR DESCRIPTION
We are benchmarking the performance of triton kernels generated by torch inductor. Some metrics like register usage and register spill are very helpful. Those information are already available in triton but not exposed.

Add this tiny PR to expose them thru CompiledKernel's attributes.

Let me know if I should have created an issue first :)

cc @ngimel  @Chillee 

