### PR TITLE
[FRONTEND] Now using strings for annotations

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -10,8 +10,6 @@ import textwrap
 from collections import defaultdict, namedtuple
 from typing import Callable, Generic, Iterable, Optional, TypeVar, Union, cast, overload
 
-import torch
-
 import triton
 
 
@@ -240,27 +238,29 @@ class JITFunction(KernelInterface[T]):
 
     def _get_arg_specialization_key(self, arg) -> str:
         arg_annotation = self.__annotations__.get(arg, None)
-        if not arg_annotation:
+        if arg_annotation is None:
             return f'({arg}.data_ptr() % {JITFunction.divisibility} == 0) if hasattr({arg}, "data_ptr") \
                         else ({arg} % {JITFunction.divisibility} == 0, {arg} == 1) if isinstance({arg}, int) \
                         else (False,)'
-        elif arg_annotation is torch.Tensor:
+        elif 'Tensor' in arg_annotation:
             return f'({arg}.data_ptr() % {JITFunction.divisibility} == 0)'
-        elif arg_annotation is int:
+        elif arg_annotation == 'int':
             return f'({arg} % {JITFunction.divisibility} == 0, {arg} == 1)'
         else:
             return '(False,)'
 
     def _get_arg_sig_key(self, arg) -> str:
         arg_annotation = self.__annotations__.get(arg, None)
-        if arg_annotation is torch.Tensor:
+        if arg_annotation is None:
+            return f'_key_of({arg})'
+        elif 'Tensor' in arg_annotation:
             return f'{arg}.dtype'
-        elif arg_annotation is bool:
+        elif arg_annotation == 'bool':
             return "i1"
-        elif arg_annotation is float:
+        elif arg_annotation == 'float':
             return 'fp32'
         else:
-            return f'_key_of({arg})'
+            assert False
 
     def _make_launcher(self):
         regular_args = [f'{arg}' for i, arg in enumerate(self.arg_names) if i not in self.constexprs]
@@ -359,12 +359,11 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
         self.kernel = None
         self.debug = os.environ.get("TRITON_DEBUG", "0") == "1" if debug is None else debug
         # annotations
-        self.annotations = {self.arg_names.index(name): ty for name, ty in fn.__annotations__.items()}
+        normalize_ty = lambda ty: ty.__name__ if isinstance(ty, type) else ty
+        self.annotations = {self.arg_names.index(name): normalize_ty(ty) for name, ty in fn.__annotations__.items()}
         self.__annotations__ = fn.__annotations__
         # index of constexprs
-        from triton.language.core import \
-            constexpr  # import here rather than at module level due to circular import tangle
-        self.constexprs = [index for index, ty in self.annotations.items() if isinstance(ty, type) and issubclass(ty, constexpr)]
+        self.constexprs = [index for index, ty in self.annotations.items() if 'constexpr' in ty]
         # launcher
         self.run = self._make_launcher()
         # re-use docs of wrapped function

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -237,8 +237,8 @@ class JITFunction(KernelInterface[T]):
         return JITFunction.cache_hook(key=key, repr=repr, fn=LegacyCompiler(module, name), compile={"key": key, **kwargs}, is_manual_warmup=False, already_compiled=False)
 
     def _get_arg_specialization_key(self, arg) -> str:
-        arg_annotation = self.__annotations__.get(arg, None)
-        if arg_annotation is None:
+        arg_annotation = self.__annotations__.get(arg, '')
+        if arg_annotation == '':
             return f'({arg}.data_ptr() % {JITFunction.divisibility} == 0) if hasattr({arg}, "data_ptr") \
                         else ({arg} % {JITFunction.divisibility} == 0, {arg} == 1) if isinstance({arg}, int) \
                         else (False,)'
@@ -250,17 +250,15 @@ class JITFunction(KernelInterface[T]):
             return '(False,)'
 
     def _get_arg_sig_key(self, arg) -> str:
-        arg_annotation = self.__annotations__.get(arg, None)
-        if arg_annotation is None:
-            return f'_key_of({arg})'
-        elif 'Tensor' in arg_annotation:
+        arg_annotation = self.__annotations__.get(arg, '')
+        if 'Tensor' in arg_annotation:
             return f'{arg}.dtype'
         elif arg_annotation == 'bool':
             return "i1"
         elif arg_annotation == 'float':
             return 'fp32'
         else:
-            assert False
+            return f'_key_of({arg})'
 
     def _make_launcher(self):
         regular_args = [f'{arg}' for i, arg in enumerate(self.arg_names) if i not in self.constexprs]
@@ -360,10 +358,9 @@ def {self.fn.__name__}({', '.join(self.arg_names)}, grid, num_warps=4, num_stage
         self.debug = os.environ.get("TRITON_DEBUG", "0") == "1" if debug is None else debug
         # annotations
         normalize_ty = lambda ty: ty.__name__ if isinstance(ty, type) else ty
-        self.annotations = {self.arg_names.index(name): normalize_ty(ty) for name, ty in fn.__annotations__.items()}
-        self.__annotations__ = fn.__annotations__
+        self.__annotations__ = {name: normalize_ty(ty) for name, ty in fn.__annotations__.items()}
         # index of constexprs
-        self.constexprs = [index for index, ty in self.annotations.items() if 'constexpr' in ty]
+        self.constexprs = [self.arg_names.index(name) for name, ty in self.__annotations__.items() if 'constexpr' in ty]
         # launcher
         self.run = self._make_launcher()
         # re-use docs of wrapped function


### PR DESCRIPTION
Works with `__future__` annotations and also avoids having to import torch just for the sake of type annotations.