### PR TITLE
[FRONTEND][BACKEND] Lower `tl.abs` to `math::Abs{I,F}Op`

### DIFF
--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -79,6 +79,7 @@ Math Ops
     :toctree: generated
     :nosignatures:
 
+    abs
     exp
     log
     cos

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1040,7 +1040,8 @@ struct AbsFOpConversion
                      ValueRange operands, Location loc) const {
     if (llvm::isa<IntegerType>(elemTy)) {
       // Mask out the sign bit
-      auto num_bits = getElementTypeOrSelf(op.getType()).getIntOrFloatBitWidth();
+      auto num_bits =
+          getElementTypeOrSelf(op.getType()).getIntOrFloatBitWidth();
       assert(num_bits <= 16);
       auto mask = (1u << (num_bits - 1u)) - 1u;
       auto maskAttr = rewriter.getIntegerAttr(elemTy, mask);

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1012,7 +1012,7 @@ struct ExpOpConversionApprox
 };
 
 struct AbsIOpConversion
-  : ElementwiseOpConversionBase<mlir::math::AbsIOp, AbsIOpConversion> {
+    : ElementwiseOpConversionBase<mlir::math::AbsIOp, AbsIOpConversion> {
   using Base =
       ElementwiseOpConversionBase<mlir::math::AbsIOp, AbsIOpConversion>;
   using Base::Base;
@@ -1023,13 +1023,13 @@ struct AbsIOpConversion
                      ValueRange operands, Location loc) const {
     auto boolFalse = rewriter.getBoolAttr(false);
     auto constFalse = rewriter.create<LLVM::ConstantOp>(loc, boolFalse);
-    return rewriter.create<LLVM::AbsOp>(
-        loc, elemTy, operands[0], /*is_int_min_poison=*/constFalse);
+    return rewriter.create<LLVM::AbsOp>(loc, elemTy, operands[0],
+                                        /*is_int_min_poison=*/constFalse);
   }
 };
 
 struct AbsFOpConversion
-  : ElementwiseOpConversionBase<mlir::math::AbsFOp, AbsFOpConversion> {
+    : ElementwiseOpConversionBase<mlir::math::AbsFOp, AbsFOpConversion> {
   using Base =
       ElementwiseOpConversionBase<mlir::math::AbsFOp, AbsFOpConversion>;
   using Base::Base;

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -176,6 +176,7 @@ void populateMathPatternsAndLegality(TritonGPUTypeConverter &typeConverter,
   // Rewrite rule
   patterns.add<GenericOpPattern<math::ExpOp>, GenericOpPattern<math::CosOp>,
                GenericOpPattern<math::SinOp>, GenericOpPattern<math::LogOp>,
+               GenericOpPattern<math::AbsFOp>, GenericOpPattern<math::AbsIOp>,
                GenericOpPattern<math::SqrtOp>>(typeConverter, context);
 }
 

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -1309,6 +1309,16 @@ void init_triton_ir(py::module &&m) {
              auto loc = self.getUnknownLoc();
              return self.create<mlir::math::SqrtOp>(loc, val);
            })
+      .def("create_fabs",
+           [](mlir::OpBuilder &self, mlir::Value &val) -> mlir::Value {
+             auto loc = self.getUnknownLoc();
+             return self.create<mlir::math::AbsFOp>(loc, val);
+           })
+      .def("create_iabs",
+           [](mlir::OpBuilder &self, mlir::Value &val) -> mlir::Value {
+             auto loc = self.getUnknownLoc();
+             return self.create<mlir::math::AbsIOp>(loc, val);
+           })
       .def("create_reduce",
            [](mlir::OpBuilder &self, mlir::Value &operand,
               mlir::triton::RedOp redOp, int axis) -> mlir::Value {

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1106,6 +1106,11 @@ def sin(x, _builder=None):
 def sqrt(x, _builder=None):
     return semantic.sqrt(x, _builder)
 
+@builtin
+@_add_math_1arg_docstr("absolute value")
+def abs(x, _builder=None):
+    return semantic.abs(x, _builder)
+
 
 # -----------------------
 # Reductions
@@ -1213,19 +1218,6 @@ def max_contiguous(input, values, _builder=None):
 # -----------------------
 # Standard library
 # -----------------------
-
-@triton.jit
-def abs(x):
-    x_dtype = x.dtype
-    if x_dtype.is_floating():
-        num_bits: constexpr = x.dtype.primitive_bitwidth
-        int_dtype = dtype(f'int{num_bits}')
-        mask = 2 ** (num_bits - 1) - 1
-        ret = x.to(int_dtype, bitcast=True) & mask.to(int_dtype)
-        ret = ret.to(x_dtype, bitcast=True)
-    else:
-        ret = where(x >= 0, x, -x)
-    return ret
 
 
 @triton.jit

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1106,6 +1106,7 @@ def sin(x, _builder=None):
 def sqrt(x, _builder=None):
     return semantic.sqrt(x, _builder)
 
+
 @builtin
 @_add_math_1arg_docstr("absolute value")
 def abs(x, _builder=None):

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1236,6 +1236,7 @@ def abs(x: tl.tensor, builder: ir.builder) -> tl.tensor:
 
 ##
 
+
 def multiple_of(x: tl.tensor, values: List[int]) -> tl.tensor:
     if len(x.shape) != len(values):
         raise ValueError("Shape of input to multiple_of does not match the length of values")

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1222,6 +1222,7 @@ def sin(x: tl.tensor, builder: ir.builder) -> tl.tensor:
 def sqrt(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_sqrt(x.handle), x.type)
 
+
 def abs(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     dtype = x.dtype
     if dtype.is_floating():

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1234,6 +1234,7 @@ def abs(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     else:
         assert False, f"Unexpected dtype {dtype}"
 
+
 ##
 
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1222,6 +1222,16 @@ def sin(x: tl.tensor, builder: ir.builder) -> tl.tensor:
 def sqrt(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_sqrt(x.handle), x.type)
 
+def abs(x: tl.tensor, builder: ir.builder) -> tl.tensor:
+    dtype = x.dtype
+    if dtype.is_floating():
+        return tl.tensor(builder.create_fabs(x.handle), x.type)
+    elif dtype.is_int_signed():
+        return tl.tensor(builder.create_iabs(x.handle), x.type)
+    elif dtype.is_int_unsigned():
+        return x  # no-op
+    else:
+        assert False, f"Unexpected dtype {dtype}"
 
 ##
 


### PR DESCRIPTION
This generates identical PTX for floating point, but for integer types the resulting PTX is much better. For example `tl.abs` for int16 currently generates

```mlir
  cvt.s32.s16 %r1, %rs2;
  neg.s16     %rs4, %rs2;
  setp.lt.s32 %p4, %r1, 0;
  selp.b16    %rs3, %rs4, %rs2, %p4;
```

After, it becomes a single `abs.s16` instruction.

This also improves LLVM's ability to optimize floats. e.g. `abs(t) * abs(t)` is optimized to `t * t` now which didn't happen before.