### PR TITLE
Add option to specify number of compilation threads during Triton compilation

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -200,7 +200,8 @@ class CMakeBuild(build_ext):
             build_args += ["--", "/m"]
         else:
             cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]
-            build_args += ['-j' + str(2 * os.cpu_count())]
+            max_jobs = os.getenv("MAX_JOBS", str(2 * os.cpu_count()))
+            build_args += ['-j' + max_jobs]
 
         env = os.environ.copy()
         subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=self.build_temp, env=env)


### PR DESCRIPTION
On some machines, the amount of available RAM might not be enough to compile Triton with `2 * num_cpus` parallelism. For example, CircleCI's `large` instance can't handle Triton compilation as is due to insufficient memory.

Instead, I propose to take PyTorch's approach where we can define a [`MAX_JOBS` env var](https://github.com/pytorch/pytorch/blob/0e4ddc2b40e8f8172bea66dc3bce50ab369eaa54/tools/setup_helpers/cmake.py#L366-L368) that gives the user the possibility to reduce (or increase) the parallelism during compilation.