### PR TITLE
[FRONTEND] Hotfix for `contains_return_op`

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -184,7 +184,7 @@ class CodeGenerator(ast.NodeVisitor):
             if check_undefined_name(node):
                 return False
             fn = self.visit(node.func)
-            if isinstance(fn, JITFunction) and fn.noinline is False:
+            if isinstance(fn, JITFunction) and fn.noinline is not True:
                 old_gscope = self.gscope
                 self.gscope = sys.modules[fn.fn.__module__].__dict__
                 ret = self.contains_return_op(fn.parse())


### PR DESCRIPTION
`noinline` can be None, False, or True, so we have to check the callee in the first two cases.