### PR TITLE
Switch the TritonGPU dialect to use MLIR Properties (NFC)

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
@@ -23,14 +23,16 @@ def TritonGPU_Dialect : Dialect {
   let extraClassDeclaration = [{
     static std::string getNumWarpsAttrName() { return "triton_gpu.num-warps"; }
     static int getNumWarps(ModuleOp mod) {
-      if(!mod->hasAttr("triton_gpu.num-warps"))
+      Attribute numWarps = mod->getDiscardableAttr("triton_gpu.num-warps");
+      if(!numWarps)
         llvm::report_fatal_error(
             "TritonGPU module should contain a triton_gpu.num-warps attribute");
-      return mod->getAttr("triton_gpu.num-warps").cast<IntegerAttr>().getInt();
+      return numWarps.cast<IntegerAttr>().getInt();
     }
   }];
 
   let useDefaultAttributePrinterParser = 1;
+  let usePropertiesForAttributes = 1;
 }
 
 #endif

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -111,15 +111,15 @@ AxisInfo AxisInfo::getPessimisticValueState(Value value) {
       }
     }
   } else if (Operation *op = value.getDefiningOp()) {
-    if (Attribute attr = op->getAttr("tt.divisibility")) {
+    if (Attribute attr = op->getDiscardableAttr("tt.divisibility")) {
       auto vals = attr.cast<DenseElementsAttr>().getValues<int>();
       knownDivisibility = DimVectorT(vals.begin(), vals.end());
     }
-    if (Attribute attr = op->getAttr("tt.contiguity")) {
+    if (Attribute attr = op->getDiscardableAttr("tt.contiguity")) {
       auto vals = attr.cast<DenseElementsAttr>().getValues<int>();
       knownContiguity = DimVectorT(vals.begin(), vals.end());
     }
-    if (Attribute attr = op->getAttr("tt.constancy")) {
+    if (Attribute attr = op->getDiscardableAttr("tt.constancy")) {
       auto vals = attr.cast<DenseElementsAttr>().getValues<int>();
       knownConstancy = DimVectorT(vals.begin(), vals.end());
     }
@@ -888,15 +888,15 @@ void AxisInfoAnalysis::visitOperation(
   auto newContiguity = curr.getContiguity();
   auto newDivisibility = curr.getDivisibility();
   auto newConstancy = curr.getConstancy();
-  if (Attribute attr = op->getAttr("tt.contiguity")) {
+  if (Attribute attr = op->getDiscardableAttr("tt.contiguity")) {
     auto vals = attr.cast<DenseElementsAttr>().getValues<int>();
     newContiguity = AxisInfo::DimVectorT(vals.begin(), vals.end());
   }
-  if (Attribute attr = op->getAttr("tt.divisibility")) {
+  if (Attribute attr = op->getDiscardableAttr("tt.divisibility")) {
     auto vals = attr.cast<DenseElementsAttr>().getValues<int>();
     newDivisibility = AxisInfo::DimVectorT(vals.begin(), vals.end());
   }
-  if (Attribute attr = op->getAttr("tt.constancy")) {
+  if (Attribute attr = op->getDiscardableAttr("tt.constancy")) {
     auto vals = attr.cast<DenseElementsAttr>().getValues<int>();
     newConstancy = AxisInfo::DimVectorT(vals.begin(), vals.end());
   }

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -118,9 +118,8 @@ protected:
     // Create an LLVM function, use external linkage by default until MLIR
     // functions have linkage.
     LLVM::Linkage linkage = LLVM::Linkage::External;
-    if (funcOp->hasAttr("llvm.linkage")) {
-      auto attr =
-          funcOp->getAttr("llvm.linkage").dyn_cast<mlir::LLVM::LinkageAttr>();
+    if (auto linkageAttr = funcOp->getDiscardableAttr("llvm.linkage")) {
+      auto attr = linkageAttr.dyn_cast<mlir::LLVM::LinkageAttr>();
       if (!attr) {
         funcOp->emitError()
             << "Contains llvm.linkage attribute not of type LLVM::LinkageAttr";

--- a/lib/Target/LLVMIR/LLVMIRTranslation.cpp
+++ b/lib/Target/LLVMIR/LLVMIRTranslation.cpp
@@ -154,12 +154,12 @@ static std::map<std::string, std::string> getExternLibs(mlir::ModuleOp module) {
       funcs.push_back(func);
   });
 
-  for (auto &func : funcs) {
-    if (func.getOperation()->hasAttr("libname")) {
-      auto name =
-          func.getOperation()->getAttr("libname").dyn_cast<StringAttr>();
-      auto path =
-          func.getOperation()->getAttr("libpath").dyn_cast<StringAttr>();
+  for (LLVM::LLVMFuncOp func : funcs) {
+    if (auto libnameAttr = func->getDiscardableAttr("libname")) {
+      auto name = libnameAttr.dyn_cast<StringAttr>();
+      auto path = func.getOperation()
+                      ->getDiscardableAttr("libpath")
+                      .dyn_cast<StringAttr>();
       if (name) {
         std::string libName = name.str();
         externLibs[libName] = path.str();
@@ -167,11 +167,8 @@ static std::map<std::string, std::string> getExternLibs(mlir::ModuleOp module) {
     }
   }
 
-  if (module.getOperation()->hasAttr("triton_gpu.externs")) {
-    auto dict = module.getOperation()
-                    ->getAttr("triton_gpu.externs")
-                    .dyn_cast<DictionaryAttr>();
-    for (auto &attr : dict) {
+  if (auto externsAttr = module->getDiscardableAttr("triton_gpu.externs")) {
+    for (auto &attr : externsAttr.cast<DictionaryAttr>()) {
       externLibs[attr.getName().strref().trim().str()] =
           attr.getValue().dyn_cast<StringAttr>().strref().trim().str();
     }


### PR DESCRIPTION
Also try to switch APIs access to the new upstream APIs that separate explicitly the access to "discardable" and "inherent" attributes (the latter being stored in properties now).

Generic accessors like `getAttr()` `setAttr()` `setAttrs()` are much more expensive and to be avoided.
