### PR TITLE
[BACKEND] Remove unnecessary async wait op

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeline.cpp
@@ -717,7 +717,6 @@ void LoopPipeliner::emitEpilogue() {
   OpBuilder builder(forOp);
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPointAfter(forOp);
-  builder.create<ttg::AsyncWaitOp>(forOp.getLoc(), 0);
 }
 
 SmallVector<Value> LoopPipeliner::collectNewLoopArgs() {


### PR DESCRIPTION
The async wait op in the epilogue is unnecessary because the last two cp.async groups will not load.