### PR TITLE
Mash stdc++fs into more targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,9 +240,12 @@ if(TRITON_BUILD_PYTHON_MODULE)
       ${TRITON_LIBRARIES}
     )
   else()
-    target_link_libraries(triton ${LLVM_LIBRARIES} z stdc++fs
+    target_link_libraries(triton ${LLVM_LIBRARIES} z
       ${TRITON_LIBRARIES}
     )
+    # TODO: Figure out which target is sufficient to fix errors; triton is
+    # apparently not enough
+    link_libraries(stdc++fs)
   endif()
 
   target_link_options(triton PRIVATE ${LLVM_LDFLAGS})


### PR DESCRIPTION
I observed that when compiling with gcc8, stdc++fs linker flag isn't
passed to enough targets.  I couldn't figure out the correct target
to add the linker flag to, so I'm just mashing it everywhere.

Signed-off-by: Edward Z. Yang <ezyang@meta.com>
