### PR TITLE
[DOCS] Fix `if ACTIVATION` compiler bug in MatMul tutorial

### DIFF
--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -229,7 +229,7 @@ def matmul_kernel(
         b_ptrs += BLOCK_SIZE_K * stride_bk
     # you can fuse arbitrary activation functions here
     # while the accumulator is still in FP32!
-    if ACTIVATION:
+    if ACTIVATION is not None:
         accumulator = ACTIVATION(accumulator)
     c = accumulator.to(tl.float16)
 


### PR DESCRIPTION
This fixes the following compiler error:
```md
triton.compiler.UnsupportedLanguageConstruct: at 68:4:        # this will access out-of-bounds memory and produce an
        # error or (worse!) incorrect results.
        a = tl.load(a_ptrs)
        b = tl.load(b_ptrs)
        # We accumulate along the K dimension
        accumulator += tl.dot(a, b)
        # Advance the ptrs to the next K block
        a_ptrs += BLOCK_SIZE_K * stride_ak
        b_ptrs += BLOCK_SIZE_K * stride_bk
    # you can fuse arbitrary activation functions here
    # while the accumulator is still in FP32!
    if ACTIVATION:
    ^
`if` conditionals can only accept values of type {int, bool}, not objects of type NoneType
```