### PR TITLE
[FRONTEND] Fix return-op related control flow issues

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2550,24 +2550,30 @@ def test_if_else():
     assert to_numpy(out)[0] == false_val[0]
 
 
-def test_if_return():
+@pytest.mark.parametrize("mode", ["dynamic", "static"])
+def test_if_return(mode):
 
     @triton.jit
-    def kernel(ExitEarly, Out):
-        if tl.load(ExitEarly):
-            tl.store(Out, 0)
-            return
+    def kernel(ExitEarly, Out, cond: tl.constexpr, mode: tl.constexpr):
+        if mode == "dynamic":
+            if tl.load(ExitEarly):
+                tl.store(Out, 0)
+                return
+        else:
+            if cond:
+                tl.store(Out, 0)
+                return
         tl.store(Out, 1)
 
     out = to_triton(np.zeros((1,), dtype=np.int32), device='cuda')
     exit_early = to_triton(np.zeros((1,), dtype=np.int32), device='cuda')
     # exit early path taken
     exit_early[0] = 1
-    kernel[(1,)](exit_early, out)
+    kernel[(1,)](exit_early, out, True, mode)
     assert to_numpy(out)[0] == 0
     # exit early path not taken
     exit_early[0] = 0
-    kernel[(1,)](exit_early, out)
+    kernel[(1,)](exit_early, out, False, mode)
     assert to_numpy(out)[0] == 1
 
 
@@ -2576,7 +2582,20 @@ def add_fn(x):
     return x + 1
 
 
-@pytest.mark.parametrize("call_type", ["attribute", "jit_function"])
+@triton.jit
+def add_fn_return(x, pid):
+    if pid == 0:
+        return x + 1
+    else:
+        return x + 2
+
+
+@triton.jit
+def add_fn_expr(Out, x):
+    tl.store(Out, x)
+
+
+@pytest.mark.parametrize("call_type", ["attribute", "jit_function", "jit_function_return", "jit_function_ifexp", "jit_function_expr"])
 def test_if_call(call_type):
     @triton.jit
     def kernel(Out, call_type: tl.constexpr):
@@ -2584,13 +2603,30 @@ def test_if_call(call_type):
         o = tl.load(Out)
         if pid == 0:
             if call_type == "attribute":
+                # call attribute
                 a = o + 1
                 a = a.to(tl.int32)
                 o = a
             else:
                 a = o
-                a = add_fn(a)
+                if call_type == "jit_function":
+                    # regular function call
+                    a = add_fn(a)
+                elif call_type == "jit_function_return":
+                    # function without end_if block
+                    a = add_fn_return(a, pid)
+                elif call_type == "jit_function_ifexp":
+                    # ifexp expression
+                    a = add_fn(a) if pid == 0 else add_fn_return(a, pid)
+                elif call_type == "jit_function_expr":
+                    if pid == 1:
+                        return
+                    a = add_fn(a)
+                    if pid == 0:
+                        # call without return
+                        add_fn_expr(Out, a)
                 o = a
+
         tl.store(Out, o)
 
     out = to_triton(np.zeros((1,), dtype=np.int32), device='cuda')

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -104,6 +104,7 @@ class CodeGenerator(ast.NodeVisitor):
         self.debug = debug
         self.noinline = noinline
         self.scf_stack = []
+        self.last_ret_type = None
         # SSA-construction
         # name => language.tensor
         self.local_defs: Dict[str, tensor] = {}
@@ -138,7 +139,7 @@ class CodeGenerator(ast.NodeVisitor):
     def set_value(self, name: str,
                   value: Union[tensor, constexpr]) -> None:
         ''' This function:
-          called by visit_Assign() & visit_FuncDef() to store left value (lvalue)
+            called by visit_Assign() & visit_FunctionDef() to store left value (lvalue)
         1. record local defined name (FIXME: should consider control flow)
         2. store tensor in self.lvalue
         '''
@@ -150,10 +151,9 @@ class CodeGenerator(ast.NodeVisitor):
     #
     def visit_compound_statement(self, stmts):
         for stmt in stmts:
-            self.last_ret_type = self.visit(stmt)
-            if isinstance(stmt, ast.Return):
-                break
-        return stmts and isinstance(stmt, ast.Return)
+            ret_type = self.visit(stmt)
+            if ret_type is not None and isinstance(stmt, ast.Return):
+                self.last_ret_type = ret_type
 
     # TODO: should be its own AST visitor
     def contains_return_op(self, node):
@@ -169,7 +169,11 @@ class CodeGenerator(ast.NodeVisitor):
             return any(pred(s) for s in node.body)
         elif isinstance(node, ast.Call):
             if isinstance(node.func, ast.Attribute):
-                return False
+                # Check if name is an undefined local variable,
+                # which can only be a tensor or a constexpr
+                name = node.func.value.id
+                if name not in self.lscope and name not in self.gscope:
+                    return False
             fn = self.visit(node.func)
             if isinstance(fn, JITFunction):
                 old_gscope = self.gscope
@@ -183,6 +187,18 @@ class CodeGenerator(ast.NodeVisitor):
             ret = any(pred(s) for s in node.body)
             if node.orelse:
                 ret = ret or any(pred(s) for s in node.orelse)
+            return ret
+        elif isinstance(node, ast.IfExp):
+            return self.contains_return_op(node.body) or self.contains_return_op(node.orelse)
+        elif isinstance(node, ast.Expr):
+            ret = False
+            for _, value in ast.iter_fields(node):
+                if isinstance(value, list):
+                    for item in value:
+                       if isinstance(item, ast.AST):
+                           ret = ret or self.contains_return_op(item)
+                elif isinstance(value, ast.AST):
+                    ret = ret or self.contains_return_op(value)
             return ret
         else:
             return False
@@ -257,9 +273,9 @@ class CodeGenerator(ast.NodeVisitor):
             self.set_value(arg_name, arg_value)
         self.builder.set_insertion_point_to_start(entry)
         # visit function body
-        has_ret = self.visit_compound_statement(node.body)
+        self.visit_compound_statement(node.body)
         # finalize function
-        if not has_ret:
+        if self.last_ret_type is None:
             self.builder.ret([])
         else:
             # update return type
@@ -271,6 +287,9 @@ class CodeGenerator(ast.NodeVisitor):
                 fn.reset_type(self.prototype.to_ir(self.builder))
         if insert_pt:
             self.builder.set_insertion_point_to_end(insert_pt)
+        # We could finalize here after last_ret_type is set
+        # because triton requires each return op to be the same type
+        fn.finalize()
 
     def visit_arguments(self, node):
         arg_names = []
@@ -421,6 +440,7 @@ class CodeGenerator(ast.NodeVisitor):
         return then_defs, else_defs, then_block, else_block, names, ret_types, ir_ret_types
 
     def visit_if_top_level(self, cond, node):
+        has_endif_block = True
         with enter_sub_region(self) as sr:
             liveins, ip_block = sr
             then_block = self.builder.create_block()
@@ -435,20 +455,25 @@ class CodeGenerator(ast.NodeVisitor):
                 self.visit_then_else_blocks(node, liveins, then_block, else_block)
             # then terminator
             self.builder.set_insertion_point_to_end(then_block)
-            if not then_block.has_terminator():
+            if not then_block.has_terminator() and not then_block.has_return():
                 self.builder.create_branch(endif_block, [then_defs[n].handle for n in names])
             # else terminator
             self.builder.set_insertion_point_to_end(else_block)
-            if not else_block.has_terminator():
+            if not else_block.has_terminator() and not else_block.has_return():
                 self.builder.create_branch(endif_block, [else_defs[n].handle for n in names])
-            for ty in ir_ret_types:
-                endif_block.add_argument(ty)
-        # change block
-        self.builder.set_insertion_point_to_start(endif_block)
-        # update value
-        for i, name in enumerate(names):
-            new_tensor = language.core.tensor(endif_block.arg(i), ret_types[i])
-            self.set_value(name, new_tensor)
+            if then_block.has_return() and else_block.has_return():
+                has_endif_block = False
+                endif_block.erase()
+            else:
+                for ty in ir_ret_types:
+                    endif_block.add_argument(ty)
+        if has_endif_block:
+            # change block
+            self.builder.set_insertion_point_to_start(endif_block)
+            # update value
+            for i, name in enumerate(names):
+                new_tensor = language.core.tensor(endif_block.arg(i), ret_types[i])
+                self.set_value(name, new_tensor)
 
     # TODO: refactor
     def visit_if_scf(self, cond, node):

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -455,16 +455,16 @@ class CodeGenerator(ast.NodeVisitor):
                 self.visit_then_else_blocks(node, liveins, then_block, else_block)
             # then terminator
             self.builder.set_insertion_point_to_end(then_block)
-            if not then_block.has_terminator() and not then_block.has_return():
-                self.builder.create_branch(endif_block, [then_defs[n].handle for n in names])
-            # else terminator
-            self.builder.set_insertion_point_to_end(else_block)
-            if not else_block.has_terminator() and not else_block.has_return():
-                self.builder.create_branch(endif_block, [else_defs[n].handle for n in names])
             if then_block.has_return() and else_block.has_return():
                 has_endif_block = False
                 endif_block.erase()
-            else:
+            if not then_block.has_terminator() and has_endif_block:
+                self.builder.create_branch(endif_block, [then_defs[n].handle for n in names])
+            # else terminator
+            self.builder.set_insertion_point_to_end(else_block)
+            if not else_block.has_terminator() and has_endif_block:
+                self.builder.create_branch(endif_block, [else_defs[n].handle for n in names])
+            if has_endif_block:
                 for ty in ir_ret_types:
                     endif_block.add_argument(ty)
         if has_endif_block:

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -287,8 +287,7 @@ class CodeGenerator(ast.NodeVisitor):
                 fn.reset_type(self.prototype.to_ir(self.builder))
         if insert_pt:
             self.builder.set_insertion_point_to_end(insert_pt)
-        # We could finalize here after last_ret_type is set
-        # because triton requires each return op to be the same type
+        # Remove dead code
         fn.finalize()
 
     def visit_arguments(self, node):


### PR DESCRIPTION
- Case 1: Return after static control flow is taken. Peel off instructions after the first `return` for each basic block.

```python
if static_condition:
    tl.store(...)
    return
return
```

- Case 2: Return exists in both `if` and `else` branches of an inlined device function

```python
if dynamic_condition:
    return a
else:
    return b
```

- Case 3: Return exists in a `JITFunction` from another module

```python
import module
if cond:
    a = module.func()
```

- Case 4: Call a function `func` without returning variables. `func` is recognized as an `Expr` first instead of a `Call`.

```python
if cond:
    foo()
else:
    bar()
```