### PR TITLE
Add missing CMake link-time dependencies.

### DIFF
--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -11,4 +11,7 @@ add_mlir_library(TritonAnalysis
 
   LINK_LIBS PUBLIC
   MLIRAnalysis
+  MLIRLLVMDialect
+  TritonIR
+  TritonGPUIR
 )

--- a/lib/Conversion/TritonToTritonGPU/CMakeLists.txt
+++ b/lib/Conversion/TritonToTritonGPU/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_conversion_library(TritonToTritonGPU
     LINK_LIBS PUBLIC
     MLIRIR
     MLIRPass
+    MLIRTransforms
     TritonIR
     TritonGPUIR
     TritonGPUTransforms

--- a/lib/Dialect/Triton/IR/CMakeLists.txt
+++ b/lib/Dialect/Triton/IR/CMakeLists.txt
@@ -10,5 +10,6 @@ add_mlir_dialect_library(TritonIR
   LINK_LIBS PUBLIC
   MLIRIR
   MLIRArithDialect
+  MLIRMathDialect
   MLIRSCFDialect
 )

--- a/lib/Dialect/Triton/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Triton/Transforms/CMakeLists.txt
@@ -9,4 +9,9 @@ add_mlir_dialect_library(TritonTransforms
   DEPENDS
   TritonTransformsIncGen
   TritonCombineIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRPass
+  MLIRTransformUtils
+  TritonIR
 )

--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -7,5 +7,6 @@ add_mlir_dialect_library(TritonGPUIR
   TritonGPUAttrDefsIncGen
 
   LINK_LIBS PUBLIC
+  MLIRGPUOps
   TritonIR
 )

--- a/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/Transforms/CMakeLists.txt
@@ -14,7 +14,9 @@ add_mlir_dialect_library(TritonGPUTransforms
   TritonGPUTransformsIncGen
 
   LINK_LIBS PUBLIC
+  MLIRTransforms
+  MLIRTransformUtils
+  TritonAnalysis
   TritonIR
   TritonGPUIR
-  MLIRTransformUtils
 )

--- a/lib/Target/LLVMIR/CMakeLists.txt
+++ b/lib/Target/LLVMIR/CMakeLists.txt
@@ -5,8 +5,17 @@ add_mlir_translation_library(TritonLLVMIR
         Core
 
         LINK_LIBS PUBLIC
+        MLIRArithToLLVM
+        MLIRBuiltinToLLVMIRTranslation
+        MLIRExecutionEngineUtils
+        MLIRIndexToLLVM
         MLIRIR
         MLIRLLVMDialect
+        MLIRLLVMToLLVMIRTranslation
+        MLIRNVVMToLLVMIRTranslation
+        MLIRROCDLToLLVMIRTranslation
+        MLIRSCFToControlFlow
         MLIRSupport
         MLIRTargetLLVMIRExport
+        TritonGPUToLLVM
         )

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_library(TritonTestAnalysis
   TestMembar.cpp
 
   LINK_LIBS PUBLIC
+  MLIRPass
   TritonAnalysis
   ${dialect_libs}
 )

--- a/unittest/Analysis/CMakeLists.txt
+++ b/unittest/Analysis/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_triton_ut(
   NAME TestTritonAnalysis
   SRCS UtilityTest.cpp
-  LIBS TritonAnalysis
+  LIBS
+    TritonAnalysis
+    TritonIR
+    TritonGPUIR
 )


### PR DESCRIPTION
These were currently missing, though building *with static linking* would still work since only the final binaries need all referenced symbols to be present in that case. These dependencies are required to produce self-contained dynamic libraries though.

My way of finding these dependencies has been rather manual: build with BUILD_SHARED_LIBS=ON (which requires to use an LLVM distribution that was built with the same flag, as well as some temporary changes to make the default visibility of symbols public) and then check with `ldd -r` if all symbols can be resolved. Concretely, I used this snippet:

find . -name "*.so.17git" | \
  while read line
  do
    echo; echo; echo $line
    LD_LIBRARY_PATH=$(find . -name "*.so.17git" | xargs dirname
                        | xargs realpath | tr "\n" :)$LD_LIBRARY_PATH \
      ldd -r $line | grep undefined | c++filt
  done

Before this commit, many libraries had many unresolved symbols; with this commit, only one missing symbol is left. That unresolved symbol is due to a cyclic dependency (see #1649), which requires moving code to break and is therefor out of the scope of this commit.