### PR TITLE
[PUBLISHING] Enable nightlies on Azure DevOps

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,6 +31,9 @@ jobs:
           echo "[build_ext]" >> python/setup.cfg
           echo "base-dir=/project" >> python/setup.cfg
 
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel twine
+
       - name: Build wheels
         run: |
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,21 +1,16 @@
 name: Wheels
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
-    #schedule:
-  #  - cron: "0 0 * * *"
-
-permissions:
-  id-token: write
-  contents: read
+  schedule:
+    - cron: "0 2 * * *"
 
 jobs:
-
   Build-Wheels:
 
-    runs-on: ubuntu-latest
-    environment: test-ado-artifacts
+    runs-on: [self-hosted, V100]
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
 
@@ -32,29 +27,28 @@ jobs:
       - id: generate-token
         name: Generate token
         run: |
-          python -m pip install cibuildwheel twine
           AZ_TOKEN=$(az account get-access-token --query accessToken)
           echo "::add-mask::$AZ_TOKEN"
           echo "access_token=$AZ_TOKEN" >> "$GITHUB_OUTPUT"
 
-      - name: Patch setup.py
+        - name: Patch setup.py
         run: |
           sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py
-          export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d' --format="%cd")
+          export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
           sed -i -r "s/version\=\"(.*)\"/version=\"\1-dev"$LATEST_DATE"\"/g" python/setup.py
           echo "" >> python/setup.cfg
           echo "[build_ext]" >> python/setup.cfg
           echo "base-dir=/project" >> python/setup.cfg
 
-      - name: Build wheels
+        - name: Build wheels
         run: |
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           export CIBW_BEFORE_BUILD="pip install cmake;"
           export CIBW_SKIP="{cp,pp}35-*"
-          export CIBW_BUILD="cp311-manylinux_x86_64"
+          export CIBW_BUILD="{cp,pp}3*-manylinux_x86_64 cp3*-musllinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse
 
-      - name: Upload wheels to Azure DevOps
+      - name: Publish wheels to Azure DevOps
         run: |
-          python3 -m twine upload -r Triton-Nightly-Test -u TritonArtifactsSP -p ${{ steps.generate-token.outputs.access_token }} --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*
+          python3 -m twine upload -r Triton-Nightly -u TritonArtifactsSP -p ${{ steps.generate-token.outputs.access_token }} --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -40,7 +40,7 @@ jobs:
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           export CIBW_BEFORE_BUILD="pip install cmake;"
           export CIBW_SKIP="{cp,pp}35-*"
-          export CIBW_BUILD="{cp,pp}3*-manylinux_x86_64 cp3*-musllinux_x86_64"
+          export CIBW_BUILD="cp311-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse
 
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,14 @@ jobs:
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
 
+      - id: generate-token
+        name: Generate token
+        run: |
+          python -m pip install cibuildwheel twine
+          AZ_TOKEN=$(az account get-access-token --query accessToken)
+          echo "::add-mask::$AZ_TOKEN"
+          echo "access_token='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":'$AZ_TOKEN'}]}'" >> "$GITHUB_OUTPUT"
+
       - name: Patch setup.py
         run: |
           sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py
@@ -30,9 +38,6 @@ jobs:
           echo "" >> python/setup.cfg
           echo "[build_ext]" >> python/setup.cfg
           echo "base-dir=/project" >> python/setup.cfg
-
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel twine
 
       - name: Build wheels
         run: |
@@ -43,7 +48,8 @@ jobs:
           export CIBW_BUILD="cp311-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse
 
-
       - name: Upload wheels to ADO
+        env:
+          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: ${{ steps.generate-token.outputs.access_token }}"
         run: |
           python3 -m twine upload -r Triton-Nightly-Test --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install cibuildwheel twine
           AZ_TOKEN=$(az account get-access-token --query accessToken)
           echo "::add-mask::$AZ_TOKEN"
-          echo access_token='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":'$AZ_TOKEN'}]}' >> "$GITHUB_OUTPUT"
+          echo "access_token=$AZ_TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Patch setup.py
         run: |
@@ -56,8 +56,5 @@ jobs:
           python3 -m cibuildwheel python --output-dir wheelhouse
 
       - name: Upload wheels to ADO
-        env:
-          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: ${{ steps.generate-token.outputs.access_token }}
         run: |
-          echo $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
-          python3 -m twine upload -r Triton-Nightly-Test --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*
+          python3 -m twine upload -r Triton-Nightly-Test -u TritonArtifactsSP -p ${{ steps.generate-token.outputs.access_token }} --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -5,6 +5,7 @@ on:
     - cron: "0 2 * * *"
 
 jobs:
+
   Build-Wheels:
 
     runs-on: [self-hosted, V100]
@@ -31,7 +32,7 @@ jobs:
           echo "::add-mask::$AZ_TOKEN"
           echo "access_token=$AZ_TOKEN" >> "$GITHUB_OUTPUT"
 
-        - name: Patch setup.py
+      - name: Patch setup.py
         run: |
           sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py
           export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
@@ -40,7 +41,7 @@ jobs:
           echo "[build_ext]" >> python/setup.cfg
           echo "base-dir=/project" >> python/setup.cfg
 
-        - name: Build wheels
+      - name: Build wheels
         run: |
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,8 @@ jobs:
         uses: azure/login@v1
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
-
+          allow-no-subscriptions: true
+          
       - name: Patch setup.py
         run: |
           sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Az CLI login
+      - name: Azure login
         uses: azure/login@v1
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
@@ -55,6 +55,6 @@ jobs:
           export CIBW_BUILD="cp311-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse
 
-      - name: Upload wheels to ADO
+      - name: Upload wheels to Azure DevOps
         run: |
           python3 -m twine upload -r Triton-Nightly-Test -u TritonArtifactsSP -p ${{ steps.generate-token.outputs.access_token }} --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,6 +15,7 @@ jobs:
   Build-Wheels:
 
     runs-on: ubuntu-latest
+    environment: test-ado-artifacts
 
     steps:
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -21,7 +21,6 @@ jobs:
         uses: azure/actions/login@v1
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
-          allow-no-subscriptions: true
 
       - name: Patch setup.py
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,11 +18,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in with Azure
-        uses: azure/login@v1
+        uses: azure/actions/login@v1
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
           allow-no-subscriptions: true
-          
+
       - name: Patch setup.py
         run: |
           sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,10 +17,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Log in with Azure
+      - name: Az CLI login
         uses: azure/login@v1
         with:
-          creds: '${{ secrets.AZURE_CREDENTIALS }}'
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - id: generate-token
         name: Generate token

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,6 +44,6 @@ jobs:
           python3 -m cibuildwheel python --output-dir wheelhouse
 
 
-      # - name: Upload wheels to PyPI
-      #   run: |
-      #     python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}
+      - name: Upload wheels to ADO
+        run: |
+          python3 -m twine upload -r Triton-Nightly-Test --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
           python -m pip install cibuildwheel twine
           AZ_TOKEN=$(az account get-access-token --query accessToken)
           echo "::add-mask::$AZ_TOKEN"
-          echo access_token='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":'$AZ_TOKEN'}]}' >> "$GITHUB_OUTPUT"
+          echo "access_token=$AZ_TOKEN" >> "$GITHUB_OUTPUT"
 
       - name: Patch setup.py
         run: |
@@ -52,4 +52,6 @@ jobs:
         env:
           VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: ${{ steps.generate-token.outputs.access_token }}
         run: |
+          export VSS_NUGET_EXTERNAL_FEED_ENDPOINTS='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":${{ steps.generate-token.outputs.access_token }}}]}'
+          echo $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
           python3 -m twine upload -r Triton-Nightly-Test --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -6,6 +6,10 @@ on:
     #schedule:
   #  - cron: "0 0 * * *"
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
 
   Build-Wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -8,16 +8,21 @@ jobs:
 
   Build-Wheels:
 
-    runs-on: [self-hosted, V100]
+    runs-on: ubuntu-latest
 
     steps:
 
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Log in with Azure
+        uses: azure/login@v1
+        with:
+          creds: '${{ secrets.AZURE_CREDENTIALS }}'
+
       - name: Patch setup.py
         run: |
-          #sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py
+          sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py
           export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d' --format="%cd")
           sed -i -r "s/version\=\"(.*)\"/version=\"\1-dev"$LATEST_DATE"\"/g" python/setup.py
           echo "" >> python/setup.cfg
@@ -34,6 +39,6 @@ jobs:
           python3 -m cibuildwheel python --output-dir wheelhouse
 
 
-      - name: Upload wheels to PyPI
-        run: |
-          python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}
+      # - name: Upload wheels to PyPI
+      #   run: |
+      #     python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install cibuildwheel twine
           AZ_TOKEN=$(az account get-access-token --query accessToken)
           echo "::add-mask::$AZ_TOKEN"
-          echo "access_token=$AZ_TOKEN" >> "$GITHUB_OUTPUT"
+          echo access_token='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":'$AZ_TOKEN'}]}' >> "$GITHUB_OUTPUT"
 
       - name: Patch setup.py
         run: |
@@ -56,7 +56,8 @@ jobs:
           python3 -m cibuildwheel python --output-dir wheelhouse
 
       - name: Upload wheels to ADO
+        env:
+          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: ${{ steps.generate-token.outputs.access_token }}
         run: |
-          export VSS_NUGET_EXTERNAL_FEED_ENDPOINTS='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":${{ steps.generate-token.outputs.access_token }}}]}'
           echo $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
           python3 -m twine upload -r Triton-Nightly-Test --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -50,6 +50,6 @@ jobs:
 
       - name: Upload wheels to ADO
         env:
-          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: ${{ steps.generate-token.outputs.access_token }}"
+          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: ${{ steps.generate-token.outputs.access_token }}
         run: |
           python3 -m twine upload -r Triton-Nightly-Test --config-file utils/nightly.pypirc --non-interactive --verbose wheelhouse/*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -49,8 +49,6 @@ jobs:
           python3 -m cibuildwheel python --output-dir wheelhouse
 
       - name: Upload wheels to ADO
-        env:
-          VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: ${{ steps.generate-token.outputs.access_token }}
         run: |
           export VSS_NUGET_EXTERNAL_FEED_ENDPOINTS='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":${{ steps.generate-token.outputs.access_token }}}]}'
           echo $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,7 +1,9 @@
 name: Wheels
 on:
   workflow_dispatch:
-  #schedule:
+  pull_request:
+    branches: [main]
+    #schedule:
   #  - cron: "0 0 * * *"
 
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in with Azure
-        uses: azure/actions/login@v1
+        uses: azure/login@v1
         with:
           creds: '${{ secrets.AZURE_CREDENTIALS }}'
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
           python -m pip install cibuildwheel twine
           AZ_TOKEN=$(az account get-access-token --query accessToken)
           echo "::add-mask::$AZ_TOKEN"
-          echo "access_token='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":'$AZ_TOKEN'}]}'" >> "$GITHUB_OUTPUT"
+          echo access_token='{"endpointCredentials": [{"endpoint":"https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/", "username":"TritonArtifactsSP", "password":'$AZ_TOKEN'}]}' >> "$GITHUB_OUTPUT"
 
       - name: Patch setup.py
         run: |

--- a/utils/nightly.pypirc
+++ b/utils/nightly.pypirc
@@ -1,6 +1,6 @@
 [distutils]
 Index-servers =
-  Triton-Nightly-Test
+  Triton-Nightly
 
-[Triton-Nightly-Test]
-Repository = https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/
+[Triton-Nightly]
+Repository = https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/upload/

--- a/utils/nightly.pypirc
+++ b/utils/nightly.pypirc
@@ -1,0 +1,6 @@
+[distutils]
+Index-servers =
+  Triton-Nightly-Test
+
+[Triton-Nightly-Test]
+Repository = https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly-Test/pypi/upload/


### PR DESCRIPTION
This reenables nightly builds and uploads them to a public AzDO, where you can use pip to install a specific version or the latest as normal. For example: `python -m pip install -i https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/ triton-nightly`