### PR TITLE
build: add libpython to libraries linked with libtriton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,34 +144,6 @@ if(NOT MLIR_DIR)
   set(MLIR_DIR ${LLVM_LIBRARY_DIR}/cmake/mlir)
 endif()
 
-# Python module
-if(TRITON_BUILD_PYTHON_MODULE)
-  message(STATUS "Adding Python module")
-  set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/python/src)
-  set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc)
-  include_directories("." ${PYTHON_SRC_PATH})
-
-  if(PYTHON_INCLUDE_DIRS)
-    include_directories(${PYTHON_INCLUDE_DIRS})
-  else()
-    find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
-    include_directories(${Python3_INCLUDE_DIRS})
-    link_directories(${Python3_LIBRARY_DIRS})
-    link_libraries(${Python3_LIBRARIES})
-    add_link_options(${Python3_LINK_OPTIONS})
-  endif()
-endif()
-
-# # Triton
-# file(GLOB_RECURSE LIBTRITON_SRC lib/*.cc)
-# if (WIN32 AND TRITON_BUILD_PYTHON_MODULE)
-# Python3_add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
-# set_target_properties(triton PROPERTIES SUFFIX ".pyd")
-# set_target_properties(triton PROPERTIES PREFIX "lib")
-# else()
-# add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
-# endif()
-
 # MLIR
 find_package(MLIR REQUIRED CONFIG PATHS ${MLIR_DIR})
 
@@ -245,7 +217,34 @@ if(TRITON_BUILD_PYTHON_MODULE)
   endif()
 
   target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
+
+  message(STATUS "Adding Python module")
+  set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/python/src)
+  set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc)
+  include_directories("." ${PYTHON_SRC_PATH})
+
+  if(PYTHON_VERSION)
+    find_package(Python3
+      ${PYTHON_VERSION} EXACT
+      REQUIRED COMPONENTS Development Interpreter)
+  else()
+    find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
+  endif()
+
+  target_link_libraries(triton ${Python3_LIBRARIES})
+  target_link_options(triton PRIVATE ${Python3_LINK_OPTIONS})
+  target_include_directories(triton PRIVATE ${Python3_INCLUDE_DIRS})
 endif()
+
+# # Triton
+# file(GLOB_RECURSE LIBTRITON_SRC lib/*.cc)
+# if (WIN32 AND TRITON_BUILD_PYTHON_MODULE)
+# Python3_add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
+# set_target_properties(triton PROPERTIES SUFFIX ".pyd")
+# set_target_properties(triton PROPERTIES PREFIX "lib")
+# else()
+# add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
+# endif()
 
 if(UNIX AND NOT APPLE)
   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")

--- a/python/setup.py
+++ b/python/setup.py
@@ -192,15 +192,16 @@ class CMakeBuild(build_ext):
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         # python directories
-        python_include_dir = sysconfig.get_path("platinclude")
+        prefix = sysconfig.get_config_var("prefix")
+        python_version = sysconfig.get_python_version()
         cmake_args = [
             "-DLLVM_ENABLE_WERROR=ON",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DTRITON_BUILD_TUTORIALS=OFF",
             "-DTRITON_BUILD_PYTHON_MODULE=ON",
-            "-DPython3_EXECUTABLE:FILEPATH=" + sys.executable,
+            "-DPython3_ROOT_DIR=" + prefix,
+            "-DPYTHON_VERSION=" + python_version,
             "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON",
-            "-DPYTHON_INCLUDE_DIRS=" + python_include_dir,
         ]
         if lit_dir is not None:
             cmake_args.append("-DLLVM_EXTERNAL_LIT=" + lit_dir)


### PR DESCRIPTION
The triton library references pybind11, which needs linking with
libpython, but prior to this patch, if the triton build was configured
using the `PYTHON_INCLUDE_DIRS` variable, then only the Python header
files (and no Python libraries) were used during the build.  This
happens to work with the existing compiler flags, but if we enable
`-Wl,-z,defs`, which detects so-called underlinking (i.e. undefined
symbols in linked object files), then the build fails.

To resolve this problem, this patch drops the flag for specifying the
Python headers and instead uses CMake's `find_package()` function to
locate Python3 headers and libraries.  Furthermore, since we want the
Python version used for running setup.py to match the Python version
used with the libtriton build, this patch adds an additional option to
the CMake script (`PYTHON_VERSION`) which is set by setup.py and which,
if specified, is used by the CMake script to fetch the exact Python
version.