### PR TITLE
build: fix code to resolve compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 include(TableGen) # required by AddMLIR
 include(AddLLVM)
 include(AddMLIR)
+include(HandleLLVMOptions)
 
 # Disable warnings that show up in external code (gtest;pybind11)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default")

--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -306,6 +306,7 @@ public:
       : CallGraph<AxisInfoMapT>(moduleOp) {
     SmallVector<FunctionOpInterface> funcs;
     for (auto root : getRoots()) {
+      (void)root;
       walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
           // Pre-order edge walk callback
           [](CallOpInterface callOp, FunctionOpInterface funcOp) {},

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -58,7 +58,7 @@ private:
   ArrayRef<int64_t> srcShape;
   Attribute srcEncoding;
   SmallVector<Type> srcElementTypes;
-  int axis;
+  unsigned axis;
 };
 
 bool maybeSharedAllocationOp(Operation *op);
@@ -82,7 +82,7 @@ inline SmallVector<T_OUT> convertType(ArrayRef<T_IN> in) {
 }
 
 template <typename Int> Int product(llvm::ArrayRef<Int> arr) {
-  return std::accumulate(arr.begin(), arr.end(), 1, std::multiplies{});
+  return std::accumulate(arr.begin(), arr.end(), 1, std::multiplies<Int>{});
 }
 
 template <typename Int> Int ceil(Int m, Int n) { return (m + n - 1) / n; }

--- a/include/triton/Conversion/TritonGPUToLLVM/GCNAsmFormat.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/GCNAsmFormat.h
@@ -15,9 +15,9 @@ class Location;
 namespace triton {
 using llvm::StringRef;
 
-class GCNInstr;
-class GCNInstrCommon;
-class GCNInstrExecution;
+struct GCNInstr;
+struct GCNInstrCommon;
+struct GCNInstrExecution;
 
 // GCNBuilder helps to manage a GCN asm program consists of one or multiple
 // instructions.
@@ -94,7 +94,7 @@ struct GCNBuilder {
     Operand() = default;
     Operand(const Operation &) = delete;
     Operand(Value value, StringRef constraint)
-        : value(value), constraint(constraint) {}
+        : constraint(constraint), value(value) {}
 
     bool isList() const { return !value && constraint.empty(); }
 
@@ -164,7 +164,7 @@ struct GCNBuilder {
   Operand *newListOperand(unsigned count, mlir::Value val,
                           const std::string &constraint) {
     auto *list = newOperand();
-    for (int i = 0; i < count; ++i) {
+    for (unsigned i = 0; i < count; ++i) {
       list->listAppend(newOperand(val, constraint));
     }
     return list;
@@ -172,7 +172,7 @@ struct GCNBuilder {
 
   Operand *newListOperand(unsigned count, const std::string &constraint) {
     auto *list = newOperand();
-    for (int i = 0; i < count; ++i) {
+    for (unsigned i = 0; i < count; ++i) {
       list->listAppend(newOperand(constraint));
     }
     return list;
@@ -223,8 +223,8 @@ private:
     return modArchive.back().get();
   }
 
-  friend class GCNInstr;
-  friend class GCNInstrCommon;
+  friend struct GCNInstr;
+  friend struct GCNInstrCommon;
 
 protected:
   llvm::SmallVector<std::unique_ptr<Operand>, 6> argArchive;
@@ -264,7 +264,7 @@ protected:
   GCNBuilder *builder{};
   llvm::SmallVector<std::string, 4> instrParts;
 
-  friend class GCNInstrExecution;
+  friend struct GCNInstrExecution;
 };
 
 template <class ConcreteT> struct GCNInstrBase : public GCNInstrCommon {
@@ -320,8 +320,8 @@ struct GCNInstrExecution {
   explicit GCNInstrExecution(GCNInstrCommon *instr,
                              llvm::ArrayRef<Operand *> oprs,
                              llvm::ArrayRef<Modifier *> modifiers)
-      : instr(instr), argsInOrder(oprs.begin(), oprs.end()),
-        mods(modifiers.begin(), modifiers.end()) {}
+      : argsInOrder(oprs.begin(), oprs.end()),
+        mods(modifiers.begin(), modifiers.end()), instr(instr) {}
 
   std::string dump() const;
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -410,9 +410,9 @@ For example, the matrix L corresponding to blockTileSize=[32,16] is:
 
       do {
         wpt_nm1 = wpt;
-        if (wpt[0] * wpt[1] < numWarps)
+        if (static_cast<int>(wpt[0] * wpt[1]) < numWarps)
           wpt[0] = std::clamp<int>(wpt[0] * 2, 1, shapeC[0] / spw[0]);
-        if (wpt[0] * wpt[1] < numWarps)
+        if (static_cast<int>(wpt[0] * wpt[1]) < numWarps)
           wpt[1] = std::clamp<int>(wpt[1] * 2, 1, shapeC[1] / spw[1]);
       } while (wpt_nm1 != wpt);
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -19,7 +19,7 @@ getThreadIds(Value threadId, ArrayRef<unsigned int> shapePerCTA,
              ConversionPatternRewriter &rewriter, Location loc) {
   int dim = order.size();
   SmallVector<Value> threadIds(dim);
-  for (unsigned k = 0; k < dim - 1; k++) {
+  for (int k = 0; k < dim - 1; k++) {
     Value dimK = i32_val(shapePerCTA[order[k]] / sizePerThread[order[k]]);
     Value rem = urem(threadId, dimK);
     threadId = udiv(threadId, dimK);
@@ -77,9 +77,9 @@ ValueTable getValueTableFromStruct(Value val, int K, int n0, int shapePerCTA,
   ValueTable res;
   auto elems = typeConverter->unpackLLElements(loc, val, rewriter, type);
   int index = 0;
-  for (unsigned k = 0; k < K; ++k) {
-    for (unsigned m = 0; m < n0; m += shapePerCTA)
-      for (unsigned mm = 0; mm < sizePerThread; ++mm) {
+  for (int k = 0; k < K; ++k) {
+    for (int m = 0; m < n0; m += shapePerCTA)
+      for (int mm = 0; mm < sizePerThread; ++mm) {
         res[{m + mm, k}] = elems[index++];
       }
   }
@@ -137,9 +137,9 @@ Value loadAFMA(Value A, Value llA, BlockedEncodingAttr dLayout, Value thread,
   int mShapePerCTA = getShapePerCTAForMN(dLayout, true /*isM*/);
   int mSizePerThread = getSizePerThreadForMN(dLayout, true /*isM*/);
 
-  for (unsigned k = 0; k < K; ++k)
-    for (unsigned m = 0; m < M; m += mShapePerCTA)
-      for (unsigned mm = 0; mm < mSizePerThread; ++mm) {
+  for (int k = 0; k < K; ++k)
+    for (int m = 0; m < M; m += mShapePerCTA)
+      for (int mm = 0; mm < mSizePerThread; ++mm) {
         Value offset =
             add(mul(i32_val(m + mm), strideAM), mul(i32_val(k), strideAK));
         Value pa = gep(ptrTy, aPtrs[0], offset);
@@ -201,9 +201,9 @@ Value loadBFMA(Value B, Value llB, BlockedEncodingAttr dLayout, Value thread,
   int nShapePerCTA = getShapePerCTAForMN(dLayout, false /*isM*/);
   int nSizePerThread = getSizePerThreadForMN(dLayout, false /*isM*/);
 
-  for (unsigned k = 0; k < K; ++k)
-    for (unsigned n = 0; n < N; n += nShapePerCTA)
-      for (unsigned nn = 0; nn < nSizePerThread; ++nn) {
+  for (int k = 0; k < K; ++k)
+    for (int n = 0; n < N; n += nShapePerCTA)
+      for (int nn = 0; nn < nSizePerThread; ++nn) {
         Value offset =
             add(mul(i32_val(n + nn), strideBN), mul(i32_val(k), strideBK));
         Value pb = gep(ptrTy, bPtrs[0], offset);

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
@@ -187,12 +187,10 @@ SmallVector<Value> MMA16816SmemLoader::computeLdsMatOffs(Value warpOff,
   SmallVector<Value> offs(numPtrs);
 
   int vecWidth = kWidth;
-  int threadsPerQuad[2] = {8, 4};
   int laneWidth = 4;
   int laneHeight = 8;
   int quadWidth = laneWidth * vecWidth;
   int quadHeight = laneHeight;
-  int numQuadI = 2;
 
   // outer index base
   Value iBase = udiv(lane, i32_val(laneWidth));

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -16,9 +16,9 @@ static ValueTableFMA getValueTableFromStructFMA(
   ValueTableFMA res;
   auto elems = typeConverter->unpackLLElements(loc, val, rewriter, type);
   int index = 0;
-  for (unsigned k = 0; k < K; ++k) {
-    for (unsigned m = 0; m < n0; m += shapePerCTA)
-      for (unsigned mm = 0; mm < sizePerThread; ++mm) {
+  for (int k = 0; k < K; ++k) {
+    for (int m = 0; m < n0; m += shapePerCTA)
+      for (int mm = 0; mm < sizePerThread; ++mm) {
         res[{m + mm, k}] = elems[index++];
       }
   }
@@ -28,12 +28,10 @@ static ValueTableFMA getValueTableFromStructFMA(
 LogicalResult convertFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                             TritonGPUToLLVMTypeConverter *typeConverter,
                             ConversionPatternRewriter &rewriter) {
-  auto *ctx = rewriter.getContext();
   auto loc = op.getLoc();
 
   auto A = op.getA();
   auto B = op.getB();
-  auto C = op.getC();
   auto D = op.getResult();
 
   auto aTensorTy = A.getType().cast<RankedTensorType>();
@@ -78,11 +76,11 @@ LogicalResult convertFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   SmallVector<Value> ret = cc;
   bool isCRow = order[0] == 1;
 
-  for (unsigned k = 0; k < K; k++) {
-    for (unsigned m = 0; m < M; m += mShapePerCTA)
-      for (unsigned n = 0; n < N; n += nShapePerCTA)
-        for (unsigned mm = 0; mm < mSizePerThread; ++mm)
-          for (unsigned nn = 0; nn < nSizePerThread; ++nn) {
+  for (int k = 0; k < K; k++) {
+    for (int m = 0; m < M; m += mShapePerCTA)
+      for (int n = 0; n < N; n += nShapePerCTA)
+        for (int mm = 0; mm < mSizePerThread; ++mm)
+          for (int nn = 0; nn < nSizePerThread; ++nn) {
             int mIdx = m / mShapePerCTA * mSizePerThread + mm;
             int nIdx = n / nShapePerCTA * nSizePerThread + nn;
 

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv1.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv1.cpp
@@ -24,7 +24,7 @@ extractLoadedOperand(Value llStruct, int NK,
   SmallVector<Value> elems = typeConverter->unpackLLElements(
       llStruct.getLoc(), llStruct, rewriter, type);
 
-  int offset = 0;
+  size_t offset = 0;
   for (int i = 0; offset < elems.size(); ++i) {
     for (int k = 0; k < NK; k += 4) {
       rcds[{i, k}] = std::make_pair(elems[offset], elems[offset + 1]);
@@ -38,7 +38,6 @@ extractLoadedOperand(Value llStruct, int NK,
 LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                             TritonGPUToLLVMTypeConverter *typeConverter,
                             ConversionPatternRewriter &rewriter) {
-  auto *ctx = op.getContext();
   auto loc = op.getLoc();
 
   Value A = op.getA();
@@ -67,6 +66,10 @@ LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   bool isBRow = BLayout.getMMAv1IsRow();
   auto [isARow_, isBRow_, isAVec4_, isBVec4_, _] =
       mmaLayout.decodeVoltaLayoutStates();
+  (void)isARow_;
+  (void)isBRow_;
+  (void)isAVec4_;
+  (void)isBVec4_;
   assert(isARow == isARow_);
   assert(isBRow == isBRow_);
 

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -103,8 +103,8 @@ struct ReturnOpConversion : public ConvertOpToLLVMPattern<triton::ReturnOp> {
 struct FuncOpConversion : public FuncOpConversionBase {
   FuncOpConversion(LLVMTypeConverter &converter, int numWarps,
                    ModuleAllocation &allocation, PatternBenefit benefit)
-      : FuncOpConversionBase(converter, benefit), allocation(allocation),
-        numWarps(numWarps) {}
+      : FuncOpConversionBase(converter, benefit), numWarps(numWarps),
+        allocation(allocation) {}
 
   triton::FuncOp amendFuncOp(triton::FuncOp funcOp,
                              ConversionPatternRewriter &rewriter) const {
@@ -185,7 +185,7 @@ struct CallOpConversion : public ConvertOpToLLVMPattern<triton::CallOp> {
   CallOpConversion(LLVMTypeConverter &converter, int numWarps,
                    ModuleAllocation &allocation, PatternBenefit benefit)
       : ConvertOpToLLVMPattern<triton::CallOp>(converter, benefit),
-        allocation(allocation), numWarps(numWarps) {}
+        numWarps(numWarps), allocation(allocation) {}
 
   LogicalResult
   matchAndRewrite(triton::CallOp callOp,
@@ -250,6 +250,7 @@ private:
   SmallVector<Value>
   getCallOpResults(triton::CallOp callOp, LLVM::CallOp newCallOp,
                    ConversionPatternRewriter &rewriter) const {
+    (void)numWarps;
     auto numResults = callOp.getNumResults();
     SmallVector<Value> results;
     if (numResults < 2) {
@@ -556,7 +557,7 @@ private:
       auto sizes = SmallVector<OpFoldResult>(dstTy.getRank(), intAttr(1));
       auto strides = SmallVector<OpFoldResult>(dstTy.getRank(), intAttr(1));
       offsets[axis] = insertSliceAsyncOp.getIndex();
-      for (size_t i = 0; i < dstTy.getRank(); i++) {
+      for (int64_t i = 0; i < dstTy.getRank(); i++) {
         if (i != axis)
           sizes[i] = intAttr(dstTy.getShape()[i]);
       }

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -106,6 +106,7 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
     return elemTy;
   if (mmaParent.isAmpere()) {
     int bitwidth = elemTy.getIntOrFloatBitWidth();
+    (void)bitwidth;
     assert(bitwidth <= 32);
     return IntegerType::get(ctx, 32);
   } else {

--- a/lib/Conversion/TritonGPUToLLVM/Utility.h
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.h
@@ -241,7 +241,7 @@ struct SharedMemoryObject {
   }
 
   Value getCSwizzleOffset(int order) const {
-    assert(order >= 0 && order < strides.size());
+    assert(order >= 0 && order < static_cast<int>(strides.size()));
     return offsets[order];
   }
 

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -29,8 +29,9 @@ struct SplatOpConversion
     return typeConverter->packLLElements(loc, elems, rewriter, resType);
   }
 
-  LogicalResult matchAndRewrite(triton::SplatOp op, OpAdaptor adaptor,
-                                ConversionPatternRewriter &rewriter) const {
+  LogicalResult
+  matchAndRewrite(triton::SplatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
     auto src = adaptor.getSrc();
     auto llStruct = convertSplatLikeOp(src.getType(), op.getType(), src,

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -554,7 +554,6 @@ public:
   LogicalResult
   matchAndRewrite(triton::CallOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto converter = getTypeConverter();
     auto newOp = rewriter.replaceOpWithNewOp<triton::CallOp>(
         op, op.getCallee(), op.getResultTypes(), adaptor.getOperands());
     addNamedAttrs(newOp, adaptor.getAttributes());
@@ -569,9 +568,7 @@ public:
   LogicalResult
   matchAndRewrite(ReturnOp op, ReturnOp::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto converter = getTypeConverter();
-    auto newOp =
-        rewriter.replaceOpWithNewOp<ReturnOp>(op, adaptor.getOperands());
+    rewriter.replaceOpWithNewOp<ReturnOp>(op, adaptor.getOperands());
     return success();
   }
 };

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -480,7 +480,6 @@ mlir::LogicalResult mlir::triton::ReduceOp::verifyRegions() {
                                << " arguments, but given block with "
                                << block.getNumArguments() << " arguments";
   }
-  unsigned i = 0;
   const auto &blockArgTypes = block.getArgumentTypes();
   for (unsigned i = 0; i < numArgs; ++i) {
     const auto &blockArgTy = blockArgTypes[i];

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -27,8 +27,6 @@ private:
 public:
   RewritedInfo() = default;
 
-  RewritedInfo(const RewritedInfo &other) = default;
-
   RewritedInfo(Value base, const SmallVector<Value> &shape,
                const SmallVector<Value> &strides,
                const SmallVector<Value> &offsets,
@@ -74,7 +72,7 @@ public:
     // Expand dimensions
     Value expandedResult =
         builder.create<arith::AddIOp>(loc, splatOffset, i64Range);
-    for (int j = 0; j < tensorShape.size(); ++j) {
+    for (size_t j = 0; j < tensorShape.size(); ++j) {
       if (j == i)
         continue;
       expandedResult =
@@ -208,7 +206,7 @@ public:
                       const SmallVector<Value> &newValues) {
     assert(index < oldOperands.size());
     SmallVector<Value> newOperands;
-    for (int i = 0; i < index; ++i)
+    for (unsigned i = 0; i < index; ++i)
       newOperands.push_back(oldOperands[i]);
     for (auto value : newValues)
       newOperands.push_back(value);
@@ -251,7 +249,7 @@ public:
     // Calculate new offsets
     assert(info.length() == op.getOffsets().size());
     SmallVector<Value> newOffsets;
-    for (int i = 0; i < info.length(); ++i) {
+    for (unsigned int i = 0; i < info.length(); ++i) {
       Value i64Offset = builder.create<arith::ExtSIOp>(
           op.getLoc(), builder.getI64Type(), op.getOffsets()[i]);
       Value newOffset = builder.create<arith::AddIOp>(

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -159,7 +159,8 @@ public:
 
     mlir::PassManager pm(m.getContext());
     pm.addPass(mlir::createCanonicalizerPass());
-    auto ret = pm.run(m);
+    if (pm.run(m).failed())
+      signalPassFailure();
 
     mlir::RewritePatternSet patterns(context);
     patterns.add<ConvertTransConvert>(context);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -572,7 +572,7 @@ scf::ForOp LoopPipeliner::createNewForOp() {
     // is modified
     auto it = std::find(loads.begin(), loads.end(), op.getOperand(0));
     if (it == loads.end()) {
-      Operation *newOp = cloneWithInferType(builder, &op, mapping);
+      cloneWithInferType(builder, &op, mapping);
       continue;
     }
 

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -88,7 +88,7 @@ void Prefetcher::cloneElementwiseOps(Value &ret, const SmallVector<Value> &vals,
                                      OpBuilder &builder) {
   IRMapping mapping;
   mapping.map(vals[0], ret);
-  for (int i = 1; i < vals.size(); i++) {
+  for (size_t i = 1; i < vals.size(); i++) {
     Value v = vals[i];
     Value curr = builder.clone(*v.getDefiningOp(), mapping)->getResult(0);
     auto retType = RankedTensorType::get(
@@ -205,6 +205,7 @@ LogicalResult Prefetcher::initialize() {
     auto bEnc = bType.getEncoding().cast<triton::gpu::DotOperandEncodingAttr>();
     int aKWidth = aEnc.getMMAv2kWidth();
     int bKWidth = bEnc.getMMAv2kWidth();
+    (void)bKWidth;
     assert(aKWidth == bKWidth);
 
     auto kSize = aType.getShape()[1];

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -208,7 +208,7 @@ void pushConversionForward(triton::gpu::ConvertLayoutOp cvt,
   }
   rewriter.setInsertionPoint(op);
   if (op->getNumResults() == 0) {
-    Operation *newOp = rewriter.clone(*op, mapping);
+    rewriter.clone(*op, mapping);
     rewriter.eraseOp(op);
     return;
   }
@@ -251,7 +251,7 @@ public:
     }
 
     IRMapping mapping;
-    for (size_t i = 0; i < numOps; i++) {
+    for (int i = 0; i < numOps; i++) {
       auto thenCvt = dyn_cast_or_null<triton::gpu::ConvertLayoutOp>(
           thenYield.getOperand(i).getDefiningOp());
       if (hasElse) {
@@ -312,7 +312,7 @@ public:
 
     rewriter.setInsertionPointAfter(newIfOp);
     SmallVector<Value> newRetValues = newIfOp.getResults();
-    for (size_t i = 0; i < numOps; i++) {
+    for (int i = 0; i < numOps; i++) {
       if (newIfOp.getResult(i).getType() != ifOp.getResult(i).getType()) {
         newRetValues[i] = rewriter.create<triton::gpu::ConvertLayoutOp>(
             newIfOp.getLoc(), ifOp.getResult(i).getType(),

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -100,7 +100,6 @@ bool expensiveLoadOrStore(Operation *op, Attribute &targetEncoding) {
       op->getParentOfType<ModuleOp>()->getAttrOfType<IntegerAttr>(
           "triton_gpu.num-warps");
   if (numWarps) {
-    int sizePerThread = triton::gpu::getTotalElemsPerThread(ptrType);
     if (ptrType.getNumElements() < numWarps.getInt() * 32)
       return false;
   }


### PR DESCRIPTION
This patch fixes the code so that when it is compiled with clang (v15)
with the same flags used for compiling LLVM (i.e. flags set in LLVM's
HandleLLVMOptions.cmake), the compiler no longer emits warnings.
Specifically, this patch makes the following changes:

 - Fixes or removes unused variables (`-Wunused-variables` and
   `-Wunused-but-set-parameter`)

 - Specifies template type explicitly (`-Wctad-maybe-unsupported`)

 - Uses consistent (`struct` versus `class`) type declarations
   (`-Wmismatched-types`)

 - Fixes order of field initialization in class constructor
   (`-Wreorder-ctor`)

 - Fixes comparison between signed and unsigned types (`-Wsign-compare`)

 - Removes redundant (and possibly dangerous) node initialization in
   MLIR dataflow analysis

 - Replaces C-style casts with `static_cast`, so that such casts are
   more easily searchable (to pin down possible bugs)

 - Marks overriden methods with `override` (`-Wsuggest-override`)

To ensure that we don't regress, this patch also adds LLVM's
HandleLLVMOptions to the top-level CMakeLists.txt.