### PR TITLE
[FRONTEND] Introduce tl.do_not_specialize to annotate arguments

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1610,3 +1610,12 @@ def extern_elementwise(lib_name: str, lib_path: str, args: list, arg_type_symbol
 def extern(fn):
     """A decorator for external functions."""
     return builtin(fn)
+
+
+# -----------------------
+# Annotations
+# -----------------------
+
+
+class do_not_specialize:
+    pass


### PR DESCRIPTION
To avoid having to keep the list of argument indices in sync with the signature

See https://github.com/openai/triton/issues/1555 for initial proposal