### PR TITLE
[FRONTEND] Data type specification for math functions

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -409,6 +409,35 @@ def test_compare_op(dtype_x, dtype_y, op, mode_x, mode_y, device='cuda'):
 
 
 # ---------------
+# test broadcast
+# ---------------
+@pytest.mark.parametrize("dtype", dtypes_with_bfloat16)
+def test_broadcast(dtype):
+    @triton.jit
+    def broadcast_kernel(x_ptr, y_ptr, y_broadcasted_ptr, M: tl.constexpr, N: tl.constexpr):
+        offset1 = tl.arange(0, M)
+        offset2 = tl.arange(0, N)
+        x = tl.load(x_ptr + N * offset1[:, None] + offset2[None, :])
+        y = tl.load(y_ptr + offset2)
+        _, y_broadcasted = tl.broadcast(x, y)
+        tl.store(y_broadcasted_ptr + N * offset1[:, None] + offset2[None, :], y_broadcasted)
+
+    M = 32
+    N = 64
+    rs = RandomState(17)
+    x = numpy_random((M, N), dtype_str=dtype, rs=rs)
+    y = numpy_random(N, dtype_str=dtype, rs=rs)
+    _, y_broadcasted_np = np.broadcast_arrays(x, y)
+
+    x_tri = to_triton(x, device='cuda', dst_type=dtype)
+    y_tri = to_triton(y, device='cuda', dst_type=dtype)
+    y_broadcasted_tri = to_triton(np.empty((M, N), dtype=y_broadcasted_np.dtype), device='cuda', dst_type=dtype)
+
+    broadcast_kernel[(1,)](x_tri, y_tri, y_broadcasted_tri, M=M, N=N)
+    assert (y_broadcasted_np == to_numpy(y_broadcasted_tri)).all()
+
+
+# ---------------
 # test where
 # ---------------
 @pytest.mark.parametrize("dtype", dtypes_with_bfloat16 + ["*int32"])
@@ -514,7 +543,7 @@ def test_unary_op(dtype_x, expr, device='cuda'):
 # ----------------
 
 
-@pytest.mark.parametrize("dtype_x, expr", [(dtype_x, expr) for dtype_x in float_dtypes for expr in ['exp', 'log', 'cos', 'sin']])
+@pytest.mark.parametrize("dtype_x, expr", [(dtype_x, expr) for dtype_x in ["float32", "float64"] for expr in ['exp', 'log', 'cos', 'sin']])
 def test_math_op(dtype_x, expr, device='cuda'):
     _test_unary(dtype_x, f'tl.{expr}(x)', f'np.{expr}(x) ', device=device)
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1374,7 +1374,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
         if DO_SOFTMAX:
             max = tl.max(z, 1)
             z = z - max[:, None]
-            num = tl.exp(z)
+            num = tl.exp(z.to(tl.float32)).to(max.dtype)
             den = tl.sum(num, 1)
             z = num / den[:, None]
         if CHAIN_DOT:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -12,9 +12,6 @@ T = TypeVar('T')
 
 TRITON_MAX_TENSOR_NUMEL = 131072
 
-
-T = TypeVar("T")
-
 TRITON_BUILTIN = "__triton_builtin__"
 
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1,12 +1,16 @@
 from __future__ import annotations  # remove after python 3.11
 
-from typing import List, Optional, Tuple
+from functools import wraps
+from typing import List, Optional, Tuple, TypeVar
 
 from . import core as tl
 from triton._C.libtriton.triton import ir
 
+T = TypeVar('T')
 
 # Create custom exception that prints message "hello"
+
+
 class IncompatibleTypeErrorImpl(Exception):
     def __init__(self, type_a, type_b):
         self.type_a = type_a
@@ -599,13 +603,13 @@ def broadcast_impl_value(lhs: tl.tensor,
         if len(lhs_shape) < len(rhs_shape):
             # Add new axes to lhs
             for dim in range(len(lhs_shape), len(rhs_shape)):
-                lhs = tl.tensor(builder.create_expand_dims(lhs.handle, dim), tl.block_type(lhs_ty.scalar, lhs_shape + [1]))
+                lhs = tl.tensor(builder.create_expand_dims(lhs.handle, 0), tl.block_type(lhs_ty.scalar, [1] + lhs_shape))
                 lhs_ty = lhs.type
                 lhs_shape = lhs_ty.get_block_shapes()
         elif len(rhs_shape) < len(lhs_shape):
             # Add new axes to rhs
             for dim in range(len(rhs_shape), len(lhs_shape)):
-                rhs = tl.tensor(builder.create_expand_dims(rhs.handle, dim), tl.block_type(rhs_ty.scalar, rhs_shape + [1]))
+                rhs = tl.tensor(builder.create_expand_dims(rhs.handle, 0), tl.block_type(rhs_ty.scalar, [1] + rhs_shape))
                 rhs_ty = rhs.type
                 rhs_shape = rhs_ty.get_block_shapes()
         assert len(rhs_shape) == len(lhs_shape)
@@ -1315,6 +1319,27 @@ def xor_sum(input: tl.tensor, axis: int, builder: ir.builder) -> tl.tensor:
 #                               Math
 # ===----------------------------------------------------------------------===
 
+def _check_dtype(dtypes: List[str]) -> T:
+    """
+    We following libdevice's convention to check accepted data types for math functions.
+    It is not a good practice to support all data types as accelerators/GPUs don't support
+    many float16 and bfloat16 math operations.
+    We should let the users know that they are using and invoke explicit cast to convert
+    the data type to the supported one.
+    """
+    def wrapper(fn):
+        def check(*args, **kwargs):
+            # concatenate args and kwargs
+            all_args = list(args) + list(kwargs.values())
+            for arg in [a for a in all_args if isinstance(a, tl.tensor)]:
+                if arg.type.scalar.name not in dtypes:
+                    raise ValueError(f"Expected dtype {dtypes} but got {arg.type.scalar.name}")
+            return fn(*args, **kwargs)
+        return check
+
+    return wrapper
+
+
 def umulhi(x: tl.tensor, y: tl.tensor, builder: ir.builder) -> tl.tensor:
     x, y = binary_op_type_checking_impl(x, y, builder)
     # FIXME(Keren): not portable, should be fixed
@@ -1322,28 +1347,34 @@ def umulhi(x: tl.tensor, y: tl.tensor, builder: ir.builder) -> tl.tensor:
     return math.mulhi(x, y, _builder=builder)
 
 
+@_check_dtype(dtypes=["fp32", "fp64"])
 def floor(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     # FIXME(Keren): not portable, should be fixed
     from . import math
     return math.floor(x, _builder=builder)
 
 
+@_check_dtype(dtypes=["fp32", "fp64"])
 def exp(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_exp(x.handle), x.type)
 
 
+@_check_dtype(dtypes=["fp32", "fp64"])
 def log(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_log(x.handle), x.type)
 
 
+@_check_dtype(dtypes=["fp32", "fp64"])
 def cos(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_cos(x.handle), x.type)
 
 
+@_check_dtype(dtypes=["fp32", "fp64"])
 def sin(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_sin(x.handle), x.type)
 
 
+@_check_dtype(dtypes=["fp32", "fp64"])
 def sqrt(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_sqrt(x.handle), x.type)
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1328,6 +1328,7 @@ def _check_dtype(dtypes: List[str]) -> T:
     the data type to the supported one.
     """
     def wrapper(fn):
+        @wraps(fn)
         def check(*args, **kwargs):
             # concatenate args and kwargs
             all_args = list(args) + list(kwargs.values())

--- a/python/triton/ops/flash_attention.py
+++ b/python/triton/ops/flash_attention.py
@@ -60,7 +60,7 @@ def _fwd_kernel(
         l_curr = tl.sum(p, 1) + l_prev
         # rescale operands of matmuls
         l_rcp = 1. / l_curr
-        p *= l_rcp
+        p *= l_rcp[:, None]
         acc *= (l_prev * l_rcp)[:, None]
         # update acc
         p = p.to(Q.dtype.element_ty)


### PR DESCRIPTION
Maybe we do want to support `exp` for fp16 and bf16 as an exception? Since there is a hardware intrinsic on NVIDIA GPUs.

fp16 requires >= sm_75
bf16 requires >= sm_90