### PR TITLE
Make lru_cache compatible for Python 3.7 or older

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -105,7 +105,7 @@ def ttgir_to_llir(mod, extern_libs, arch):
 
 # PTX translation
 
-@functools.lru_cache
+@functools.lru_cache()
 def ptx_get_version(cuda_version) -> int:
     '''
     Get the highest PTX version supported by the current CUDA driver.
@@ -121,7 +121,7 @@ def ptx_get_version(cuda_version) -> int:
     raise RuntimeError("Triton only support CUDA 10.0 or higher")
 
 
-@functools.lru_cache
+@functools.lru_cache()
 def path_to_ptxas():
     base_dir = os.path.join(os.path.dirname(__file__), os.pardir)
     paths = [


### PR DESCRIPTION
Change the usage of LRU cache decorator from @functools.lru_cache to @functools.lru_cache().
The former raises an error TypeError('Expected maxsize to be an integer or None' for Python 3.7 or older.