### PR TITLE
Integration fix for MLIR change D152814

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -74,9 +74,8 @@ public:
           dstType.getShape(), dstType.getElementType(), dstParentMma);
       auto tmp = rewriter.create<triton::gpu::ConvertLayoutOp>(
           convert.getLoc(), tmpType, convert.getOperand());
-      auto newConvert = rewriter.create<triton::gpu::ConvertLayoutOp>(
-          convert.getLoc(), dstType, tmp);
-      rewriter.replaceOp(op, {newConvert});
+      rewriter.replaceOpWithNewOp<triton::gpu::ConvertLayoutOp>(op, dstType,
+                                                                tmp);
       return mlir::success();
     }
     return mlir::failure();


### PR DESCRIPTION
https://reviews.llvm.org/D152814

The API of `RewriterBase::replaceOp` was extended and a fix is needed so that the called function is not ambiguous.

This change is compatible with both the old and the new API.