### PR TITLE
[BACKEND] Fix `triton-convert-arith-to-index`.

### DIFF
--- a/include/triton/Conversion/Passes.td
+++ b/include/triton/Conversion/Passes.td
@@ -60,7 +60,7 @@ def TritonConvertArithToIndex : Pass<"triton-convert-arith-to-index", "mlir::Mod
       We need this because SCFToCF conversion currently generates arith ops on indices.
     }];
 
-    let dependentDialects = ["mlir::arith::ArithDialect"];
+    let dependentDialects = ["mlir::index::IndexDialect"];
 }
 
 #endif

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Pass/Pass.h"


### PR DESCRIPTION
The dialect of created ops needs to be part of dependent dialects.