### PR TITLE
enhancement: support f-strings in compiler with `constexpr` conversion

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -916,7 +916,7 @@ class CodeGenerator(ast.NodeVisitor):
                 if not isinstance(evaluated, triton.language.constexpr):
                     raise NotImplementedError("Cannot evaluate f-string containing non-constexpr conversion values,"
                                               " found conversion of type " + str(type(evaluated)))
-                values[i] = ("{}" if conversion_code < 0 else "{:!" + chr(conversion_code) + "}").format(evaluated.value)
+                values[i] = ("{}" if conversion_code < 0 else "{!" + chr(conversion_code) + "}").format(evaluated.value)
             else:
                 raise AssertionError("encountered unexpected node of type {} in a JoinedStr node".format(type(value)))
         return ''.join(values)

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1014,7 +1014,7 @@ def build_triton_ir(fn, signature, specialization, constants, debug=False):
         generator.visit(fn.parse())
     except Exception as e:
         node = generator.last_node
-        if node is None or isinstance(e, (NotImplementedError, CompilationError)):
+        if node is None or isinstance(e, CompilationError):
             raise e
         raise CompilationError(fn.src, node) from e
     ret = generator.module


### PR DESCRIPTION
This addition allows explanatory messages upon assertion failures:

```python
@triton.jit
def my_single_block_kernel(
    matrix_extent: tl.constexpr,
    block_size: tl.constexpr,      # must be >= extent (single block)
    matrix: Tensor,
    ...
):
    tl.static_assert(matrix_extent <= block_size, 
                     f"`matrix_extent` should not be more than the block size ({block_size}), but is {matrix_extent}")
```

Yielding, when called incorrectly:
```
AssertionError: `matrix_extent` should not be more than the block size (32), but is 57
```
     
