### PR TITLE
More friendly error message when non-Triton function is called from Triton function

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -78,7 +78,7 @@ class DependenciesFinder(ast.NodeVisitor):
             return
         if func.__module__ and func.__module__.startswith('triton.'):
             return
-        assert isinstance(func, JITFunction)
+        assert isinstance(func, JITFunction), f"Function {func.__name__} is being called from a Triton function but is not a Triton function itself. Decorate it with @triton.jit to fix this"
         if func.hash is None:
             tree = ast.parse(func.src)
             finder = DependenciesFinder(func.__globals__, func.src)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -78,7 +78,7 @@ class DependenciesFinder(ast.NodeVisitor):
             return
         if func.__module__ and func.__module__.startswith('triton.'):
             return
-        assert isinstance(func, JITFunction), f"Function {func.__name__} is being called from a Triton function but is not a Triton function itself. Decorate it with @triton.jit to fix this"
+        assert isinstance(func, JITFunction), f"Function \"{func.__name__}\" is being called from a Triton function but is not a Triton function itself. Decorate it with @triton.jit to fix this"
         if func.hash is None:
             tree = ast.parse(func.src)
             finder = DependenciesFinder(func.__globals__, func.src)


### PR DESCRIPTION
For a kernel like this:

```
import triton, torch

def my_special_activation(x): return x * 5

@triton.jit
def _kernel(x):
    my_special_activation(x)

_kernel[(1,)](torch.zeros(1))
```

Error message before:

```
  File "/usr/lib/python3.8/ast.py", line 371, in visit
    return visitor(node)
  File "/usr/local/lib/python3.8/dist-packages/triton/runtime/jit.py", line 63, in visit_Call
    assert isinstance(func, JITFunction)
AssertionError
```

Error message after:

```
  File "/usr/lib/python3.8/ast.py", line 371, in visit
    return visitor(node)
  File "/usr/local/lib/python3.8/dist-packages/triton/runtime/jit.py", line 62, in visit_Call
    assert isinstance(func, JITFunction), f"Function {func.__name__} is being called from a Triton function but is not a Triton function itself. Decorate it with @triton.jit to fix this"
AssertionError: Function "my_special_activation" is being called from a Triton function but is not a Triton function itself. Decorate it with @triton.jit to fix this
```