### PR TITLE
`JITFunction`: infer constexpr arg only if annotated as such

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -316,7 +316,8 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
         self.annotations = {self.arg_names.index(name): ty for name, ty in fn.__annotations__.items()}
         self.__annotations__ = fn.__annotations__
         # index of constexprs
-        self.constexprs = [self.arg_names.index(ann) for ann in self.__annotations__.keys()]
+        from triton.language.core import constexpr  # import here rather than at module level due to circular import tangle
+        self.constexprs = [index for index, ty in self.annotations.items() if ty is constexpr]
         # launcher
         self.run = self._make_launcher()
         # re-use docs of wrapped function

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -316,7 +316,8 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
         self.annotations = {self.arg_names.index(name): ty for name, ty in fn.__annotations__.items()}
         self.__annotations__ = fn.__annotations__
         # index of constexprs
-        from triton.language.core import constexpr  # import here rather than at module level due to circular import tangle
+        from triton.language.core import \
+            constexpr  # import here rather than at module level due to circular import tangle
         self.constexprs = [index for index, ty in self.annotations.items() if issubclass(ty, constexpr)]
         # launcher
         self.run = self._make_launcher()

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -317,7 +317,7 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
         self.__annotations__ = fn.__annotations__
         # index of constexprs
         from triton.language.core import constexpr  # import here rather than at module level due to circular import tangle
-        self.constexprs = [index for index, ty in self.annotations.items() if ty is constexpr]
+        self.constexprs = [index for index, ty in self.annotations.items() if issubclass(ty, constexpr)]
         # launcher
         self.run = self._make_launcher()
         # re-use docs of wrapped function


### PR DESCRIPTION
Fixed `JITFunction.__init__` to mark args as constexpr only when the annotation is actually `tl.constexpr`, rather than treating any annotated arg as constexpr.