### PR TITLE
[BACKEND] Don't erase an op that has been replaced

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -790,7 +790,6 @@ public:
     if (failed(rewriter.convertRegionTypes(newOp.getFalseDest()->getParent(),
                                            *converter)))
       return failure();
-    rewriter.eraseOp(op);
     return success();
   }
 };


### PR DESCRIPTION
Otherwise it will trigger errors using llvm compiled with assert enabled.