### PR TITLE
[FRONTEND] Change calling convention from METH_VARARGS to METH_FASTCALL

### DIFF
--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1602,12 +1602,8 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   if(PyErr_Occurred()) {{
     return NULL;
   }}
-  // return None
-  Py_INCREF(Py_None);
-  if(py_args != NULL) {{
-    Py_DECREF(py_args);
-  }}
-  return Py_None;
+  Py_XDECREF(py_args);
+  Py_RETURN_NONE;
 }}
 
 static PyMethodDef ModuleMethods[] = {{

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1578,8 +1578,17 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   {" ".join([f"PyObject* _arg{i} = args[{10+i}];" if ty[0] == "*" else "" for i, ty in signature.items()])};
   {" ".join([f"{ty_to_cpp(ty)} _arg{i} = ({ty_to_cpp(ty)}) {ty_to_cast_method(ty)}(args[{10+i}]);" if ty[0] != "*" else "" for i, ty in signature.items()])};
 
+  PyObject *py_args = NULL;
+  if(launch_enter_hook != Py_None || launch_exit_hook != Py_None) {{
+    py_args = PyTuple_New(nargs);
+    for(Py_ssize_t i = 0; i < nargs; ++i) {{
+        Py_INCREF(args[i]);
+        PyTuple_SetItem(py_args, i, args[i]);
+    }}
+  }}
+
   if (launch_enter_hook != Py_None) {{
-    PyObject_CallObject(launch_enter_hook, *args);
+    PyObject_CallObject(launch_enter_hook, py_args);
   }}
 
   // raise exception asap
@@ -1587,7 +1596,7 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   _launch(gridX, gridY, gridZ, num_warps, shared_memory, (CUstream)_stream, (CUfunction)_function, {', '.join(f"ptr_info{i}.dev_ptr" if ty[0]=="*" else f"_arg{i}"for i, ty in signature.items())});
 
   if (launch_exit_hook != Py_None) {{
-    PyObject_CallObject(launch_exit_hook, *args);
+    PyObject_CallObject(launch_exit_hook, py_args);
   }}
 
   if(PyErr_Occurred()) {{
@@ -1595,6 +1604,9 @@ static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs)
   }}
   // return None
   Py_INCREF(Py_None);
+  if(py_args != NULL) {{
+    Py_DECREF(py_args);
+  }}
   return Py_None;
 }}
 

--- a/python/triton/compiler.py
+++ b/python/triton/compiler.py
@@ -1561,7 +1561,7 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
   return ptr_info;
 }}
 
-static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs, PyObject* kwnames) {{
+static PyObject* launch(PyObject* self, PyObject* const* args, Py_ssize_t nargs) {{
   int gridX = (int) PyLong_AsLong(args[0]);
   int gridY = (int) PyLong_AsLong(args[1]);
   int gridZ = (int) PyLong_AsLong(args[2]);


### PR DESCRIPTION
Reducing the kernel launch overhead by using `METH_FASTCALL` for `launch` instead of `METH_VARARGS`.