### PR TITLE
[BACKEND] Minor fix for expensiveCat

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -359,7 +359,12 @@ bool expensiveCat(triton::CatOp cat, Attribute &targetEncoding) {
   // convert encoding that goes through shared memory anyway. So we consider it
   // as expensive.
   auto tensorTy = cat.getResult().getType().cast<RankedTensorType>();
-  auto totalElemsPerThread = triton::gpu::getTotalElemsPerThread(tensorTy);
+  auto lhsTy = cat.getLhs().getType().cast<RankedTensorType>();
+  auto rhsTy = cat.getRhs().getType().cast<RankedTensorType>();
+  auto lhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(lhsTy);
+  auto rhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(rhsTy);
+  auto totalElemsPerThread =
+      nextPowOf2(lhsTotalElemsPerThread + rhsTotalElemsPerThread);
   auto shape = tensorTy.getShape();
   auto elemTy = tensorTy.getElementType();
   auto newTotalElemsPerThread =

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -364,7 +364,7 @@ bool expensiveCat(triton::CatOp cat, Attribute &targetEncoding) {
   auto elemTy = tensorTy.getElementType();
   auto newTotalElemsPerThread =
       triton::gpu::getTotalElemsPerThread(targetEncoding, shape, elemTy);
-  return newTotalElemsPerThread <= totalElemsPerThread;
+  return newTotalElemsPerThread != totalElemsPerThread;
 }
 
 } // namespace gpu

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -355,7 +355,7 @@ bool isaDistributedLayout(Attribute layout) {
 }
 
 bool expensiveCat(triton::CatOp cat, Attribute &targetEncoding) {
-  // If the new elements per thread is less than the old one, we will need to do
+  // If the new elements per thread is less than the required, we will need to do
   // convert encoding that goes through shared memory anyway. So we consider it
   // as expensive.
   auto lhsTy = cat.getLhs().getType().cast<RankedTensorType>();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -355,7 +355,7 @@ bool isaDistributedLayout(Attribute layout) {
 }
 
 bool expensiveCat(triton::CatOp cat, Attribute &targetEncoding) {
-  // If the new elements per thread is less than the required, we will need to do
+  // If the new elements per thread is less than required, we will need to do
   // convert encoding that goes through shared memory anyway. So we consider it
   // as expensive.
   auto lhsTy = cat.getLhs().getType().cast<RankedTensorType>();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -364,7 +364,7 @@ bool expensiveCat(triton::CatOp cat, Attribute &targetEncoding) {
   auto elemTy = tensorTy.getElementType();
   auto newTotalElemsPerThread =
       triton::gpu::getTotalElemsPerThread(targetEncoding, shape, elemTy);
-  return newTotalElemsPerThread < totalElemsPerThread;
+  return newTotalElemsPerThread <= totalElemsPerThread;
 }
 
 } // namespace gpu

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -358,13 +358,13 @@ bool expensiveCat(triton::CatOp cat, Attribute &targetEncoding) {
   // If the new elements per thread is less than the old one, we will need to do
   // convert encoding that goes through shared memory anyway. So we consider it
   // as expensive.
-  auto tensorTy = cat.getResult().getType().cast<RankedTensorType>();
   auto lhsTy = cat.getLhs().getType().cast<RankedTensorType>();
   auto rhsTy = cat.getRhs().getType().cast<RankedTensorType>();
   auto lhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(lhsTy);
   auto rhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(rhsTy);
   auto totalElemsPerThread =
       nextPowOf2(lhsTotalElemsPerThread + rhsTotalElemsPerThread);
+  auto tensorTy = cat.getResult().getType().cast<RankedTensorType>();
   auto shape = tensorTy.getShape();
   auto elemTy = tensorTy.getElementType();
   auto newTotalElemsPerThread =


### PR DESCRIPTION
`lhs` encoding and `rhs` encoding can be changed in remove layout conversion, so that the result encoding may have already been invalid. For the reason, we want to recompute the total number of elements per thread.