### PR TITLE
Add canonicalize/fold for ExpandDimsOp, ViewOp and BroadcastOp

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -246,6 +246,9 @@ def TT_ExpandDimsOp : TT_Op<"expand_dims", [Pure,
     let results = (outs TT_Tensor:$result);
 
     let assemblyFormat = "$src attr-dict `:` functional-type(operands, results)";
+
+    let hasCanonicalizeMethod = 1;
+    let hasFolder = 1;
 }
 
 // view is not `pure` because it may reorder elements
@@ -259,6 +262,8 @@ def TT_ViewOp : TT_Op<"view", [NoMemoryEffect,
 
     let assemblyFormat = "$src attr-dict `:` functional-type(operands, results)";
 
+    let hasCanonicalizeMethod = 1;
+    let hasFolder = 1;
 }
 
 def TT_BroadcastOp : TT_Op<"broadcast", [Pure,
@@ -272,6 +277,7 @@ def TT_BroadcastOp : TT_Op<"broadcast", [Pure,
 
     let assemblyFormat = "$src attr-dict `:` functional-type(operands, results)";
 
+    let hasCanonicalizeMethod = 1;
     let hasFolder = 1;
 }
 

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -291,12 +291,12 @@ bool mlir::triton::ReduceOp::withIndex(mlir::triton::RedOp redOp) {
 
 //-- SplatOp --
 OpFoldResult SplatOp::fold(FoldAdaptor adaptor) {
-  auto constOperand = getSrc().getDefiningOp<arith::ConstantOp>();
-  if (!constOperand)
+  auto value = adaptor.getSrc();
+  if (!value)
     return {};
   auto shapedType = getType().cast<ShapedType>();
   auto ret = SplatElementsAttr::get(
-      shapedType, ArrayRef<Attribute>(constOperand.getValue()));
+      shapedType, ArrayRef<Attribute>(value));
   return ret;
 }
 
@@ -329,24 +329,94 @@ mlir::LogicalResult mlir::triton::ExpandDimsOp::inferReturnTypes(
   return mlir::success();
 }
 
-//-- BroadcastOp --
-OpFoldResult BroadcastOp::fold(FoldAdaptor adaptor) {
-  auto constOperand = getSrc().getDefiningOp<arith::ConstantOp>();
-  if (!constOperand)
+LogicalResult ExpandDimsOp::canonicalize(ExpandDimsOp op, PatternRewriter &rewriter) {
+  auto definingOp = op.getOperand().getDefiningOp();
+  if (!definingOp) {
+    return mlir::failure();
+  }
+  // expand_dims(splat) -> splat
+  if (auto splat = dyn_cast<triton::SplatOp>(definingOp)) {
+    rewriter.replaceOpWithNewOp<triton::SplatOp>(
+      op, op.getType(), splat.getOperand());
+    return mlir::success();
+  }
+  return mlir::failure();
+}
+
+template <typename ViewLikeOp>
+static OpFoldResult foldViewLikeOp(ViewLikeOp op, Attribute value) {
+  if (!value)
     return {};
 
-  auto shapedType = getType().cast<ShapedType>();
-  auto value = constOperand.getValue();
+  auto shapedType = op.getType().template cast<mlir::ShapedType>();
   if (auto denseElemsAttr = value.dyn_cast<DenseElementsAttr>()) {
-    if (!denseElemsAttr.isSplat())
-      return {};
-    return SplatElementsAttr::get(shapedType,
-                                  denseElemsAttr.getSplatValue<Attribute>());
-  } else if (value.getType().isIntOrIndexOrFloat()) {
-    return SplatElementsAttr::get(shapedType, value);
-  } else {
-    return {};
+    return denseElemsAttr.reshape(shapedType);
   }
+  return {};
+}
+
+OpFoldResult ExpandDimsOp::fold(FoldAdaptor adaptor) {
+  return foldViewLikeOp(*this, adaptor.getSrc());
+}
+
+//-- ViewOp --
+template <typename OpType>
+LogicalResult canonicalizeViewOrBroadcast(OpType op, PatternRewriter &rewriter) {
+  auto definingOp = op.getOperand().getDefiningOp();
+  if (!definingOp) {
+    return mlir::failure();
+  }
+
+  // view(view) -> view
+  if (auto parent_view = dyn_cast<OpType>(definingOp)) {
+    rewriter.replaceOpWithNewOp<OpType>(
+      op, op.getType(), parent_view.getOperand());
+    return mlir::success();
+  }
+
+  // view(splat) -> splat
+  if (auto splat = dyn_cast<triton::SplatOp>(definingOp)) {
+    rewriter.replaceOpWithNewOp<triton::SplatOp>(
+      op, op.getType(), splat.getOperand());
+    return mlir::success();
+  }
+
+  return mlir::failure();
+}
+LogicalResult ViewOp::canonicalize(ViewOp op, PatternRewriter &rewriter) {
+  return canonicalizeViewOrBroadcast(op, rewriter);
+}
+
+
+OpFoldResult ViewOp::fold(FoldAdaptor adaptor) {
+  if (getType() == getOperand().getType()) {
+    // no-op
+    return getOperand();
+  }
+
+  return foldViewLikeOp(*this, adaptor.getSrc());
+}
+
+//-- BroadcastOp --
+LogicalResult BroadcastOp::canonicalize(BroadcastOp op, PatternRewriter &rewriter) {
+  return canonicalizeViewOrBroadcast(op, rewriter);
+}
+
+OpFoldResult BroadcastOp::fold(FoldAdaptor adaptor) {
+  if (getType() == getOperand().getType()) {
+    // no-op
+    return getOperand();
+  }
+
+  auto value = adaptor.getSrc();
+  if (!value)
+    return {};
+
+  if (auto denseElemsAttr = value.dyn_cast<SplatElementsAttr>()) {
+    auto shapedType = getType().cast<ShapedType>();
+    return denseElemsAttr.reshape(shapedType);
+  }
+  return {};
 }
 
 } // namespace triton

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -350,7 +350,11 @@ static OpFoldResult foldViewLikeOp(ViewLikeOp op, Attribute value) {
 
   auto shapedType = op.getType().template cast<mlir::ShapedType>();
   if (auto denseElemsAttr = value.dyn_cast<DenseElementsAttr>()) {
-    return denseElemsAttr.reshape(shapedType);
+    if (denseElemsAttr.isSplat()) {
+      return denseElemsAttr.resizeSplat(shapedType);
+    } else {
+      return denseElemsAttr.reshape(shapedType);
+    }
   }
   return {};
 }
@@ -415,7 +419,7 @@ OpFoldResult BroadcastOp::fold(FoldAdaptor adaptor) {
 
   if (auto denseElemsAttr = value.dyn_cast<SplatElementsAttr>()) {
     auto shapedType = getType().cast<ShapedType>();
-    return denseElemsAttr.reshape(shapedType);
+    return denseElemsAttr.resizeSplat(shapedType);
   }
   return {};
 }

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -295,8 +295,7 @@ OpFoldResult SplatOp::fold(FoldAdaptor adaptor) {
   if (!value)
     return {};
   auto shapedType = getType().cast<ShapedType>();
-  auto ret = SplatElementsAttr::get(
-      shapedType, ArrayRef<Attribute>(value));
+  auto ret = SplatElementsAttr::get(shapedType, ArrayRef<Attribute>(value));
   return ret;
 }
 
@@ -329,15 +328,16 @@ mlir::LogicalResult mlir::triton::ExpandDimsOp::inferReturnTypes(
   return mlir::success();
 }
 
-LogicalResult ExpandDimsOp::canonicalize(ExpandDimsOp op, PatternRewriter &rewriter) {
+LogicalResult ExpandDimsOp::canonicalize(ExpandDimsOp op,
+                                         PatternRewriter &rewriter) {
   auto definingOp = op.getOperand().getDefiningOp();
   if (!definingOp) {
     return mlir::failure();
   }
   // expand_dims(splat) -> splat
   if (auto splat = dyn_cast<triton::SplatOp>(definingOp)) {
-    rewriter.replaceOpWithNewOp<triton::SplatOp>(
-      op, op.getType(), splat.getOperand());
+    rewriter.replaceOpWithNewOp<triton::SplatOp>(op, op.getType(),
+                                                 splat.getOperand());
     return mlir::success();
   }
   return mlir::failure();
@@ -361,7 +361,8 @@ OpFoldResult ExpandDimsOp::fold(FoldAdaptor adaptor) {
 
 //-- ViewOp --
 template <typename OpType>
-LogicalResult canonicalizeViewOrBroadcast(OpType op, PatternRewriter &rewriter) {
+LogicalResult canonicalizeViewOrBroadcast(OpType op,
+                                          PatternRewriter &rewriter) {
   auto definingOp = op.getOperand().getDefiningOp();
   if (!definingOp) {
     return mlir::failure();
@@ -369,15 +370,15 @@ LogicalResult canonicalizeViewOrBroadcast(OpType op, PatternRewriter &rewriter) 
 
   // view(view) -> view
   if (auto parent_view = dyn_cast<OpType>(definingOp)) {
-    rewriter.replaceOpWithNewOp<OpType>(
-      op, op.getType(), parent_view.getOperand());
+    rewriter.replaceOpWithNewOp<OpType>(op, op.getType(),
+                                        parent_view.getOperand());
     return mlir::success();
   }
 
   // view(splat) -> splat
   if (auto splat = dyn_cast<triton::SplatOp>(definingOp)) {
-    rewriter.replaceOpWithNewOp<triton::SplatOp>(
-      op, op.getType(), splat.getOperand());
+    rewriter.replaceOpWithNewOp<triton::SplatOp>(op, op.getType(),
+                                                 splat.getOperand());
     return mlir::success();
   }
 
@@ -386,7 +387,6 @@ LogicalResult canonicalizeViewOrBroadcast(OpType op, PatternRewriter &rewriter) 
 LogicalResult ViewOp::canonicalize(ViewOp op, PatternRewriter &rewriter) {
   return canonicalizeViewOrBroadcast(op, rewriter);
 }
-
 
 OpFoldResult ViewOp::fold(FoldAdaptor adaptor) {
   if (getType() == getOperand().getType()) {
@@ -398,7 +398,8 @@ OpFoldResult ViewOp::fold(FoldAdaptor adaptor) {
 }
 
 //-- BroadcastOp --
-LogicalResult BroadcastOp::canonicalize(BroadcastOp op, PatternRewriter &rewriter) {
+LogicalResult BroadcastOp::canonicalize(BroadcastOp op,
+                                        PatternRewriter &rewriter) {
   return canonicalizeViewOrBroadcast(op, rewriter);
 }
 


### PR DESCRIPTION
These eliminate no-op reshapes, and simplify some combinations of view ops into a single view. e.g. viewing a splat becomes a single splat.