### PR TITLE
[DOC] Fix syntax errors, typos, formatting; increase consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,26 +38,25 @@ pip install -U --pre triton
 ```
 git clone https://github.com/openai/triton.git;
 cd triton/python;
-pip install cmake; # build time dependency
+pip install cmake; # build-time dependency
 pip install -e .
 ```
 
 # Changelog
 
 Version 2.0 is out! New features include:
-- Many, many bugfixes
+- Many, many bug fixes
 - Performance improvements
 - Backend rewritten to use MLIR
 - Support for kernels that contain back-to-back matmuls (e.g., flash attention)
 
 # Contributing
 
-Community contributions are more than welcome, whether it be to fix bugs or to add new features. Feel free to open GitHub issues about your contribution ideas, and we will review them. 
-Please do not submit PRs that simply fix simple typos in our documentation -- unless they can lead to confusion.
+Community contributions are more than welcome, whether it be to fix bugs or to add new features. Feel free to open GitHub issues about your contribution ideas, and we will review them. Please do not submit PRs that simply fix simple typos in our documentation -- unless they can lead to confusion.
 
 Note 1: A more detailed contributor's guide containing general guidelines is coming soon!
-Note 2: If you’re interested in joining our team and working on Triton & GPU kernels, [we’re hiring](https://openai.com/jobs/#acceleration)!
 
+Note 2: If you’re interested in joining our team and working on Triton & GPU kernels, [we’re hiring](https://openai.com/jobs/#acceleration)!
 
 # Compatibility
 

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -1,4 +1,3 @@
-
 # - Find LLVM headers and libraries.
 # This module locates LLVM and adapts the llvm-config output for use with
 # CMake.

--- a/docs/getting-started/installation.rst
+++ b/docs/getting-started/installation.rst
@@ -1,10 +1,10 @@
-==============
+============
 Installation
-==============
+============
 
----------------------
+--------------------
 Binary Distributions
----------------------
+--------------------
 
 You can install the latest stable release of Triton from pip:
 
@@ -21,13 +21,13 @@ And the latest nightly release:
       pip install -U --pre triton
 
 
---------------
+-----------
 From Source
---------------
+-----------
 
-+++++++++++++++
+++++++++++++++
 Python Package
-+++++++++++++++
+++++++++++++++
 
 You can install the Python package from source by running the following commands:
 
@@ -35,7 +35,7 @@ You can install the Python package from source by running the following commands
 
       git clone https://github.com/openai/triton.git;
       cd triton/python;
-      pip install cmake; # build time dependency
+      pip install cmake; # build-time dependency
       pip install -e .
 
 Note that, if llvm-11 is not present on your system, the setup.py script will download the official LLVM11 static libraries link against that.
@@ -51,5 +51,5 @@ and the benchmarks
 
 .. code-block:: bash
       
-      cd bench/
+      cd bench
       python -m run --with-plots --result-dir /tmp/triton-bench

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,7 @@ Welcome to Triton's documentation!
 
 Triton is a language and compiler for parallel programming. It aims to provide a Python-based programming environment for productively writing custom DNN compute kernels capable of running at maximal throughput on modern GPU hardware.
 
+
 Getting Started
 ---------------
 
@@ -17,8 +18,9 @@ Getting Started
    getting-started/installation
    getting-started/tutorials/index
 
+
 Python API
--------------------
+----------
 
 - :doc:`triton <python-api/triton>`
 - :doc:`triton.language <python-api/triton.language>`
@@ -36,7 +38,7 @@ Python API
 
    
 Going Further
-------------------
+-------------
 
 Check out the following documents to learn more about Triton and how it compares against other DSLs for DNNs:
 

--- a/docs/programming-guide/chapter-1/introduction.rst
+++ b/docs/programming-guide/chapter-1/introduction.rst
@@ -1,18 +1,18 @@
-==============
+============
 Introduction
-==============
+============
 
---------------
+-----------
 Motivations
---------------
+-----------
 
-Over the past decade, Deep Neural Networks (DNNs) have emerged as an important class of Machine Learning (ML) models, capable of  achieving state-of-the-art performance across many domains ranging from natural language processing [SUTSKEVER2014]_ to computer vision [REDMON2016]_ to computational neuroscience [LEE2017]_. The strength of these models lies in their hierarchical structure, composed of a sequence of parametric (e.g., convolutional) and non-parametric (e.g., rectified linearity) *layers*. This pattern, though notoriously computationally expensive, also generates a large amount of highly parallelizable work particularly well suited for multi- and many- core processors.
+Over the past decade, Deep Neural Networks (DNNs) have emerged as an important class of Machine Learning (ML) models, capable of achieving state-of-the-art performance across many domains ranging from natural language processing [SUTSKEVER2014]_ to computer vision [REDMON2016]_ to computational neuroscience [LEE2017]_. The strength of these models lies in their hierarchical structure, composed of a sequence of parametric (e.g., convolutional) and non-parametric (e.g., rectified linearity) *layers*. This pattern, though notoriously computationally expensive, also generates a large amount of highly parallelizable work particularly well suited for multi- and many- core processors.
 
 As a consequence, Graphics Processing Units (GPUs) have become a cheap and accessible resource for exploring and/or deploying novel research ideas in the field. This trend has been accelerated by the release of several frameworks for General-Purpose GPU (GPGPU) computing, such as CUDA and OpenCL, which have made the development of high-performance programs easier. Yet, GPUs remain incredibly challenging to optimize for locality and parallelism, especially for computations that cannot be efficiently implemented using a combination of pre-existing optimized primitives. To make matters worse, GPU architectures are also rapidly evolving and specializing, as evidenced by the addition of tensor cores to NVIDIA (and more recently AMD) micro-architectures.
 
-This tension between the computational opportunities offered by DNNs and the practical difficulty of GPU programming has created substantial academic and industrial interest for Domain-Specific Languages (DSLs) and compilers. Regrettably, these systems -- whether they be based on  polyhedral machinery (*e.g.*, Tiramisu [BAGHDADI2021]_, Tensor Comprehensions [VASILACHE2018]_) or scheduling languages (*e.g.*, Halide [JRK2013]_, TVM [CHEN2018]_) -- remain less flexible and (for the same algorithm) markedly slower than the best handwritten compute kernels available in libraries like `cuBLAS <https://docs.nvidia.com/cuda/cublas/index.html>`_, `cuDNN <https://docs.nvidia.com/deeplearning/cudnn/api/index.html>`_ or `TensorRT <https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html>`_.
+This tension between the computational opportunities offered by DNNs and the practical difficulty of GPU programming has created substantial academic and industrial interest for Domain-Specific Languages (DSLs) and compilers. Regrettably, these systems -- whether they be based on polyhedral machinery (e.g., Tiramisu [BAGHDADI2021]_, Tensor Comprehensions [VASILACHE2018]_) or scheduling languages (e.g., Halide [JRK2013]_, TVM [CHEN2018]_) -- remain less flexible and (for the same algorithm) markedly slower than the best handwritten compute kernels available in libraries like `cuBLAS <https://docs.nvidia.com/cuda/cublas/index.html>`_, `cuDNN <https://docs.nvidia.com/deeplearning/cudnn/api/index.html>`_ or `TensorRT <https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html>`_.
 
-The main premise of this project is the following: programming paradigms based on blocked algorithms [LAM1991]_ can facilitate the construction of high-performance compute kernels for neural networks.  We specifically revisit traditional "Single Program, Multiple Data" (SPMD [AUGUIN1983]_) execution models for GPUs, and propose a variant in which programs -- rather than threads -- are blocked. For example, in the case of matrix multiplication, CUDA and Triton differ as follows:
+The main premise of this project is the following: programming paradigms based on blocked algorithms [LAM1991]_ can facilitate the construction of high-performance compute kernels for neural networks. We specifically revisit traditional "Single Program, Multiple Data" (SPMD [AUGUIN1983]_) execution models for GPUs, and propose a variant in which programs -- rather than threads -- are blocked. For example, in the case of matrix multiplication, CUDA and Triton differ as follows:
 
 .. table::
     :widths: 50 50
@@ -31,8 +31,8 @@ The main premise of this project is the following: programming paradigms based o
     |   #pragma parallel                                  |   #pragma parallel                                  |
     |   for(int n = 0; j < N; n++){                       |   for(int n = 0; n < N; n += NB){                   |
     |     float acc = 0;                                  |     float acc[MB, NB] = 0;                          |
-    |     for(int k = 0; k < K;k ++)                      |     for(int k = 0; k < K; k += KB)                  |
-    |       acc += A[i, k]* B[k, j];                      |       acc +=  A[m:m+MB, k:k+KB]                     |
+    |     for(int k = 0; k < K; k++)                      |     for(int k = 0; k < K; k += KB)                  |
+    |       acc += A[i, k] * B[k, j];                     |       acc +=  A[m:m+MB, k:k+KB]                     |
     |                                                     |             @ B[k:k+KB, n:n+NB];                    |
     |     C[i, j] = acc;                                  |     C[m:m+MB, n:n+NB] = acc;                        |
     |   }                                                 |   }                                                 |
@@ -48,15 +48,17 @@ The main premise of this project is the following: programming paradigms based o
 
 A key benefit of this approach is that it leads to block-structured iteration spaces that offer programmers more flexibility than existing DSLs when implementing sparse operations, all while allowing compilers to aggressively optimize programs for data locality and parallelism.
 
---------------
+
+----------
 Challenges
---------------
+----------
 
 The main challenge posed by our proposed paradigm is that of work scheduling, i.e., how the work done by each program instance should be partitioned for efficient execution on modern GPUs. To address this issue, the Triton compiler makes heavy use of *block-level data-flow analysis*, a technique for scheduling iteration blocks statically based on the control- and data-flow structure of the target program. The resulting system actually works surprisingly well: our compiler manages to apply a broad range of interesting optimization automatically (e.g., automatic coalescing, thread swizzling, pre-fetching, automatic vectorization, tensor core-aware instruction selection, shared memory allocation/synchronization, asynchronous copy scheduling). Of course doing all this is not trivial; one of the purposes of this guide is to give you a sense of how it works.
 
---------------
+
+----------
 References
---------------
+----------
 
 .. [SUTSKEVER2014] I. Sutskever et al., "Sequence to Sequence Learning with Neural Networks", NIPS 2014
 .. [REDMON2016] J. Redmon et al., "You Only Look Once: Unified, Real-Time Object Detection", CVPR 2016

--- a/docs/programming-guide/chapter-2/related-work.rst
+++ b/docs/programming-guide/chapter-2/related-work.rst
@@ -1,18 +1,19 @@
-==============
+============
 Related Work
-==============
+============
 
 At first sight, Triton may seem like just yet another DSL for DNNs. The purpose of this section is to contextualize Triton and highlight its differences with the two leading approaches in this domain: polyhedral compilation and scheduling languages.
 
------------------------
+
+----------------------
 Polyhedral Compilation
------------------------
+----------------------
 
 Traditional compilers typically rely on intermediate representations, such as LLVM-IR [LATTNER2004]_, that encode control flow information using (un)conditional branches. This relatively low-level format makes it difficult to statically analyze the runtime behavior (e.g., cache misses) of input programs, and to  automatically optimize loops accordingly through the use of tiling [WOLFE1989]_, fusion [DARTE1999]_ and interchange [ALLEN1984]_. To solve this issue, polyhedral compilers [ANCOURT1991]_ rely on program representations that have statically predictable control flow, thereby enabling aggressive compile-time program transformations for data locality and parallelism. Though this strategy has been adopted by many languages and compilers for DNNs such as Tiramisu [BAGHDADI2021]_, Tensor Comprehensions [VASILACHE2018]_, Diesel [ELANGO2018]_ and the Affine dialect in MLIR [LATTNER2019]_, it also comes with a number of limitations that will be described later in this section.
 
-+++++++++++++++++++++++
+++++++++++++++++++++++
 Program Representation
-+++++++++++++++++++++++
+++++++++++++++++++++++
 
 Polyhedral compilation is a vast area of research. In this section we only outline the most basic aspects of this topic, but readers interested in the solid mathematical foundations underneath may refer to the ample literature on linear and integer programming.
 
@@ -105,9 +106,9 @@ Where :math:`\Theta_S(\mathbf{x})` is a p-dimensional vector representing the sl
 
 where :math:`i` and :math:`j` are respectively the slowest and fastest growing loop indices in the nest. If :math:`T_S` is a vector (resp. tensor), then :math:`\Theta_S` is a said to be one-dimensional (resp. multi-dimensional).
 
-+++++++++++
+++++++++++
 Advantages
-+++++++++++
+++++++++++
 
 Programs amenable to polyhedral compilation can be aggressively transformed and optimized. Most of these transformations actually boil down to the production of  schedules and iteration domains that enable loop transformations promoting parallelism and spatial/temporal data locality (e.g., fusion, interchange, tiling, parallelization).
 
@@ -115,9 +116,9 @@ Polyhedral compilers can also automatically go through complex verification proc
 
 All in all, polyhedral machinery is extremely powerful, when applicable. It has been shown to support most common loop transformations, and has indeed achieved performance comparable to state-of-the-art GPU libraries for dense matrix multiplication [ELANGO2018]_. Additionally, it is also fully automatic and doesn't require any hint from programmers apart from source-code in a C-like format. 
 
-++++++++++++
++++++++++++
 Limitations
-++++++++++++
++++++++++++
 
 Unfortunately, polyhedral compilers suffer from two major limitations that have prevented its adoption as a universal method for code generation in neural networks.
 
@@ -127,9 +128,10 @@ Second, the polyhedral framework is not very generally applicable; SCoPs are rel
 
 On the other hand, blocked program representations advocated by this dissertation are less restricted in scope and can achieve close to peak performance using standard dataflow analysis.
 
------------------------
+
+--------------------
 Scheduling Languages
------------------------
+--------------------
 
 Separation of concerns [DIJKSTRA82]_ is a well-known design principle in computer science: programs should be decomposed into modular layers of abstraction that separate the semantics of their algorithms from the details of their implementation. Systems like Halide and TVM push this philosophy one step further, and enforce this separation at the grammatical level through the use of a  **scheduling language**. The benefits of this methodology are particularly visible in the case of matrix multiplication, where, as one can see below, the definition of the algorithm (Line 1-7) is completely disjoint from its implementation (Line 8-16), meaning that both can be maintained, optimized and distributed independently. 
 
@@ -156,17 +158,17 @@ Separation of concerns [DIJKSTRA82]_ is a well-known design principle in compute
 
 The resulting code may however not be completely portable, as schedules can sometimes rely on execution models (e.g., SPMD) or hardware intrinsics (e.g., matrix-multiply-accumulate) that are not widely available. This issue can be mitigated by auto-scheduling mechanisms [MULLAPUDI2016]_.
 
-+++++++++++
+++++++++++
 Advantages
-+++++++++++
+++++++++++
 
 The main advantage of this approach is that it allows programmers to write an algorithm *only once*, and focus on performance optimization separately. It makes it possible to manually specify optimizations that a polyhedral compiler wouldn't be able to figure out automatically using static data-flow analysis.
 
 Scheduling languages are, without a doubt, one of the most popular approaches for neural network code generation. The most popular system for this purpose is probably TVM, which provides good performance across a wide range of platforms as well as built-in automatic scheduling mechanisms.
 
-++++++++++++
++++++++++++
 Limitations
-++++++++++++
++++++++++++
 
 This ease-of-development comes at a cost. First of all, existing systems that follow this paradigm tend to be noticeably slower than Triton on modern hardware when applicable (e.g., V100/A100 tensor cores w/ equal tile sizes). I do believe that this is not a fundamental issue of scheduling languages -- in the sense that it could probably be solved with more efforts -- but it could mean that these systems are harder to engineer. More importantly, existing scheduling languages generate loops whose bounds and increments cannot depend on surrounding loop indices without at least imposing severe constraints on possible schedules -- if not breaking the system entirely. This is problematic for sparse computations, whose iteration spaces may be irregular.
 
@@ -181,7 +183,7 @@ This ease-of-development comes at a cost. First of all, existing systems that fo
     |   for(int j = 0; j < 4; j++)                        |                                                     |
     |     float acc = 0;                                  |                                                     |
     |     for(int k = 0; k < K[i]; k++)                   |                                                     |
-    |       acc += A[i][col[i,k]]*B[k][j]                 |                                                     |
+    |       acc += A[i][col[i, k]] * B[k][j]              |                                                     |
     |     C[i][j] = acc;                                  |                                                     |
     +-----------------------------------------------------+-----------------------------------------------------+
 
@@ -190,9 +192,10 @@ This ease-of-development comes at a cost. First of all, existing systems that fo
 
 On the other hand, the block-based program representation that we advocate for through this work allows for block-structured iteration spaces and allows programmers to manually handle load-balancing as they wish.
 
---------------
+
+----------
 References
---------------
+----------
 
 .. [LATTNER2004] C. Lattner et al., "LLVM: a compilation framework for lifelong program analysis transformation", CGO 2004
 .. [WOLFE1989] M. Wolfe, "More Iteration Space Tiling", SC 1989

--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -1,11 +1,11 @@
 triton.language
-================
+===============
 
 .. currentmodule:: triton.language
 
 
 Programming Model
--------------------
+-----------------
 
 .. autosummary::
     :toctree: generated
@@ -16,7 +16,7 @@ Programming Model
 
 
 Creation Ops
--------------
+------------
 
 .. autosummary::
     :toctree: generated
@@ -27,7 +27,7 @@ Creation Ops
 
 
 Shape Manipulation Ops
------------------------
+----------------------
 
 .. autosummary::
     :toctree: generated
@@ -40,7 +40,7 @@ Shape Manipulation Ops
 
 
 Linear Algebra Ops
--------------------
+------------------
 
 .. autosummary::
     :toctree: generated
@@ -48,8 +48,9 @@ Linear Algebra Ops
 
     dot
 
+
 Memory Ops
---------------------
+----------
 
 .. autosummary::
     :toctree: generated
@@ -62,7 +63,7 @@ Memory Ops
 
 
 Indexing Ops
---------------
+------------
 
 .. autosummary::
     :toctree: generated
@@ -72,7 +73,7 @@ Indexing Ops
 
 
 Math Ops
-----------
+--------
 
 .. autosummary::
     :toctree: generated
@@ -88,7 +89,7 @@ Math Ops
 
 
 Reduction Ops
----------------
+-------------
 
 .. autosummary::
     :toctree: generated
@@ -98,8 +99,9 @@ Reduction Ops
     min
     sum
 
+
 Atomic Ops
----------------
+----------
 
 .. autosummary::
     :toctree: generated
@@ -112,7 +114,7 @@ Atomic Ops
 
 
 Comparison ops
----------------
+--------------
 
 .. autosummary::
     :toctree: generated
@@ -124,7 +126,7 @@ Comparison ops
 .. _Random Number Generation:
 
 Random Number Generation
--------------------------
+------------------------
 
 .. autosummary::
     :toctree: generated
@@ -135,8 +137,9 @@ Random Number Generation
     rand
     randn
 
+
 Compiler Hint Ops
--------------------
+-----------------
 
 .. autosummary::
     :toctree: generated

--- a/docs/python-api/triton.rst
+++ b/docs/python-api/triton.rst
@@ -1,5 +1,5 @@
 triton
-========
+======
 
 .. currentmodule:: triton
 

--- a/docs/python-api/triton.testing.rst
+++ b/docs/python-api/triton.testing.rst
@@ -1,5 +1,5 @@
 triton.testing
-================
+==============
 
 .. currentmodule:: triton.testing
 

--- a/include/triton/Conversion/CMakeLists.txt
+++ b/include/triton/Conversion/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 set(LLVM_TARGET_DEFINITIONS Passes.td)
 mlir_tablegen(Passes.h.inc -gen-pass-decls)
 add_public_tablegen_target(TritonConversionPassIncGen)

--- a/include/triton/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/include/triton/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -9,4 +9,3 @@ set(LLVM_TARGET_DEFINITIONS TritonGPUAttrDefs.td)
 mlir_tablegen(TritonGPUAttrDefs.h.inc -gen-attrdef-decls)
 mlir_tablegen(TritonGPUAttrDefs.cpp.inc -gen-attrdef-defs)
 add_public_tablegen_target(TritonGPUAttrDefsIncGen)
-

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -65,7 +65,7 @@ getScratchConfigForCvtLayout(triton::gpu::ConvertLayoutOp op, unsigned &inVec,
         return {};
 
   assert(srcLayout && dstLayout &&
-         "Unexpect layout in getScratchConfigForCvtLayout()");
+         "Unexpected layout in getScratchConfigForCvtLayout()");
   auto [inOrd, outOrd] = getCvtOrder(srcLayout, dstLayout);
   unsigned srcContigPerThread = getContigPerThread(srcLayout)[inOrd[0]];
   unsigned dstContigPerThread = getContigPerThread(dstLayout)[outOrd[0]];

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -234,9 +234,9 @@ private:
     }
   }
 
-  // The MMAV1's result is quite different from the exising "Replica" structure,
+  // The MMAV1's result is quite different from the existing "Replica" structure,
   // add a new simple but clear implementation for it to avoid modificating the
-  // logic of the exising one.
+  // logic of the existing one.
   void processReplicaForMMAV1(Location loc, ConversionPatternRewriter &rewriter,
                               bool stNotRd, RankedTensorType type,
                               ArrayRef<unsigned> multiDimRepId, unsigned vec,

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -234,9 +234,9 @@ private:
     }
   }
 
-  // The MMAV1's result is quite different from the existing "Replica" structure,
-  // add a new simple but clear implementation for it to avoid modificating the
-  // logic of the existing one.
+  // The MMAV1's result is quite different from the existing "Replica"
+  // structure, add a new simple but clear implementation for it to avoid
+  // modifying the logic of the existing one.
   void processReplicaForMMAV1(Location loc, ConversionPatternRewriter &rewriter,
                               bool stNotRd, RankedTensorType type,
                               ArrayRef<unsigned> multiDimRepId, unsigned vec,

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.cpp
@@ -1356,7 +1356,7 @@ int DotOpFMAConversionHelper::getNumElemsPerThread(
   auto shapePerCTA = getShapePerCTA(blockedLayout);
   auto sizePerThread = getSizePerThread(blockedLayout);
 
-  // TODO[Superjomn]: we assume the k aixs is fixed for $a and $b here, fix it
+  // TODO[Superjomn]: we assume the k axis is fixed for $a and $b here, fix it
   // if not.
   int K = dotOpLayout.getOpIdx() == 0 ? shape[1] : shape[0];
   int otherDim = dotOpLayout.getOpIdx() == 1 ? shape[1] : shape[0];

--- a/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpHelpers.h
@@ -332,7 +332,7 @@ private:
 };
 
 // This class helps to adapt the existing DotOpConversion to the latest
-// DotOpOperand layout design. It decouples the exising implementation to two
+// DotOpOperand layout design. It decouples the existing implementation to two
 // parts:
 // 1. loading the specific operand matrix(for $a, $b, $c) from smem
 // 2. passing the loaded value and perform the mma codegen

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -434,7 +434,7 @@ private:
 
     // We could avoid this barrier in some of the layouts, however this is not
     // the general case.
-    // TODO: optimize the barrier incase the layouts are accepted.
+    // TODO: optimize the barrier in case the layouts are accepted.
     barrier();
 
     // set output values

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -299,7 +299,7 @@ public:
       Value idxRow = idx[outOrder[1]]; // discontiguous dimension
       Value strideCol = srcStrides[outOrder[0]];
       Value strideRow = srcStrides[outOrder[1]];
-      // extract dynamic/static offset for immediate offseting
+      // extract dynamic/static offset for immediate offsetting
       unsigned immedateOffCol = 0;
       if (auto add = dyn_cast_or_null<LLVM::AddOp>(idxCol.getDefiningOp()))
         if (auto _cst = dyn_cast_or_null<LLVM::ConstantOp>(
@@ -311,7 +311,7 @@ public:
           idxCol = cacheCol[key];
           immedateOffCol = cst / (outVec * maxPhase) * (outVec * maxPhase);
         }
-      // extract dynamic/static offset for immediate offseting
+      // extract dynamic/static offset for immediate offsetting
       unsigned immedateOffRow = 0;
       if (auto add = dyn_cast_or_null<LLVM::AddOp>(idxRow.getDefiningOp()))
         if (auto _cst = dyn_cast_or_null<LLVM::ConstantOp>(
@@ -363,7 +363,7 @@ public:
     auto srcDistributedLayout = srcTy.getEncoding();
     if (auto mmaLayout = srcDistributedLayout.dyn_cast<MmaEncodingAttr>()) {
       assert((!mmaLayout.isVolta()) &&
-             "ConvertLayout MMAv1->Shared is not suppported yet");
+             "ConvertLayout MMAv1->Shared is not supported yet");
     }
     auto dstSharedLayout =
         dstTy.getEncoding().cast<triton::gpu::SharedEncodingAttr>();
@@ -618,7 +618,7 @@ private:
 
     SmallVector<Value> multiDimBase(rank);
     for (unsigned k = 0; k < rank; ++k) {
-      // Wrap around multiDimWarpId/multiDimThreadId incase
+      // Wrap around multiDimWarpId/multiDimThreadId in case
       // shape[k] > shapePerCTA[k]
       auto maxWarps =
           ceil<unsigned>(shape[k], sizePerThread[k] * threadsPerWarp[k]);

--- a/python/examples/copy_strided.py
+++ b/python/examples/copy_strided.py
@@ -1,4 +1,3 @@
-
 import triton
 import triton.language as tl
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1177,7 +1177,7 @@ def test_permute(dtype_str, shape, perm, device='cuda'):
                                            [128, 128, 64, 4],
                                            [64, 128, 128, 4],
                                            [32, 128, 64, 2],
-                                           # triggers nvptx/ptxas bug on V100 curently
+                                           # triggers nvptx/ptxas bug on V100 currently
                                            # [128, 128, 64, 2],
                                            [64, 128, 128, 2]]
                           for allow_tf32 in [True]
@@ -2018,7 +2018,7 @@ def test_while():
 # -----------------------
 # test layout conversions
 # -----------------------
-# TODO: backend hsould be tested separately
+# TODO: backend should be tested separately
 
 
 class MmaLayout:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -898,7 +898,7 @@ def load(pointer, mask=None, other=None, cache_modifier="", eviction_policy="", 
     :param other: if mask[idx] is false, return other[idx]
     :type other: Block, optional
     :param cache_modifier: changes cache option in nvidia ptx
-    'type cache_modifier: str, optional
+    :type cache_modifier: str, optional
     """
     # mask, other can be constexpr
     if _constexpr_to_value(mask) is not None:
@@ -1065,7 +1065,7 @@ def _add_math_1arg_docstr(name: str) -> Callable[[T], T]:
 
     def _decorator(func: T) -> T:
         docstr = """
-    Computes the element-wise {name} of :code:`x`
+    Computes the element-wise {name} of :code:`x`.
 
     :param x: the input values
     :type x: Block
@@ -1275,7 +1275,7 @@ def softmax(x, ieee_rounding=False):
 @triton.jit
 def ravel(x):
     """
-    Returns a contiguous flattened view of :code:`x`
+    Returns a contiguous flattened view of :code:`x`.
 
     :param x: the input tensor
     :type x: Block

--- a/python/triton/language/random.py
+++ b/python/triton/language/random.py
@@ -106,7 +106,7 @@ def uint32_to_uniform_float(x):
 def rand(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offset` block,
-    returns a block of random :code:`float32` in :math:`U(0, 1)`
+    returns a block of random :code:`float32` in :math:`U(0, 1)`.
 
     :param seed: The seed for generating random numbers.
     :param offsets: The offsets to generate random numbers for.
@@ -120,7 +120,7 @@ def rand(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
 def rand4x(seed, offsets, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offsets` block,
-    returns a 4 blocks of random :code:`float32` in :math:`U(0, 1)`
+    returns a 4 blocks of random :code:`float32` in :math:`U(0, 1)`.
 
     :param seed: The seed for generating random numbers.
     :param offsets: The offsets to generate random numbers for.
@@ -151,7 +151,7 @@ def pair_uniform_to_normal(u1, u2):
 def randn(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offset` block,
-    returns a block of random :code:`float32` in :math:`\\mathcal{N}(0, 1)`
+    returns a block of random :code:`float32` in :math:`\\mathcal{N}(0, 1)`.
 
     :param seed: The seed for generating random numbers.
     :param offsets: The offsets to generate random numbers for.
@@ -167,7 +167,7 @@ def randn(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
 def randn4x(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offset` block,
-    returns a 4 blocks of random :code:`float32` in :math:`\\mathcal{N}(0, 1)`
+    returns a 4 blocks of random :code:`float32` in :math:`\\mathcal{N}(0, 1)`.
 
     :param seed: The seed for generating random numbers.
     :param offsets: The offsets to generate random numbers for.

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -165,7 +165,7 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None):
         @triton.jit
         def kernel(x_ptr, x_size, **META):
             BLOCK_SIZE = META['BLOCK_SIZE']
-    :note: When all the configurations are evaluated, the kernel will run multiple time.
+    :note: When all the configurations are evaluated, the kernel will run multiple times.
            This means that whatever value the kernel updates will be updated multiple times.
            To avoid this undesired behavior, you can use the `reset_to_zero` argument, which
            resets the value of the provided tensor to `zero` before running any configuration.
@@ -209,9 +209,9 @@ def heuristics(values):
         @triton.jit
         def kernel(x_ptr, x_size, **META):
             BLOCK_SIZE = META['BLOCK_SIZE'] # smallest power-of-two >= x_size
-    .param values: a dictionary of meta-parameter names and functions that compute the value of the meta-parameter.
+    :param values: a dictionary of meta-parameter names and functions that compute the value of the meta-parameter.
                    each such function takes a list of positional arguments as input.
-    .type values: dict[str, Callable[[list[Any]], Any]]
+    :type values: dict[str, Callable[[list[Any]], Any]]
     """
     def decorator(fn):
         return Heuristics(fn, fn.arg_names, values)

--- a/python/tutorials/01-vector-add.py
+++ b/python/tutorials/01-vector-add.py
@@ -1,8 +1,10 @@
 """
 Vector Addition
-=================
-In this tutorial, you will write a simple vector addition using Triton and learn about:
+===============
 
+In this tutorial, you will write a simple vector addition using Triton.
+
+In doing so, you will learn about:
 - The basic programming model of Triton.
 - The `triton.jit` decorator, which is used to define Triton kernels.
 - The best practices for validating and benchmarking your custom ops against native reference implementations.
@@ -10,7 +12,7 @@ In this tutorial, you will write a simple vector addition using Triton and learn
 
 # %%
 # Compute Kernel
-# --------------------------
+# --------------
 
 import torch
 
@@ -92,9 +94,10 @@ print(
 
 # %%
 # Benchmark
-# -----------
+# ---------
+#
 # We can now benchmark our custom op on vectors of increasing sizes to get a sense of how it does relative to PyTorch.
-# To make things easier, Triton has a set of built-in utilities that allow us to concisely plot the performance of your custom ops.
+# To make things easier, Triton has a set of built-in utilities that allow us to concisely plot the performance of our custom ops.
 # for different problem sizes.
 
 

--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -1,10 +1,10 @@
 """
 Matrix Multiplication
-======================
+=====================
 In this tutorial, you will write a 25-lines high-performance FP16 matrix multiplication
 kernel that achieves performance on par with cuBLAS.
-You will specifically learn about:
 
+In doing so, you will learn about:
 - Block-level matrix multiplications
 - Multi-dimensional pointer arithmetic
 - Program re-ordering for improved L2 cache hit rate
@@ -13,7 +13,8 @@ You will specifically learn about:
 
 # %%
 # Motivations
-# -------------
+# -----------
+#
 # Matrix multiplications are a key building block of most modern high-performance computing systems.
 # They are notoriously hard to optimize, hence their implementation is generally done by
 # hardware vendors themselves as part of so-called "kernel libraries" (e.g., cuBLAS).
@@ -42,15 +43,16 @@ You will specifically learn about:
 
 # %%
 # Compute Kernel
-# ----------------
+# --------------
 #
 # The above algorithm is, actually, fairly straightforward to implement in Triton.
 # The main difficulty comes from the computation of the memory locations at which blocks
 # of :code:`A` and :code:`B` must be read in the inner loop. For that, we need
-# multi-dimensional pointer arithmetics.
+# multi-dimensional pointer arithmetic.
 #
-# Pointer Arithmetics
-# ~~~~~~~~~~~~~~~~~~~~
+#
+# Pointer Arithmetic
+# ~~~~~~~~~~~~~~~~~~
 #
 # For a row-major 2D tensor :code:`X`, the memory location of :code:`X[i, j]` is given b
 # y :code:`&X[i, j] = X + i*stride_xi + j*stride_xj`.
@@ -81,7 +83,7 @@ You will specifically learn about:
 #
 #
 # L2 Cache Optimizations
-# ~~~~~~~~~~~~~~~~~~~~~~~~
+# ~~~~~~~~~~~~~~~~~~~~~~
 #
 # As mentioned above, each program instance computes a :code:`[BLOCK_SIZE_M, BLOCK_SIZE_N]`
 # block of :code:`C`.
@@ -137,8 +139,7 @@ You will specifically learn about:
 
 # %%
 # Final Result
-# -------------
-#
+# ------------
 
 import torch
 
@@ -201,7 +202,7 @@ def matmul_kernel(
     # and accumulate
     # a_ptrs is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
     # b_ptrs is a block of [BLOCK_SIZE_K, BLOCK_SIZE_n] pointers
-    # see above `Pointer Arithmetics` section for details
+    # see above `Pointer Arithmetic` section for details
     offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     offs_k = tl.arange(0, BLOCK_SIZE_K)
@@ -281,7 +282,7 @@ def matmul(a, b, activation=None):
 
 # %%
 # Unit Test
-# -----------
+# ---------
 #
 # We can test our custom matrix multiplication operation against a native torch implementation (i.e., cuBLAS)
 
@@ -299,10 +300,11 @@ else:
 
 # %%
 # Benchmark
-# --------------
+# ---------
 #
 # Square Matrix Performance
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~
+#
 # We can now compare the performance of our kernel against that of cuBLAS. Here we focus on square matrices, but feel free to arrange this script as you wish to benchmark any other matrix shape.
 
 

--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -3,15 +3,16 @@ Layer Normalization
 ====================
 In this tutorial, you will write a high-performance layer normalization
 kernel that runs faster than the PyTorch implementation.
-You will specifically learn about:
 
-- How to implement backward pass in Triton
-- How to implement parallel reduction in Triton
+In doing so, you will learn about:
+- Implementing backward pass in Triton
+- Implementing parallel reduction in Triton
 """
 
 # %%
 # Motivations
-# -------------
+# -----------
+#
 # The *LayerNorm* operator was first introduced in [BA2016]_ as a way to improve the performance
 # of sequential models (e.g., Transformers) or neural networks with small batch size.
 # It takes a vector :math:`x` as input and produces a vector :math:`y` of the same shape as output.
@@ -23,7 +24,7 @@ You will specifically learn about:
 #    y = \frac{ x - \text{E}[x] }{ \sqrt{\text{Var}(x) + \epsilon} } * w + b
 #
 # where :math:`\epsilon` is a small constant added to the denominator for numerical stability.
-# Let’s first take a look at the foward pass implementation.
+# Let’s first take a look at the forward pass implementation.
 
 import torch
 
@@ -91,7 +92,8 @@ def _layer_norm_fwd_fused(
 
 # %%
 # Backward pass
-# ---------------------------------
+# -------------
+#
 # The backward pass for the layer normalization operator is a bit more involved than the forward pass.
 # Let :math:`\hat{x}` be the normalized inputs :math:`\frac{ x - \text{E}[x] }{ \sqrt{\text{Var}(x) + \epsilon} }` before the linear transformation,
 # the Vector-Jacobian Products (VJP) :math:`\nabla_{x}` of :math:`x` are given by:
@@ -218,7 +220,8 @@ def _layer_norm_bwd_dwdb(
 
 # %%
 # Benchmark
-# ---------------------------------
+# ---------
+#
 # We can now compare the performance of our kernel against that of PyTorch.
 # Here we focus on inputs that have Less than 64KB per feature.
 # Specifically, one can set :code:`'mode': 'backward'` to benchmark the backward pass.
@@ -362,6 +365,6 @@ bench_layer_norm.run(save_path='.', print_data=True)
 
 # %%
 # References
-# --------------
+# ----------
 #
 # .. [BA2016] Jimmy Lei Ba and Jamie Ryan Kiros and Geoffrey E. Hinton, "Layer Normalization", Arxiv 2016

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -1,6 +1,7 @@
 """
 Fused Attention
 ===============
+
 This is a Triton implementation of the Flash Attention algorithm
 (see: Dao et al., https://arxiv.org/pdf/2205.14135v2.pdf; Rabe and Staats https://arxiv.org/pdf/2112.05682v2.pdf)
 """

--- a/python/tutorials/README.rst
+++ b/python/tutorials/README.rst
@@ -1,5 +1,5 @@
 Tutorials
-==================
+=========
 
 Below is a gallery of tutorials for writing various basic operations with Triton. It is recommended that you read through the tutorials in order, starting with the simplest one.
 

--- a/test/TritonGPU/prefetch.mlir
+++ b/test/TritonGPU/prefetch.mlir
@@ -62,4 +62,3 @@ func.func @matmul_loop(%lb : index, %ub : index, %step : index, %A : !tt.ptr<f16
   }
   return
 }
-

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 include (${CMAKE_CURRENT_SOURCE_DIR}/googletest.cmake)
 
 include(GoogleTest)


### PR DESCRIPTION
This PR;
- Fixes syntax errors like `.type values: dict[str, Callable[[list[Any]], Any]]` to `:type values: dict[str, Callable[[list[Any]], Any]]`,
- Fixes typos,
- Fixes formatting like `k ++` to ` k++`,
- Increases consistency (e.g. by transforming the minority `cd dir/` to the majority `cd dir`).

I could add some more possible improvements, but wasn't sure about some aspects:

- I found quite a lot of issues under directories matching `*/third-party/*`, but did not fix those assuming they are not to be touched. If it's desirable, I can also fix those.
- The link in the readme (`https://openai.com/jobs/#acceleration`) does not point to anywhere special, i.e. `#acceleration` is redundant. Could you have meant `https://openai.com/careers/search?c=research-acceleration`? If not, should I simply replace it with `https://openai.com/jobs`?
- There are pieces of shell code in the form
  ```sh
  cmd1;
  cmd2;
  cmd3
  ```
  but also
  ```sh
  cmd1
  cmd2
  cmd3
  ```
  Should I unify those to one of the forms?

---

Edit: It's not quite hundreds of typos fixed as said in #1356, but I went through pretty much the whole codebase and these are all the typos I found, both manually and via `codespell`. Furthermore, this PR has some additional fixes apart from just typos and formatting, so I thought it would be acceptable.