### PR TITLE
Fix pre-commit to only run on intended files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,8 @@ repos:
       - id: isort
         name: isort
         entry: isort
-        args: ["./python"]
+        files: "python/.*"
+        exclude: "python/build/.*"
         language: python
         types: [python]
         additional_dependencies:
@@ -13,7 +14,9 @@ repos:
       - id: autopep8
         name: autopep8
         entry: autopep8
-        args: ["-a", "-r", "-i", "./python/"]
+        args: ["-a", "-r", "-i"]
+        files: "python/.*"
+        exclude: "python/build/.*"
         language: python
         types: [python]
         additional_dependencies:


### PR DESCRIPTION
`pre-commit run --all-files` currently produces a diff of 2400 lines making `pre-commit` unusable. This seems to be because it runs on the entire codebase, not just the files listed in the arguments e.g. it shouldn't run on `docs/conf.py` or `test/lit.cfg.py` but does.