### PR TITLE
[FRONTEND] Fix cast when both `src_ty` and `dst_ty` are of block_type

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -641,7 +641,7 @@ def bitcast(input: tl.tensor,
             builder: ir.builder) -> tl.tensor:
     src_ty = input.type
     if src_ty.is_block():
-        dst_ty = tl.block_type(dst_ty, input.type.get_block_shapes())
+        dst_ty = tl.block_type(dst_ty.scalar, input.type.get_block_shapes())
     if src_ty == dst_ty:
         return input
     src_sca_ty = src_ty.scalar
@@ -665,7 +665,7 @@ def cast(input: tl.tensor,
     if isinstance(dst_ty, tl.constexpr):
         dst_ty = dst_ty.value
     if src_ty.is_block():
-        dst_ty = tl.block_type(dst_ty, input.type.get_block_shapes())
+        dst_ty = tl.block_type(dst_ty.scalar, input.type.get_block_shapes())
     if src_ty == dst_ty:
         return input
 


### PR DESCRIPTION
Commonly used in atomic_rmw ops