### PR TITLE
witch Triton dialect to use MLIR properties

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonDialect.td
+++ b/include/triton/Dialect/Triton/IR/TritonDialect.td
@@ -37,6 +37,7 @@ def Triton_Dialect : Dialect {
 
   let hasConstantMaterializer = 1;
   let useDefaultTypePrinterParser = 1;
+  let usePropertiesForAttributes = 1;
 }
 
 include "triton/Dialect/Triton/IR/TritonTypes.td"

--- a/test/Conversion/triton_ops.mlir
+++ b/test/Conversion/triton_ops.mlir
@@ -76,40 +76,64 @@ tt.func @load_store_ops_scalar(%ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, 
   tt.return
 }
 
+// CHECK-LABEL: reduce_ops_infer
 tt.func @reduce_ops_infer(%ptr: !tt.ptr<f32>, %v : tensor<1x2x4xf32>) {
   // Test if reduce ops infer types correctly
 
-  // CHECK: }) {axis = 0 : i32} : (tensor<1x2x4xf32>) -> tensor<2x4xf32>
+  // CHECK: tt.reduce
+  // CHECK-SAME: axis = 0
+  // CHECK: tt.reduce.return
+  // CHECK-NEXT: (tensor<1x2x4xf32>) -> tensor<2x4xf32>
   %a = "tt.reduce" (%v) ({
   ^bb0(%arg0: f32, %arg1: f32):
     %add = arith.addf %arg0, %arg1 : f32
     tt.reduce.return %add : f32
   }) {axis = 0 : i32}  : (tensor<1x2x4xf32>) -> tensor<2x4xf32>
-  // CHECK: }) {axis = 1 : i32}  : (tensor<1x2x4xf32>) -> tensor<1x4xf32>
+
+  // CHECK: tt.reduce
+  // CHECK-SAME: axis = 1
+  // CHECK: tt.reduce.return
+  // CHECK-NEXT: (tensor<1x2x4xf32>) -> tensor<1x4xf32>
   %b = "tt.reduce" (%v) ({
   ^bb0(%arg0: f32, %arg1: f32):
     %add = arith.addf %arg0, %arg1 : f32
     tt.reduce.return %add : f32
   }) {axis = 1 : i32}  : (tensor<1x2x4xf32>) -> tensor<1x4xf32>
-  // CHECK: }) {axis = 2 : i32}  : (tensor<1x2x4xf32>) -> tensor<1x2xf32>
+
+  // CHECK: tt.reduce
+  // CHECK-SAME: axis = 2
+  // CHECK: tt.reduce.return
+  // CHECK-NEXT: (tensor<1x2x4xf32>) -> tensor<1x2xf32>
   %c = "tt.reduce" (%v) ({
   ^bb0(%arg0: f32, %arg1: f32):
     %add = arith.addf %arg0, %arg1 : f32
     tt.reduce.return %add : f32
   }) {axis = 2 : i32}  : (tensor<1x2x4xf32>) -> tensor<1x2xf32>
-  // CHECK: }) {axis = 1 : i32}  : (tensor<1x4xf32>) -> tensor<1xf32>
+
+  // CHECK: tt.reduce
+  // CHECK-SAME: axis = 1
+  // CHECK: tt.reduce.return
+  // CHECK-NEXT: (tensor<1x4xf32>) -> tensor<1xf32>
   %e = "tt.reduce" (%b) ({
   ^bb0(%arg0: f32, %arg1: f32):
     %add = arith.addf %arg0, %arg1 : f32
     tt.reduce.return %add : f32
   }) {axis = 1 : i32}  : (tensor<1x4xf32>) -> tensor<1xf32>
-  // CHECK: }) {axis = 0 : i32}  : (tensor<2x4xf32>) -> tensor<4xf32>
+
+  // CHECK: tt.reduce
+  // CHECK-SAME: axis = 0
+  // CHECK: tt.reduce.return
+  // CHECK-NEXT: (tensor<2x4xf32>) -> tensor<4xf32>
   %f = "tt.reduce" (%a) ({
   ^bb0(%arg0: f32, %arg1: f32):
     %add = arith.addf %arg0, %arg1 : f32
     tt.reduce.return %add : f32
   }) {axis = 0 : i32}  : (tensor<2x4xf32>) -> tensor<4xf32>
-  // CHECK: }) {axis = 0 : i32}  : (tensor<4xf32>) -> f32
+
+  // CHECK: tt.reduce
+  // CHECK-SAME: axis = 0
+  // CHECK: tt.reduce.return
+  // CHECK-NEXT: (tensor<4xf32>) -> f32
   %g = "tt.reduce" (%f) ({
   ^bb0(%arg0: f32, %arg1: f32):
     %add = arith.addf %arg0, %arg1 : f32

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -1054,7 +1054,9 @@ module attributes {"triton_gpu.num-warps" = 2 : i32} {
 // Check if the SimplifyReduceCvt handles convert_layout lifted from the for loop.
 // CHECK-LABEL: reduce_cvt2
 // Match the reduction
-// CHECK: }) {axis = 1 : i32} : (tensor<1x256xf32, #blocked>) -> tensor<1xf32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+// CHECK: tt.reduce
+// CHECK-SAME: axis = 1
+// CHECK: (tensor<1x256xf32, #blocked>) -> tensor<1xf32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
 // CHECK-NEXT: triton_gpu.convert_layout
 // CHECK-NOT: triton_gpu.convert_layout
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [0, 1]}>


### PR DESCRIPTION
This does not change the compiler behavior, it is purely an internal change: it'll store inherent attributes (the one defined in ODS) within the operations themselves instead of in a DictionaryAttr in the MLIRContext.

The use of generic accessors like getAttribute("axis") should be avoided and direct access to the properties is prefered, like

 reduceOp.getProperties().axis

Also `getAttrs()` or `getAttrDictionary()` are gonna be deprecated and users should move to `getDiscardableAttrDictionary()` instead.