### PR TITLE
[SETUP] Removing `torch` as a test dependency

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -294,7 +294,6 @@ setup(
             "numpy",
             "pytest",
             "scipy>=1.7.1",
-            "torch",
         ],
         "tutorials": [
             "matplotlib",


### PR DESCRIPTION
circular dependency is causing troubles now that our interpreter depends on torch 2.0 ...