### PR TITLE
Increase the paylog of the globaltimer kernel to reduce chances of fl…

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2838,7 +2838,7 @@ def test_globaltimer():
     def kernel(Out1, Out2):
         start = tl.extra.cuda.globaltimer()
         off = tl.arange(0, 128)
-        for i in range(100):
+        for i in range(10000):
             tl.store(Out1 + off, tl.load(Out1 + off) + 1)
         end = tl.extra.cuda.globaltimer()
         tl.store(Out2, end - start)


### PR DESCRIPTION
…akiness

If the kernel is too small, on a very fast GPU we may get 0 because the resolution of the timer seems too coarse.

Fixes #1725