### PR TITLE
Assert that for loop bounds must be ints

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -700,6 +700,8 @@ class CodeGenerator(ast.NodeVisitor):
         ub = language.core._to_tensor(ub, self.builder)
         step = language.core._to_tensor(step, self.builder)
         # induction variable type
+        if not lb.dtype.is_int() or not ub.dtype.is_int() or not step.dtype.is_int():
+            raise TypeError(f"For loop bounds and step must all be ints, are ({lb.dtype}, {ub.dtype}, {step.dtype})")
         iv_type = language.semantic.integer_promote_impl(lb.dtype, ub.dtype)
         iv_type = language.semantic.integer_promote_impl(iv_type, step.dtype)
         iv_ir_type = iv_type.to_ir(self.builder)


### PR DESCRIPTION
As stands if you have a for loop with bounds that are not ints, it will fail with the inscrutable error `'dtype' object has no attribute 'int_bitwidth'`. This is confusing. Instead, we can assert for loop lower and upper bounds be ints, so we can get a much nicer error: `TypeError('For loop bounds and step must all be ints, are (int32, fp32, int32)')`.

Old error traceback:
```
Traceback (most recent call last):
  File "/root/triton/python/triton/compiler/code_generator.py", line 1033, in ast_to_ttir
    generator.visit(fn.parse())
  File "/root/triton/python/triton/compiler/code_generator.py", line 933, in visit
    return super().visit(node)
  File "/usr/lib/python3.8/ast.py", line 371, in visit
    return visitor(node)
  File "/root/triton/python/triton/compiler/code_generator.py", line 227, in visit_Module
    ast.NodeVisitor.generic_visit(self, node)
  File "/usr/lib/python3.8/ast.py", line 379, in generic_visit
    self.visit(item)
  File "/root/triton/python/triton/compiler/code_generator.py", line 933, in visit
    return super().visit(node)
  File "/usr/lib/python3.8/ast.py", line 371, in visit
    return visitor(node)
  File "/root/triton/python/triton/compiler/code_generator.py", line 296, in visit_FunctionDef
    self.visit_compound_statement(node.body)
  File "/root/triton/python/triton/compiler/code_generator.py", line 165, in visit_compound_statement
    ret_type = self.visit(stmt)
  File "/root/triton/python/triton/compiler/code_generator.py", line 933, in visit
    return super().visit(node)
  File "/usr/lib/python3.8/ast.py", line 371, in visit
    return visitor(node)
  File "/root/triton/python/triton/compiler/code_generator.py", line 705, in visit_For
    iv_type = language.semantic.integer_promote_impl(lb.dtype, ub.dtype)
  File "/root/triton/python/triton/language/semantic.py", line 40, in integer_promote_impl
    b_rank = b_ty.int_bitwidth
AttributeError: 'dtype' object has no attribute 'int_bitwidth'
```