### PR TITLE
[FRONTEND] Refine arithmetic checks and corresponding tests for extern_elementwise 

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2087,7 +2087,9 @@ def test_num_warps_pow2():
 @pytest.mark.parametrize("dtype_str, expr, lib_path",
                          [('int32', 'math.ffs', ''),
                           ('float32', 'math.log2', ''),
-                          ('float32', 'math.pow', tl.math.LIBDEVICE_PATH),
+                          ('float32', 'math.scalbn', ''),
+                          ('float32', 'math.pow', tl.math.libdevice_path()),
+                          ('float64', 'math.pow_dtype', tl.math.libdevice_path()),
                           ('float64', 'math.norm4d', '')])
 def test_math_tensor(dtype_str, expr, lib_path):
 
@@ -2103,20 +2105,27 @@ def test_math_tensor(dtype_str, expr, lib_path):
     x = numpy_random(shape, dtype_str=dtype_str, rs=rs)
 
     if expr == 'math.log2':
-        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'tl.broadcast_to(tl.math.log2(5.0), x.shape)'})
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.broadcast_to(tl.{expr}(5.0), x.shape)'})
         y_ref = np.log2(5.0)
     elif expr == 'math.ffs':
-        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'tl.math.ffs(x)'})
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.{expr}(x)'})
         y_ref = np.zeros(shape, dtype=x.dtype)
         for i in range(shape[0]):
             y_ref[i] = (int(x[i]) & int(-x[i])).bit_length()
+    elif expr == 'math.scalbn':
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.{expr}(x, 2)'})
+        y_ref = x * pow(2, 2)
+    elif expr == 'math.pow_dtype':
+        x = np.abs(x)
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.math.pow(x, 0.5)'})
+        y_ref = np.power(x, 0.5)
     elif expr == 'math.pow':
         # numpy does not allow negative factors in power, so we use abs()
         x = np.abs(x)
-        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'tl.math.pow(x, x)'})
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.{expr}(x, x)'})
         y_ref = np.power(x, x)
     elif expr == 'math.norm4d':
-        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'tl.math.norm4d(x, x, x, x)'})
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'tl.{expr}(x, x, x, x)'})
         y_ref = np.sqrt(4 * np.power(x, 2))
 
     x_tri = to_triton(x)
@@ -2132,7 +2141,8 @@ def test_math_tensor(dtype_str, expr, lib_path):
 
 @pytest.mark.parametrize("dtype_str, expr, lib_path",
                          [('float32', 'math.pow', ''),
-                          ('float64', 'math.pow', tl.math.LIBDEVICE_PATH)])
+                          ('float64', 'math.pow_dtype', ''),
+                          ('float64', 'math.pow', tl.math.libdevice_path())])
 def test_math_scalar(dtype_str, expr, lib_path):
 
     @triton.jit
@@ -2148,9 +2158,14 @@ def test_math_scalar(dtype_str, expr, lib_path):
     y_ref = np.zeros(shape, dtype=x.dtype)
 
     # numpy does not allow negative factors in power, so we use abs()
-    x = np.abs(x)
-    kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'tl.math.pow(x, x)'})
-    y_ref[:] = np.power(x, x)
+    if expr == 'math.pow':
+        x = np.abs(x)
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'tl.math.pow(x, x)'})
+        y_ref[:] = np.power(x, x)
+    elif expr == 'math.pow_dtype':
+        x = np.abs(x)
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': 'tl.math.pow(x, 0.5)'})
+        y_ref[:] = np.power(x, 0.5)
 
     # triton result
     x_tri = to_triton(x)[0].item()

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1595,22 +1595,23 @@ def extern_elementwise(lib_name: str, lib_path: str, args: list, arg_type_symbol
         arg_types.append(dispatch_args[i].dtype)
         if dispatch_args[i].type.is_block():
             all_scalar = False
-    arg_types = tuple(arg_types)
-    arithmetic_check = True
-    # If there's a type tuple that is not supported by the library, we will do arithmetic check
-    if arg_types in arg_type_symbol_dict:
-        arithmetic_check = False
-    broadcast_arg = dispatch_args[0]
-    # Get the broadcast shape over all the arguments
-    for i, item in enumerate(dispatch_args):
-        _, broadcast_arg = semantic.binary_op_type_checking_impl(
-            item, broadcast_arg, _builder, arithmetic_check=arithmetic_check)
-    # Change the shape of each argument based on the broadcast shape
-    for i in range(len(dispatch_args)):
-        dispatch_args[i], _ = semantic.binary_op_type_checking_impl(
-            dispatch_args[i], broadcast_arg, _builder, arithmetic_check=arithmetic_check)
-    if not all_scalar:
-        ret_shape = broadcast_arg.shape
+    if len(arg_types) > 0:
+        arg_types = tuple(arg_types)
+        arithmetic_check = True
+        # If there's a type tuple that is not supported by the library, we will do arithmetic check
+        if arg_types in arg_type_symbol_dict:
+            arithmetic_check = False
+        broadcast_arg = dispatch_args[0]
+        # Get the broadcast shape over all the arguments
+        for i, item in enumerate(dispatch_args):
+            _, broadcast_arg = semantic.binary_op_type_checking_impl(
+                item, broadcast_arg, _builder, arithmetic_check=arithmetic_check)
+        # Change the shape of each argument based on the broadcast shape
+        for i in range(len(dispatch_args)):
+            dispatch_args[i], _ = semantic.binary_op_type_checking_impl(
+                dispatch_args[i], broadcast_arg, _builder, arithmetic_check=arithmetic_check)
+        if not all_scalar:
+            ret_shape = broadcast_arg.shape
     func = getattr(_builder, "create_extern_elementwise")
     return dispatch(func, lib_name, lib_path, dispatch_args, arg_type_symbol_dict, ret_shape, is_pure, _builder)
 

--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -1,14 +1,18 @@
+import functools
 import os
 
 from ..runtime import driver
 from . import core
 
-LIBDEVICE_PATH = os.getenv("TRITON_LIBDEVICE_PATH", driver.libdevice_path)
+
+@functools.lru_cache()
+def libdevice_path():
+    return os.getenv("TRITON_LIBDEVICE_PATH", driver.libdevice_path)
 
 
 @core.extern
 def clz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_clz", core.dtype("int32")),
                                     (core.dtype("int64"),): ("__nv_clzll", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
@@ -16,7 +20,7 @@ def clz(arg0, _builder=None):
 
 @core.extern
 def popc(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_popc", core.dtype("int32")),
                                     (core.dtype("int64"),): ("__nv_popcll", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
@@ -24,14 +28,14 @@ def popc(arg0, _builder=None):
 
 @core.extern
 def byte_perm(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("int32"), core.dtype("int32"), core.dtype("int32"),): ("__nv_byte_perm", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def min(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("int32"),): ("__nv_min", core.dtype("int32")),
                                     (core.dtype("uint32"), core.dtype("uint32"),): ("__nv_umin", core.dtype("uint32")),
                                     (core.dtype("int64"), core.dtype("int64"),): ("__nv_llmin", core.dtype("int64")),
@@ -43,7 +47,7 @@ def min(arg0, arg1, _builder=None):
 
 @core.extern
 def max(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("int32"),): ("__nv_max", core.dtype("int32")),
                                     (core.dtype("uint32"), core.dtype("uint32"),): ("__nv_umax", core.dtype("uint32")),
                                     (core.dtype("int64"), core.dtype("int64"),): ("__nv_llmax", core.dtype("int64")),
@@ -55,7 +59,7 @@ def max(arg0, arg1, _builder=None):
 
 @core.extern
 def mulhi(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("int32"),): ("__nv_mulhi", core.dtype("int32")),
                                     (core.dtype("uint32"), core.dtype("uint32"),): ("__nv_umulhi", core.dtype("uint32")),
                                     (core.dtype("int64"), core.dtype("int64"),): ("__nv_mul64hi", core.dtype("int64")),
@@ -65,7 +69,7 @@ def mulhi(arg0, arg1, _builder=None):
 
 @core.extern
 def mul24(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("int32"),): ("__nv_mul24", core.dtype("int32")),
                                     (core.dtype("uint32"), core.dtype("uint32"),): ("__nv_umul24", core.dtype("uint32")),
                                     }, is_pure=True, _builder=_builder)
@@ -73,7 +77,7 @@ def mul24(arg0, arg1, _builder=None):
 
 @core.extern
 def brev(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_brev", core.dtype("int32")),
                                     (core.dtype("int64"),): ("__nv_brevll", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
@@ -81,7 +85,7 @@ def brev(arg0, _builder=None):
 
 @core.extern
 def sad(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("int32"), core.dtype("int32"), core.dtype("uint32"),): ("__nv_sad", core.dtype("int32")),
                                     (core.dtype("uint32"), core.dtype("uint32"), core.dtype("uint32"),): ("__nv_usad", core.dtype("uint32")),
                                     }, is_pure=True, _builder=_builder)
@@ -89,7 +93,7 @@ def sad(arg0, arg1, arg2, _builder=None):
 
 @core.extern
 def abs(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_abs", core.dtype("int32")),
                                     (core.dtype("int64"),): ("__nv_llabs", core.dtype("int64")),
                                     (core.dtype("fp32"),): ("__nv_fabsf", core.dtype("fp32")),
@@ -99,7 +103,7 @@ def abs(arg0, _builder=None):
 
 @core.extern
 def floor(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_floorf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_floor", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -107,14 +111,14 @@ def floor(arg0, _builder=None):
 
 @core.extern
 def rcp64h(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_rcp64h", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def rsqrt(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_rsqrtf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_rsqrt", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -122,7 +126,7 @@ def rsqrt(arg0, _builder=None):
 
 @core.extern
 def ceil(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_ceil", core.dtype("fp64")),
                                     (core.dtype("fp32"),): ("__nv_ceilf", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -130,7 +134,7 @@ def ceil(arg0, _builder=None):
 
 @core.extern
 def trunc(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_trunc", core.dtype("fp64")),
                                     (core.dtype("fp32"),): ("__nv_truncf", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -138,7 +142,7 @@ def trunc(arg0, _builder=None):
 
 @core.extern
 def exp2(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_exp2f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_exp2", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -146,14 +150,14 @@ def exp2(arg0, _builder=None):
 
 @core.extern
 def saturatef(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_saturatef", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fma_rn(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmaf_rn", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_fma_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -161,7 +165,7 @@ def fma_rn(arg0, arg1, arg2, _builder=None):
 
 @core.extern
 def fma_rz(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmaf_rz", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_fma_rz", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -169,7 +173,7 @@ def fma_rz(arg0, arg1, arg2, _builder=None):
 
 @core.extern
 def fma_rd(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmaf_rd", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_fma_rd", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -177,7 +181,7 @@ def fma_rd(arg0, arg1, arg2, _builder=None):
 
 @core.extern
 def fma_ru(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmaf_ru", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_fma_ru", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -185,14 +189,14 @@ def fma_ru(arg0, arg1, arg2, _builder=None):
 
 @core.extern
 def fast_dividef(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fast_fdividef", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def div_rn(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fdiv_rn", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_ddiv_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -200,7 +204,7 @@ def div_rn(arg0, arg1, _builder=None):
 
 @core.extern
 def div_rz(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fdiv_rz", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_ddiv_rz", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -208,7 +212,7 @@ def div_rz(arg0, arg1, _builder=None):
 
 @core.extern
 def div_rd(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fdiv_rd", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_ddiv_rd", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -216,7 +220,7 @@ def div_rd(arg0, arg1, _builder=None):
 
 @core.extern
 def div_ru(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fdiv_ru", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_ddiv_ru", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -224,7 +228,7 @@ def div_ru(arg0, arg1, _builder=None):
 
 @core.extern
 def rcp_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_frcp_rn", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_drcp_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -232,7 +236,7 @@ def rcp_rn(arg0, _builder=None):
 
 @core.extern
 def rcp_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_frcp_rz", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_drcp_rz", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -240,7 +244,7 @@ def rcp_rz(arg0, _builder=None):
 
 @core.extern
 def rcp_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_frcp_rd", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_drcp_rd", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -248,7 +252,7 @@ def rcp_rd(arg0, _builder=None):
 
 @core.extern
 def rcp_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_frcp_ru", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_drcp_ru", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -256,7 +260,7 @@ def rcp_ru(arg0, _builder=None):
 
 @core.extern
 def sqrt_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fsqrt_rn", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_dsqrt_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -264,7 +268,7 @@ def sqrt_rn(arg0, _builder=None):
 
 @core.extern
 def sqrt_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fsqrt_rz", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_dsqrt_rz", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -272,7 +276,7 @@ def sqrt_rz(arg0, _builder=None):
 
 @core.extern
 def sqrt_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fsqrt_rd", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_dsqrt_rd", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -280,7 +284,7 @@ def sqrt_rd(arg0, _builder=None):
 
 @core.extern
 def sqrt_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fsqrt_ru", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_dsqrt_ru", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -288,7 +292,7 @@ def sqrt_ru(arg0, _builder=None):
 
 @core.extern
 def sqrt(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_sqrtf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_sqrt", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -296,7 +300,7 @@ def sqrt(arg0, _builder=None):
 
 @core.extern
 def add_rn(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dadd_rn", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fadd_rn", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -304,7 +308,7 @@ def add_rn(arg0, arg1, _builder=None):
 
 @core.extern
 def add_rz(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dadd_rz", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fadd_rz", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -312,7 +316,7 @@ def add_rz(arg0, arg1, _builder=None):
 
 @core.extern
 def add_rd(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dadd_rd", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fadd_rd", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -320,7 +324,7 @@ def add_rd(arg0, arg1, _builder=None):
 
 @core.extern
 def add_ru(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dadd_ru", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fadd_ru", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -328,7 +332,7 @@ def add_ru(arg0, arg1, _builder=None):
 
 @core.extern
 def mul_rn(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dmul_rn", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmul_rn", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -336,7 +340,7 @@ def mul_rn(arg0, arg1, _builder=None):
 
 @core.extern
 def mul_rz(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dmul_rz", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmul_rz", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -344,7 +348,7 @@ def mul_rz(arg0, arg1, _builder=None):
 
 @core.extern
 def mul_rd(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dmul_rd", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmul_rd", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -352,7 +356,7 @@ def mul_rd(arg0, arg1, _builder=None):
 
 @core.extern
 def mul_ru(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dmul_ru", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmul_ru", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
@@ -360,567 +364,567 @@ def mul_ru(arg0, arg1, _builder=None):
 
 @core.extern
 def double2float_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2float_rn", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2float_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2float_rz", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2float_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2float_rd", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2float_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2float_ru", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2int_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2int_rn", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2int_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2int_rz", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2int_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2int_rd", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2int_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2int_ru", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2uint_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2uint_rn", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2uint_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2uint_rz", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2uint_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2uint_rd", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2uint_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2uint_ru", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def int2double_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_int2double_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def uint2double_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint32"),): ("__nv_uint2double_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2int_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2int_rn", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2int_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2int_rz", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2int_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2int_rd", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2int_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2int_ru", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2uint_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2uint_rn", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2uint_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2uint_rz", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2uint_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2uint_rd", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2uint_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2uint_ru", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def int2float_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_int2float_rn", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def int2float_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_int2float_rz", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def int2float_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_int2float_rd", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def int2float_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_int2float_ru", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def uint2float_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint32"),): ("__nv_uint2float_rn", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def uint2float_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint32"),): ("__nv_uint2float_rz", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def uint2float_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint32"),): ("__nv_uint2float_rd", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def uint2float_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint32"),): ("__nv_uint2float_ru", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def hiloint2double(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("int32"),): ("__nv_hiloint2double", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2loint(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2loint", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2hiint(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2hiint", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2ll_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2ll_rn", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2ll_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2ll_rz", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2ll_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2ll_rd", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2ll_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2ll_ru", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2ull_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2ull_rn", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2ull_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2ull_rz", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2ull_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2ull_rd", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float2ull_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float2ull_ru", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2ll_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2ll_rn", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2ll_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2ll_rz", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2ll_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2ll_rd", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2ll_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2ll_ru", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2ull_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2ull_rn", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2ull_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2ull_rz", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2ull_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2ull_rd", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double2ull_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double2ull_ru", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ll2float_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_ll2float_rn", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ll2float_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_ll2float_rz", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ll2float_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_ll2float_rd", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ll2float_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_ll2float_ru", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ull2float_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint64"),): ("__nv_ull2float_rn", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ull2float_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint64"),): ("__nv_ull2float_rz", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ull2float_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint64"),): ("__nv_ull2float_rd", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ull2float_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint64"),): ("__nv_ull2float_ru", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ll2double_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_ll2double_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ll2double_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_ll2double_rz", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ll2double_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_ll2double_rd", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ll2double_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_ll2double_ru", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ull2double_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint64"),): ("__nv_ull2double_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ull2double_rz(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint64"),): ("__nv_ull2double_rz", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ull2double_rd(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint64"),): ("__nv_ull2double_rd", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ull2double_ru(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint64"),): ("__nv_ull2double_ru", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def int_as_float(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_int_as_float", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float_as_int(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float_as_int", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def uint_as_float(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("uint32"),): ("__nv_uint_as_float", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def float_as_uint(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_float_as_uint", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def longlong_as_double(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int64"),): ("__nv_longlong_as_double", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def double_as_longlong(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_double_as_longlong", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_sinf(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fast_sinf", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_cosf(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fast_cosf", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_log2f(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fast_log2f", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_logf(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fast_logf", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_expf(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fast_expf", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_tanf(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fast_tanf", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_exp10f(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fast_exp10f", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_log10f(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_fast_log10f", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def fast_powf(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fast_powf", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def hadd(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("int32"),): ("__nv_hadd", core.dtype("int32")),
                                     (core.dtype("uint32"), core.dtype("uint32"),): ("__nv_uhadd", core.dtype("uint32")),
                                     }, is_pure=True, _builder=_builder)
@@ -928,7 +932,7 @@ def hadd(arg0, arg1, _builder=None):
 
 @core.extern
 def rhadd(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("int32"),): ("__nv_rhadd", core.dtype("int32")),
                                     (core.dtype("uint32"), core.dtype("uint32"),): ("__nv_urhadd", core.dtype("uint32")),
                                     }, is_pure=True, _builder=_builder)
@@ -936,7 +940,7 @@ def rhadd(arg0, arg1, _builder=None):
 
 @core.extern
 def sub_rn(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fsub_rn", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dsub_rn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -944,7 +948,7 @@ def sub_rn(arg0, arg1, _builder=None):
 
 @core.extern
 def sub_rz(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fsub_rz", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dsub_rz", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -952,7 +956,7 @@ def sub_rz(arg0, arg1, _builder=None):
 
 @core.extern
 def sub_rd(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fsub_rd", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dsub_rd", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -960,7 +964,7 @@ def sub_rd(arg0, arg1, _builder=None):
 
 @core.extern
 def sub_ru(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fsub_ru", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_dsub_ru", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -968,14 +972,14 @@ def sub_ru(arg0, arg1, _builder=None):
 
 @core.extern
 def rsqrt_rn(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_frsqrt_rn", core.dtype("fp32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def ffs(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("int32"),): ("__nv_ffs", core.dtype("int32")),
                                     (core.dtype("int64"),): ("__nv_ffsll", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
@@ -983,7 +987,7 @@ def ffs(arg0, _builder=None):
 
 @core.extern
 def rint(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_rintf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_rint", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -991,7 +995,7 @@ def rint(arg0, _builder=None):
 
 @core.extern
 def llrint(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_llrintf", core.dtype("int64")),
                                     (core.dtype("fp64"),): ("__nv_llrint", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
@@ -999,7 +1003,7 @@ def llrint(arg0, _builder=None):
 
 @core.extern
 def nearbyint(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_nearbyintf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_nearbyint", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1007,7 +1011,7 @@ def nearbyint(arg0, _builder=None):
 
 @core.extern
 def isnan(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_isnanf", core.dtype("int32")),
                                     (core.dtype("fp64"),): ("__nv_isnand", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
@@ -1015,7 +1019,7 @@ def isnan(arg0, _builder=None):
 
 @core.extern
 def signbit(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_signbitf", core.dtype("int32")),
                                     (core.dtype("fp64"),): ("__nv_signbitd", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
@@ -1023,7 +1027,7 @@ def signbit(arg0, _builder=None):
 
 @core.extern
 def copysign(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_copysignf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_copysign", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1031,14 +1035,14 @@ def copysign(arg0, arg1, _builder=None):
 
 @core.extern
 def finitef(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_finitef", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
 
 
 @core.extern
 def isinf(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_isinff", core.dtype("int32")),
                                     (core.dtype("fp64"),): ("__nv_isinfd", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
@@ -1046,7 +1050,7 @@ def isinf(arg0, _builder=None):
 
 @core.extern
 def nextafter(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_nextafterf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_nextafter", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1054,7 +1058,7 @@ def nextafter(arg0, arg1, _builder=None):
 
 @core.extern
 def sin(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_sinf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_sin", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1062,7 +1066,7 @@ def sin(arg0, _builder=None):
 
 @core.extern
 def cos(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_cosf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_cos", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1070,7 +1074,7 @@ def cos(arg0, _builder=None):
 
 @core.extern
 def sinpi(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_sinpif", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_sinpi", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1078,7 +1082,7 @@ def sinpi(arg0, _builder=None):
 
 @core.extern
 def cospi(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_cospif", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_cospi", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1086,7 +1090,7 @@ def cospi(arg0, _builder=None):
 
 @core.extern
 def tan(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_tanf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_tan", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1094,7 +1098,7 @@ def tan(arg0, _builder=None):
 
 @core.extern
 def log2(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_log2f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_log2", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1102,7 +1106,7 @@ def log2(arg0, _builder=None):
 
 @core.extern
 def exp(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_expf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_exp", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1110,7 +1114,7 @@ def exp(arg0, _builder=None):
 
 @core.extern
 def exp10(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_exp10f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_exp10", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1118,7 +1122,7 @@ def exp10(arg0, _builder=None):
 
 @core.extern
 def cosh(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_coshf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_cosh", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1126,7 +1130,7 @@ def cosh(arg0, _builder=None):
 
 @core.extern
 def sinh(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_sinhf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_sinh", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1134,7 +1138,7 @@ def sinh(arg0, _builder=None):
 
 @core.extern
 def tanh(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_tanhf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_tanh", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1142,7 +1146,7 @@ def tanh(arg0, _builder=None):
 
 @core.extern
 def atan2(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_atan2f", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_atan2", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1150,7 +1154,7 @@ def atan2(arg0, arg1, _builder=None):
 
 @core.extern
 def atan(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_atanf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_atan", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1158,7 +1162,7 @@ def atan(arg0, _builder=None):
 
 @core.extern
 def asin(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_asinf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_asin", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1166,7 +1170,7 @@ def asin(arg0, _builder=None):
 
 @core.extern
 def acos(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_acosf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_acos", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1174,7 +1178,7 @@ def acos(arg0, _builder=None):
 
 @core.extern
 def log(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_logf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_log", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1182,7 +1186,7 @@ def log(arg0, _builder=None):
 
 @core.extern
 def log10(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_log10f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_log10", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1190,7 +1194,7 @@ def log10(arg0, _builder=None):
 
 @core.extern
 def log1p(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_log1pf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_log1p", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1198,7 +1202,7 @@ def log1p(arg0, _builder=None):
 
 @core.extern
 def acosh(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_acoshf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_acosh", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1206,7 +1210,7 @@ def acosh(arg0, _builder=None):
 
 @core.extern
 def asinh(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_asinhf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_asinh", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1214,7 +1218,7 @@ def asinh(arg0, _builder=None):
 
 @core.extern
 def atanh(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_atanhf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_atanh", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1222,7 +1226,7 @@ def atanh(arg0, _builder=None):
 
 @core.extern
 def expm1(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_expm1f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_expm1", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1230,7 +1234,7 @@ def expm1(arg0, _builder=None):
 
 @core.extern
 def hypot(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_hypotf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_hypot", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1238,7 +1242,7 @@ def hypot(arg0, arg1, _builder=None):
 
 @core.extern
 def rhypot(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_rhypotf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_rhypot", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1246,7 +1250,7 @@ def rhypot(arg0, arg1, _builder=None):
 
 @core.extern
 def norm3d(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_norm3df", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_norm3d", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1254,7 +1258,7 @@ def norm3d(arg0, arg1, arg2, _builder=None):
 
 @core.extern
 def rnorm3d(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_rnorm3df", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_rnorm3d", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1262,7 +1266,7 @@ def rnorm3d(arg0, arg1, arg2, _builder=None):
 
 @core.extern
 def norm4d(arg0, arg1, arg2, arg3, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, arg3, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, arg3, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_norm4df", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_norm4d", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1270,7 +1274,7 @@ def norm4d(arg0, arg1, arg2, arg3, _builder=None):
 
 @core.extern
 def rnorm4d(arg0, arg1, arg2, arg3, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, arg3, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, arg3, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_rnorm4df", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_rnorm4d", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1278,7 +1282,7 @@ def rnorm4d(arg0, arg1, arg2, arg3, _builder=None):
 
 @core.extern
 def cbrt(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_cbrtf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_cbrt", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1286,7 +1290,7 @@ def cbrt(arg0, _builder=None):
 
 @core.extern
 def rcbrt(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_rcbrtf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_rcbrt", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1294,7 +1298,7 @@ def rcbrt(arg0, _builder=None):
 
 @core.extern
 def j0(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_j0f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_j0", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1302,7 +1306,7 @@ def j0(arg0, _builder=None):
 
 @core.extern
 def j1(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_j1f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_j1", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1310,7 +1314,7 @@ def j1(arg0, _builder=None):
 
 @core.extern
 def y0(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_y0f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_y0", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1318,7 +1322,7 @@ def y0(arg0, _builder=None):
 
 @core.extern
 def y1(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_y1f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_y1", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1326,7 +1330,7 @@ def y1(arg0, _builder=None):
 
 @core.extern
 def yn(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("fp32"),): ("__nv_ynf", core.dtype("fp32")),
                                     (core.dtype("int32"), core.dtype("fp64"),): ("__nv_yn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1334,7 +1338,7 @@ def yn(arg0, arg1, _builder=None):
 
 @core.extern
 def jn(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("int32"), core.dtype("fp32"),): ("__nv_jnf", core.dtype("fp32")),
                                     (core.dtype("int32"), core.dtype("fp64"),): ("__nv_jn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1342,7 +1346,7 @@ def jn(arg0, arg1, _builder=None):
 
 @core.extern
 def cyl_bessel_i0(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_cyl_bessel_i0f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_cyl_bessel_i0", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1350,7 +1354,7 @@ def cyl_bessel_i0(arg0, _builder=None):
 
 @core.extern
 def cyl_bessel_i1(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_cyl_bessel_i1f", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_cyl_bessel_i1", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1358,7 +1362,7 @@ def cyl_bessel_i1(arg0, _builder=None):
 
 @core.extern
 def erf(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_erff", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_erf", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1366,7 +1370,7 @@ def erf(arg0, _builder=None):
 
 @core.extern
 def erfinv(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_erfinvf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_erfinv", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1374,7 +1378,7 @@ def erfinv(arg0, _builder=None):
 
 @core.extern
 def erfc(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_erfcf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_erfc", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1382,7 +1386,7 @@ def erfc(arg0, _builder=None):
 
 @core.extern
 def erfcx(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_erfcxf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_erfcx", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1390,7 +1394,7 @@ def erfcx(arg0, _builder=None):
 
 @core.extern
 def erfcinv(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_erfcinvf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_erfcinv", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1398,7 +1402,7 @@ def erfcinv(arg0, _builder=None):
 
 @core.extern
 def normcdfinv(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_normcdfinvf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_normcdfinv", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1406,7 +1410,7 @@ def normcdfinv(arg0, _builder=None):
 
 @core.extern
 def normcdf(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_normcdff", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_normcdf", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1414,7 +1418,7 @@ def normcdf(arg0, _builder=None):
 
 @core.extern
 def lgamma(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_lgammaf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_lgamma", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1422,7 +1426,7 @@ def lgamma(arg0, _builder=None):
 
 @core.extern
 def ldexp(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("int32"),): ("__nv_ldexpf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("int32"),): ("__nv_ldexp", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1430,7 +1434,7 @@ def ldexp(arg0, arg1, _builder=None):
 
 @core.extern
 def scalbn(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("int32"),): ("__nv_scalbnf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("int32"),): ("__nv_scalbn", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1438,7 +1442,7 @@ def scalbn(arg0, arg1, _builder=None):
 
 @core.extern
 def fmod(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmodf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_fmod", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1446,7 +1450,7 @@ def fmod(arg0, arg1, _builder=None):
 
 @core.extern
 def remainder(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_remainderf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_remainder", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1454,7 +1458,7 @@ def remainder(arg0, arg1, _builder=None):
 
 @core.extern
 def fma(arg0, arg1, arg2, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, arg2, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, arg2, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fmaf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"), core.dtype("fp64"),): ("__nv_fma", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1462,7 +1466,7 @@ def fma(arg0, arg1, arg2, _builder=None):
 
 @core.extern
 def pow(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("int32"),): ("__nv_powif", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("int32"),): ("__nv_powi", core.dtype("fp64")),
                                     (core.dtype("fp32"), core.dtype("fp32"),): ("__nv_powf", core.dtype("fp32")),
@@ -1472,7 +1476,7 @@ def pow(arg0, arg1, _builder=None):
 
 @core.extern
 def tgamma(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_tgammaf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_tgamma", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1480,7 +1484,7 @@ def tgamma(arg0, _builder=None):
 
 @core.extern
 def round(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_roundf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_round", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1488,7 +1492,7 @@ def round(arg0, _builder=None):
 
 @core.extern
 def llround(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_llroundf", core.dtype("int64")),
                                     (core.dtype("fp64"),): ("__nv_llround", core.dtype("int64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1496,7 +1500,7 @@ def llround(arg0, _builder=None):
 
 @core.extern
 def fdim(arg0, arg1, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, arg1, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, arg1, ],
                                    {(core.dtype("fp32"), core.dtype("fp32"),): ("__nv_fdimf", core.dtype("fp32")),
                                     (core.dtype("fp64"), core.dtype("fp64"),): ("__nv_fdim", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1504,7 +1508,7 @@ def fdim(arg0, arg1, _builder=None):
 
 @core.extern
 def ilogb(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_ilogbf", core.dtype("int32")),
                                     (core.dtype("fp64"),): ("__nv_ilogb", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)
@@ -1512,7 +1516,7 @@ def ilogb(arg0, _builder=None):
 
 @core.extern
 def logb(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp32"),): ("__nv_logbf", core.dtype("fp32")),
                                     (core.dtype("fp64"),): ("__nv_logb", core.dtype("fp64")),
                                     }, is_pure=True, _builder=_builder)
@@ -1520,6 +1524,6 @@ def logb(arg0, _builder=None):
 
 @core.extern
 def isfinited(arg0, _builder=None):
-    return core.extern_elementwise("libdevice", LIBDEVICE_PATH, [arg0, ],
+    return core.extern_elementwise("libdevice", libdevice_path(), [arg0, ],
                                    {(core.dtype("fp64"),): ("__nv_isfinited", core.dtype("int32")),
                                     }, is_pure=True, _builder=_builder)

--- a/python/triton/tools/build_extern.py
+++ b/python/triton/tools/build_extern.py
@@ -287,13 +287,17 @@ class Libdevice(ExternLibrary):
         # @extern.extern
         # def <op_name>(<args>, _builder=None):
         #   arg_type_symbol_dict = {[arg_type]: {(symbol, ret_type)}}
-        #   return extern.dispatch("libdevice", <path>, <args>, <arg_type_symbol_dict>, _builder)
+        #   return core.extern_elementwise("libdevice", <path>, <args>, <arg_type_symbol_dict>, _builder)
         import_str = "from . import core\n"
         import_str += "from ..runtime import driver\n"
         import_str += "import os\n"
+        import_str += "import functools\n"
 
         header_str = ""
-        header_str += "LIBDEVICE_PATH = os.getenv(\"TRITON_LIBDEVICE_PATH\", driver.libdevice_path)\n"
+        header_str += "@functools.lru_cache()\n"
+        header_str += "def libdevice_path():\n"
+        header_str += "    return os.getenv(\"TRITON_LIBDEVICE_PATH\", driver().libdevice_path)\n\n"
+
         func_str = ""
         for symbols in self._symbol_groups.values():
             func_str += "@core.extern\n"
@@ -302,7 +306,7 @@ class Libdevice(ExternLibrary):
                 func_name_str += f"{arg_name}, "
             func_name_str += "_builder=None):\n"
 
-            return_str = f"\treturn core.extern_elementwise(\"{self._name}\", LIBDEVICE_PATH, ["
+            return_str = f"\treturn core.extern_elementwise(\"{self._name}\", libdevice_path(), ["
             for arg_name in symbols[0].arg_names:
                 return_str += f"{arg_name}, "
             return_str += "], \n"


### PR DESCRIPTION
The current main would fail on `math.scalbn` because we implicitly cast the first argument from `int32` to `float32`, while the function only accepts `int32` as the first argument and `float32` as the second argument.

So we update the type matching logic as follows:

1. Check if there's a type tuple that matches the types of the input arguments
2. If yes, we don't allow arithmetic check.
3. If not, we will do arithmetic check to implicitly cast types among arguments.
4. If we still don't find a corresponding function that accepts the casted types, throwing an error.
