### PR TITLE
Switch absolute imports to relative imports in Triton

### DIFF
--- a/python/triton/common/backend.py
+++ b/python/triton/common/backend.py
@@ -3,7 +3,7 @@ import importlib
 import importlib.util
 from typing import Dict
 
-from triton.runtime.driver import DriverBase
+from ..runtime.driver import DriverBase
 
 
 class BaseBackend:

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -6,12 +6,12 @@ import warnings
 from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
 
 from .. import language
+from .._C.libtriton.triton import ir
 from ..language import constexpr, tensor
 # ideally we wouldn't need any runtime component
 from ..runtime import JITFunction
 from .errors import (CompilationError, CompileTimeAssertionFailure,
                      UnsupportedLanguageConstruct)
-from .._C.libtriton.triton import ir
 
 
 def mangle_ty(ty):

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -11,7 +11,7 @@ from ..language import constexpr, tensor
 from ..runtime import JITFunction
 from .errors import (CompilationError, CompileTimeAssertionFailure,
                      UnsupportedLanguageConstruct)
-from triton._C.libtriton.triton import ir
+from .._C.libtriton.triton import ir
 
 
 def mangle_ty(ty):

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -11,10 +11,12 @@ from collections import namedtuple
 from pathlib import Path
 from typing import Any, Tuple
 
-import triton
-import triton._C.libtriton.triton as _triton
+# import triton
+from .._C.libtriton.triton import ir, add_external_libs, translate_triton_gpu_to_llvmir, translate_llvmir_to_ptx, compile_ptx_to_cubin, translate_llvmir_to_hsaco, get_shared_memory_size
 from ..common.backend import get_backend
-from ..runtime import driver
+from ..runtime.driver import driver
+from ..runtime.jit import jit, JITFunction, get_current_device, get_device_capability, version_key, get_cuda_stream
+# from ..runtime import driver, jit, JITFunction
 # TODO: runtime.errors
 from ..runtime.autotuner import OutOfResources
 from ..runtime.cache import get_cache_manager
@@ -24,7 +26,7 @@ from .make_launcher import make_stub
 
 
 def inline_triton_ir(mod):
-    pm = _triton.ir.pass_manager(mod.context)
+    pm = ir.pass_manager(mod.context)
     pm.enable_debug()
     pm.add_inliner_pass()
     pm.run(mod)
@@ -34,7 +36,7 @@ def inline_triton_ir(mod):
 def ttir_compute_capability_rewrite(mod, arch):
     # For hardware without support, we must rewrite all load/store
     # with block (tensor) pointers into tensors of pointers
-    pm = _triton.ir.pass_manager(mod.context)
+    pm = ir.pass_manager(mod.context)
     pm.enable_debug()
     if _is_cuda(arch):
         pm.add_rewrite_tensor_pointer_pass(arch)
@@ -45,7 +47,7 @@ def ttir_compute_capability_rewrite(mod, arch):
 def optimize_ttir(mod, arch):
     mod = inline_triton_ir(mod)
     mod = ttir_compute_capability_rewrite(mod, arch)
-    pm = _triton.ir.pass_manager(mod.context)
+    pm = ir.pass_manager(mod.context)
     pm.enable_debug()
     pm.add_inliner_pass()
     pm.add_triton_combine_pass()
@@ -58,14 +60,14 @@ def optimize_ttir(mod, arch):
 
 
 def ttir_to_ttgir(mod, num_warps):
-    pm = _triton.ir.pass_manager(mod.context)
+    pm = ir.pass_manager(mod.context)
     pm.add_convert_triton_to_tritongpu_pass(num_warps)
     pm.run(mod)
     return mod
 
 
 def optimize_ttgir(mod, num_stages, arch):
-    pm = _triton.ir.pass_manager(mod.context)
+    pm = ir.pass_manager(mod.context)
     pm.enable_debug()
     pm.add_tritongpu_coalesce_pass()
     pm.add_tritongpu_remove_layout_conversions_pass()
@@ -89,7 +91,7 @@ def _add_external_libs(mod, libs):
     for name, path in libs.items():
         if len(name) == 0 or len(path) == 0:
             return
-    _triton.add_external_libs(mod, list(libs.keys()), list(libs.values()))
+    add_external_libs(mod, list(libs.keys()), list(libs.values()))
 
 
 def ttgir_to_llir(mod, extern_libs, arch):
@@ -97,9 +99,9 @@ def ttgir_to_llir(mod, extern_libs, arch):
         _add_external_libs(mod, extern_libs)
     # TODO: separate tritongpu_to_llvmir for different backends
     if _is_cuda(arch):
-        return _triton.translate_triton_gpu_to_llvmir(mod, arch, False)
+        return translate_triton_gpu_to_llvmir(mod, arch, False)
     else:
-        return _triton.translate_triton_gpu_to_llvmir(mod, 0, True)
+        return translate_triton_gpu_to_llvmir(mod, 0, True)
 
 
 # PTX translation
@@ -147,7 +149,7 @@ def llir_to_ptx(mod: Any, arch: int, ptx_version: int = None) -> str:
     if ptx_version is None:
         _, cuda_version = path_to_ptxas()
         ptx_version = ptx_get_version(cuda_version)
-    return _triton.translate_llvmir_to_ptx(mod, arch, ptx_version)
+    return translate_llvmir_to_ptx(mod, arch, ptx_version)
 
 
 def ptx_to_cubin(ptx: str, arch: int):
@@ -158,7 +160,7 @@ def ptx_to_cubin(ptx: str, arch: int):
     :return: str
     '''
     ptxas, _ = path_to_ptxas()
-    return _triton.compile_ptx_to_cubin(ptx, ptxas, arch)
+    return compile_ptx_to_cubin(ptx, ptxas, arch)
 
 
 # AMDGCN translation
@@ -224,7 +226,7 @@ def llir_to_amdgcn_and_hsaco(mod: Any, gfx_arch: str, gfx_triple: str, gfx_featu
         - AMDGCN code
         - Path to HSACO object
     '''
-    return _triton.translate_llvmir_to_hsaco(mod, gfx_arch, gfx_triple, gfx_features)
+    return translate_llvmir_to_hsaco(mod, gfx_arch, gfx_triple, gfx_features)
 
 
 # ------------------------------------------------------------------------------
@@ -251,7 +253,7 @@ def convert_type_repr(x):
 
 
 def make_hash(fn, arch, **kwargs):
-    if isinstance(fn, triton.runtime.JITFunction):
+    if isinstance(fn, JITFunction):
         configs = kwargs["configs"]
         signature = kwargs["signature"]
         constants = kwargs.get("constants", dict())
@@ -264,7 +266,7 @@ def make_hash(fn, arch, **kwargs):
         key = f"{fn.cache_key}-{''.join(signature.values())}-{configs_key}-{constants}-{num_warps}-{num_stages}-{debug}-{arch}"
         return hashlib.md5(key.encode("utf-8")).hexdigest()
     assert isinstance(fn, str)
-    return hashlib.md5((Path(fn).read_text() + triton.runtime.jit.version_key()).encode("utf-8")).hexdigest()
+    return hashlib.md5((Path(fn).read_text() + version_key()).encode("utf-8")).hexdigest()
 
 
 # - ^\s*tt\.func\s+ : match the start of the string, any leading whitespace, the keyword func,
@@ -308,7 +310,7 @@ def _get_jsonable_constants(constants):
 
 
 def parse_mlir_module(path, context):
-    module = _triton.ir.parse_mlir_module(path, context)
+    module = ir.parse_mlir_module(path, context)
     # module takes ownership of the context
     module.context = context
     return module
@@ -329,8 +331,8 @@ def get_architecture_descriptor(capability):
         raise ImportError("Triton requires PyTorch to be installed")
     if capability is None:
         if torch.version.hip is None:
-            device = triton.runtime.jit.get_current_device()
-            capability = triton.runtime.jit.get_device_capability(device)
+            device = get_current_device()
+            capability = get_device_capability(device)
             capability = capability[0] * 10 + capability[1]
         else:
             capability = get_amdgpu_arch_fulldetails()
@@ -376,7 +378,7 @@ def compile(fn, **kwargs):
 
     is_cuda = device_type == "cuda" and _is_cuda(arch)
     is_hip = device_type in ["cuda", "hip"] and not is_cuda
-    context = _triton.ir.context()
+    context = ir.context()
     asm = dict()
     constants = kwargs.get("constants", dict())
     num_warps = kwargs.get("num_warps", 4)
@@ -403,7 +405,7 @@ def compile(fn, **kwargs):
         _device_backend.add_stages(arch, extern_libs, stages)
 
     # find out the signature of the function
-    if isinstance(fn, triton.runtime.JITFunction):
+    if isinstance(fn, JITFunction):
         configs = kwargs.get("configs", None)
         signature = kwargs["signature"]
         if configs is None:
@@ -417,20 +419,20 @@ def compile(fn, **kwargs):
         kwargs["signature"] = signature
     else:
         assert isinstance(fn, str)
-        _, ir = os.path.basename(fn).split(".")
+        _, ir_name = os.path.basename(fn).split(".")
         src = Path(fn).read_text()
         import re
-        match = re.search(prototype_pattern[ir], src, re.MULTILINE)
+        match = re.search(prototype_pattern[ir_name], src, re.MULTILINE)
         name, signature = match.group(1), match.group(2)
-        types = re.findall(arg_type_pattern[ir], signature)
-        if ir == 'ttgir':
+        types = re.findall(arg_type_pattern[ir_name], signature)
+        if ir_name == 'ttgir':
             num_warps_matches = re.findall(ttgir_num_warps_pattern, src)
             assert len(num_warps_matches) == 1, "Expected exactly one match for num_warps"
             assert "num_warps" not in kwargs or int(num_warps_matches[0]) == num_warps, "num_warps in ttgir does not match num_warps in compile"
             num_warps = int(num_warps_matches[0])
         param_tys = [convert_type_repr(ty) for ty in types]
         signature = {k: v for k, v in enumerate(param_tys)}
-        first_stage = list(stages.keys()).index(ir)
+        first_stage = list(stages.keys()).index(ir_name)
 
     # cache manager
     if is_cuda or is_hip:
@@ -441,7 +443,7 @@ def compile(fn, **kwargs):
     # create cache manager
     fn_cache_manager = get_cache_manager(make_hash(fn, arch, **kwargs))
     # determine name and extension type of provided function
-    if isinstance(fn, triton.runtime.JITFunction):
+    if isinstance(fn, JITFunction):
         name, ext = fn.__name__, "ast"
     else:
         name, ext = os.path.basename(fn).split(".")
@@ -477,10 +479,10 @@ def compile(fn, **kwargs):
     asm = dict()
     module = fn
     # run compilation pipeline  and populate metadata
-    for ir, (parse, compile_kernel) in list(stages.items())[first_stage:]:
-        ir_filename = f"{name}.{ir}"
+    for ir_name, (parse, compile_kernel) in list(stages.items())[first_stage:]:
+        ir_filename = f"{name}.{ir_name}"
 
-        if ir == ext:
+        if ir_name == ext:
             next_module = parse(fn)
         else:
             path = metadata_group.get(ir_filename)
@@ -494,7 +496,7 @@ def compile(fn, **kwargs):
                     metadata_group[ir_filename] = fn_cache_manager.put(next_module, ir_filename)
                     fn_cache_manager.put(next_module, ir_filename)
             else:
-                if ir == "amdgcn":
+                if ir_name == "amdgcn":
                     extra_file_name = f"{name}.hsaco_path"
                     hasco_path = metadata_group.get(extra_file_name)
                     assert hasco_path is not None, "Expected to have hsaco_path in metadata when we have the amdgcn"
@@ -502,21 +504,21 @@ def compile(fn, **kwargs):
                 else:
                     next_module = parse(path)
 
-        if ir == "cubin":
-            asm[ir] = next_module
-        elif ir == "amdgcn":
-            asm[ir] = str(next_module[0])
+        if ir_name == "cubin":
+            asm[ir_name] = next_module
+        elif ir_name == "amdgcn":
+            asm[ir_name] = str(next_module[0])
         else:
-            asm[ir] = str(next_module)
-        if ir == "llir" and "shared" not in metadata:
-            metadata["shared"] = _triton.get_shared_memory_size(module)
-        if ir == "ptx":
+            asm[ir_name] = str(next_module)
+        if ir_name == "llir" and "shared" not in metadata:
+            metadata["shared"] = get_shared_memory_size(module)
+        if ir_name == "ptx":
             metadata["name"] = get_kernel_name(next_module, pattern='// .globl')
-        if ir == "amdgcn":
+        if ir_name == "amdgcn":
             metadata["name"] = get_kernel_name(next_module[0], pattern='.globl')
             asm["hsaco_path"] = next_module[1]
         if not is_cuda and not is_hip:
-            _device_backend.add_meta_info(ir, module, next_module, metadata, asm)
+            _device_backend.add_meta_info(ir_name, module, next_module, metadata, asm)
         module = next_module
     # write-back metadata, if it didn't come from the cache
     if metadata_path is None:
@@ -562,7 +564,7 @@ class CompiledKernel:
             return
 
         if self.device_type in ["cuda", "hip"]:
-            device = triton.runtime.jit.get_current_device()
+            device = get_current_device()
             bin_path = {
                 driver.HIP: "hsaco_path",
                 driver.CUDA: "cubin"
@@ -597,7 +599,7 @@ class CompiledKernel:
         def runner(*args, stream=None):
             if stream is None:
                 if self.device_type in ["cuda", "rocm"]:
-                    stream = triton.runtime.jit.get_cuda_stream()
+                    stream = get_cuda_stream()
                 else:
                     stream = get_backend(self.device_type).get_stream(None)
             self.c_wrapper(grid[0], grid[1], grid[2], self.num_warps, self.shared, stream, self.cu_function,

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -12,14 +12,18 @@ from pathlib import Path
 from typing import Any, Tuple
 
 # import triton
-from .._C.libtriton.triton import ir, add_external_libs, translate_triton_gpu_to_llvmir, translate_llvmir_to_ptx, compile_ptx_to_cubin, translate_llvmir_to_hsaco, get_shared_memory_size
+from .._C.libtriton.triton import (add_external_libs, compile_ptx_to_cubin,
+                                   get_shared_memory_size, ir,
+                                   translate_llvmir_to_hsaco, translate_llvmir_to_ptx,
+                                   translate_triton_gpu_to_llvmir)
 from ..common.backend import get_backend
-from ..runtime.driver import driver
-from ..runtime.jit import jit, JITFunction, get_current_device, get_device_capability, version_key, get_cuda_stream
 # from ..runtime import driver, jit, JITFunction
 # TODO: runtime.errors
 from ..runtime.autotuner import OutOfResources
 from ..runtime.cache import get_cache_manager
+from ..runtime.driver import driver
+from ..runtime.jit import (JITFunction, get_cuda_stream, get_current_device,
+                           get_device_capability, version_key)
 from ..tools.disasm import extract
 from .code_generator import ast_to_ttir
 from .make_launcher import make_stub

--- a/python/triton/debugger/debugger.py
+++ b/python/triton/debugger/debugger.py
@@ -2,13 +2,16 @@ import itertools
 import random
 from typing import Tuple
 
-import triton
-import triton.language as tl
+# import triton
+
+# import .language.core as lcore
+from ..language import core as lcore
+from .. import language as tl
 from .core import ExecutionContext
 from .memory_map import MemoryMap
 from .tl_lang import (TritonLangProxy, WrappedTensor, _primitive_to_tensor,
                       debugger_constexpr)
-from triton.debugger import torch_wrapper
+from . import torch_wrapper
 
 torch = torch_wrapper.torch
 tl_method_backup = {}
@@ -59,12 +62,12 @@ class DebuggerFunction:
         self.grid = grid
 
     def _is_constexpr(self, name):
-        return name in self.func.__annotations__ and self.func.__annotations__[name] is triton.language.core.constexpr
+        return name in self.func.__annotations__ and self.func.__annotations__[name] is lcore.constexpr
 
     def _get_constexpr(self):
         result = []
         for name, annotation in self.func.__annotations__.items():
-            if annotation is triton.language.core.constexpr:
+            if annotation is lcore.constexpr:
                 result.append(name)
         return result
 

--- a/python/triton/debugger/debugger.py
+++ b/python/triton/debugger/debugger.py
@@ -2,16 +2,17 @@ import itertools
 import random
 from typing import Tuple
 
-# import triton
-
+from .. import language as tl
 # import .language.core as lcore
 from ..language import core as lcore
-from .. import language as tl
+from . import torch_wrapper
 from .core import ExecutionContext
 from .memory_map import MemoryMap
 from .tl_lang import (TritonLangProxy, WrappedTensor, _primitive_to_tensor,
                       debugger_constexpr)
-from . import torch_wrapper
+
+# import triton
+
 
 torch = torch_wrapper.torch
 tl_method_backup = {}

--- a/python/triton/debugger/memory_map.py
+++ b/python/triton/debugger/memory_map.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import dataclasses
 
-from triton.debugger import torch_wrapper
+from . import torch_wrapper
 
 torch = torch_wrapper.torch
 

--- a/python/triton/debugger/tl_lang.py
+++ b/python/triton/debugger/tl_lang.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 # import triton
 from ..language import core as lcore
+from . import torch_wrapper
 from .core import ExecutionContext
 from .memory_map import MemoryMap
-from . import torch_wrapper
 
 torch = torch_wrapper.torch
 

--- a/python/triton/debugger/tl_lang.py
+++ b/python/triton/debugger/tl_lang.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import triton
+# import triton
+from ..language import core as lcore
 from .core import ExecutionContext
 from .memory_map import MemoryMap
-from triton.debugger import torch_wrapper
+from . import torch_wrapper
 
 torch = torch_wrapper.torch
 
@@ -389,7 +390,7 @@ class TritonLangProxy:
             if not isinstance(d.value, int):
                 raise TypeError(f"Shape element {i} must have type `constexpr[int]`, got `constexpr[{type(d.value)}]")
         shape = [x.value for x in shape]
-        if isinstance(dtype, triton.language.core.dtype):
+        if isinstance(dtype, lcore.dtype):
             if dtype.is_fp32():
                 dtype = torch.float32
             elif dtype.is_fp16():

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -77,7 +77,7 @@ from .core import (
     static_range,
     tensor,
     trans,
-    triton,
+    # triton,
     uint16,
     uint32,
     uint64,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -5,11 +5,10 @@ from enum import Enum
 from functools import wraps
 from typing import Callable, List, Sequence, TypeVar
 
+from .._C.libtriton.triton import ir
 # import triton
 from ..runtime.jit import jit
-
 from . import semantic
-from .._C.libtriton.triton import ir
 
 T = TypeVar('T')
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -5,9 +5,11 @@ from enum import Enum
 from functools import wraps
 from typing import Callable, List, Sequence, TypeVar
 
-import triton
+# import triton
+from ..runtime.jit import jit
+
 from . import semantic
-from triton._C.libtriton.triton import ir
+from .._C.libtriton.triton import ir
 
 T = TypeVar('T')
 
@@ -1344,7 +1346,7 @@ def _reduce_with_indices(input, axis, combine_fn, _builder=None, _generator=None
     return rvalue, rindices
 
 
-@triton.jit
+@jit
 def minimum(x, y):
     """
     Computes the element-wise minimum of :code:`x` and :code:`y`.
@@ -1357,7 +1359,7 @@ def minimum(x, y):
     return where(x < y, x, y)
 
 
-@triton.jit
+@jit
 def maximum(x, y):
     """
     Computes the element-wise maximum of :code:`x` and :code:`y`.
@@ -1372,12 +1374,12 @@ def maximum(x, y):
 # max and argmax
 
 
-@triton.jit
+@jit
 def _max_combine(a, b):
     return maximum(a, b)
 
 
-@triton.jit
+@jit
 def _argmax_combine(value1, index1, value2, index2):
     gt = value1 > value2
     value_ret = where(gt, value1, value2)
@@ -1385,7 +1387,7 @@ def _argmax_combine(value1, index1, value2, index2):
     return value_ret, index_ret
 
 
-@triton.jit
+@jit
 @_add_reduction_docstr("maximum")
 def max(input, axis=None, return_indices=False):
     input = _promote_reduction_input(input)
@@ -1395,7 +1397,7 @@ def max(input, axis=None, return_indices=False):
         return reduce(input, axis, _max_combine)
 
 
-@triton.jit
+@jit
 @_add_reduction_docstr("maximum index")
 def argmax(input, axis):
     (_, ret) = max(input, axis, return_indices=True)
@@ -1404,13 +1406,13 @@ def argmax(input, axis):
 # min and argmin
 
 
-@triton.jit
+@jit
 def _min_combine(a, b):
     # TODO: minimum/maximum doesn't get lowered to fmin/fmax...
     return minimum(a, b)
 
 
-@triton.jit
+@jit
 def _argmin_combine(value1, index1, value2, index2):
     lt = value1 < value2
     value_ret = where(lt, value1, value2)
@@ -1418,7 +1420,7 @@ def _argmin_combine(value1, index1, value2, index2):
     return value_ret, index_ret
 
 
-@triton.jit
+@jit
 @_add_reduction_docstr("minimum")
 def min(input, axis=None, return_indices=False):
     input = _promote_reduction_input(input)
@@ -1428,28 +1430,28 @@ def min(input, axis=None, return_indices=False):
         return reduce(input, axis, _min_combine)
 
 
-@triton.jit
+@jit
 @_add_reduction_docstr("minimum index")
 def argmin(input, axis):
     _, ret = min(input, axis, return_indices=True)
     return ret
 
 
-@triton.jit
+@jit
 def _sum_combine(a, b):
     return a + b
 
 # sum
 
 
-@triton.jit
+@jit
 @_add_reduction_docstr("sum")
 def sum(input, axis=None):
     input = _promote_reduction_input(input)
     return reduce(input, axis, _sum_combine)
 
 
-@triton.jit
+@jit
 def _xor_combine(a, b):
     return a ^ b
 

--- a/python/triton/language/random.py
+++ b/python/triton/language/random.py
@@ -1,4 +1,4 @@
-import triton
+from ..runtime.jit import jit
 from . import core as tl
 
 PHILOX_KEY_A: tl.constexpr = 0x9E3779B9
@@ -12,7 +12,7 @@ N_ROUNDS_DEFAULT = 10  # Default number of rounds for philox
 # -------------------
 
 
-@triton.jit
+@jit
 def philox_impl(c0, c1, c2, c3, k0, k1, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Run `n_rounds` rounds of Philox for state (c0, c1, c2, c3) and key (k0, k1).
@@ -33,7 +33,7 @@ def philox_impl(c0, c1, c2, c3, k0, k1, n_rounds: tl.constexpr = N_ROUNDS_DEFAUL
     return c0, c1, c2, c3
 
 
-@triton.jit
+@jit
 def philox(seed, c0, c1, c2, c3, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     seed = seed.to(tl.uint64)
     seed_hi = ((seed >> 32) & 0xffffffff).to(tl.uint32)
@@ -45,7 +45,7 @@ def philox(seed, c0, c1, c2, c3, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     return philox_impl(c0, c1, c2, c3, seed_lo, seed_hi, n_rounds)
 
 
-@triton.jit
+@jit
 def randint(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offset` block, returns a single
@@ -61,7 +61,7 @@ def randint(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     return ret
 
 
-@triton.jit
+@jit
 def randint4x(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offset` block, returns four
@@ -82,7 +82,7 @@ def randint4x(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
 # rand
 # -------------------
 
-# @triton.jit
+# @jit
 # def uint32_to_uniform_float(x):
 #     """
 #     Numerically stable function to convert a random uint32 into a random float uniformly sampled in [0, 1).
@@ -90,7 +90,7 @@ def randint4x(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
 #     two_to_the_minus_32: tl.constexpr = 2.328306e-10
 #     return x * two_to_the_minus_32
 
-@triton.jit
+@jit
 def uint32_to_uniform_float(x):
     """
     Numerically stable function to convert a random uint32 into a random float uniformly sampled in [0, 1).
@@ -102,7 +102,7 @@ def uint32_to_uniform_float(x):
     return x * scale
 
 
-@triton.jit
+@jit
 def rand(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offset` block,
@@ -116,7 +116,7 @@ def rand(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     return uint32_to_uniform_float(source)
 
 
-@triton.jit
+@jit
 def rand4x(seed, offsets, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offsets` block,
@@ -138,7 +138,7 @@ def rand4x(seed, offsets, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
 # -------------------
 
 
-@triton.jit
+@jit
 def pair_uniform_to_normal(u1, u2):
     """Box-Muller transform"""
     u1 = tl.maximum(1.0e-7, u1)
@@ -147,7 +147,7 @@ def pair_uniform_to_normal(u1, u2):
     return r * tl.cos(th), r * tl.sin(th)
 
 
-@triton.jit
+@jit
 def randn(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offset` block,
@@ -163,7 +163,7 @@ def randn(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     return n1
 
 
-@triton.jit
+@jit
 def randn4x(seed, offset, n_rounds: tl.constexpr = N_ROUNDS_DEFAULT):
     """
     Given a :code:`seed` scalar and an :code:`offset` block,

--- a/python/triton/ops/blocksparse/matmul.py
+++ b/python/triton/ops/blocksparse/matmul.py
@@ -1,10 +1,11 @@
 import torch
 
+from ... import cdiv, heuristics, jit
+from ... import language as tl
+
 # import triton
 # import language as tl
 
-from ... import jit, next_power_of_2, heuristics, cdiv
-from ... import language as tl
 # ********************************************************
 # --------------------------------------------------------
 # Sparse = Dense x Dense (SDD)

--- a/python/triton/ops/blocksparse/matmul.py
+++ b/python/triton/ops/blocksparse/matmul.py
@@ -1,8 +1,10 @@
 import torch
 
-import triton
-import triton.language as tl
+# import triton
+# import language as tl
 
+from ... import jit, next_power_of_2, heuristics, cdiv
+from ... import language as tl
 # ********************************************************
 # --------------------------------------------------------
 # Sparse = Dense x Dense (SDD)
@@ -13,10 +15,10 @@ import triton.language as tl
 # ********************************************************
 
 
-@triton.heuristics({
+@heuristics({
     'EVEN_K': lambda nargs: nargs['K'] % nargs['TILE_K'] == 0,
 })
-@triton.jit
+@jit
 def _sdd_kernel(
     A, B, C,
     stride_za, stride_ha, stride_ma, stride_ak,
@@ -127,7 +129,7 @@ def sdd_lut(layout, block, device):
 # -----------------------------
 
 
-@triton.jit
+@jit
 def _dsd_kernel(
     A, B, C,
     stride_az, stride_ha, stride_am, stride_ak,
@@ -227,7 +229,7 @@ def dsd_matmul(a, b, trans_a, trans_b, trans_c, spdims, block, lut, width, out=N
     # meta-parameter heuristics
     TILE_N = 128
     # compute output
-    grid = lambda meta: [triton.cdiv(BS3, meta['TILE_N']), width, BS0]
+    grid = lambda meta: [cdiv(BS3, meta['TILE_N']), width, BS0]
     _dsd_kernel[grid](
         a, b, c,
         a.stride(0), a.stride(1), a.stride(3 if trans_a else 2), a.stride(2 if trans_a else 3),

--- a/python/triton/ops/blocksparse/softmax.py
+++ b/python/triton/ops/blocksparse/softmax.py
@@ -2,8 +2,10 @@ import torch
 
 # import triton
 # import language as tl
-from ... import jit, next_power_of_2
+from ... import jit
 from ... import language as tl
+from ... import next_power_of_2
+
 
 def num_warps(n):
     if n <= 128:

--- a/python/triton/ops/blocksparse/softmax.py
+++ b/python/triton/ops/blocksparse/softmax.py
@@ -1,8 +1,9 @@
 import torch
 
-import triton
-import triton.language as tl
-
+# import triton
+# import language as tl
+from ... import jit, next_power_of_2
+from ... import language as tl
 
 def num_warps(n):
     if n <= 128:
@@ -16,7 +17,7 @@ def num_warps(n):
     return 16
 
 
-@triton.jit
+@jit
 def _blocksparse_softmax_fwd(
     Out, A, stride_xz, LUT,
     R, extent, stride_zr, stride_hr,  # relative attention
@@ -71,7 +72,7 @@ def _blocksparse_softmax_fwd(
     tl.store(Out + off_a + lane_n, out, mask=mask)
 
 
-@triton.jit
+@jit
 def _blocksparse_softmax_bwd(
     DA, stride_zdx,
     DOut, stride_zdout,
@@ -169,7 +170,7 @@ class _softmax(torch.autograd.Function):
             scale,
             is_causal,
             BLOCK_SIZE=block,
-            ROW_SIZE=triton.next_power_of_2(maxlut),
+            ROW_SIZE=next_power_of_2(maxlut),
             IS_DENSE=is_dense,
             num_warps=num_warps(maxlut)
         )
@@ -208,7 +209,7 @@ class _softmax(torch.autograd.Function):
             dr, ctx.rel_shape[-1], ctx.rel_strides[0], ctx.rel_strides[1], ctx.rel_strides[2],
             ctx.is_causal,
             BLOCK_SIZE=ctx.block,
-            ROW_SIZE=triton.next_power_of_2(ctx.maxlut),
+            ROW_SIZE=next_power_of_2(ctx.maxlut),
             IS_DENSE=ctx.is_dense,
             num_warps=num_warps(ctx.maxlut)
         )

--- a/python/triton/ops/cross_entropy.py
+++ b/python/triton/ops/cross_entropy.py
@@ -1,7 +1,9 @@
 import torch
 
-import triton
-import triton.language as tl
+# import triton
+# import language as tl
+from .. import jit, heuristics, next_power_of_2
+from .. import language as tl
 
 
 def num_warps(N):
@@ -12,9 +14,9 @@ def num_warps(N):
     return 16
 
 
-@triton.heuristics({'num_warps': lambda nargs: num_warps(nargs['N'])})
-@triton.heuristics({'BLOCK': lambda nargs: triton.next_power_of_2(nargs['N'])})
-@triton.jit
+@heuristics({'num_warps': lambda nargs: num_warps(nargs['N'])})
+@heuristics({'BLOCK': lambda nargs: next_power_of_2(nargs['N'])})
+@jit
 def _forward(LOGITS, PROBS, IDX, LOSS, N, BLOCK: tl.constexpr):
     row = tl.program_id(0)
     cols = tl.arange(0, BLOCK)
@@ -37,9 +39,9 @@ def _forward(LOGITS, PROBS, IDX, LOSS, N, BLOCK: tl.constexpr):
     tl.store(LOSS + row, probs)
 
 
-@triton.heuristics({'num_warps': lambda nargs: num_warps(nargs['N'])})
-@triton.heuristics({'BLOCK': lambda nargs: triton.next_power_of_2(nargs['N'])})
-@triton.jit
+@heuristics({'num_warps': lambda nargs: num_warps(nargs['N'])})
+@heuristics({'BLOCK': lambda nargs: next_power_of_2(nargs['N'])})
+@jit
 def _backward(PROBS, IDX, DPROBS, N, BLOCK: tl.constexpr):
     row = tl.program_id(0)
     cols = tl.arange(0, BLOCK)

--- a/python/triton/ops/cross_entropy.py
+++ b/python/triton/ops/cross_entropy.py
@@ -2,8 +2,9 @@ import torch
 
 # import triton
 # import language as tl
-from .. import jit, heuristics, next_power_of_2
+from .. import heuristics, jit
 from .. import language as tl
+from .. import next_power_of_2
 
 
 def num_warps(N):

--- a/python/triton/ops/flash_attention.py
+++ b/python/triton/ops/flash_attention.py
@@ -7,11 +7,12 @@ This is a Triton implementation of the Flash Attention algorithm
 
 import torch
 
+from .. import cdiv, jit
+from .. import language as tl
+
 # import triton
 # import language as tl
 
-from .. import jit, heuristics, next_power_of_2, cdiv
-from .. import language as tl
 
 @jit
 def _fwd_kernel(

--- a/python/triton/ops/matmul.py
+++ b/python/triton/ops/matmul.py
@@ -1,11 +1,11 @@
 import torch
 
-# import triton
-# import language as tl
-
-from .. import jit, heuristics, next_power_of_2, Config, cdiv, autotune
+from .. import Config, autotune, cdiv, heuristics, jit
 from .. import language as tl
 from .matmul_perf_model import early_config_prune, estimate_matmul_time
+
+# import triton
+# import language as tl
 
 
 def init_to_zero(name):
@@ -21,11 +21,11 @@ def get_configs_io_bound():
                     num_warps = 2 if block_n <= 64 else 4
                     configs.append(
                         Config({'BLOCK_M': block_m, 'BLOCK_N': block_n, 'BLOCK_K': block_k, 'SPLIT_K': 1},
-                                      num_stages=num_stages, num_warps=num_warps))
+                               num_stages=num_stages, num_warps=num_warps))
                     # split_k
                     for split_k in [2, 4, 8, 16]:
                         configs.append(Config({'BLOCK_M': block_m, 'BLOCK_N': block_n, 'BLOCK_K': block_k, 'SPLIT_K': split_k},
-                                                     num_stages=num_stages, num_warps=num_warps, pre_hook=init_to_zero('C')))
+                                              num_stages=num_stages, num_warps=num_warps, pre_hook=init_to_zero('C')))
     return configs
 
 

--- a/python/triton/ops/matmul.py
+++ b/python/triton/ops/matmul.py
@@ -1,7 +1,10 @@
 import torch
 
-import triton
-import triton.language as tl
+# import triton
+# import language as tl
+
+from .. import jit, heuristics, next_power_of_2, Config, cdiv, autotune
+from .. import language as tl
 from .matmul_perf_model import early_config_prune, estimate_matmul_time
 
 
@@ -17,37 +20,37 @@ def get_configs_io_bound():
                 for block_n in [32, 64, 128, 256]:
                     num_warps = 2 if block_n <= 64 else 4
                     configs.append(
-                        triton.Config({'BLOCK_M': block_m, 'BLOCK_N': block_n, 'BLOCK_K': block_k, 'SPLIT_K': 1},
+                        Config({'BLOCK_M': block_m, 'BLOCK_N': block_n, 'BLOCK_K': block_k, 'SPLIT_K': 1},
                                       num_stages=num_stages, num_warps=num_warps))
                     # split_k
                     for split_k in [2, 4, 8, 16]:
-                        configs.append(triton.Config({'BLOCK_M': block_m, 'BLOCK_N': block_n, 'BLOCK_K': block_k, 'SPLIT_K': split_k},
+                        configs.append(Config({'BLOCK_M': block_m, 'BLOCK_N': block_n, 'BLOCK_K': block_k, 'SPLIT_K': split_k},
                                                      num_stages=num_stages, num_warps=num_warps, pre_hook=init_to_zero('C')))
     return configs
 
 
-@triton.autotune(
+@autotune(
     configs=[
         # basic configs for compute-bound matmuls
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=3, num_warps=8),
-        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=3, num_warps=8),
-        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 64, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 256, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 128, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 32, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=5, num_warps=2),
+        Config({'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=3, num_warps=8),
+        Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=3, num_warps=8),
+        Config({'BLOCK_M': 256, 'BLOCK_N': 64, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 64, 'BLOCK_N': 256, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 128, 'BLOCK_N': 64, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 64, 'BLOCK_N': 128, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 128, 'BLOCK_N': 32, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 64, 'BLOCK_N': 32, 'BLOCK_K': 32, 'SPLIT_K': 1}, num_stages=5, num_warps=2),
         # good for int8
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=3, num_warps=8),
-        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=3, num_warps=8),
-        triton.Config({'BLOCK_M': 256, 'BLOCK_N': 64, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 256, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 64, 'BLOCK_K': 64, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 128, 'BLOCK_K': 64, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 128, 'BLOCK_N': 32, 'BLOCK_K': 64, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
-        triton.Config({'BLOCK_M': 64, 'BLOCK_N': 32, 'BLOCK_K': 64, 'SPLIT_K': 1}, num_stages=5, num_warps=2),
+        Config({'BLOCK_M': 128, 'BLOCK_N': 256, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=3, num_warps=8),
+        Config({'BLOCK_M': 256, 'BLOCK_N': 128, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=3, num_warps=8),
+        Config({'BLOCK_M': 256, 'BLOCK_N': 64, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 64, 'BLOCK_N': 256, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 128, 'BLOCK_N': 128, 'BLOCK_K': 128, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 128, 'BLOCK_N': 64, 'BLOCK_K': 64, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 64, 'BLOCK_N': 128, 'BLOCK_K': 64, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 128, 'BLOCK_N': 32, 'BLOCK_K': 64, 'SPLIT_K': 1}, num_stages=4, num_warps=4),
+        Config({'BLOCK_M': 64, 'BLOCK_N': 32, 'BLOCK_K': 64, 'SPLIT_K': 1}, num_stages=5, num_warps=2),
     ] + get_configs_io_bound(),
     key=['M', 'N', 'K'],
     prune_configs_by={
@@ -56,10 +59,10 @@ def get_configs_io_bound():
         'top_k': 10
     },
 )
-@triton.heuristics({
+@heuristics({
     'EVEN_K': lambda args: args['K'] % (args['BLOCK_K'] * args['SPLIT_K']) == 0,
 })
-@triton.jit
+@jit
 def _kernel(A, B, C, M, N, K,
             stride_am, stride_ak,
             stride_bk, stride_bn,
@@ -146,7 +149,7 @@ class _matmul(torch.autograd.Function):
             else:
                 dot_out_dtype = tl.int32
         # launch kernel
-        grid = lambda META: (triton.cdiv(M, META['BLOCK_M']) * triton.cdiv(N, META['BLOCK_N']), META['SPLIT_K'])
+        grid = lambda META: (cdiv(M, META['BLOCK_M']) * cdiv(N, META['BLOCK_N']), META['SPLIT_K'])
         _kernel[grid](a, b, c, M, N, K,
                       a.stride(0), a.stride(1),
                       b.stride(0), b.stride(1),

--- a/python/triton/ops/matmul_perf_model.py
+++ b/python/triton/ops/matmul_perf_model.py
@@ -4,9 +4,9 @@ import torch
 
 # import triton
 from .. import cdiv
+from .._C.libtriton.triton import runtime
 from ..runtime import driver
 from ..testing import get_dram_gbps, get_max_simd_tflops, get_max_tensorcore_tflops
-from .._C.libtriton.triton import runtime
 
 
 def get_tensorcore_tflops(backend, device, num_ctas, num_warps, dtype):

--- a/python/triton/ops/matmul_perf_model.py
+++ b/python/triton/ops/matmul_perf_model.py
@@ -2,10 +2,11 @@ import heapq
 
 import torch
 
-import triton
-import triton._C.libtriton.triton as _triton
-from triton.runtime import driver
-from triton.testing import get_dram_gbps, get_max_simd_tflops, get_max_tensorcore_tflops
+# import triton
+from .. import cdiv
+from ..runtime import driver
+from ..testing import get_dram_gbps, get_max_simd_tflops, get_max_tensorcore_tflops
+from .._C.libtriton.triton import runtime
 
 
 def get_tensorcore_tflops(backend, device, num_ctas, num_warps, dtype):
@@ -41,13 +42,13 @@ def estimate_matmul_time(
 ):
     ''' return estimated running time in ms
           = max(compute, loading) + store '''
-    backend = _triton.runtime.backend.CUDA
+    backend = runtime.backend.CUDA
     device = torch.cuda.current_device()
     dtype = A.dtype
     dtsize = A.element_size()
 
-    num_cta_m = triton.cdiv(M, BLOCK_M)
-    num_cta_n = triton.cdiv(N, BLOCK_N)
+    num_cta_m = cdiv(M, BLOCK_M)
+    num_cta_n = cdiv(N, BLOCK_N)
     num_cta_k = SPLIT_K
     num_ctas = num_cta_m * num_cta_n * num_cta_k
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -20,6 +20,7 @@ from ..common.backend import get_backend
 TRITON_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 TRITON_VERSION = "2.1.0"
 
+
 def get_cuda_stream(idx=None):
     if idx is None:
         idx = get_current_device()

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -4,7 +4,7 @@ import subprocess
 import sys
 from contextlib import contextmanager
 
-import triton._C.libtriton.triton as _triton
+from ._C.libtriton.triton import runtime
 
 
 def nvsmi(attrs):
@@ -281,7 +281,7 @@ def get_dram_gbps(backend=None, device=None):
 
     from .runtime import driver
     if not backend:
-        backend = _triton.runtime.backend.CUDA
+        backend = runtime.backend.CUDA
     if not device:
         device = torch.cuda.current_device()
     mem_clock_khz = driver.utils.get_device_properties(device)["mem_clock_rate"]  # in kHz
@@ -295,7 +295,7 @@ def get_max_tensorcore_tflops(dtype, backend=None, device=None, clock_rate=None)
 
     from .runtime import driver
     if not backend:
-        backend = _triton.runtime.backend.CUDA
+        backend = runtime.backend.CUDA
     if not device:
         device = torch.cuda.current_device()
 
@@ -398,7 +398,7 @@ def get_max_simd_tflops(dtype, backend=None, device=None):
 
     from .runtime import driver
     if not backend:
-        backend = _triton.runtime.backend.CUDA
+        backend = runtime.backend.CUDA
     if not device:
         device = torch.cuda.current_device()
 

--- a/python/triton/tools/aot.py
+++ b/python/triton/tools/aot.py
@@ -3,9 +3,9 @@ import sys
 
 from .._C.libtriton.triton import ir
 # import triton.compiler.compiler as tc
-from ..compiler.compile import (get_amdgpu_arch_fulldetails, llir_to_amdgcn_and_hsaco,
-                                llir_to_ptx, optimize_ttgir, optimize_ttir,
-                                ttgir_to_llir, ttir_to_ttgir)
+from ..compiler.compiler import (get_amdgpu_arch_fulldetails, llir_to_amdgcn_and_hsaco,
+                                 llir_to_ptx, optimize_ttgir, optimize_ttir,
+                                 ttgir_to_llir, ttir_to_ttgir)
 
 if __name__ == '__main__':
 

--- a/python/triton/tools/aot.py
+++ b/python/triton/tools/aot.py
@@ -3,7 +3,10 @@ import sys
 
 from .._C.libtriton.triton import ir
 # import triton.compiler.compiler as tc
-from ..compiler.compile import optimize_ttir, ttir_to_ttgir, optimize_ttgir, ttgir_to_llir, llir_to_amdgcn_and_hsaco, get_amdgpu_arch_fulldetails, llir_to_ptx
+from ..compiler.compile import (get_amdgpu_arch_fulldetails, llir_to_amdgcn_and_hsaco,
+                                llir_to_ptx, optimize_ttgir, optimize_ttir,
+                                ttgir_to_llir, ttir_to_ttgir)
+
 if __name__ == '__main__':
 
     # valid source and target formats

--- a/python/triton/tools/aot.py
+++ b/python/triton/tools/aot.py
@@ -1,9 +1,9 @@
 import argparse
 import sys
 
-import triton._C.libtriton.triton as libtriton
-import triton.compiler.compiler as tc
-
+from .._C.libtriton.triton import ir
+# import triton.compiler.compiler as tc
+from ..compiler.compile import optimize_ttir, ttir_to_ttgir, optimize_ttgir, ttgir_to_llir, llir_to_amdgcn_and_hsaco, get_amdgpu_arch_fulldetails, llir_to_ptx
 if __name__ == '__main__':
 
     # valid source and target formats
@@ -32,12 +32,12 @@ if __name__ == '__main__':
         sys.exit(0)
 
     # parse source file to MLIR module
-    context = libtriton.ir.context()
-    module = libtriton.ir.parse_mlir_module(args.src, context)
+    context = ir.context()
+    module = ir.parse_mlir_module(args.src, context)
     module.context = context
 
     # optimizer triton-ir
-    module = tc.optimize_ttir(module, arch=args.sm)
+    module = optimize_ttir(module, arch=args.sm)
     if args.target == 'triton-ir':
         print(module.str())
         sys.exit(0)
@@ -49,7 +49,7 @@ if __name__ == '__main__':
     if args.target == 'amdgcn':
         # auto detect available architecture and features
         # if nothing detected, set with default values
-        arch_details = tc.get_amdgpu_arch_fulldetails()
+        arch_details = get_amdgpu_arch_fulldetails()
         if not arch_details:
             arch_name = ""
             arch_triple = "amdgcn-amd-amdhsa"
@@ -71,13 +71,13 @@ if __name__ == '__main__':
 
         # triton-ir -> triton-gpu-ir
         # use compute_capability == 80
-        module = tc.ttir_to_ttgir(module, num_warps=args.num_warps)  # num_stages=3, compute_capability=80)
-        module = tc.optimize_ttgir(module, num_stages=3, arch=80)
+        module = ttir_to_ttgir(module, num_warps=args.num_warps)  # num_stages=3, compute_capability=80)
+        module = optimize_ttgir(module, num_stages=3, arch=80)
         # triton-gpu-ir -> llvm-ir
         # use compute_capability == 80
-        module = tc.ttgir_to_llir(module, extern_libs=None, arch=80)
+        module = ttgir_to_llir(module, extern_libs=None, arch=80)
         # llvm-ir -> amdgcn asm, hsaco binary
-        module, hsaco_path = tc.llir_to_amdgcn_and_hsaco(module, arch_name, arch_triple, arch_features)
+        module, hsaco_path = llir_to_amdgcn_and_hsaco(module, arch_name, arch_triple, arch_features)
 
         print(hsaco_path)
         print(module)
@@ -87,14 +87,14 @@ if __name__ == '__main__':
         raise argparse.ArgumentError(None, "Must specify --sm for PTX compilation")
 
     # triton-ir -> triton-gpu-ir
-    module = tc.ttir_to_ttgir(module, num_warps=args.num_warps)
-    module = tc.optimize_ttgir(module, num_stages=3, arch=args.sm)
+    module = ttir_to_ttgir(module, num_warps=args.num_warps)
+    module = optimize_ttgir(module, num_stages=3, arch=args.sm)
     if args.target == 'triton-gpu-ir':
         print(module.str())
         sys.exit(0)
 
     # triton-gpu-ir -> llvm-ir
-    module = tc.ttgir_to_llir(module, extern_libs=None, arch=args.sm)
+    module = ttgir_to_llir(module, extern_libs=None, arch=args.sm)
     if args.target == 'llvm-ir':
         print(module)
         sys.exit(0)
@@ -103,12 +103,12 @@ if __name__ == '__main__':
     if args.target == 'ptx':
         if not args.ptx_version:
             raise argparse.ArgumentError(None, "Must specify --ptx-version for PTX compilation")
-        module = tc.llir_to_ptx(module, arch=args.sm, ptx_version=args.ptx_version)
+        module = llir_to_ptx(module, arch=args.sm, ptx_version=args.ptx_version)
 
     # llvm-ir -> amdgcn
     if args.target == 'amdgcn':
         if not args.gfx:
             raise argparse.ArgumentError(None, "Must specify --gfx for AMDGCN compilation")
-        module, hsaco_path = tc.llir_to_amdgcn_and_hsaco(module, args.gfx)
+        module, hsaco_path = llir_to_amdgcn_and_hsaco(module, args.gfx)
 
     print(module)


### PR DESCRIPTION
The idea behind this change is that it allows for continued use of Triton 2.0.0 under Torch Inductor, but also allows the main branch (2.1.0) to be used at the same time in the same scripts.  

With absolute imports only 1 version can be used at a time.

All files in triton/python/triton are changed to use relative imports over absolute imports.  The trickiest file was runtime/jit.py where I switched to use `__spec__` in the JITFunction here: https://github.com/IzzyPutterman/triton/blob/iputterman/relative-imports/python/triton/runtime/jit.py#L324
https://github.com/IzzyPutterman/triton/blob/iputterman/relative-imports/python/triton/runtime/jit.py#L398

And again in the jit.py file to compare against the triton module
https://github.com/IzzyPutterman/triton/blob/iputterman/relative-imports/python/triton/runtime/jit.py#L76

