### PR TITLE
Improve `tl.dot` error messages

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1218,12 +1218,13 @@ def dot(lhs: tl.tensor,
         out_dtype: tl.dtype,
         builder: ir.builder) -> tl.tensor:
     assert lhs.type.is_block() and rhs.type.is_block()
-    assert lhs.dtype == rhs.dtype, f"lhs ({lhs.dtype}) and rhs ({rhs.dtype}) must have the same dtype!"
-    assert len(lhs.shape) == 2 and len(rhs.shape) == 2
-    assert lhs.shape[1].value == rhs.shape[0].value
+    assert lhs.dtype == rhs.dtype, f"First input ({lhs.dtype}) and second input ({rhs.dtype}) must have the same dtype!"
+    assert len(lhs.shape) == 2, f"First input shape ({lhs.shape}) is not two dimensional!"
+    assert len(rhs.shape) == 2, f"Second input shape ({rhs.shape}) is not two dimensional!"
+    assert lhs.shape[1].value == rhs.shape[0].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[1].value}) must be equal to first index of second shape ({rhs.shape[0].value})"
     assert lhs.shape[0].value >= 16 and lhs.shape[1].value >= 16 \
         and rhs.shape[1].value >= 16,\
-        "small blocks not supported!"
+        f"All values in both first input shape ({lhs.shape}) and second input shape ({rhs.shape}) must be >= 16!"
     if lhs.type.scalar.is_int():
         assert lhs.type.scalar == tl.int8, "only int8 supported!"
         # TODO: This is CUDA specific, check if ROCm has the same limitation

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1218,7 +1218,7 @@ def dot(lhs: tl.tensor,
         out_dtype: tl.dtype,
         builder: ir.builder) -> tl.tensor:
     assert lhs.type.is_block() and rhs.type.is_block()
-    assert lhs.dtype == rhs.dtype, "lhs and rhs must have the same dtype!"
+    assert lhs.dtype == rhs.dtype, f"lhs ({lhs.dtype}) and rhs ({rhs.dtype}) must have the same dtype!"
     assert len(lhs.shape) == 2 and len(rhs.shape) == 2
     assert lhs.shape[1].value == rhs.shape[0].value
     assert lhs.shape[0].value >= 16 and lhs.shape[1].value >= 16 \


### PR DESCRIPTION
This makes it easier to figure out what's going on when you get these error messages.