### PR TITLE
Avoid using EXTRA_INDEX_URL in pip install

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,7 +52,6 @@ jobs:
         if: ${{(matrix.runner[0] == 'self-hosted') && (matrix.runner[1] == 'gfx908')}}
         run: |
           echo "BACKEND=ROCM" >> "${GITHUB_ENV}"
-          echo "PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/rocm5.2" >> "${GITHUB_ENV}"
 
       - name: Clear cache
         run: |
@@ -79,7 +78,8 @@ jobs:
         if: ${{ env.BACKEND == 'ROCM'}}
         run: |
           cd python
-          python3 -m pip install cmake==3.24 torch==1.13.1
+          python3 -m pip install cmake==3.24
+          python3 -m pip install torch==1.13.1 --index-url https://download.pytorch.org/whl/rocm5.2
           python3 -m pip install -vvv -e '.[tests]'
 
       - name: Run lit tests


### PR DESCRIPTION
While not currently a vulnerability, using this option can introduce risks of supply chain attacks, where an attacker adds a malicious package into the default public repository with the same name as one that you are installing. The best practice is to instead use --index-url when a package is not available in the default repo, so I've updated to use this option instead.

For full disclosure, this is currently causing Microsoft's internal security checks to fail when building triton (which is why I care about this theoretical issue/best practice).