### PR TITLE
[BACKEND] Make call to RewriterBase::replaceOp compatible with overload.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -76,7 +76,7 @@ public:
           convert.getLoc(), tmpType, convert.getOperand());
       auto newConvert = rewriter.create<triton::gpu::ConvertLayoutOp>(
           convert.getLoc(), dstType, tmp);
-      rewriter.replaceOp(op, {newConvert});
+      rewriter.replaceOp(op, newConvert);
       return mlir::success();
     }
     return mlir::failure();


### PR DESCRIPTION
In upstream, llvm/llvm-project@71d50c89 introduced a new overload to that function, which made one call to that function ambiguous. This commit disambiguates the call.