### PR TITLE
Mangle signed and unsigned integer types differently

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -57,7 +57,9 @@ def mangle_ty(ty):
     if ty.is_ptr():
         return 'P' + mangle_ty(ty.element_ty)
     if ty.is_int():
-        return 'i' + str(ty.int_bitwidth)
+        SIGNED = triton.language.dtype.SIGNEDNESS.SIGNED
+        prefix = 'i' if ty.int_signedness == SIGNED else 'u'
+        return prefix + str(ty.int_bitwidth)
     if ty.is_fp8():
         return 'fp8'
     if ty.is_fp16():


### PR DESCRIPTION
This is cherry-picked from #1305

If you call a `JITFunction` twice in the same kernel, first with `int32` then with `uint32`, the second call will treat the unsigned value as signed. This passes through MLIR without error because MLIR uses the same types for both, but different operation calls will be generated so you may silently get the wrong result.