### PR TITLE
[BUILD] Use a persistent directory for cmake

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           python3 -m pip install lit
           cd python
-          LIT_TEST_DIR="build/$(ls build | grep -i temp)/test"
+          LIT_TEST_DIR="build/$(ls build | grep -i cmake)/test"
           if [ ! -d "${LIT_TEST_DIR}" ]; then
             echo "Coult not find '${LIT_TEST_DIR}'" ; exit -1
           fi
@@ -105,7 +105,7 @@ jobs:
         if: ${{ env.BACKEND != 'ROCM'}}
         run: |
           cd python
-          cd "build/$(ls build | grep -i temp)"
+          cd "build/$(ls build | grep -i cmake)"
           ctest
 
       - name: Run python tests on ROCM

--- a/python/setup.py
+++ b/python/setup.py
@@ -161,6 +161,14 @@ class CMakeBuild(build_ext):
         for ext in self.extensions:
             self.build_extension(ext)
 
+    def get_cmake_dir(self):
+        plat_name = sysconfig.get_platform()
+        python_version = sysconfig.get_python_version()
+        dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
+        cmake_dir = Path(self.base_dir) / "python" / "build" / dir_name
+        cmake_dir.mkdir(parents=True, exist_ok=True)
+        return cmake_dir
+
     def build_extension(self, ext):
         lit_dir = shutil.which('lit')
         user_home = os.getenv("HOME") or os.getenv("USERPROFILE") or \
@@ -204,8 +212,9 @@ class CMakeBuild(build_ext):
             build_args += ['-j' + max_jobs]
 
         env = os.environ.copy()
-        subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=self.build_temp, env=env)
-        subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=self.build_temp)
+        cmake_dir = self.get_cmake_dir()
+        subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=cmake_dir, env=env)
+        subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=cmake_dir)
 
 
 download_and_copy_ptxas()
@@ -228,6 +237,10 @@ setup(
         "triton/ops",
         "triton/ops/blocksparse",
         "triton/runtime",
+        "triton/runtime/backends",
+        "triton/third_party/cuda/bin",
+        "triton/third_party/cuda/include",
+        "triton/third_party/cuda/lib",
         "triton/tools",
     ],
     install_requires=[


### PR DESCRIPTION
Fixes #1545

`build_temp` is a temporary directory which `distutils` used to keep in the `./build` directory, but when `pyproject.toml` is present `pip` now puts it in `/tmp` and removes it at the end of the build.

Instead, this creates a new permanent directory like `python/build/cmake.linux_x86_64-cpython-3.8` (the old name but with cmake instead of temp).

While I was looking at the verbose pip output, I also noticed a bunch of warnings like
```
Python recognizes 'triton/runtime.backends' as an importable package,
but it is not listed in the `packages` configuration of setuptools.

'triton/runtime.backends' has been automatically added to the distribution only
because it may contain data files, but this behavior is likely to change
in future versions of setuptools (and therefore is considered deprecated).
```

So I've also added these to the packages list.