### PR TITLE
Enable tests for argmin/max and fix some bugs

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -478,8 +478,8 @@ struct TritonReducePattern : public OpConversionPattern<triton::ReduceOp> {
     addNamedAttrs(newReduce, adaptor.getAttributes());
 
     auto &newCombineOp = newReduce.getCombineOp();
-    rewriter.inlineRegionBefore(op.getCombineOp(), newCombineOp,
-                                newCombineOp.end());
+    rewriter.cloneRegionBefore(op.getCombineOp(), newCombineOp,
+                               newCombineOp.end());
     rewriter.replaceOp(op, newReduce.getResult());
     return success();
   }

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -137,11 +137,12 @@ public:
           op->getLoc(), newTy, newOperands[i]);
     }
 
+    rewriter.setInsertionPoint(reduce);
     auto newReduce = rewriter.create<triton::ReduceOp>(
         op->getLoc(), newOperands, reduce.getAxis());
     auto &newCombineOp = newReduce.getCombineOp();
-    rewriter.inlineRegionBefore(reduce.getCombineOp(), newCombineOp,
-                                newCombineOp.end());
+    rewriter.cloneRegionBefore(reduce.getCombineOp(), newCombineOp,
+                               newCombineOp.end());
 
     SmallVector<Value> newRet = newReduce.getResult();
     auto oldTypes = reduce.getResult().getType();

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1183,7 +1183,7 @@ def test_reduce1d(op, dtype_str, shape, device='cuda'):
 # TODO: [Qingyi] Fix argmin / argmax
 reduce_configs1 = [
     (op, dtype, (1, 1024), axis) for dtype in dtypes_with_bfloat16
-    for op in ['min', 'max', 'sum']
+    for op in ['min', 'max', 'sum', 'argmin', 'argmax']
     for axis in [1]
 ]
 
@@ -1199,7 +1199,7 @@ if 'V100' in torch.cuda.get_device_name(0):
 
 reduce_configs2 = [
     (op, 'float32', shape, axis)
-    for op in ['min', 'max', 'sum']
+    for op in ['min', 'max', 'sum', 'argmin', 'argmax']
     for shape in reduce2d_shapes
     for axis in [0, 1]
 ]

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -704,7 +704,7 @@ class tensor:
             elif sl == slice(None, None, None):
                 pass
             else:
-                assert False, "unsupported"
+                assert False, f"unsupported tensor index: {sl}"
         return ret
 
     @property
@@ -1281,7 +1281,7 @@ def _argreduce(input, axis, combine_fn, _builder=None, _generator=None):
 
     if len(input.shape) > 1:
         # Broadcast index across the non-reduced axes
-        expand_dims_index = [None] * len(input.shape)
+        expand_dims_index = [constexpr(None)] * len(input.shape)
         expand_dims_index[axis] = slice(None)
         index = index.__getitem__(expand_dims_index, _builder=_builder)
         index = broadcast_to(index, input.shape, _builder=_builder)


### PR DESCRIPTION
`argmin`/`argmax` is currently only tested in 1d and when we enable the tests for 2d it reveals a few bugs.