### PR TITLE
[FRONTEND] Fix tt.print printer format

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -479,7 +479,7 @@ def TT_PrintOp : TT_Op<"print", [MemoryEffects<[MemWrite]>]>,
     format are generated automatically from the arguments.
   }];
   let assemblyFormat = [{
-    $prefix attr-dict `:` ($args^ `:` type($args))?
+    $prefix attr-dict (`:` $args^ `:` type($args))?
   }];
 }
 

--- a/test/Conversion/triton_ops.mlir
+++ b/test/Conversion/triton_ops.mlir
@@ -154,3 +154,12 @@ tt.func @dot_ops_infer(%ptr: !tt.ptr<f32>, %v : f32) {
   tt.store %ptr1x1, %r4 : tensor<1x1xf32>
   tt.return
 }
+
+// CHECK-LABEL: @print_no_arg
+tt.func @print_no_arg(%arg0: !tt.ptr<f32>) {
+// CHECK: tt.print "test"
+  tt.print "test"
+  %0 = tt.load %arg0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : f32
+  tt.store %arg0, %0 {cache = 1 : i32, evict = 1 : i32} : f32
+  tt.return
+}


### PR DESCRIPTION
Ideally the MLIR generator should detect the ambiguity and error out.

Fixes #1683