### PR TITLE
[BACKEND] Pipeline pass rewrite part 1: functionality fixes

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -533,7 +533,6 @@ private:
       auto vecBitWidth = resElemTy.getIntOrFloatBitWidth() * minVec;
       auto bitWidth = std::min<unsigned>(maxBitWidth, vecBitWidth);
       auto byteWidth = bitWidth / 8;
-      llvm::errs() << "byteWidth: " << byteWidth << "\n";
 
       // If the load byte width is not eligible or the current compute
       // capability does not support async copy, then we do decompose

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -307,8 +307,7 @@ public:
     // Preprocess
     decomposeMmaToDotOperand(mod, numWarps);
     decomposeBlockedToDotOperand(mod);
-    if (failed(decomposeInsertSliceAsyncOp(mod)))
-      return signalPassFailure();
+    decomposeInsertSliceAsyncOp(mod);
 
     // Allocate shared memory and set barrier
     ModuleAllocation allocation(mod);
@@ -487,7 +486,7 @@ private:
     });
   }
 
-  LogicalResult decomposeInsertSliceAsyncOp(ModuleOp mod) const {
+  void decomposeInsertSliceAsyncOp(ModuleOp mod) const {
     ModuleAxisInfoAnalysis axisInfoAnalysis(mod);
     // TODO(Keren): This is a hacky knob that may cause performance regression
     // when decomposition has been performed. We should remove this knob once we
@@ -515,6 +514,7 @@ private:
       // Get the vectorized load size
       auto src = insertSliceAsyncOp.getSrc();
       auto dst = insertSliceAsyncOp.getDst();
+      auto mask = insertSliceAsyncOp.getMask();
       auto srcTy = src.getType().cast<RankedTensorType>();
       auto dstTy = dst.getType().cast<RankedTensorType>();
       auto srcBlocked =
@@ -523,6 +523,9 @@ private:
           dstTy.getEncoding().dyn_cast<triton::gpu::SharedEncodingAttr>();
       auto resElemTy = dstTy.getElementType();
       unsigned inVec = axisInfoAnalysis.getPtrContiguity(src);
+      if (mask)
+        inVec =
+            std::min<unsigned>(axisInfoAnalysis.getMaskAlignment(mask), inVec);
       unsigned outVec = resSharedLayout.getVec();
       unsigned minVec = std::min(outVec, inVec);
       auto maxBitWidth =
@@ -530,6 +533,7 @@ private:
       auto vecBitWidth = resElemTy.getIntOrFloatBitWidth() * minVec;
       auto bitWidth = std::min<unsigned>(maxBitWidth, vecBitWidth);
       auto byteWidth = bitWidth / 8;
+      llvm::errs() << "byteWidth: " << byteWidth << "\n";
 
       // If the load byte width is not eligible or the current compute
       // capability does not support async copy, then we do decompose
@@ -586,7 +590,6 @@ private:
         asyncWaitOp.erase();
       }
     });
-    return success();
   }
 };
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -618,7 +618,7 @@ scf::ForOp LoopPipeliner::createNewForOp() {
   size_t depArgsBeginIdx = newLoopArgs.size();
   for (auto [depArg, useStage] : depArgUseStage) {
     depArgsIdx[depArg] = newLoopArgs.size();
-    auto defStage = getArgDefStage(depArg, numStages - 1);
+    auto defStage = getArgDefStage(depArg, useStage);
     assert(defStage >= 0 &&
            "newLoopArgs has null args without a define op. Consider either "
            "rewrite the loop to reduce cross iteration dependencies or "

--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -600,8 +600,7 @@ scf::ForOp LoopPipeliner::createNewForOp() {
   newLoopArgs.push_back(loopIterIdx);
 
   for (size_t i = 0; i < newLoopArgs.size(); ++i)
-    assert(newLoopArgs[i] &&
-           "newLoopArgs has null args without a define op.");
+    assert(newLoopArgs[i] && "newLoopArgs has null args without a define op.");
 
   // 1. signature of the new ForOp
   auto newForOp = builder.create<scf::ForOp>(
@@ -655,12 +654,6 @@ scf::ForOp LoopPipeliner::createNewForOp() {
     else if (op.getNumResults() > 0 && loads.contains(op.getResult(0)))
       orderedDeps.push_back(&op);
   }
-  for (auto [depOp, stage] : depOps) {
-    llvm::errs() << "dep op " << *depOp << " stage " << stage << "\n";
-  }
-  llvm::errs() << "depOps.size(): " << depOps.size() << "\n";
-  llvm::errs() << "loads.size(): " << loads.size() << "\n";
-  llvm::errs() << "orderedDeps.size(): " << orderedDeps.size() << "\n";
   assert(depOps.size() + loads.size() == orderedDeps.size() &&
          "depOps contains invalid values");
   IRMapping nextMapping;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -579,22 +579,22 @@ scf::ForOp LoopPipeliner::createNewForOp() {
   for (auto [depArg, defStage] : depArgs) {
     depArgsIdx[depArg] = newLoopArgs.size();
     for (int stage = numStages - 1; stage >= defStage; --stage) {
-      Value defOp = valueMapping[depArg][stage];
-      assert(defOp &&
+      Value def = valueMapping[depArg][stage];
+      assert(def &&
              "newLoopArgs has null args without a define op. Consider either "
              "rewrite the loop to reduce cross iteration dependencies or "
              "increase the num_stages value.");
-      if (!isa<BlockArgument>(defOp)) {
-        auto *op = defOp.getDefiningOp();
-        if (stage == numStages - 1 && depOps.contains(op) &&
-            depOps[op] == numStages - 2) {
+      if (!isa<BlockArgument>(def)) {
+        auto *defOp = def.getDefiningOp();
+        if (stage == numStages - 1 && depOps.contains(defOp) &&
+            depOps[defOp] == numStages - 2) {
           newLoopArgs.push_back(valueMapping[depArg][numStages - 2]);
         } else {
           newLoopArgs.push_back(valueMapping[depArg][stage]);
         }
         break;
       } else
-        depArg = defOp.cast<BlockArgument>();
+        depArg = def.cast<BlockArgument>();
     }
   }
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -193,7 +193,7 @@ LogicalResult LoopPipeliner::collectDeps(Value v, int stage,
     if (arg.getArgNumber() > 0) {
       // If we've found the first definition of this arg, we're done, don't
       // recurse
-      if (addDep(v, stage, depStage).failed())
+      if (addDep(v, stage, depStage).succeeded())
         if (collectDeps(yieldOp->getOperand(arg.getArgNumber() - 1), stage - 1,
                         depStage)
                 .failed())

--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -903,10 +903,8 @@ struct PipelinePass : public TritonGPUPipelineBase<PipelinePass> {
     getOperation()->walk([&](scf::ForOp forOp) -> void {
       LoopPipeliner pipeliner(forOp, numStages);
 
-      if (pipeliner.initialize().failed()) {
-        llvm::errs() << "failed\n";
+      if (pipeliner.initialize().failed())
         return;
-      }
 
       pipeliner.emitPrologue();
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -580,6 +580,10 @@ scf::ForOp LoopPipeliner::createNewForOp() {
     depArgsIdx[depArg] = newLoopArgs.size();
     for (int stage = numStages - 1; stage >= defStage; --stage) {
       Value defOp = valueMapping[depArg][stage];
+      assert(defOp &&
+             "newLoopArgs has null args without a define op. Consider either "
+             "rewrite the loop to reduce cross iteration dependencies or "
+             "increase the num_stages value.");
       if (!isa<BlockArgument>(defOp)) {
         auto *op = defOp.getDefiningOp();
         if (stage == numStages - 1 && depOps.contains(op) &&
@@ -598,9 +602,6 @@ scf::ForOp LoopPipeliner::createNewForOp() {
   newLoopArgs.push_back(valueMapping[forOp.getInductionVar()][numStages - 2]);
   newLoopArgs.push_back(pipelineIterIdx);
   newLoopArgs.push_back(loopIterIdx);
-
-  for (size_t i = 0; i < newLoopArgs.size(); ++i)
-    assert(newLoopArgs[i] && "newLoopArgs has null args without a define op.");
 
   // 1. signature of the new ForOp
   auto newForOp = builder.create<scf::ForOp>(

--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -253,7 +253,8 @@ LogicalResult LoopPipeliner::initialize() {
   ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
   ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
 
-  // can we use forOp.walk(...) here?
+  // We cannot use forOp.walk(...) here because we only want to visit the
+  // operations in the loop body block. Nested blocks are handled separately.
   SmallVector<triton::LoadOp, 2> validLoads;
   for (Operation &op : *loop)
     if (auto loadOp = dyn_cast<triton::LoadOp>(&op)) {

--- a/python/test/regression/test_functional_regressions.py
+++ b/python/test/regression/test_functional_regressions.py
@@ -183,7 +183,7 @@ def test_iv_dependent_matmul(type):
             if type == "post_load":
                 a_ptrs = a_ptr + (k + 1) * BLOCK_SIZE_K * stride_ak
                 b_ptrs = b_ptr + (k + 1) * BLOCK_SIZE_K * stride_bk
-            elif type == "post_load_two_iters":
+            elif type == "post_pre_mixed":
                 b_ptrs = b_ptr + (k + 1) * BLOCK_SIZE_K * stride_bk
             elif type == "post_load_two_iters":
                 a_ptrs = a_ptrs_next

--- a/python/test/regression/test_functional_regressions.py
+++ b/python/test/regression/test_functional_regressions.py
@@ -1,8 +1,8 @@
 import numpy as np
+import pytest
 import torch
 from numpy.random import RandomState
 
-import pytest
 import triton
 import triton.language as tl
 

--- a/python/test/regression/test_functional_regressions.py
+++ b/python/test/regression/test_functional_regressions.py
@@ -222,9 +222,9 @@ def test_iv_dependent_matmul(type):
     def grid(META):
         return (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']),)
 
+    num_stages = 4 if type == "post_load_three_iters" else 3
     kernel[grid](a, b, triton_output, M, N, K, a.stride(0), a.stride(1),
                  b.stride(0), b.stride(1), triton_output.stride(0), triton_output.stride(1),
                  BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
-                 type=type)
+                 type=type, num_stages=num_stages)
     torch.testing.assert_allclose(torch_output, triton_output, rtol=1e-2, atol=1e-2)
-                                                                                                                   

--- a/python/test/regression/test_functional_regressions.py
+++ b/python/test/regression/test_functional_regressions.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 from numpy.random import RandomState
 
+import pytest
 import triton
 import triton.language as tl
 
@@ -134,3 +135,80 @@ def test_vecmat():
     C_ref = np.sum(AB, axis=2)
 
     np.testing.assert_allclose(C_ref, C_tri.cpu().numpy(), rtol=0.01, atol=1e-3)
+
+
+@pytest.mark.parametrize("type", ["pre_load", "post_load", "post_load_two_iters"])
+def test_iv_dependent_matmul(type):
+    @triton.jit
+    def kernel(
+        a_ptr, b_ptr, c_ptr,
+        M, N, K,
+        stride_am, stride_ak,
+        stride_bk, stride_bn,
+        stride_cm, stride_cn,
+        BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
+        type: tl.constexpr
+    ):
+        pid = tl.program_id(axis=0)
+        num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+        pid_m = pid // num_pid_n
+        pid_n = pid % num_pid_n
+
+        offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+        offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+        offs_k = tl.arange(0, BLOCK_SIZE_K)
+        a_ptr = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+        b_ptr = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+        a_ptrs = a_ptr
+        b_ptrs = b_ptr
+        if type == "post_load_two_iters":
+            a_ptrs_next = a_ptr + BLOCK_SIZE_K * stride_ak
+            b_ptrs_next = b_ptr + BLOCK_SIZE_K * stride_bk
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            if type == "pre_load":
+                a_ptrs = a_ptr + k * BLOCK_SIZE_K * stride_ak
+                b_ptrs = b_ptr + k * BLOCK_SIZE_K * stride_bk
+            a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+            b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+            accumulator += tl.dot(a, b)
+            if type == "post_load":
+                a_ptrs = a_ptr + (k + 1) * BLOCK_SIZE_K * stride_ak
+                b_ptrs = b_ptr + (k + 1) * BLOCK_SIZE_K * stride_bk
+            if type == "post_load_two_iters":
+                a_ptrs = a_ptrs_next
+                b_ptrs = b_ptrs_next
+                a_ptrs_next = a_ptr + (k + 2) * BLOCK_SIZE_K * stride_ak
+                b_ptrs_next = b_ptr + (k + 2) * BLOCK_SIZE_K * stride_bk
+        c = accumulator.to(tl.float16)
+
+        offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+        offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+        c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+        c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+        tl.store(c_ptrs, c, mask=c_mask)
+
+    M = 256
+    K = 256
+    N = 256
+    BLOCK_SIZE_K = 32
+    BLOCK_SIZE_N = 32
+    BLOCK_SIZE_M = 32
+
+    a = torch.rand((M, K), device='cuda')
+    b = torch.rand((K, N), device='cuda')
+
+    torch_output = torch.mm(a, b)
+    triton_output = torch.empty_like(
+        torch_output, device=torch_output.device)
+
+    def grid(META):
+        return (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']),)
+
+    kernel[grid](a, b, triton_output, M, N, K, a.stride(0), a.stride(1),
+                 b.stride(0), b.stride(1), triton_output.stride(0), triton_output.stride(1),
+                 BLOCK_SIZE_M=BLOCK_SIZE_M, BLOCK_SIZE_N=BLOCK_SIZE_N, BLOCK_SIZE_K=BLOCK_SIZE_K,
+                 type=type)
+    torch.testing.assert_allclose(torch_output, triton_output, rtol=1e-2, atol=1e-2)
+                                                                                                                   


### PR DESCRIPTION
Support the following three cases:
1. Operands of `load` depend on induction variables before `load`s.
2. Mixed use of induction variables and offset to update the `ptr`.
3. Cross iteration (>1) dependency values.