### PR TITLE
[FRONTEND] Expose Autotuner to users

### DIFF
--- a/python/triton/runtime/__init__.py
+++ b/python/triton/runtime/__init__.py
@@ -1,5 +1,5 @@
 from . import driver
-from .autotuner import Config, Heuristics, OutOfResources, autotune, heuristics
+from .autotuner import Config, Heuristics, OutOfResources, autotune, heuristics, Autotuner
 from .jit import (JITFunction, KernelInterface, MockTensor, TensorWrapper, reinterpret,
                   version_key)
 

--- a/python/triton/runtime/__init__.py
+++ b/python/triton/runtime/__init__.py
@@ -16,4 +16,5 @@ __all__ = [
     "TensorWrapper",
     "OutOfResources",
     "MockTensor",
+    "Autotuner",
 ]

--- a/python/triton/runtime/__init__.py
+++ b/python/triton/runtime/__init__.py
@@ -1,5 +1,6 @@
 from . import driver
-from .autotuner import Config, Heuristics, OutOfResources, autotune, heuristics, Autotuner
+from .autotuner import (Autotuner, Config, Heuristics, OutOfResources, autotune,
+                        heuristics)
 from .jit import (JITFunction, KernelInterface, MockTensor, TensorWrapper, reinterpret,
                   version_key)
 


### PR DESCRIPTION
The Autotuner is a handy utility. By allowing external access to the Autotuner, users can overwrite some functions (e.g., `run`) to load/store best configurations, initialize tensors based on configuration values, and change benchmarking standard (e.g., based on bytes instead of time).