### PR TITLE
[FRONTEND] Fix calling local variables’ attribute functions in the if statement

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -168,6 +168,8 @@ class CodeGenerator(ast.NodeVisitor):
             pred = lambda s: self.contains_return_op(s)
             return any(pred(s) for s in node.body)
         elif isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Attribute):
+                return False
             fn = self.visit(node.func)
             if isinstance(fn, JITFunction):
                 old_gscope = self.gscope


### PR DESCRIPTION
If `node.func` is an `ast.Attribute`, it won't cause an early return. (Not sure if I interpret it correctly)

https://github.com/openai/triton/issues/1591