### PR TITLE
Cache path to ptxas

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -121,6 +121,7 @@ def ptx_get_version(cuda_version) -> int:
     raise RuntimeError("Triton only support CUDA 10.0 or higher")
 
 
+@functools.lru_cache
 def path_to_ptxas():
     base_dir = os.path.join(os.path.dirname(__file__), os.pardir)
     paths = [


### PR DESCRIPTION
When running python 3.8, I've found that process creation gets slower over time (e.g. after creating a CUDA context, it can take 50-300ms per subprocess.run), and we do one of these calls to `ptxas --version` for every kernel, so a model with thousands of kernels can end up spending substantial time just calling ptxas redundantly.