### PR TITLE
Prototype for converting `triton` to `linalg`

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -6,6 +6,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
+#include "triton/Conversion/TritonToLinalg/Passes.h"
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
 
 #include "mlir/InitAllPasses.h"
@@ -27,6 +28,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::test::registerTestAlignmentPass();
   mlir::test::registerTestAllocationPass();
   mlir::test::registerTestMembarPass();
+  mlir::triton::registerTritonToLinalgPass();
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::registerConvertTritonGPUToLLVMPass();
 

--- a/include/triton/Analysis/MaskAnalysis.h
+++ b/include/triton/Analysis/MaskAnalysis.h
@@ -1,0 +1,135 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_ANALYSIS_MASKANALYSIS_H
+#define TRITON_ANALYSIS_MASKANALYSIS_H
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir {
+
+class ConversionPatternRewriter;
+
+namespace triton {
+// Data structure used to decode the pattern in a mask used for load and store.
+// start and end field represent the start and end index of a range (produced
+// by make_range, addi, etc.). While multi-dimensional data is possible, we
+// assume range comparison can only be done on 1 dimension at a time (and
+// results of range comparions across dimensions can be combined), hence start
+// and end are not vectors. dims represents the real access size for ld/st
+// (instead of the tensor/memref size specified by the IR). scalar is a shortcut
+// used when the entire state contains a single scalar value.
+//
+// The general lifetime of this data structure is roughly:
+// 1. A range is created by make_range and optionally operated on by addi w/
+// result of splat, expand_dims, etc. During this phase, either (1) both start
+// and end are populated, or (2) scalar is populated. Only one of the dimensions
+// (that contains the range) can have dim > 1.
+// 2. Result from step 1 is compared with a another MaskState that represents a
+// scalar value. The resulting state only has dims populated.
+// 3. Optionally, result from step 2 can be broadcasted and anded with other
+// results from step 2. The resulting state only has dims populated.
+//
+// Example of creating 2D mask:
+//  mask = (rows[:, None] < M) & (cols[None, :] < N)
+struct MaskState {
+  OpFoldResult start;
+  OpFoldResult end;
+  SmallVector<OpFoldResult> dims;
+  OpFoldResult scalar;
+
+  int64_t getRank() const { return dims.size(); }
+
+  bool isEmpty() const { return getRank() == 0 && !scalar && !start && !end; }
+
+  bool isMask() const { return !start && !end && !scalar && dims.size() != 0; }
+
+  // Recursively parse a Value; call the coresponding function based on the
+  // defining operation and Value type
+  LogicalResult parse(Value operand, const Location loc,
+                      ConversionPatternRewriter &rewriter);
+
+  tensor::ExtractSliceOp
+  getExtractSlice(Value source, const Location loc,
+                  ConversionPatternRewriter &rewriter) const;
+
+  memref::SubViewOp getSubview(Value source, const Location loc,
+                               ConversionPatternRewriter &rewriter) const;
+
+private:
+  // -------
+  // Utility functions to operate on MaskState
+  // -------
+  LogicalResult addStateScalar(const MaskState &state,
+                               const OpFoldResult scalar, Location loc,
+                               ConversionPatternRewriter &rewriter);
+
+  LogicalResult addStates(const MaskState &lhsState, const MaskState &rhsState,
+                          Location loc, ConversionPatternRewriter &rewriter);
+
+  LogicalResult minStates(const MaskState &lhsState, const MaskState &rhsState,
+                          Location loc, ConversionPatternRewriter &rewriter);
+  // -------
+  // Helper functions to parse values to populate MaskState
+  // -------
+
+  // Operand is the result of a constant
+  // Get the value of the constant and assign it to scalar.
+  LogicalResult parseConstant(arith::ConstantOp constOp, const Location loc,
+                              ConversionPatternRewriter &rewriter);
+
+  // Operand is an integer scalar
+  LogicalResult parseIntScalar(Value scalar, const Location loc,
+                               ConversionPatternRewriter &rewriter);
+
+  // Operand is the result of addi
+  // One and only one of the operands should be a scalar. Increment both start
+  // and end, dims remains unchanged, and scalar is empty.
+  LogicalResult parseAdd(arith::AddIOp addOp, const Location loc,
+                         ConversionPatternRewriter &rewriter);
+  // Operand is the result of andi
+  // Each of the result state dims is smaller of the two operands' dims.
+  // Insert instruction if needed to get new dims.
+  LogicalResult parseAnd(arith::AndIOp andOp, const Location loc,
+                         ConversionPatternRewriter &rewriter);
+
+  // Operand is the result of cmpi
+  // Assume only of the dimensions have size > 1. Only support slt for now.
+  // For that dimension, calculate this new dim as: dim = min(end, value) -
+  // start
+  LogicalResult parseCmp(arith::CmpIOp cmpOp, const Location loc,
+                         ConversionPatternRewriter &rewriter);
+  // Operand is the result of make_range
+  // Set start and end accordingly; step size must be 1.
+  LogicalResult parseMakeRange(triton::MakeRangeOp rangeOp, const Location loc,
+                               ConversionPatternRewriter &rewriter);
+  // Operand is the result of broadcast
+  // Change dims only; assume only applies to tensors.
+  LogicalResult parseBroadcast(triton::BroadcastOp broadcastOp,
+                               const Location loc,
+                               ConversionPatternRewriter &rewriter);
+  // Operand is the result of splat
+  // Assume only applies to scalar. start and end are left empty; scalar will
+  // be assigned, and dims will be updated.
+  LogicalResult parseSplat(triton::SplatOp splatOp, const Location loc,
+                           ConversionPatternRewriter &rewriter);
+  // Operand is the result of expand_dims
+  // Insert additional dims; start and end do not change and correspond to the
+  // dimension that contains the range.
+  LogicalResult parseExpandDims(triton::ExpandDimsOp expandDimsOp,
+                                const Location loc,
+                                ConversionPatternRewriter &rewriter);
+};
+
+} // namespace triton
+
+} // namespace mlir
+
+#endif

--- a/include/triton/Analysis/OpFoldResultUtils.h
+++ b/include/triton/Analysis/OpFoldResultUtils.h
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_ANALYSIS_OPFOLDRESULT_UTILS_H
+#define TRITON_ANALYSIS_OPFOLDRESULT_UTILS_H
+
+#include "mlir/IR/Location.h"
+#include "mlir/IR/OpDefinition.h"
+
+#include <optional>
+
+namespace mlir {
+
+class ConversionPatternRewriter;
+
+// Return integer if ofr is an IntegerAttr. Note that this function differs
+// from getConstantIntValue, which returns an integer if ofr is the constant
+// result of an operation too.
+std::optional<int64_t> getIntAttr(const OpFoldResult ofr);
+
+// Process addition of two OFRs. If both OFRs are Integer Attributes, result
+// is an Integer Attribute. Otherwise, insert the arith.addi instruction if
+// needed and use its result Value.
+OpFoldResult addOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
+                     const Location loc, ConversionPatternRewriter &rewriter);
+
+// Produce result = lhs - rhs. If both OFRs are Integer Attributes, result
+// is an Integer Attribute. Otherwise, insert the arith.addi instruction if
+// needed and use its result Value.
+OpFoldResult subOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
+                     const Location loc, ConversionPatternRewriter &rewriter);
+
+// Process multiplication of two OFRs. If both OFRs are Integer Attributes,
+// result is an Integer Attribtue. Otherwise, insert the arith.muli
+// instruction if needed and use its result Value.
+OpFoldResult mulOFRValue(const OpFoldResult lhs, const Value rhs,
+                         const Location loc,
+                         ConversionPatternRewriter &rewriter);
+
+OpFoldResult minOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
+                     const Location loc, ConversionPatternRewriter &rewriter);
+
+} // namespace mlir
+
+#endif

--- a/include/triton/Analysis/PtrAnalysis.h
+++ b/include/triton/Analysis/PtrAnalysis.h
@@ -1,0 +1,206 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_ANALYSIS_PTRANALYSIS_H
+#define TRITON_ANALYSIS_PTRANALYSIS_H
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include <set>
+
+namespace mlir {
+
+class ConversionPatternRewriter;
+
+namespace triton {
+
+// Data structure used to decode pointer arithmetics and potentially to be
+// translate it into memref. offsets, sizes, and strides are in unit of elements
+// in a linearly laid-out memory, which is the same as pointer arithmetic
+// operations in Triton language. scalar is a shortcut used when the entire
+// state describes a single scalar value. source is the base pointer.
+struct PtrState {
+  SmallVector<OpFoldResult> offsets;
+  SmallVector<OpFoldResult> sizes;
+  SmallVector<OpFoldResult> strides;
+  Value source;
+  Value scalar;
+
+  int64_t getRank() const;
+
+  bool isEmpty() const;
+
+  // Process addition of two PtrStates.
+  void addState(const PtrState &lhsState, const PtrState &rhsState,
+                Location loc, ConversionPatternRewriter &rewriter);
+
+  // Process multiplication of two PtrStates
+  void mulState(const PtrState &lhsState, const PtrState &rhsState,
+                const Location loc, ConversionPatternRewriter &rewriter);
+
+  // Produce a reinterpret cast based on the current PtrState. Additional
+  // instructions may be inserted in calculating the final offset.
+  memref::ReinterpretCastOp createCastOp(ArrayRef<int64_t> resultShape,
+                                         const Location loc,
+                                         ConversionPatternRewriter &rewriter);
+};
+
+class PtrAnalysis {
+public:
+  using IndexMapSet = std::map<int, std::set<int>>;
+
+  // Recursively parse a Value; call the corresponding
+  // function based on the defining operation and argument type.
+  static void
+  visitOperand(Value operand, PtrState &state, const Location loc,
+               ConversionPatternRewriter &rewriter,
+               const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of arith.addi. Process both arguments and insert any
+  // arith.addi instruction as needed.
+  // Main assumptions:
+  //  Only one of lhsState and rhsState has source field set
+  //  Current PtrState should be empty
+  // Expected result:
+  //  source = lhsState.source ? lhsState.source : rhsState.source
+  //  sizes[i] = lhsState.sizes[i] (which should match rhsState.sizes[i])
+  //  offsets[i] = lhsState.offsets[i] + rhsState.offsets[i]
+  //  strides[i] = lhsState.strides[i] + rhsState.strides[i]
+  static void
+  visitOperandAdd(arith::AddIOp addOp, PtrState &state, const Location loc,
+                  ConversionPatternRewriter &rewriter,
+                  const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of arith.muli. Process both arguments and insert any
+  // arith.muli instruction as needed.
+  // Main assumptions:
+  //  Neither lhsState nor rhsState has source field set
+  //  Current PtrState should be empty
+  //  Currently only support one of the operand is a scalar index
+  // Expected result (scalar and tensorState represent the two operands):
+  //  source = null
+  //  sizes[i] = tensorState.sizes[i]
+  //  offsets[i] = tensorState.offsets[i] * scalar
+  //  strides[i] = tensorState.strides[i] * scalar
+  static void
+  visitOperandMul(arith::MulIOp mulOp, PtrState &state, const Location loc,
+                  ConversionPatternRewriter &rewriter,
+                  const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of make_range.
+  // Main assumptions:
+  //  start, end, and shape are all statically known
+  //  The output of make_range is 1-dimensional
+  //  Does not check validity of inputs (e.g., stride > 0)
+  // Expected result:
+  //  source = null
+  //  sizes[0] = shape[0]
+  //  offset[0] = start
+  //  strides[0] = ceiling( (end - start) / shape[0] )
+  static void
+  visitOperandMakeRange(triton::MakeRangeOp rangeOp, PtrState &state,
+                        Location loc, ConversionPatternRewriter &rewriter,
+                        const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of expand_dims
+  // Main assumptions:
+  //  Only 1 dimension changes for each invocation of reshape
+  //  The changed dimension must have size of 1
+  // Expected result:
+  //  Insert a dimension of size 1, stride 0, and offset 0
+  static void
+  visitOperandExpandDims(triton::ExpandDimsOp expandDimsOp, PtrState &state,
+                         const Location loc,
+                         ConversionPatternRewriter &rewriter,
+                         const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of broadcast
+  // Main assumptions:
+  //  Rank of soure and result is the same
+  // Expected result:
+  //  Update sizes[i] only, no changes to other fields
+  static void
+  visitOperandBroadcast(triton::BroadcastOp broadcastOp, PtrState &state,
+                        const Location loc, ConversionPatternRewriter &rewriter,
+                        const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of splat
+  // Main assumptions:
+  //  Source is a scalar value (i.e., an integer or a pointer, not a tensor)
+  // Expected result:
+  //  sizes[i] reflect the shape of the result, strides[i] = 0,  offsets[i] = 0
+  //  if source is an integer, offset[0] = scalar = source
+  static void
+  visitOperandSplat(triton::SplatOp splatOp, PtrState &state,
+                    const Location loc, ConversionPatternRewriter &rewriter,
+                    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of arith.constant that is a splat
+  // Main assumptions:
+  //  Source is a constant op that produces a constant dense tensor where all
+  //  elements are the same (i.e.: a constant that is splatted)
+  // Expected result:
+  //  sizes[i] reflect the shape of the result, strides[i] = 0,  offsets[i] =
+  //  splat value if i == 0, otherwise 0
+  static void
+  visitOperandConstSplat(arith::ConstantOp op, PtrState &state,
+                         const Location loc,
+                         ConversionPatternRewriter &rewriter,
+                         const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of addptr.
+  // Main assumptions:
+  //  The ptr field should populate the source field
+  //  ptr and offset fields should result in same rank
+  // Expected result:
+  //  The resulting state for ptr and offset wil be added
+  static void
+  visitOperandAddptr(triton::AddPtrOp addptrOp, PtrState &state,
+                     const Location loc, ConversionPatternRewriter &rewriter,
+                     const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Operand is the result of reinterpret_cast.
+  // Main assumptions:
+  //  None
+  // Expected result:
+  //  Directly grab all corresponding fields from reinterpret_cast.
+  static void
+  visitOperandReintCast(memref::ReinterpretCastOp reintCastOp, PtrState &state,
+                        const Location loc, ConversionPatternRewriter &rewriter,
+                        const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Parse the state of AddPtrOp, insert any instruction needed to
+  // calculate strides and offsets, build PtrState for this operand, and record
+  // PtrState for knownPtrs.
+  static void rewriteAddptrOp(triton::AddPtrOp op,
+                              ConversionPatternRewriter &rewriter,
+                              llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  // Parse the state of YieldOp, insert any instruction needed to calculate
+  // strides and offsets, build PtrState for this operand, and record PtrState
+  // in knownPtrs.
+  static void
+  rewriteYieldOp(scf::YieldOp op, ConversionPatternRewriter &rewriter,
+                 const IndexMapSet &levelToBlockArgIndex, const int level,
+                 const llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  static void rewriteForOp(scf::ForOp op, ConversionPatternRewriter &rewriter,
+                           IndexMapSet &levelToBlockArgIndex, const int level,
+                           llvm::SmallDenseMap<Value, PtrState> &knownPtrs);
+
+  static Value getScalarMemRef(Value ptr, Value memRef, const Location loc,
+                               ConversionPatternRewriter &rewriter);
+};
+
+} // namespace triton
+
+} // namespace mlir
+
+#endif

--- a/include/triton/Analysis/UseAnalysis.h
+++ b/include/triton/Analysis/UseAnalysis.h
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_ANALYSIS_USEANALYSIS_H
+#define TRITON_ANALYSIS_USEANALYSIS_H
+
+#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
+#include "mlir/Pass/Pass.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<Pass> createTritonUseAnalysisPass();
+
+enum class UseType {
+  Undefined, // Initial state
+  DataUse,   // value used for tensor computation only
+  MetaUse,   // value used for metadata only
+  MixUse     // value used for both tensor computation and metadata
+};
+
+struct UseInfo : public dataflow::AbstractSparseLattice {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(UseInfo)
+  using AbstractSparseLattice::AbstractSparseLattice;
+
+  // Lattice state transfer function
+  ChangeResult meetUseType(const UseType &other) {
+    if (other == UseType::Undefined)
+      return ChangeResult::NoChange;
+
+    switch (type) {
+    case UseType::Undefined:
+      type = other;
+      return ChangeResult::Change;
+    case UseType::DataUse:
+    case UseType::MetaUse:
+      if (type == other) {
+        return ChangeResult::NoChange;
+      } else {
+        type = UseType::MixUse;
+        return ChangeResult::Change;
+      }
+    case UseType::MixUse:
+      return ChangeResult::NoChange;
+    }
+  }
+
+  ChangeResult meet(const AbstractSparseLattice &other) override {
+    auto rhs = reinterpret_cast<const UseInfo *>(&other);
+    return meetUseType(rhs->type);
+  }
+
+  void print(raw_ostream &os) const override {
+    switch (type) {
+    case UseType::DataUse:
+      os << "DataUse";
+      break;
+    case UseType::MetaUse:
+      os << "MetaUse";
+      break;
+    case UseType::MixUse:
+      os << "MixUse";
+      break;
+    default:
+      os << "Undefined";
+    }
+  }
+
+  UseType type = UseType::Undefined;
+};
+
+class UseAnalysis : public dataflow::SparseBackwardDataFlowAnalysis<UseInfo> {
+public:
+  using SparseBackwardDataFlowAnalysis::SparseBackwardDataFlowAnalysis;
+  void visitOperation(Operation *op, ArrayRef<UseInfo *> operands,
+                      ArrayRef<const UseInfo *> results) override;
+
+  void visitBranchOperand(OpOperand &operand) override { return; }
+
+  void setToExitState(UseInfo *lattice) override {
+    lattice->type = UseType::Undefined;
+  }
+
+private:
+  void propagateUse(UseInfo *lattice, const UseType &type) {
+    auto changed = lattice->meetUseType(type);
+    propagateIfChanged(lattice, changed);
+  }
+
+  void propagateResults(UseInfo *lattice, ArrayRef<const UseInfo *> results) {
+    auto changed = ChangeResult::NoChange;
+    for (auto result : results)
+      changed |= lattice->meet(*result);
+    propagateIfChanged(lattice, changed);
+  }
+};
+
+// Use SparseBackwardDataAnalysis to identify operations whose results are used
+// as data tensor operations, meta operations (address calculation,
+// broadcasting/splating constant, etc.), or both. For operations used as both
+// purposes, clone them so that the remaining pass built on
+// ConversionPatternRewriter can replace all tensor producers cleanly and simply
+// delete meta data producers.
+LogicalResult runUseAnalysis(triton::FuncOp &funcOp);
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_CONVERSION_TRITONTOAFFINE_TRITONUSEANALYSIS_H

--- a/include/triton/Conversion/CMakeLists.txt
+++ b/include/triton/Conversion/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(TritonToTritonGPU)
 add_subdirectory(TritonGPUToLLVM)
+add_subdirectory(TritonToLinalg)

--- a/include/triton/Conversion/TritonToLinalg/CMakeLists.txt
+++ b/include/triton/Conversion/TritonToLinalg/CMakeLists.txt
@@ -1,0 +1,9 @@
+#===------------------------------------------------------------------------===#
+#
+# Copyright (c) Triton Project Contributors.
+#
+#===------------------------------------------------------------------------===#
+
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls --name TritonToLinalg)
+add_public_tablegen_target(TritonToLinalgConversionPassIncGen)

--- a/include/triton/Conversion/TritonToLinalg/Passes.h
+++ b/include/triton/Conversion/TritonToLinalg/Passes.h
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_TO_LINALG_CONVERSION_PASSES_H
+#define TRITON_TO_LINALG_CONVERSION_PASSES_H
+
+#include "triton/Conversion/TritonToLinalg/TritonToLinalg.h"
+
+namespace mlir {
+namespace triton {
+
+#define GEN_PASS_REGISTRATION
+#include "triton/Conversion/TritonToLinalg/Passes.h.inc"
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/include/triton/Conversion/TritonToLinalg/Passes.td
+++ b/include/triton/Conversion/TritonToLinalg/Passes.td
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_TO_LINALG_CONVERSION_PASSES
+#define TRITON_TO_LINALG_CONVERSION_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def TritonToLinalg : Pass<"triton-to-linalg", "mlir::ModuleOp"> {
+  let summary = "Convert Triton to Linalg dialect";
+  let constructor = "triton::createTritonToLinalgPass()";
+}
+
+#endif

--- a/include/triton/Conversion/TritonToLinalg/TritonToLinalg.h
+++ b/include/triton/Conversion/TritonToLinalg/TritonToLinalg.h
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_CONVERSION_TRITONTOLINALG_TRITONTOLINALG_H
+#define TRITON_CONVERSION_TRITONTOLINALG_TRITONTOLINALG_H
+
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir {
+namespace triton {
+
+std::unique_ptr<OperationPass<ModuleOp>> createTritonToLinalgPass();
+
+void populateTritonToLinalgCanonicalizationPatterns(
+    RewritePatternSet &patterns);
+
+void populateTritonToLinalgConversionPatterns(TypeConverter &typeConverter,
+                                              RewritePatternSet &patterns,
+                                              unsigned int launchGridRank);
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_CONVERSION_TRITONTOLINALG_TRITONTOLINALG_H

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -4,6 +4,10 @@ add_mlir_library(TritonAnalysis
   Membar.cpp
   Alias.cpp
   Utility.cpp
+  UseAnalysis.cpp
+  MaskAnalysis.cpp
+  PtrAnalysis.cpp
+  OpFoldResultUtils.cpp
 
   DEPENDS
   TritonTableGen

--- a/lib/Analysis/MaskAnalysis.cpp
+++ b/lib/Analysis/MaskAnalysis.cpp
@@ -1,0 +1,329 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/MaskAnalysis.h"
+#include "triton/Analysis/OpFoldResultUtils.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+
+namespace triton {
+
+LogicalResult MaskState::parse(Value operand, const Location loc,
+                               ConversionPatternRewriter &rewriter) {
+  if (auto op = operand.getDefiningOp<arith::ConstantOp>()) {
+    return this->parseConstant(op, loc, rewriter);
+  } else if (operand.getType().isa<IntegerType>()) {
+    return this->parseIntScalar(operand, loc, rewriter);
+  } else if (auto op = operand.getDefiningOp<arith::AddIOp>()) {
+    return this->parseAdd(op, loc, rewriter);
+  } else if (auto op = operand.getDefiningOp<arith::AndIOp>()) {
+    return this->parseAnd(op, loc, rewriter);
+  } else if (auto op = operand.getDefiningOp<arith::CmpIOp>()) {
+    return this->parseCmp(op, loc, rewriter);
+  } else if (auto op = operand.getDefiningOp<triton::MakeRangeOp>()) {
+    return this->parseMakeRange(op, loc, rewriter);
+  } else if (auto op = operand.getDefiningOp<triton::BroadcastOp>()) {
+    return this->parseBroadcast(op, loc, rewriter);
+  } else if (auto op = operand.getDefiningOp<triton::SplatOp>()) {
+    return this->parseSplat(op, loc, rewriter);
+  } else if (auto op = operand.getDefiningOp<triton::ExpandDimsOp>()) {
+    return this->parseExpandDims(op, loc, rewriter);
+  } else {
+    return failure();
+  }
+}
+
+tensor::ExtractSliceOp
+MaskState::getExtractSlice(Value source, const Location loc,
+                           ConversionPatternRewriter &rewriter) const {
+  auto sourceType = source.getType().cast<RankedTensorType>();
+  SmallVector<OpFoldResult> offsets(getRank(), rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> strides(getRank(), rewriter.getIndexAttr(1));
+
+  auto dstType = tensor::ExtractSliceOp::inferResultType(sourceType, offsets,
+                                                         dims, strides);
+
+  return rewriter.create<tensor::ExtractSliceOp>(loc, dstType, source, offsets,
+                                                 dims, strides);
+}
+
+memref::SubViewOp
+MaskState::getSubview(Value source, const Location loc,
+                      ConversionPatternRewriter &rewriter) const {
+  auto sourceType = source.getType().cast<MemRefType>();
+  SmallVector<OpFoldResult> offsets(getRank(), rewriter.getIndexAttr(0));
+  SmallVector<OpFoldResult> strides(getRank(), rewriter.getIndexAttr(1));
+  auto dstType =
+      memref::SubViewOp::inferResultType(sourceType, offsets, dims, strides);
+
+  return rewriter.create<memref::SubViewOp>(loc, dstType.cast<MemRefType>(),
+                                            source, offsets, dims, strides);
+}
+
+LogicalResult MaskState::addStateScalar(const MaskState &state,
+                                        const OpFoldResult scalar, Location loc,
+                                        ConversionPatternRewriter &rewriter) {
+  start = addOFRs(state.start, scalar, loc, rewriter);
+  end = addOFRs(state.end, scalar, loc, rewriter);
+  dims = state.dims;
+  return success();
+}
+
+LogicalResult MaskState::addStates(const MaskState &lhsState,
+                                   const MaskState &rhsState, Location loc,
+                                   ConversionPatternRewriter &rewriter) {
+  if (lhsState.scalar && rhsState.scalar) {
+    InFlightDiagnostic diag =
+        emitError(loc) << "Unexpected case where both lhs and rhs are scalars";
+    return failure();
+  }
+
+  if (!lhsState.scalar && !rhsState.scalar) {
+    InFlightDiagnostic diag =
+        emitError(loc)
+        << "Unsupported scenario where neither lhs nor rhs is a scalar";
+    return failure();
+  }
+
+  if (lhsState.scalar)
+    return addStateScalar(rhsState, lhsState.scalar, loc, rewriter);
+  else
+    return addStateScalar(lhsState, rhsState.scalar, loc, rewriter);
+}
+
+LogicalResult MaskState::minStates(const MaskState &lhsState,
+                                   const MaskState &rhsState, Location loc,
+                                   ConversionPatternRewriter &rewriter) {
+  if (lhsState.getRank() != rhsState.getRank()) {
+    InFlightDiagnostic diag =
+        emitError(loc)
+        << "Unexpected case where lhs and rhs have different ranks";
+    return failure();
+  }
+
+  for (uint32_t i = 0; i < lhsState.getRank(); i++) {
+    auto lhsDim = lhsState.dims[i];
+    auto rhsDim = rhsState.dims[i];
+    dims.push_back(minOFRs(lhsDim, rhsDim, loc, rewriter));
+  }
+  return success();
+}
+
+LogicalResult MaskState::parseConstant(arith::ConstantOp constOp,
+                                       const Location loc,
+                                       ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+
+  if (isa<DenseElementsAttr>(constOp.getValue())) {
+    auto attr = cast<DenseElementsAttr>(constOp.getValue());
+    auto elementType = attr.getElementType();
+    assert(attr.isSplat() && elementType.isa<IntegerType>() &&
+           "All elements must share a single integer constant value");
+    auto values = attr.getValues<IntegerAttr>();
+    auto value = values[0].getValue();
+    auto constAttr = rewriter.getIndexAttr(value.getSExtValue());
+    auto op = rewriter.create<arith::ConstantOp>(loc, constAttr,
+                                                 rewriter.getIndexType());
+    this->scalar = op.getValue();
+  } else {
+    auto value = constOp.getValue().cast<IntegerAttr>().getInt();
+    this->scalar = rewriter.getIndexAttr(value);
+  }
+
+  return success();
+}
+
+LogicalResult MaskState::parseIntScalar(Value scalar, const Location loc,
+                                        ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+  auto castOp =
+      rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(), scalar);
+  this->scalar = castOp.getResult();
+  return success();
+}
+
+LogicalResult MaskState::parseAdd(arith::AddIOp addOp, const Location loc,
+                                  ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+
+  MaskState lhsState;
+  if (failed(lhsState.parse(addOp.getLhs(), loc, rewriter)))
+    return failure();
+
+  MaskState rhsState;
+  if (failed(rhsState.parse(addOp.getRhs(), loc, rewriter)))
+    return failure();
+
+  return this->addStates(lhsState, rhsState, loc, rewriter);
+}
+
+LogicalResult MaskState::parseAnd(arith::AndIOp andOp, const Location loc,
+                                  ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+
+  MaskState lhsState;
+  if (failed(lhsState.parse(andOp.getLhs(), loc, rewriter)) ||
+      !lhsState.isMask())
+    return failure();
+
+  MaskState rhsState;
+  if (failed(rhsState.parse(andOp.getRhs(), loc, rewriter)) ||
+      !rhsState.isMask())
+    return failure();
+
+  return this->minStates(lhsState, rhsState, loc, rewriter);
+}
+
+LogicalResult MaskState::parseCmp(arith::CmpIOp cmpOp, const Location loc,
+                                  ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+
+  if (cmpOp.getPredicate() != arith::CmpIPredicate::slt) {
+    InFlightDiagnostic diag = emitError(loc) << "Unsupported cmpi predicate";
+    return failure();
+  }
+
+  MaskState lhsState;
+  if (failed(lhsState.parse(cmpOp.getLhs(), loc, rewriter)))
+    return failure();
+
+  MaskState rhsState;
+  if (failed(rhsState.parse(cmpOp.getRhs(), loc, rewriter)))
+    return failure();
+
+  assert((!lhsState.scalar && rhsState.scalar) && "Unsupported cmpi scenario");
+
+  int32_t cmpDim = -1;
+  for (int32_t i = 0; i < lhsState.getRank(); i++) {
+    auto dimIntAttr = getIntAttr(lhsState.dims[i]);
+    if (!dimIntAttr || dimIntAttr.value() != 1) {
+      if (cmpDim != -1) {
+        InFlightDiagnostic diag = emitError(loc)
+                                  << "Unsupported cmpi with more than one "
+                                     "dimension with size larger than 1";
+        return failure();
+      }
+      cmpDim = i;
+    }
+  }
+  assert(cmpDim != -1 &&
+         "Unexpected case where no dimension has size larger than 1");
+
+  auto newEnd = minOFRs(lhsState.end, rhsState.scalar, loc, rewriter);
+  auto newDim = subOFRs(newEnd, lhsState.start, loc, rewriter);
+
+  for (int32_t i = 0; i < lhsState.getRank(); i++) {
+    if (i == cmpDim)
+      this->dims.push_back(newDim);
+    else
+      this->dims.push_back(lhsState.dims[i]);
+  }
+
+  return success();
+}
+
+LogicalResult MaskState::parseMakeRange(triton::MakeRangeOp rangeOp,
+                                        const Location loc,
+                                        ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+
+  auto shape = rangeOp.getType().cast<ShapedType>().getShape();
+  auto start = rangeOp.getStart();
+  auto end = rangeOp.getEnd();
+  auto stride = (end - start + shape[0] - 1) / shape[0];
+
+  if (stride != 1) {
+    InFlightDiagnostic diag =
+        emitError(loc)
+        << "stride must be 1 for make_range whose result is used "
+           "as load or store masks";
+    return failure();
+  }
+
+  this->start = rewriter.getIndexAttr(start);
+  this->end = rewriter.getIndexAttr(end);
+  this->dims.push_back(rewriter.getIndexAttr(shape[0]));
+
+  return success();
+}
+
+LogicalResult MaskState::parseBroadcast(triton::BroadcastOp broadcastOp,
+                                        const Location loc,
+                                        ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+
+  auto src = broadcastOp.getSrc();
+  auto dst = broadcastOp.getResult();
+  assert(src.getType().isa<ShapedType>() &&
+         "input to tt.broadcast should be a tensor");
+
+  auto srcShape = src.getType().cast<ShapedType>().getShape();
+  auto dstShape = dst.getType().cast<ShapedType>().getShape();
+  assert(srcShape.size() == dstShape.size() &&
+         "rank of source and destination should match");
+
+  if (failed(parse(src, loc, rewriter)))
+    return failure();
+
+  for (size_t i = 0; i < srcShape.size(); i++) {
+    if (srcShape[i] == dstShape[i])
+      continue;
+    else if (srcShape[i] < dstShape[i])
+      this->dims[i] = rewriter.getIndexAttr(dstShape[i]);
+    else
+      llvm_unreachable("unexpected dimensions used in broadcast");
+  }
+
+  return success();
+}
+
+LogicalResult MaskState::parseSplat(triton::SplatOp splatOp, const Location loc,
+                                    ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+
+  auto src = splatOp.getSrc();
+  auto dst = splatOp.getResult();
+  auto dstShape = dst.getType().cast<ShapedType>().getShape();
+
+  if (!src.getType().isa<IntegerType>()) {
+    InFlightDiagnostic diag =
+        emitError(loc)
+        << "splat source must be an integer scalar for load/store masks";
+    return failure();
+  }
+
+  if (failed(this->parse(src, loc, rewriter)))
+    return failure();
+
+  for (auto s : dstShape)
+    this->dims.push_back(rewriter.getIndexAttr(s));
+
+  return success();
+}
+
+LogicalResult MaskState::parseExpandDims(triton::ExpandDimsOp expandDimsOp,
+                                         const Location loc,
+                                         ConversionPatternRewriter &rewriter) {
+  assert(this->isEmpty());
+
+  if (failed(this->parse(expandDimsOp.getSrc(), loc, rewriter)))
+    return failure();
+
+  auto dstShape =
+      expandDimsOp.getResult().getType().cast<ShapedType>().getShape();
+  auto axis = expandDimsOp.getAxis();
+  assert(dstShape[axis] == 1 &&
+         "expect changed dimension to be 1 in expand_dims");
+  this->dims.insert(this->dims.begin() + axis, rewriter.getIndexAttr(1));
+
+  return success();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/lib/Analysis/OpFoldResultUtils.cpp
+++ b/lib/Analysis/OpFoldResultUtils.cpp
@@ -1,0 +1,179 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/OpFoldResultUtils.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+
+// Return integer if ofr is an IntegerAttr. Note that this function differs
+// from getConstantIntValue, which returns an integer if ofr is the constant
+// result of an operation too.
+std::optional<int64_t> getIntAttr(const OpFoldResult ofr) {
+  if (ofr.is<Attribute>() && ofr.get<Attribute>().isa<IntegerAttr>())
+    return ofr.get<Attribute>().dyn_cast<IntegerAttr>().getInt();
+
+  return std::nullopt;
+}
+
+// Process addition of two OFRs. If both OFRs are Integer Attributes, result
+// is an Integer Attribute. Otherwise, insert the arith.addi instruction if
+// needed and use its result Value.
+OpFoldResult addOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
+                     const Location loc, ConversionPatternRewriter &rewriter) {
+  auto lhsIntAttr = getIntAttr(lhs);
+  auto rhsIntAttr = getIntAttr(rhs);
+
+  // shortcut for special cases
+  if (!lhsIntAttr && rhsIntAttr && rhsIntAttr.value() == 0)
+    return lhs;
+  if (!rhsIntAttr && lhsIntAttr && lhsIntAttr.value() == 0)
+    return rhs;
+
+  // both lhs and rhs are constants, return result directly
+  if (lhsIntAttr && rhsIntAttr)
+    return rewriter.getIndexAttr(lhsIntAttr.value() + rhsIntAttr.value());
+
+  // otherwise, need to create instructions to calculate new attribute value
+  auto lhsValue = lhs.dyn_cast<Value>();
+  if (lhsIntAttr) {
+    auto lhsOp = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(lhsIntAttr.value()));
+    lhsValue = lhsOp.getResult();
+  } else {
+    assert(lhsValue.getType().isa<IndexType>());
+  }
+
+  auto rhsValue = rhs.dyn_cast<Value>();
+  if (rhsIntAttr) {
+    auto rhsOp = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(rhsIntAttr.value()));
+    rhsValue = rhsOp.getResult();
+  } else {
+    assert(lhsValue.getType().isa<IndexType>());
+  }
+
+  return rewriter.create<arith::AddIOp>(loc, lhsValue, rhsValue).getResult();
+}
+
+// Produce result = lhs - rhs. If both OFRs are Integer Attributes, result
+// is an Integer Attribute. Otherwise, insert the arith.addi instruction if
+// needed and use its result Value.
+OpFoldResult subOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
+                     const Location loc, ConversionPatternRewriter &rewriter) {
+  auto lhsIntAttr = getIntAttr(lhs);
+  auto rhsIntAttr = getIntAttr(rhs);
+
+  // shortcut for special cases
+  if (!lhsIntAttr && rhsIntAttr && rhsIntAttr.value() == 0)
+    return lhs;
+
+  // both lhs and rhs are constants, return result directly
+  if (lhsIntAttr && rhsIntAttr)
+    return rewriter.getIndexAttr(lhsIntAttr.value() - rhsIntAttr.value());
+
+  // otherwise, need to create instructions to calculate new attribute value
+  auto lhsValue = lhs.dyn_cast<Value>();
+  if (lhsIntAttr) {
+    auto lhsOp = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(lhsIntAttr.value()));
+    lhsValue = lhsOp.getResult();
+  }
+
+  auto rhsValue = rhs.dyn_cast<Value>();
+  if (rhsIntAttr) {
+    auto rhsOp = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(rhsIntAttr.value()));
+    rhsValue = rhsOp.getResult();
+  }
+
+  auto sumOp = rewriter.create<arith::SubIOp>(loc, lhsValue, rhsValue);
+  return sumOp.getResult();
+}
+
+// Process multiplication of two OFRs. If both OFRs are Integer Attributes,
+// result is an Integer Attribtue. Otherwise, insert the arith.muli
+// instruction if needed and use its result Value.
+OpFoldResult mulOFRValue(const OpFoldResult lhs, const Value rhs,
+                         const Location loc,
+                         ConversionPatternRewriter &rewriter) {
+  auto lhsIntAttr = getIntAttr(lhs);
+
+  auto rhsIsConst = false;
+  // if rhs is not a const, use max value since min is used to represent
+  // dynamic size or stride
+  auto rhsConstValue = std::numeric_limits<int64_t>::max();
+  auto rhsOp = rhs.getDefiningOp<arith::ConstantOp>();
+  if (rhsOp) {
+    rhsIsConst = true;
+    rhsConstValue = rhsOp.getValue().cast<IntegerAttr>().getInt();
+  }
+
+  // shortcuts for special cases
+  if (lhsIntAttr) {
+    if (lhsIntAttr.value() == 0)
+      return lhs;
+    if (lhsIntAttr.value() == 1)
+      return rhs;
+  }
+  if (rhsIsConst) {
+    if (rhsConstValue == 0)
+      return rhsOp.getResult();
+    if (rhsConstValue == 1)
+      return lhs;
+  }
+
+  // 0. both lhs and rhs are constants
+  if (lhsIntAttr && rhsIsConst)
+    return rewriter.getIndexAttr(lhsIntAttr.value() * rhsConstValue);
+
+  // 1. if lhs is constant but rhs is not
+  if (lhsIntAttr && !rhsIsConst) {
+    auto lhsConstOp = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(lhsIntAttr.value()));
+    auto mulOp =
+        rewriter.create<arith::MulIOp>(loc, lhsConstOp.getResult(), rhs);
+    return mulOp.getResult();
+  }
+
+  // 2. if lhs is not constant
+  assert(!lhsIntAttr);
+  auto mulOp = rewriter.create<arith::MulIOp>(loc, lhs.get<Value>(), rhs);
+  return mulOp.getResult();
+}
+
+OpFoldResult minOFRs(const OpFoldResult lhs, const OpFoldResult rhs,
+                     const Location loc, ConversionPatternRewriter &rewriter) {
+  auto lhsIntAttr = getIntAttr(lhs);
+  auto rhsIntAttr = getIntAttr(rhs);
+
+  // both lhs and rhs are constants, return result directly
+  if (lhsIntAttr && rhsIntAttr)
+    return rewriter.getIndexAttr(
+        std::min(lhsIntAttr.value(), rhsIntAttr.value()));
+
+  // otherwise, need to create instructions to calculate new attribute value
+  auto lhsValue = lhs.dyn_cast<Value>();
+  if (lhsIntAttr) {
+    auto lhsOp = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(lhsIntAttr.value()));
+    lhsValue = lhsOp.getResult();
+  }
+
+  auto rhsValue = rhs.dyn_cast<Value>();
+  if (rhsIntAttr) {
+    auto rhsOp = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getIndexAttr(rhsIntAttr.value()));
+    rhsValue = rhsOp.getResult();
+  }
+
+  auto minOp = rewriter.create<arith::MinSIOp>(loc, lhsValue, rhsValue);
+  return minOp.getResult();
+}
+
+} // namespace mlir

--- a/lib/Analysis/PtrAnalysis.cpp
+++ b/lib/Analysis/PtrAnalysis.cpp
@@ -1,0 +1,837 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/PtrAnalysis.h"
+#include "triton/Analysis/OpFoldResultUtils.h"
+
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "llvm/Support/Debug.h"
+#include <set>
+
+#define DEBUG_TYPE "triton-ptr-analysis"
+
+namespace mlir {
+
+namespace triton {
+
+int64_t PtrState::getRank() const {
+  assert(offsets.size() == sizes.size() && offsets.size() == strides.size());
+  return offsets.size();
+}
+
+bool PtrState::isEmpty() const {
+  return (getRank() == 0 && !source && !scalar);
+}
+
+void PtrState::addState(const PtrState &lhsState, const PtrState &rhsState,
+                        Location loc, ConversionPatternRewriter &rewriter) {
+  assert(isEmpty() && lhsState.getRank() == rhsState.getRank());
+
+  // at most one of lhs and rhs should have valid source, since otherwise we
+  // will be losing information
+  assert(!(lhsState.source && rhsState.source));
+  source = lhsState.source ? lhsState.source : rhsState.source;
+
+  if (lhsState.scalar && rhsState.scalar) {
+    auto addOp =
+        rewriter.create<arith::AddIOp>(loc, lhsState.scalar, rhsState.scalar);
+    scalar = addOp.getResult();
+  } else if (lhsState.getRank() == 0) { // both lhs and rhs are scalars
+    scalar = lhsState.scalar ? lhsState.scalar : rhsState.scalar;
+  }
+
+  for (uint64_t i = 0; i < lhsState.sizes.size(); i++) {
+    auto newOffset =
+        addOFRs(lhsState.offsets[i], rhsState.offsets[i], loc, rewriter);
+    offsets.push_back(newOffset);
+
+    auto newStride =
+        addOFRs(lhsState.strides[i], rhsState.strides[i], loc, rewriter);
+    strides.push_back(newStride);
+
+    sizes.push_back(lhsState.sizes[i]);
+  }
+}
+
+void PtrState::mulState(const PtrState &lhsState, const PtrState &rhsState,
+                        const Location loc,
+                        ConversionPatternRewriter &rewriter) {
+  bool rhsScalar = true;
+  assert(isEmpty() && lhsState.getRank() == rhsState.getRank());
+
+  // neither lhs nor rhs should have source, since multiplying base pointer
+  // does not make sense
+  assert(!(lhsState.source && rhsState.source));
+
+  source = lhsState.source ? lhsState.source : rhsState.source;
+
+  assert((lhsState.scalar || rhsState.scalar) &&
+         !(lhsState.scalar && rhsState.scalar) &&
+         "currently does not support both tensors are effectively non-scalar");
+
+  if (!rhsState.scalar && lhsState.scalar)
+    rhsScalar = false;
+
+  for (uint64_t i = 0; i < lhsState.sizes.size(); i++) {
+    OpFoldResult newOffset;
+    OpFoldResult newStride;
+    if (rhsScalar) {
+      newOffset =
+          mulOFRValue(lhsState.offsets[i], rhsState.scalar, loc, rewriter);
+      newStride =
+          mulOFRValue(lhsState.strides[i], rhsState.scalar, loc, rewriter);
+    } else {
+      newOffset =
+          mulOFRValue(rhsState.offsets[i], lhsState.scalar, loc, rewriter);
+      newStride =
+          mulOFRValue(rhsState.strides[i], lhsState.scalar, loc, rewriter);
+    }
+    offsets.push_back(newOffset);
+    strides.push_back(newStride);
+    sizes.push_back(lhsState.sizes[i]);
+  }
+}
+
+memref::ReinterpretCastOp
+PtrState::createCastOp(ArrayRef<int64_t> resultShape, const Location loc,
+                       ConversionPatternRewriter &rewriter) {
+  // Accumulate final offset
+  OpFoldResult targetOffset = rewriter.getIndexAttr(0);
+  for (auto o : offsets)
+    targetOffset = addOFRs(targetOffset, o, loc, rewriter);
+
+  // Create result MemRefType
+  SmallVector<int64_t> staticOffset;
+  SmallVector<Value> dynamicOffset;
+  SmallVector<int64_t> staticStrides;
+  SmallVector<Value> dynamicStrides;
+  dispatchIndexOpFoldResult(targetOffset, dynamicOffset, staticOffset);
+  dispatchIndexOpFoldResults(strides, dynamicStrides, staticStrides);
+
+  auto elementType = source.getType().cast<BaseMemRefType>().getElementType();
+  auto layout = StridedLayoutAttr::get(source.getContext(), staticOffset[0],
+                                       staticStrides);
+  auto resultType = MemRefType::get(resultShape, elementType, layout);
+
+  // Create reinterpret cast
+  return rewriter.create<memref::ReinterpretCastOp>(
+      loc, resultType, source, targetOffset, sizes, strides);
+}
+
+void PtrAnalysis::visitOperandAdd(
+    arith::AddIOp addOp, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  PtrState lhsState;
+  visitOperand(addOp.getLhs(), lhsState, loc, rewriter, knownPtrs);
+
+  PtrState rhsState;
+  visitOperand(addOp.getRhs(), rhsState, loc, rewriter, knownPtrs);
+
+  state.addState(lhsState, rhsState, loc, rewriter);
+}
+
+void PtrAnalysis::visitOperandMul(
+    arith::MulIOp mulOp, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  PtrState lhsState;
+  visitOperand(mulOp.getLhs(), lhsState, loc, rewriter, knownPtrs);
+
+  PtrState rhsState;
+  visitOperand(mulOp.getRhs(), rhsState, loc, rewriter, knownPtrs);
+
+  state.mulState(lhsState, rhsState, loc, rewriter);
+}
+
+void PtrAnalysis::visitOperandMakeRange(
+    triton::MakeRangeOp rangeOp, PtrState &state, Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  assert(state.isEmpty());
+
+  auto shape = rangeOp.getType().cast<ShapedType>().getShape();
+
+  auto start = rangeOp.getStart();
+  auto end = rangeOp.getEnd();
+  auto stride = (end - start + shape[0] - 1) / shape[0];
+
+  state.offsets.push_back(rewriter.getIndexAttr(start));
+  state.sizes.push_back(rewriter.getIndexAttr(shape[0]));
+  state.strides.push_back(rewriter.getIndexAttr(stride));
+}
+
+void PtrAnalysis::visitOperandExpandDims(
+    triton::ExpandDimsOp expandDimsOp, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  assert(state.isEmpty());
+
+  visitOperand(expandDimsOp.getSrc(), state, loc, rewriter, knownPtrs);
+
+  auto dstShape =
+      expandDimsOp.getResult().getType().cast<ShapedType>().getShape();
+  auto axis = expandDimsOp.getAxis();
+
+  assert(dstShape[axis] == 1 &&
+         "expect changed dimension to be 1 in expand_dims");
+
+  // insert dimension info
+  state.offsets.insert(state.offsets.begin() + axis, rewriter.getIndexAttr(0));
+  state.sizes.insert(state.sizes.begin() + axis, rewriter.getIndexAttr(1));
+  state.strides.insert(state.strides.begin() + axis, rewriter.getIndexAttr(0));
+}
+
+void PtrAnalysis::visitOperandBroadcast(
+    triton::BroadcastOp broadcastOp, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  assert(state.isEmpty());
+
+  auto src = broadcastOp.getSrc();
+  auto dst = broadcastOp.getResult();
+  assert(src.getType().isa<ShapedType>() &&
+         "input to tt.broadcast should be a tensor");
+
+  auto srcShape = src.getType().cast<ShapedType>().getShape();
+  auto dstShape = dst.getType().cast<ShapedType>().getShape();
+  assert(srcShape.size() == dstShape.size() &&
+         "rank of source and destination should match");
+
+  visitOperand(src, state, loc, rewriter, knownPtrs);
+
+  for (size_t i = 0; i < srcShape.size(); i++) {
+    if (srcShape[i] == dstShape[i])
+      continue;
+    else if (srcShape[i] < dstShape[i])
+      state.sizes[i] = rewriter.getIndexAttr(dstShape[i]);
+    else
+      llvm_unreachable("unexpected dimensions used in broadcast");
+  }
+
+  return;
+}
+
+void PtrAnalysis::visitOperandSplat(
+    triton::SplatOp splatOp, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  assert(state.isEmpty());
+
+  auto src = splatOp.getSrc();
+  auto dst = splatOp.getResult();
+  auto dstShape = dst.getType().cast<ShapedType>().getShape();
+
+  visitOperand(src, state, loc, rewriter, knownPtrs);
+
+  if (src.getType().isa<IntegerType>() ||
+      src.getType().isa<triton::PointerType>()) {
+    for (auto s : dstShape) {
+      state.offsets.push_back(rewriter.getIndexAttr(0));
+      state.sizes.push_back(rewriter.getIndexAttr(s));
+      state.strides.push_back(rewriter.getIndexAttr(0));
+    }
+  } else {
+    // src is a memref that represent a scalar pointer; it should have one
+    // dimension of size 1. This happens inside a for loop that originally has
+    // an init arg that is a tensor of pointers; this arg would have been
+    // replaced by rewriteForOp.
+    auto srcType = src.getType().cast<MemRefType>();
+    assert(srcType.getRank() == 1 && state.getRank() == 1 &&
+           "splat MemRef source should have rank 1");
+    assert(srcType.getShape()[0] == 1 &&
+           getIntAttr(state.sizes[0]).value() == 1 &&
+           "splat MemRef source should have size 1");
+
+    // Stride[0] will have value of 1 set in visitOperandAddPtr. This value will
+    // be represented by a constOp. Clear this value.
+    state.strides[0] = rewriter.getIndexAttr(0);
+
+    for (auto [i, s] : llvm::enumerate(dstShape)) {
+      if (i == 0) {
+        state.sizes[i] = rewriter.getIndexAttr(s);
+        continue;
+      }
+      state.offsets.push_back(rewriter.getIndexAttr(0));
+      state.sizes.push_back(rewriter.getIndexAttr(s));
+      state.strides.push_back(rewriter.getIndexAttr(0));
+    }
+  }
+
+  // If we splat a integer value, scalar should become the offset of the outer
+  // most dimension
+  if (state.scalar)
+    state.offsets[0] = state.scalar;
+
+  return;
+}
+
+void PtrAnalysis::visitOperandAddptr(
+    triton::AddPtrOp addptrOp, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  assert(state.isEmpty());
+
+  PtrState ptrState;
+  visitOperand(addptrOp.getPtr(), ptrState, addptrOp.getLoc(), rewriter,
+               knownPtrs);
+
+  PtrState offsetState;
+  visitOperand(addptrOp.getOffset(), offsetState, addptrOp.getLoc(), rewriter,
+               knownPtrs);
+
+  assert(ptrState.source && "ptr field should provide source / base pointer");
+
+  // Handle the special case when we are in a for loop, ptr is originally a
+  // scalar pointer but replaced with a memref. In this case, ptrState will have
+  // rank 1 and offsetState will have rank 0.
+  // TODO:
+  //  Passing a block argument pointer directly into a for loop not supported
+  if (ptrState.getRank() == 1 && offsetState.getRank() == 0) {
+    offsetState.sizes.push_back(rewriter.getIndexAttr(1));
+    offsetState.offsets.push_back(offsetState.scalar);
+    offsetState.strides.push_back(rewriter.getIndexAttr(0));
+  }
+
+  assert(ptrState.getRank() == offsetState.getRank() &&
+         "ptr and offset field should have the same rank");
+
+  state.addState(ptrState, offsetState, addptrOp.getLoc(), rewriter);
+}
+
+void PtrAnalysis::visitOperandReintCast(
+    memref::ReinterpretCastOp reintCastOp, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  assert(state.isEmpty());
+
+  state.offsets = reintCastOp.getMixedOffsets();
+  state.sizes = reintCastOp.getMixedSizes();
+  state.strides = reintCastOp.getMixedStrides();
+  state.source = reintCastOp.getSource();
+
+  // getMixedOffsets produces staticOffsets (which is the result of collapsing
+  // multiple dimensions). Populate the rest of the dimensions with zeroes.
+  assert(state.offsets.size() == 1);
+  for (size_t i = 1; i < state.sizes.size(); i++) {
+    state.offsets.push_back(rewriter.getIndexAttr(0));
+  }
+}
+
+void PtrAnalysis::visitOperand(
+    Value operand, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+
+  if (knownPtrs.find(operand) != knownPtrs.end()) {
+    state = knownPtrs.lookup(operand);
+    return;
+  }
+
+  if (operand.getType().isa<IntegerType>()) {
+    auto castOp = rewriter.create<arith::IndexCastOp>(
+        loc, rewriter.getIndexType(), operand);
+    state.scalar = castOp.getResult();
+    return;
+  }
+
+  if (operand.getType().isa<triton::PointerType>()) {
+    auto remappedPtr = rewriter.getRemappedValue(operand);
+    assert(remappedPtr);
+
+    // A scalar pointer can either be produced by AddPtrOp or a block argument
+    if (auto op = operand.getDefiningOp()) {
+      assert(operand.getDefiningOp<triton::AddPtrOp>() &&
+             "Assume only addptr can produce a scalar pointer");
+      visitOperandAddptr(cast<triton::AddPtrOp>(op), state, loc, rewriter,
+                         knownPtrs);
+    } else {
+      state.source = remappedPtr;
+    }
+    return;
+  }
+
+  if (auto op = operand.getDefiningOp<arith::AddIOp>()) {
+    visitOperandAdd(op, state, loc, rewriter, knownPtrs);
+  } else if (auto op = operand.getDefiningOp<arith::MulIOp>()) {
+    visitOperandMul(op, state, loc, rewriter, knownPtrs);
+  } else if (auto op = operand.getDefiningOp<triton::MakeRangeOp>()) {
+    visitOperandMakeRange(op, state, loc, rewriter, knownPtrs);
+  } else if (auto op = operand.getDefiningOp<triton::BroadcastOp>()) {
+    visitOperandBroadcast(op, state, loc, rewriter, knownPtrs);
+  } else if (auto op = operand.getDefiningOp<triton::SplatOp>()) {
+    visitOperandSplat(op, state, loc, rewriter, knownPtrs);
+  } else if (auto op = operand.getDefiningOp<triton::ExpandDimsOp>()) {
+    visitOperandExpandDims(op, state, loc, rewriter, knownPtrs);
+  } else if (auto op = operand.getDefiningOp<triton::AddPtrOp>()) {
+    visitOperandAddptr(op, state, loc, rewriter, knownPtrs);
+  } else if (auto op = operand.getDefiningOp<arith::ConstantOp>()) {
+    visitOperandConstSplat(op, state, loc, rewriter, knownPtrs);
+  } else {
+    operand.getDefiningOp()->dump();
+    llvm_unreachable("encountered addptr operand produced by an "
+                     "unsupported operation");
+  }
+}
+
+void PtrAnalysis::visitOperandConstSplat(
+    arith::ConstantOp op, PtrState &state, const Location loc,
+    ConversionPatternRewriter &rewriter,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  assert(state.isEmpty());
+  // this condition is to handle cases where tt.broadcast and tt.splat are
+  // folded
+  auto attr = cast<DenseElementsAttr>(op.getValue());
+  auto elementType = attr.getElementType();
+  assert(attr.isSplat() && elementType.isa<IntegerType>());
+  auto values = attr.getValues<IntegerAttr>();
+  auto value = values[0].getValue();
+  auto constAttr = rewriter.getIndexAttr(value.getSExtValue());
+  auto constOp = rewriter.create<arith::ConstantOp>(loc, constAttr,
+                                                    rewriter.getIndexType());
+
+  state.scalar = constOp;
+
+  auto resultType = cast<ShapedType>(op.getResult().getType());
+  for (auto i = 0; i < resultType.getShape().size(); i++) {
+    if (i == 0) {
+      state.offsets.push_back(constOp.getResult());
+    } else {
+      state.offsets.push_back(rewriter.getIndexAttr(0));
+    }
+
+    state.sizes.push_back(rewriter.getIndexAttr(resultType.getShape()[i]));
+    state.strides.push_back(rewriter.getIndexAttr(0));
+  }
+}
+
+void PtrAnalysis::rewriteAddptrOp(
+    triton::AddPtrOp op, ConversionPatternRewriter &rewriter,
+    llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  // any inserted instruction should be before this addptr
+  auto origIp = rewriter.saveInsertionPoint();
+  rewriter.setInsertionPoint(op);
+
+  PtrState state;
+  visitOperandAddptr(op, state, op.getLoc(), rewriter, knownPtrs);
+
+  // If the result is a scalar pointer, visitOperandAddptr will not populate
+  // sizes, strides, and offsets. We need to do it here.
+  if (state.sizes.size() == 0) {
+    state.sizes.push_back(rewriter.getIndexAttr(1));
+    state.strides.push_back(rewriter.getIndexAttr(0));
+    state.offsets.push_back(state.scalar);
+  }
+
+  SmallVector<int64_t> scalarShape(1, 1);
+  ArrayRef<int64_t> resultShape;
+  if (auto shapedType = op.getResult().getType().dyn_cast<ShapedType>()) {
+    resultShape = shapedType.getShape();
+  } else {
+    // scalar pointer, should produce a one dimensional memref
+    resultShape = scalarShape;
+    assert(state.getRank() == 1);
+  }
+
+  // If there are dimensions with size 1 and stride 0, replace stride 0 with 1
+  // so inferResultType below works as expected.
+  for (size_t i = 0; i < state.sizes.size(); i++) {
+    auto strideIntAttr = getIntAttr(state.strides[i]);
+    auto sizeIntAttr = getIntAttr(state.sizes[i]);
+
+    if (!strideIntAttr || strideIntAttr != 0)
+      continue;
+
+    if (sizeIntAttr && sizeIntAttr.value() == 1)
+      state.strides[i] = rewriter.getIndexAttr(1);
+  }
+
+  auto castOp = state.createCastOp(resultShape, op.getLoc(), rewriter);
+  LLVM_DEBUG({
+    llvm::dbgs() << "cast MemRefType:\n";
+    castOp.getOperation()->print(llvm::dbgs(),
+                                 OpPrintingFlags().printGenericOpForm());
+    llvm::dbgs() << "\n";
+  });
+
+  state.source = castOp.getResult();
+  rewriter.replaceOp(op, castOp.getResult());
+
+  knownPtrs[op.getResult()] = state;
+
+  rewriter.restoreInsertionPoint(origIp);
+}
+
+void PtrAnalysis::rewriteYieldOp(
+    scf::YieldOp op, ConversionPatternRewriter &rewriter,
+    const IndexMapSet &levelToBlockArgIndex, const int level,
+    const llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  // any inserted instruction should be before this yield
+  OpBuilder::InsertionGuard insertionGuard{rewriter};
+  rewriter.setInsertionPoint(op);
+
+  auto adaptor = scf::YieldOp::Adaptor(op);
+
+  SmallVector<PtrState> initArgState;
+  SmallVector<Value> operands(adaptor.getOperands());
+
+  // For each of the init arg that we added additional Values in for loop, we
+  // need to add corresponding Values as yield operands. The loop below gathers
+  // PtrState for those values.
+  for (auto [i, v] : llvm::enumerate(adaptor.getOperands())) {
+    if (auto mappedV = rewriter.getRemappedValue(v)) {
+      // If this value is a tensor of pointers produced by AddPtrOp,
+      // TritonTypeConverter should have converted to MemRefType without layout
+      // information. Since it doesn't match with the MemRefType that we
+      // produced in rewriteAddptrOp (which is in canonical form with layout
+      // information), an unrealized_conversion_cast should have been added. We
+      // need to trace it back through this unrealized_conversion_cast to get
+      // the original reinterpret_cast. Also see comments in
+      // TritonTypeConverter::addConversion.
+      //
+      // For TritonToLinalg, we do not use any TypeConverters, hence we can
+      // access the reinterpret_cast directly.
+      if (v.getDefiningOp<triton::AddPtrOp>()) {
+        if (auto castOp = mappedV.getDefiningOp<UnrealizedConversionCastOp>()) {
+          auto castInputs = castOp.getInputs();
+          assert(castInputs.size() == 1 &&
+                 "only expect 1:1 mapping for unrealized_conversion_cast that "
+                 "were "
+                 "automatically inserted during legalizing");
+          v = castInputs[0];
+        } else if (auto castOp =
+                       mappedV.getDefiningOp<memref::ReinterpretCastOp>()) {
+          v = castOp;
+        } else {
+          llvm_unreachable("mapped value defined by an unexpected op");
+        }
+      } else {
+        // If this value is not a tensor of pointers, we will use the mapped
+        // value, and rely on the conversion will happen later automatically
+        // when we legalize loop body.
+
+        // TODO:
+        //  The scenario where a value is a tensor of pointers but not produced
+        //  by AddPtrOp is not supported
+        if (mappedV.getType().isa<TensorType>() &&
+            mappedV.getType()
+                .dyn_cast<TensorType>()
+                .getElementType()
+                .isa<triton::PointerType>())
+          llvm_unreachable("unsupported scenario where a value is a tensor of "
+                           "pointers but not produced by AddPtrOp");
+        v = mappedV;
+      }
+    }
+
+    if (levelToBlockArgIndex.find(level) == levelToBlockArgIndex.end())
+      continue;
+    auto thisSet = levelToBlockArgIndex.find(level)->second;
+    if (thisSet.find(i) == thisSet.end())
+      continue;
+
+    auto reintCastOp = v.getDefiningOp<memref::ReinterpretCastOp>();
+    assert(
+        reintCastOp ||
+        (v.getType().isa<TensorType>() &&
+         v.getType().dyn_cast<TensorType>().getElementType().isa<IndexType>()));
+
+    PtrState state;
+    if (reintCastOp) {
+      visitOperandReintCast(reintCastOp, state, op.getLoc(), rewriter,
+                            knownPtrs);
+    } else {
+      visitOperand(v, state, op.getLoc(), rewriter, knownPtrs);
+    }
+    initArgState.push_back(state);
+  }
+
+  // For each of the PtrState recorded in the last step, extract value
+  // that correspond to offset and stride for each dimension and append
+  // them to yield operands.
+  for (auto state : initArgState) {
+    for (auto s : state.offsets) {
+      // offsets can be IntAttr zeroes, since reinterpret_cast collapses them
+      // for the input memref, and the for loop may not update offsets other
+      // than offsets[0]. Create constants Values for those zeroes.
+      if (auto sIntAttr = getIntAttr(s)) {
+        assert(sIntAttr.value() == 0 && "attribute offsets should be zeroes");
+        auto constOp = rewriter.create<arith::ConstantOp>(
+            op.getLoc(), rewriter.getIndexAttr(0));
+        operands.push_back(constOp.getResult());
+      } else {
+        operands.push_back(s.get<Value>());
+      }
+    }
+
+    for (auto s : state.strides) {
+      assert(!getIntAttr(s) &&
+             "PtrState strides for yield within for loop not expected to be "
+             "attribute.");
+      operands.push_back(s.get<Value>());
+    }
+  }
+
+  // Yield is a terminator op that must be at the end of the function
+  rewriter.setInsertionPointAfter(op);
+  auto newOp = rewriter.replaceOpWithNewOp<scf::YieldOp>(op, operands);
+  assert(op->getNumResults() == 0);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "new yield:";
+    newOp.getOperation()->print(llvm::dbgs(),
+                                OpPrintingFlags().printGenericOpForm());
+    llvm::dbgs() << "\n";
+  });
+}
+
+void PtrAnalysis::rewriteForOp(
+    scf::ForOp op, ConversionPatternRewriter &rewriter,
+    IndexMapSet &levelToBlockArgIndex, const int level,
+    llvm::SmallDenseMap<Value, PtrState> &knownPtrs) {
+  SmallVector<Value> newInitArgs;
+
+  SmallVector<std::pair<int, PtrState>> initArgIndexState;
+  SmallVector<std::pair<int, PtrState>> knownPtrsTmp;
+
+  // Create a new list of init args
+  for (auto [i, arg] : llvm::enumerate(op.getInitArgs())) {
+    auto mappedV = rewriter.getRemappedValue(arg);
+
+    // Trace back the original value. See comments in rewriteYieldOp.
+    // This block is unreachable for TritonToLinalg because we don't use
+    // TypeConverters.
+    if (mappedV && mappedV.getDefiningOp<UnrealizedConversionCastOp>()) {
+      auto castOp = mappedV.getDefiningOp<UnrealizedConversionCastOp>();
+      assert(castOp && "expected unrealized_conversion_cast");
+      auto castInputs = castOp.getInputs();
+      assert(castInputs.size() == 1 &&
+             "only expect 1:1 mapping for unrealized_conversion_cast that were "
+             "automatically inserted during legalizing");
+      mappedV = castInputs[0];
+    }
+
+    memref::ReinterpretCastOp reintCastOp;
+
+    // If this init arg is supposed to be remapped, use the remapped value
+    // instead. In addition, if this init arg is a memref created by a
+    // reinterpret_cast or a tensor of index, there is a chance that it will be
+    // used in addptr. Create PtrState for each such init arg.
+    if (mappedV) {
+      // TODO:
+      //  Passing a block argument pointer directly into a for loop not
+      assert(!(mappedV.dyn_cast<BlockArgument>() &&
+               mappedV.getType().isa<UnrankedMemRefType>()) &&
+             "cannot take pointer block argument as init arg for for loop");
+      reintCastOp = mappedV.getDefiningOp<memref::ReinterpretCastOp>();
+      newInitArgs.push_back(mappedV);
+    } else {
+      newInitArgs.push_back(arg);
+    }
+
+    auto indexTensor =
+        arg.getType().isa<TensorType>() &&
+        arg.getType().dyn_cast<TensorType>().getElementType().isa<IndexType>();
+
+    if (!reintCastOp && !indexTensor)
+      continue;
+
+    PtrState state;
+    if (reintCastOp) {
+      visitOperandReintCast(reintCastOp, state, op.getLoc(), rewriter,
+                            llvm::SmallDenseMap<Value, PtrState>(0));
+    } else {
+      // TODO:
+      visitOperand(arg, state, op.getLoc(), rewriter,
+                   llvm::SmallDenseMap<Value, PtrState>(0));
+    }
+
+    // Record the PtrState for later processing
+    initArgIndexState.push_back(std::make_pair(i, state));
+  }
+
+  // Set insertion point to be before the for loop for new variables passed
+  // into the new loop.
+  auto origIp = rewriter.saveInsertionPoint();
+  rewriter.setInsertionPoint(op);
+
+  // For each of the PtrState recorded in the last step, insert new
+  // instructions to describe offset and stride for each dimension and append
+  // them to init args
+  for (auto [i, state] : initArgIndexState) {
+    // For each dimension, if the corresponding offset and stride is an
+    // integer attribute, create a constant value and append them at the end
+    // of init arg list.
+    for (auto [j, s] : llvm::enumerate(state.offsets)) {
+      auto sIntAttr = getIntAttr(s);
+      if (sIntAttr) {
+        auto constOp = rewriter.create<arith::ConstantOp>(
+            op.getLoc(), rewriter.getIndexAttr(sIntAttr.value()));
+        newInitArgs.push_back(constOp.getResult());
+        state.offsets[j] = constOp.getResult();
+      } else {
+        newInitArgs.push_back(s.get<Value>());
+      }
+    }
+
+    for (auto [j, s] : llvm::enumerate(state.strides)) {
+      auto sIntAttr = getIntAttr(s);
+      if (sIntAttr) {
+        auto constOp = rewriter.create<arith::ConstantOp>(
+            op.getLoc(), rewriter.getIndexAttr(sIntAttr.value()));
+        newInitArgs.push_back(constOp.getResult());
+        state.strides[j] = constOp.getResult();
+      } else {
+        newInitArgs.push_back(s.get<Value>());
+      }
+    }
+
+    // Note that we want the knownPtrs to be indexed by block arg, but we only
+    // have index for now. Also, the state we record is the init arg, but want
+    // to to use newly created block arg. These block args are not created yet.
+    // We will translate this mapping later.
+    knownPtrsTmp.push_back(std::make_pair(i, state));
+    levelToBlockArgIndex[level].insert(i);
+
+    // If the original init arg is a memref produced by reinterpret_cast, create
+    // a new memref using new strides and offsets created above. This produces a
+    // canonicalized memref, which will match what the for loop generates if it
+    // modifies the memref. E.g., original reinterpret_cast can produce a memref
+    // with const stride:
+    //  - memref<4x256xbf16, affine_map<(d0, d1)[s0, s1] -> (d0 * 256 + s0 + d1
+    //  * s1)>>
+    // The new reinterpret_cast will always have dynamic stride and offset:
+    //  - memref<4x256xbf16, affine_map<(d0, d1)[s0, s1, s2] -> (d0 * s1 + s0 +
+    //  d1 * s2)>>
+    if (auto reintCastOp =
+            newInitArgs[i].getDefiningOp<memref::ReinterpretCastOp>()) {
+      SmallVector<int64_t> resultShape;
+      for (auto s : state.sizes) {
+        auto sIntAttr = getIntAttr(s);
+        assert(sIntAttr && "expected constant size");
+        resultShape.push_back(sIntAttr.value());
+      }
+      auto castOp = state.createCastOp(resultShape, op.getLoc(), rewriter);
+
+      LLVM_DEBUG({
+        llvm::dbgs() << "new reinterpret_cast with dynamic sizes "
+                        "and offsets:";
+        castOp->print(llvm::dbgs(), OpPrintingFlags().printGenericOpForm());
+        llvm::dbgs() << "\n";
+      });
+
+      newInitArgs[i] = castOp.getResult();
+    }
+  }
+
+  rewriter.restoreInsertionPoint(origIp);
+
+  // create a new scf::ForOp that uses updated init args and same loop body
+  auto newOp = rewriter.create<scf::ForOp>(
+      op.getLoc(), op.getLowerBound(), op.getUpperBound(), op.getStep(),
+      newInitArgs, [&](OpBuilder &b, Location loc, Value iv, ValueRange args) {
+        IRMapping mapping;
+        mapping.map(op.getInductionVar(), iv);
+        mapping.map(op.getInitArgs(), newInitArgs);
+        mapping.map(op.getRegionIterArgs(), args);
+        for (auto &bodyOp : op.getLoopBody().getOps()) {
+          b.clone(bodyOp, mapping);
+        }
+      });
+
+  // Convert the book-keeping data structure to use the correct key and value.
+  // Key is converted from init arg index to newly created block arg, and
+  // Value's PtrState fields are converted from init arg to newly created block
+  // arg
+  int cnt = op.getRegionIterArgs().size();
+  for (auto [i, state] : knownPtrsTmp) {
+    for (auto it = state.offsets.begin(); it != state.offsets.end(); it++) {
+      *it = newOp.getRegionIterArgs()[cnt];
+      cnt++;
+    }
+
+    for (auto it = state.strides.begin(); it != state.strides.end(); it++) {
+      *it = newOp.getRegionIterArgs()[cnt];
+      cnt++;
+    }
+
+    auto key = newOp.getRegionIterArgs()[i];
+    knownPtrs.insert(std::make_pair(key, state));
+  }
+  assert(static_cast<size_t>(cnt) == newOp.getRegionIterArgs().size() &&
+         "expect to remap all new block args");
+
+  // replace only the results that correspond to the original scf.for
+  auto resultsToReplaceWith = ResultRange(
+      newOp.result_begin(), newOp.result_begin() + op.getNumResults());
+  rewriter.replaceOp(op, resultsToReplaceWith);
+
+  // Update the loop body. Manually invoke the rewrite logic on addptr and yield
+  // in the loop body, so we can take advantage of the states we built up
+  for (auto &bodyOp : newOp.getLoopBody().getOps()) {
+    if (auto addptrOp = dyn_cast<triton::AddPtrOp>(bodyOp)) {
+      rewriteAddptrOp(addptrOp, rewriter, knownPtrs);
+    } else if (auto forOp = dyn_cast<scf::ForOp>(bodyOp)) {
+      // TODO:
+      //  Nested for loops are not supported at the moment
+      assert(0 && "nested loops currently not supported");
+      // rewriteForOp(forOp, rewriter, levelToBlockArgIndex, level+1,
+      // knownPtrs); levelToBlockArgIndex.erase(level+1);
+    }
+  }
+
+  if (op.getNumRegionIterArgs()) {
+    auto yieldOp = cast<scf::YieldOp>(newOp.getBody()->getTerminator());
+    rewriteYieldOp(yieldOp, rewriter, levelToBlockArgIndex, level, knownPtrs);
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "new for\n";
+    newOp.getOperation()->print(llvm::dbgs(),
+                                OpPrintingFlags().printGenericOpForm());
+    llvm::dbgs() << "\n";
+  });
+}
+
+Value PtrAnalysis::getScalarMemRef(Value ptr, Value memRef, const Location loc,
+                                   ConversionPatternRewriter &rewriter) {
+  assert(ptr.getType().cast<triton::PointerType>() &&
+         "expected scalar pointer");
+
+  // If pointer is generated by tt.addptr, TypeConverter will have inserted an
+  // unrealized conversion cast for ptr to cast its type from tt.ptr to unranked
+  // memref. Input of this cast is the actual source memref.
+  //
+  // For TritonToLinalg, we can access the reinterpret_cast directly due to no
+  // usages of TypeConverters.
+  if (ptr.getDefiningOp<triton::AddPtrOp>()) {
+    if (auto uCast = memRef.getDefiningOp<UnrealizedConversionCastOp>()) {
+      assert(uCast && "expected unrealized conversion inserted by type "
+                      "converter not found");
+      return uCast.getInputs()[0];
+    } else if (auto castOp =
+                   memRef.getDefiningOp<memref::ReinterpretCastOp>()) {
+      return castOp.getResult();
+    } else {
+      llvm_unreachable("pointer value is defined by an unexpected op");
+    }
+  }
+
+  assert(isa<BlockArgument>(ptr) &&
+         "pointer is neither produced by addptr nor a block argument");
+  PtrState state;
+  state.source = memRef;
+  state.offsets.push_back(rewriter.getIndexAttr(0));
+  state.sizes.push_back(rewriter.getIndexAttr(1));
+  state.strides.push_back(rewriter.getIndexAttr(1));
+  auto castOp = state.createCastOp(SmallVector<int64_t>(1, 1), loc, rewriter);
+  return castOp.getResult();
+}
+
+} // namespace triton
+} // namespace mlir

--- a/lib/Analysis/UseAnalysis.cpp
+++ b/lib/Analysis/UseAnalysis.cpp
@@ -1,0 +1,217 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/UseAnalysis.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+using namespace mlir;
+using namespace triton;
+using namespace dataflow;
+
+#define DEBUG_TYPE "triton-use-analysis"
+
+//===----------------------------------------------------------------------===//
+// Use Analysis
+// Note that logic below should evolve with triton-to-affine pass
+//===----------------------------------------------------------------------===//
+void triton::UseAnalysis::visitOperation(Operation *op,
+                                         ArrayRef<UseInfo *> operands,
+                                         ArrayRef<const UseInfo *> results) {
+  // If an op only produces pointer, all its operands are used as meta data.
+  // This accounts for scenarios such as addptr in a loop whose result is
+  // yielded. In this case, if the loop returns data tensors, addptr will be
+  // marked correctly as meta use.
+  if (op->getResults().size() == 1) {
+    auto resultType = op->getResult(0).getType().dyn_cast<ShapedType>();
+    if (resultType && isa<triton::PointerType>(resultType.getElementType())) {
+      for (auto opnd : operands)
+        propagateUse(opnd, UseType::MetaUse);
+    }
+  }
+
+  TypeSwitch<Operation *>(op)
+      .Case<triton::LoadOp>([&](auto load) {
+        propagateUse(operands[0], UseType::MetaUse);
+        auto mask = load.getMask();
+        auto other = load.getOther();
+        if (mask) {
+          assert(mask != other && "mask and other cannot be the same");
+          propagateUse(operands[1], UseType::MetaUse);
+        }
+        if (other) {
+          // TODO:
+          // More complicated patterns that generate other is unsupported.
+          propagateUse(operands[2], UseType::MetaUse);
+        }
+      })
+      .Case<triton::StoreOp>([&](auto store) {
+        propagateUse(operands[0], UseType::MetaUse);
+        propagateUse(operands[1], UseType::DataUse);
+        auto value = store.getValue();
+        auto mask = store.getMask();
+        if (mask) {
+          assert(mask != value && "mask and data cannot be the same");
+          propagateUse(operands[2], UseType::MetaUse);
+        }
+      })
+      .Case<triton::DotOp>([&](auto dot) {
+        propagateResults(operands[0], results);
+        propagateResults(operands[1], results);
+
+        auto opc = dot.getC();
+        triton::SplatOp splat;
+        if (opc)
+          splat = opc.template getDefiningOp<triton::SplatOp>();
+
+        if (opc && splat && splat.getSrc().getDefiningOp<arith::ConstantOp>())
+          propagateUse(operands[2], UseType::MetaUse);
+        else
+          propagateUse(operands[2], UseType::DataUse);
+      })
+      .Default([&](Operation *op) {
+        // this condition account for tt.addptr
+        for (auto operand : operands) {
+          propagateResults(operand, results);
+        }
+      });
+}
+
+LogicalResult triton::runUseAnalysis(triton::FuncOp &funcOp) {
+  MLIRContext *context = funcOp.getContext();
+  SymbolTableCollection symbolTable;
+
+  DataFlowSolver solver;
+  solver.load<DeadCodeAnalysis>();
+  solver.load<SparseConstantPropagation>();
+  solver.load<UseAnalysis>(symbolTable);
+  if (failed(solver.initializeAndRun(funcOp)))
+    return failure();
+
+  // Walk the func op, convert tags on operands to tags on operations
+  funcOp.walk([&](Operation *op) {
+    UseType useType = UseType::Undefined;
+    for (auto result : op->getResults()) {
+      auto use = solver.lookupState<UseInfo>(result);
+      assert(use && "Lattice value not found");
+      auto thisUseType = use->type;
+      if (thisUseType == UseType::Undefined)
+        continue;
+      if (useType == UseType::Undefined)
+        useType = thisUseType;
+      if (thisUseType == UseType::MixUse || thisUseType != useType) {
+        useType = UseType::MixUse;
+        break;
+      }
+    }
+
+    if (useType == UseType::Undefined) {
+      LLVM_DEBUG({ op->setAttr("Undefined", UnitAttr::get(context)); });
+      return;
+    } else if (useType == UseType::MetaUse) {
+      assert(op->getNumResults() == 1 &&
+             "Ops used for meta computation are expected to have one result");
+      // Only set the tag if the operation uses tensors
+      if (op->getResult(0).getType().isa<ShapedType>()) {
+        // Setting tag for erasing op later
+        op->setAttr("MetaUse", UnitAttr::get(context));
+      }
+      return;
+    } else if (useType == UseType::DataUse) {
+      LLVM_DEBUG({ op->setAttr("DataUse", UnitAttr::get(context)); });
+      return;
+    }
+
+    assert(useType == UseType::MixUse);
+
+    // If the operation only produces scalars, no need to clone it
+    bool shapedResult = true;
+    for (auto result : op->getResults())
+      shapedResult &= result.getType().isa<ShapedType>();
+    if (!shapedResult) {
+      LLVM_DEBUG({ op->setAttr("MixUse", UnitAttr::get(context)); });
+      return;
+    }
+
+    // Value has MixUse. However, the operation may or may not have direct
+    // MetaUse. E.g., it may only have MixUse, or only have MixUse and
+    // DataUse.
+    // - If the operation has direct MetaUse, clone it, tag the clone as
+    // MetaUse only and point meta users to use the clone.
+    // - If not, do nothing; this operation will still be materlized.
+    llvm::SetVector<Operation *> metaUsers;
+    for (auto result : op->getResults()) {
+      for (auto user : result.getUsers()) {
+        TypeSwitch<Operation *>(user)
+            .Case<triton::LoadOp>([&](auto load) {
+              auto ptr = load.getPtr();
+              auto mask = load.getMask();
+              auto other = load.getOther();
+              if (result == ptr || result == mask || result == other)
+                metaUsers.insert(user);
+            })
+            .Case<triton::StoreOp>([&](auto store) {
+              auto ptr = store.getPtr();
+              auto mask = store.getMask();
+              if (result == ptr || result == mask)
+                metaUsers.insert(user);
+            })
+            .Case<triton::DotOp>([&](auto dot) {
+              auto opc = dot.getC();
+              triton::SplatOp splat;
+              if (opc)
+                splat = opc.template getDefiningOp<triton::SplatOp>();
+
+              if (opc && splat &&
+                  splat.getSrc().getDefiningOp<arith::ConstantOp>())
+                metaUsers.insert(user);
+            })
+            .Default([&](Operation *op) {
+              // if all output of user are used as meta data, user is a meta
+              // user. This condition account for addptr, or an addi whose
+              // output only feeds into addptr
+              bool allMeta = true;
+              for (auto res : op->getResults()) {
+                auto resUse = solver.lookupState<UseInfo>(res);
+                if (resUse->type != UseType::MetaUse) {
+                  allMeta = false;
+                  break;
+                }
+              }
+              if (allMeta)
+                metaUsers.insert(user);
+            });
+      }
+    }
+
+    // If the operation doesn't have direct meta users, no need to clone it
+    if (metaUsers.empty()) {
+      LLVM_DEBUG({ op->setAttr("MixUse", UnitAttr::get(context)); });
+      return;
+    }
+
+    // Clone the operation; switch all meta users to use the clone
+    OpBuilder builder(op);
+    auto clone = builder.clone(*op);
+    LLVM_DEBUG({ op->setAttr("MixUse", UnitAttr::get(context)); });
+
+    // Setting tag for erasing op later
+    clone->setAttr("MetaUse", UnitAttr::get(context));
+
+    for (auto [res_i, result] : llvm::enumerate(op->getResults()))
+      for (auto user : metaUsers)
+        for (auto &operand : user->getOpOperands())
+          if (operand.get() == result)
+            operand.set(clone->getResult(res_i));
+  });
+
+  return success();
+}

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(TritonToTritonGPU)
 add_subdirectory(TritonGPUToLLVM)
+add_subdirectory(TritonToLinalg)

--- a/lib/Conversion/TritonToLinalg/CMakeLists.txt
+++ b/lib/Conversion/TritonToLinalg/CMakeLists.txt
@@ -1,0 +1,33 @@
+#===------------------------------------------------------------------------===#
+#
+# Copyright (c) Triton Project Contributors.
+#
+#===------------------------------------------------------------------------===#
+
+add_mlir_conversion_library(TritonToLinalg
+  TritonToLinalg.cpp
+  TritonToLinalgPass.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${PROJECT_SOURCE_DIR}/include/triton/Conversion/TritonToLinalg
+  ${PROJECT_BINARY_DIR}/include/triton/Conversion/TritonToLinalg
+
+  DEPENDS
+  TritonToLinalgConversionPassIncGen
+
+  LINK_COMPONENTS
+  Core
+
+  LINK_LIBS PUBLIC
+  MLIRArithDialect
+  MLIRDialectUtils
+  MLIRIR
+  MLIRMathDialect
+  MLIRPass
+  MLIRTensorDialect
+  MLIRTransforms
+  MLIRSupport
+  TritonAnalysis
+  TritonIR
+  TritonTransforms
+)

--- a/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
+++ b/lib/Conversion/TritonToLinalg/TritonToLinalg.cpp
@@ -1,0 +1,923 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Conversion/TritonToLinalg/TritonToLinalg.h"
+#include "triton/Analysis/MaskAnalysis.h"
+#include "triton/Analysis/PtrAnalysis.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/FormatVariadic.h"
+
+#include <numeric>
+
+using namespace mlir;
+using namespace triton;
+
+#define GEN_PASS_CLASSES
+#include "triton/Conversion/TritonToLinalg/Passes.h.inc"
+
+//===----------------------------------------------------------------------===//
+// Utilities
+//===----------------------------------------------------------------------===//
+
+// Extract a scalar value from v.
+// If v is a scalar, return that directly. Otherwise, parse through operations
+// (currently only support splat and sitofp) that produce it and to extract they
+// underlying scalar value . If no scalar value can be extracted, a nullptr is
+// returned.
+static std::optional<Value>
+getScalarValue(Value v, Location loc, ConversionPatternRewriter &rewriter) {
+  // Record if an sitofp op was in the chain of ops that produce the scalar
+  Operation *siToFp = nullptr;
+
+  while (true) {
+    if (!v.getType().dyn_cast<ShapedType>()) {
+      break;
+    } else if (auto op = v.getDefiningOp<arith::ConstantOp>()) {
+      if (auto attr = op.getValue().dyn_cast<DenseElementsAttr>()) {
+        if (!attr.isSplat()) {
+          InFlightDiagnostic diag = emitError(loc)
+                                    << "other value used in masked load "
+                                       "produced by unsupported instruction";
+          return nullptr;
+        }
+        auto elemValue = attr.getSplatValue<Attribute>();
+        auto constOp =
+            rewriter.create<arith::ConstantOp>(op.getLoc(), elemValue);
+        v = constOp.getResult();
+      }
+    } else if (auto op = v.getDefiningOp<triton::SplatOp>()) {
+      v = op.getSrc();
+    } else if (auto op = v.getDefiningOp<arith::SIToFPOp>()) {
+      siToFp = op;
+      v = op.getIn();
+    } else {
+      InFlightDiagnostic diag = emitError(loc)
+                                << "other value used in masked load produced "
+                                   "by unsupported instruction";
+      return nullptr;
+    }
+  }
+
+  if (siToFp) {
+    auto resType = siToFp->getResult(0).getType();
+    if (auto shapedType = dyn_cast<ShapedType>(resType)) {
+      resType = shapedType.getElementType();
+    }
+    return rewriter.create<arith::SIToFPOp>(loc, resType, v);
+  }
+  return v;
+}
+
+static SmallVector<utils::IteratorType> getNParallelLoopsAttrs(unsigned n) {
+  return SmallVector<utils::IteratorType>(n, utils::IteratorType::parallel);
+}
+
+static Value getTransposedValue(Value source, const Location loc,
+                                ConversionPatternRewriter &rewriter) {
+
+  auto sourceType = source.getType().cast<RankedTensorType>();
+  auto sourceRank = sourceType.getRank();
+
+  SmallVector<int64_t> perm(sourceRank);
+  std::iota(std::begin(perm), std::end(perm), 0);
+  std::swap(perm[sourceRank - 1], perm[sourceRank - 2]);
+
+  SmallVector<int64_t> transposedShape(sourceType.getShape());
+  std::swap(transposedShape[sourceRank - 1], transposedShape[sourceRank - 2]);
+
+  Value transposeInit = rewriter.create<tensor::EmptyOp>(
+      loc, transposedShape, sourceType.getElementType());
+
+  Value transpose =
+      rewriter.create<linalg::TransposeOp>(loc, source, transposeInit, perm)
+          .getResults()[0];
+
+  return transpose;
+}
+
+//===----------------------------------------------------------------------===//
+// Op Lowering Patterns
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct SplatConverter : public OpConversionPattern<triton::SplatOp> {
+  using OpConversionPattern<triton::SplatOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::SplatOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto opType = op.getType().cast<TensorType>();
+    auto loc = op.getLoc();
+
+    auto init = rewriter.create<tensor::EmptyOp>(loc, opType.getShape(),
+                                                 opType.getElementType());
+
+    auto filledTensor =
+        rewriter
+            .create<linalg::FillOp>(loc, ValueRange{adaptor.getSrc()},
+                                    ValueRange{init})
+            .result();
+
+    rewriter.replaceOp(op, filledTensor);
+    return success();
+  }
+};
+
+struct BroadcastConverter : public OpConversionPattern<triton::BroadcastOp> {
+private:
+  using OpConversionPattern<triton::BroadcastOp>::OpConversionPattern;
+
+  SmallVector<int64_t> getBroadcastDims(RankedTensorType src,
+                                        RankedTensorType dst) const {
+    SmallVector<int64_t> broadcastDims;
+    auto srcShape = src.getShape();
+    auto dstShape = dst.getShape();
+
+    for (size_t i = 0; i < srcShape.size(); i++) {
+      if (dstShape[i] != srcShape[i]) {
+        assert(srcShape[i] == 1);
+        broadcastDims.push_back(i);
+      }
+    }
+    assert(!broadcastDims.empty() && "cannot identify broadcast dimension");
+    return broadcastDims;
+  }
+
+  // Broadcasts input tensor based on TosaToLinalg's broadcastToShape
+  AffineMap getBroadcastAffineMap(MLIRContext *context,
+                                  ArrayRef<int64_t> inputShape,
+                                  ArrayRef<int64_t> broadcastToShape) const {
+
+    assert(broadcastToShape.size() >= inputShape.size());
+
+    // Create affine map and shapes for tensor initialization.
+    SmallVector<AffineExpr> outExpr;
+
+    size_t diff = broadcastToShape.size() - inputShape.size();
+    for (size_t i = 0; i < broadcastToShape.size(); i++) {
+      if (i < diff) {
+        continue;
+      }
+      size_t j = i - diff;
+      if (inputShape[j] == 1) {
+        // Broadcast singleton dimension
+        outExpr.push_back(mlir::getAffineConstantExpr(0, context));
+        continue;
+      }
+      // Non-broadcast case
+      outExpr.push_back(mlir::getAffineDimExpr(i, context));
+    }
+    return AffineMap::get(broadcastToShape.size(), 0, outExpr, context);
+  }
+
+public:
+  LogicalResult
+  matchAndRewrite(triton::BroadcastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+
+    assert(op->getNumResults() == 1 && "code assumes single result!");
+    RankedTensorType sourceType =
+        cast<RankedTensorType>(adaptor.getSrc().getType());
+    RankedTensorType resultType = cast<RankedTensorType>(op.getType());
+    auto elementType = resultType.getElementType();
+    size_t resultRank = resultType.getRank();
+
+    SmallVector<AffineMap> indexingMaps;
+    indexingMaps.reserve(op->getNumOperands() + op->getNumResults());
+
+    indexingMaps.push_back(getBroadcastAffineMap(
+        op->getContext(), sourceType.getShape(), resultType.getShape()));
+    indexingMaps.append(op->getNumResults(),
+                        rewriter.getMultiDimIdentityMap(resultRank));
+
+    assert(op->getNumResults() == 1 && "code assumes single result!");
+    auto init = rewriter.create<tensor::EmptyOp>(loc, resultType.getShape(),
+                                                 elementType);
+
+    auto linalgOp = rewriter.create<linalg::GenericOp>(
+        loc, op->getResultTypes(), ValueRange{adaptor.getSrc()},
+        ValueRange{init}, indexingMaps, getNParallelLoopsAttrs(resultRank),
+        [&](OpBuilder &nestedBuilder, Location nestedLoc,
+            ValueRange blockArgs) {
+          Value opResult = blockArgs[0];
+          nestedBuilder.create<linalg::YieldOp>(loc, opResult);
+        });
+
+    linalgOp->setAttr("broadcastDims",
+                      rewriter.getDenseI64ArrayAttr(
+                          getBroadcastDims(sourceType, resultType)));
+
+    rewriter.replaceOp(op, linalgOp->getResults());
+    return success();
+  }
+};
+
+struct ExpandDimsConverter : public OpConversionPattern<triton::ExpandDimsOp> {
+  using OpConversionPattern<triton::ExpandDimsOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::ExpandDimsOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto src = adaptor.getSrc();
+    auto srcRank = src.getType().cast<RankedTensorType>().getRank();
+    auto resType = op->getResultTypes()[0].cast<RankedTensorType>();
+    SmallVector<ReassociationIndices> reassoc;
+    int64_t c = 0;
+    for (int64_t i = 0; i < srcRank; i++) {
+      ReassociationIndices g;
+      g.push_back(c++);
+      if (op.getAxis() == i)
+        g.push_back(c++);
+      else if (op.getAxis() == i + 1 && i == srcRank - 1)
+        g.push_back(c++);
+      reassoc.push_back(g);
+    }
+
+    auto expandShapeOp = rewriter.create<tensor::ExpandShapeOp>(
+        op.getLoc(), resType, src, reassoc);
+
+    rewriter.replaceOp(op, expandShapeOp.getResult());
+    return success();
+  }
+};
+
+struct TransposeConverter : public OpConversionPattern<triton::TransOp> {
+  using OpConversionPattern<triton::TransOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::TransOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto src = adaptor.getSrc();
+    auto srcRank = src.getType().cast<ShapedType>().getRank();
+    assert(srcRank == 2 && "only expect transposing 2D data");
+
+    auto res = getTransposedValue(src, op.getLoc(), rewriter);
+    rewriter.replaceOp(op, res);
+    return success();
+  }
+};
+
+struct MakeRangeConverter : public OpConversionPattern<triton::MakeRangeOp> {
+  using OpConversionPattern<triton::MakeRangeOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::MakeRangeOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    auto type = op.getResult().getType().cast<TensorType>();
+    auto shape = type.getShape();
+    auto elementType = type.getElementType();
+    auto context = rewriter.getContext();
+
+    assert(type.getShape().size() == 1 &&
+           type.getElementType().getIntOrFloatBitWidth() == 32 &&
+           "make range can only return 1D int32 tensor");
+
+    SmallVector<AffineMap> indexingMaps{AffineMap::get(
+        /* dimCount */ 1, /* symbolCount */ 0,
+        SmallVector<AffineExpr>{mlir::getAffineDimExpr(0, context)}, context)};
+
+    auto init = rewriter.create<tensor::EmptyOp>(loc, shape, elementType);
+    auto linalgOp = rewriter.create<linalg::GenericOp>(
+        loc, op->getResultTypes(), /* operands */ ValueRange{},
+        ValueRange{init}, indexingMaps, getNParallelLoopsAttrs(1),
+        [&](OpBuilder &nestedBuilder, Location nestedLoc,
+            ValueRange blockArgs) {
+          Value index = nestedBuilder.create<linalg::IndexOp>(loc, 0);
+          Value res = nestedBuilder.create<arith::IndexCastOp>(
+              loc, type.getElementType(), index);
+          nestedBuilder.create<linalg::YieldOp>(loc, res);
+        });
+
+    rewriter.replaceOp(op, linalgOp->getResults());
+    return success();
+  }
+};
+
+struct AddPtrConverter : public OpConversionPattern<triton::AddPtrOp> {
+  using OpConversionPattern<triton::AddPtrOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::AddPtrOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    llvm::SmallDenseMap<Value, PtrState> knwonPtrs;
+    PtrAnalysis::rewriteAddptrOp(op, rewriter, knwonPtrs);
+    return success();
+  }
+};
+
+struct AssertConverter : public OpConversionPattern<triton::AssertOp> {
+  using OpConversionPattern<triton::AssertOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::AssertOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto condVal = op.getCondition();
+
+    if (condVal.getType().isa<mlir::TensorType>()) {
+      auto scalarVal = getScalarValue(op.getCondition(), op.getLoc(), rewriter);
+      condVal = scalarVal.value_or(condVal);
+    }
+    assert(condVal && condVal.getType().isa<mlir::IntegerType>() &&
+           "Only asserts on scalars are currently supported");
+
+    if (!condVal.getType().isInteger(1)) {
+      auto zero =
+          rewriter.create<mlir::arith::ConstantIntOp>(op.getLoc(), 0, 32);
+      auto newCond = rewriter.create<mlir::arith::CmpIOp>(
+          op.getLoc(), arith::CmpIPredicate::ne, condVal, zero);
+      condVal = newCond.getResult();
+    }
+
+    auto assertMessage =
+        llvm::formatv("{0}.py:{1}: {2} Assertion `{3}` failed", op.getFile(),
+                      op.getLine(), op.getFunc(), op.getMessage());
+    auto assertOp = rewriter.create<mlir::cf::AssertOp>(op.getLoc(), condVal,
+                                                        assertMessage.str());
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct BitcastConverter : public OpConversionPattern<triton::BitcastOp> {
+  using OpConversionPattern<triton::BitcastOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::BitcastOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto arithBitcast = rewriter.create<arith::BitcastOp>(
+        op.getLoc(), op.getType(), op.getOperand());
+
+    rewriter.replaceOp(op, arithBitcast.getResult());
+    return success();
+  }
+};
+
+struct LoadConverter : public OpConversionPattern<triton::LoadOp> {
+private:
+  using OpConversionPattern<triton::LoadOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::LoadOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto ptr = adaptor.getPtr();
+    auto mask = op.getMask();
+    auto other = op.getOther();
+    auto loc = op.getLoc();
+
+    // 0. Shortcut for scalar loads
+    if (!op.getResult().getType().isa<ShapedType>()) {
+      // Temporarily disbale scalar load until later passes support it
+      op.emitError("Scalar load is currently not supported");
+      return failure();
+
+      auto sMemRef = PtrAnalysis::getScalarMemRef(op.getPtr(), adaptor.getPtr(),
+                                                  loc, rewriter);
+      auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
+      auto loadOp = rewriter.create<AffineLoadOp>(op.getLoc(), sMemRef, zeroMap,
+                                                  std::nullopt);
+      rewriter.replaceOp(op, loadOp.getResult());
+      return success();
+    }
+
+    // 1. Simple case where no mask is used.
+    auto type = ptr.getType().cast<MemRefType>();
+    auto tensorType =
+        RankedTensorType::get(type.getShape(), type.getElementType());
+    auto alloc = rewriter.create<memref::AllocOp>(
+        loc, MemRefType::get(type.getShape(), type.getElementType()));
+
+    if (!mask) {
+      assert(!other && "other value used in non-masked load");
+      rewriter.create<memref::CopyOp>(loc, ptr, alloc);
+      Value tensor = rewriter.create<bufferization::ToTensorOp>(
+          loc, tensorType, alloc, true /* restrict */, true /* writable */);
+      rewriter.replaceOp(op, tensor);
+      return success();
+    }
+
+    // 2. Continuous masked loads.
+    // Analyze the mask operand to determine at runtime the size of the data we
+    // are moving.
+    MaskState mstate;
+    auto isContMask = mstate.parse(mask, loc, rewriter);
+
+    if (isContMask.failed())
+      return failure();
+
+    auto castOp = ptr.getDefiningOp<memref::ReinterpretCastOp>();
+    assert(castOp);
+    ptr = castOp.getResult();
+
+    auto srcSubview = mstate.getSubview(ptr, loc, rewriter);
+    auto dstSubview = mstate.getSubview(alloc, loc, rewriter);
+
+    // fill load destination with other value
+    if (other) {
+      auto scalarOther = getScalarValue(other, loc, rewriter);
+      assert(scalarOther.has_value() &&
+             "other value used in masked load produced by "
+             "unsupported instruction");
+
+      // For each dimension check if mstate.dims[i] < shape[i], or-accumulate
+      // the result
+      auto shape = type.getShape();
+      auto accBase =
+          rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(false))
+              .getResult();
+      for (size_t i = 0; i < type.getShape().size(); i++) {
+        auto shapei = rewriter.create<arith::ConstantOp>(
+            loc, rewriter.getIndexAttr(shape[i]));
+
+        Value dimi = mstate.dims[i].dyn_cast<Value>();
+        if (!dimi) {
+          dimi = rewriter.create<arith::ConstantOp>(
+              loc, mstate.dims[i].get<Attribute>().cast<IntegerAttr>());
+        }
+
+        auto cmpOp = rewriter.create<arith::CmpIOp>(
+            loc, arith::CmpIPredicate::slt, dimi, shapei);
+        accBase = rewriter.create<arith::OrIOp>(loc, accBase, cmpOp.getResult())
+                      .getResult();
+      }
+
+      // condition the memset on the or-accumulation
+      // initialize with padding prior to CopyOp
+      rewriter.create<scf::IfOp>(
+          loc, accBase, [&](OpBuilder &builder, Location loc) {
+            builder.create<linalg::FillOp>(loc, ValueRange{scalarOther.value()},
+                                           ValueRange{alloc});
+            builder.create<scf::YieldOp>(loc);
+          });
+    }
+
+    rewriter.create<memref::CopyOp>(loc, srcSubview, dstSubview);
+    Value tensor = rewriter.create<bufferization::ToTensorOp>(
+        loc, tensorType, alloc, true /* restrict */, true /* writable */);
+    rewriter.replaceOp(op, tensor);
+
+    return success();
+  }
+};
+
+struct StoreConverter : public OpConversionPattern<triton::StoreOp> {
+  using OpConversionPattern<triton::StoreOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::StoreOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto ptr = adaptor.getPtr();
+    auto val = adaptor.getValue();
+    auto mask = op.getMask();
+    auto loc = op.getLoc();
+
+    // 0. Shortcut for scalar stores
+    if (!val.getType().isa<ShapedType>()) {
+      auto sMemRef =
+          PtrAnalysis::getScalarMemRef(op.getPtr(), ptr, loc, rewriter);
+      auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
+      rewriter.create<AffineStoreOp>(loc, val, sMemRef, zeroMap, std::nullopt);
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // 1. Simple case where no mask is used.
+    if (!mask) {
+      rewriter.create<memref::TensorStoreOp>(loc, val, ptr);
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    // 2. Continuous masked stores.
+    // Analyze the mask operand to determine at runtime the size of the data we
+    // are moving.
+    MaskState mstate;
+    auto isContMask = mstate.parse(mask, loc, rewriter);
+
+    if (isContMask.failed())
+      return failure();
+
+    auto srcSlice = mstate.getExtractSlice(val, loc, rewriter);
+    auto dstSubview = mstate.getSubview(ptr, loc, rewriter);
+
+    rewriter.create<memref::TensorStoreOp>(loc, srcSlice, dstSubview);
+    rewriter.eraseOp(op);
+
+    return success();
+  }
+};
+
+struct LoopConverter : public OpConversionPattern<scf::ForOp> {
+  using OpConversionPattern<scf::ForOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::ForOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    llvm::SmallDenseMap<Value, PtrState> knownPtrs;
+    PtrAnalysis::IndexMapSet
+        levelToBlockArgIndex; // level -> set of block arg index to be replaced
+
+    PtrAnalysis::rewriteForOp(op, rewriter, levelToBlockArgIndex, 0, knownPtrs);
+    return success();
+  }
+};
+
+struct YieldConverter : public OpConversionPattern<scf::YieldOp> {
+  using OpConversionPattern<scf::YieldOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(scf::YieldOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<scf::YieldOp>(op, adaptor.getOperands());
+    return success();
+  }
+};
+
+struct MatmulConverter : public OpConversionPattern<triton::DotOp> {
+  using OpConversionPattern<triton::DotOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto dstType = op.getType().cast<RankedTensorType>();
+    auto loc = op.getLoc();
+
+    auto opa = adaptor.getA();
+    auto opb = adaptor.getB();
+    auto opc = adaptor.getC();
+    auto opcOrig = op.getC();
+
+    bool skipC = false;
+    if (auto splatOp = opcOrig.getDefiningOp<triton::SplatOp>()) {
+      if (auto val = splatOp.getSrc().getDefiningOp<arith::ConstantOp>()) {
+        if (val.getValue().cast<FloatAttr>().getValueAsDouble() == 0.) {
+          skipC = true;
+        }
+      }
+    } else if (auto constOp = opcOrig.getDefiningOp<arith::ConstantOp>()) {
+      if (auto denseAttr = dyn_cast<DenseElementsAttr>(constOp.getValue())) {
+        if (denseAttr.isSplat() &&
+            denseAttr.getSplatValue<FloatAttr>().getValueAsDouble() == 0.) {
+          skipC = true;
+        }
+      }
+    }
+
+    auto init = rewriter.create<tensor::EmptyOp>(loc, dstType.getShape(),
+                                                 dstType.getElementType());
+
+    auto res = rewriter
+                   .create<linalg::MatmulOp>(loc, ValueRange{opa, opb},
+                                             ValueRange{init})
+                   .getResult(0);
+
+    if (!skipC) {
+      res = rewriter.create<arith::AddFOp>(loc, res, opc);
+    }
+
+    rewriter.replaceOp(op, res);
+    return success();
+  }
+};
+
+struct ReduceConverter : public OpConversionPattern<triton::ReduceOp> {
+  using OpConversionPattern<triton::ReduceOp>::OpConversionPattern;
+
+private:
+  llvm::SmallVector<Operation *> getRedOps(triton::ReduceOp redOp) const {
+    auto reduceBlock = redOp.getBody();
+    llvm::SmallVector<Operation *> ops;
+    for (auto &op : reduceBlock->without_terminator()) {
+      ops.push_back(&op);
+    }
+    return ops;
+  }
+
+  bool isReductionOpSupported(Operation *redOp) const {
+    return isa<arith::AddFOp, arith::MaxFOp>(redOp);
+  }
+
+  float getRedBaseVal(Operation *redOp) const {
+    return llvm::TypeSwitch<Operation *, float>(redOp)
+        .Case([](arith::AddFOp) { return 0; })
+        .Case([](arith::MaxFOp) {
+          return -std::numeric_limits<float>::infinity();
+        })
+        .Default([](Operation *op) {
+          op->dump();
+          llvm_unreachable("Reduction op not yet supported");
+          return -1;
+        });
+  }
+
+  bool requiresF32Conversion(const Type elemType, Operation *redOp) const {
+    return elemType.isa<FloatType>() &&
+           elemType.getIntOrFloatBitWidth() <
+               Float32Type::get(elemType.getContext()).getWidth() &&
+           isa<arith::AddFOp>(redOp);
+  }
+
+  Value getRedElement(Value lhs, Value rhs, const Location loc,
+                      Operation *redOp, OpBuilder &b,
+                      const bool convertLhsToF32Precision) const {
+    return llvm::TypeSwitch<Operation *, Value>(redOp)
+        .Case([&](arith::AddFOp) {
+          if (convertLhsToF32Precision) {
+            lhs = b.create<arith::ExtFOp>(loc, Float32Type::get(b.getContext()),
+                                          lhs);
+          }
+          return b.create<arith::AddFOp>(loc, lhs, rhs);
+        })
+        .Case([&](arith::MaxFOp) {
+          return b.create<arith::MaxFOp>(loc, lhs, rhs);
+        })
+        .Default([](Operation *op) {
+          op->dump();
+          llvm_unreachable("Reduction op not yet supported");
+          return nullptr;
+        });
+  }
+
+  LogicalResult
+  convertToLinalgReduce(triton::ReduceOp op,
+                        typename triton::ReduceOp::Adaptor adaptor,
+                        ConversionPatternRewriter &rewriter) const {
+    auto source = adaptor.getOperands().front();
+    auto sourceType = cast<RankedTensorType>(source.getType());
+    auto elemType = sourceType.getElementType();
+    auto resType = op.getResult().front().getType();
+    auto loc = op.getLoc();
+    auto reductionOps = getRedOps(op);
+
+    // Reduction of arbitrary operations isn't supported because using the first
+    // element across the reduction dimension requires us to iterate over a
+    // subview that skips over each first element.
+    if (reductionOps.size() != 1 ||
+        !isReductionOpSupported(reductionOps.front())) {
+      return op.emitError("Only support lowering reduction with body "
+                          "containing 1 maxf or addf.");
+    }
+
+    auto rop = reductionOps.front();
+    auto axis = op.getAxis();
+    auto isVectorReduce = sourceType.getRank() == 1;
+
+    if (axis == sourceType.getRank() - 1 && !isVectorReduce) {
+      source = getTransposedValue(source, op.getLoc(), rewriter);
+      axis = sourceType.getRank() - 2;
+    }
+
+    bool convertToF32Precision = requiresF32Conversion(resType, rop);
+
+    auto constantType = convertToF32Precision
+                            ? Float32Type::get(rewriter.getContext())
+                            : elemType;
+    float accBaseVal = getRedBaseVal(rop);
+    auto accBase = rewriter.create<arith::ConstantOp>(
+        loc, constantType, rewriter.getFloatAttr(constantType, accBaseVal));
+    Value initTensor;
+
+    if (isVectorReduce) {
+      // The affine vectorizer cannot vectorize affine loops generated from
+      // linalg.reduce for the vector reduce case, so we must rewrite the
+      // linalg.reduce to affine loops manually. Here we lower to AllocTensor
+      // directly instead of EmptyOp so that the subsequent pass can recognize
+      // the patterns (EmptyOp is susceptible to being CSE'd away, making it
+      // harder to match the patterns correctly).
+      initTensor = rewriter.create<bufferization::AllocTensorOp>(
+          loc, RankedTensorType::get({}, constantType), ValueRange{});
+      initTensor = rewriter.create<tensor::InsertOp>(loc, accBase, initTensor,
+                                                     ValueRange{});
+    } else {
+      Value init = rewriter.create<tensor::EmptyOp>(
+          loc, cast<RankedTensorType>(resType).getShape(), constantType);
+      initTensor = rewriter
+                       .create<linalg::FillOp>(loc, ValueRange{accBase},
+                                               ValueRange{init})
+                       .result();
+    }
+
+    Value finalResult =
+        rewriter
+            .create<linalg::ReduceOp>(
+                loc, ValueRange{source}, ValueRange{initTensor},
+                SmallVector<int64_t>{axis},
+                [&](OpBuilder &opBuilder, Location loc, ValueRange inputs) {
+                  assert(inputs.size() == 2);
+                  Value result =
+                      getRedElement(inputs[0], inputs[1], loc, rop, opBuilder,
+                                    convertToF32Precision);
+                  opBuilder.create<linalg::YieldOp>(loc, result);
+                })
+            .getResult(0);
+
+    if (sourceType.getRank() == 1) {
+      finalResult =
+          rewriter.create<tensor::ExtractOp>(loc, constantType, finalResult);
+    }
+
+    if (convertToF32Precision) {
+      finalResult = rewriter.create<arith::TruncFOp>(
+          loc, BFloat16Type::get(rewriter.getContext()), finalResult);
+    }
+
+    rewriter.replaceOp(op, finalResult);
+    return success();
+  }
+
+public:
+  LogicalResult
+  matchAndRewrite(triton::ReduceOp op,
+                  typename triton::ReduceOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto sourceType =
+        adaptor.getOperands().front().getType().cast<RankedTensorType>();
+    assert(sourceType.hasRank() && "Expected input is "
+                                   "ranked");
+
+    int64_t axis = op.getAxis();
+    assert(axis >= 0 && axis < sourceType.getRank() &&
+           "Expected reduction "
+           "axis is within "
+           "operand's rank");
+
+    return convertToLinalgReduce(op, adaptor, rewriter);
+  }
+};
+
+struct GetProgramIDConverter
+    : public OpConversionPattern<triton::GetProgramIdOp> {
+  using OpConversionPattern<triton::GetProgramIdOp>::OpConversionPattern;
+
+private:
+  const unsigned int LAUNCH_GRID_RANK;
+
+public:
+  GetProgramIDConverter(MLIRContext *context, unsigned int launchGridRank)
+      : OpConversionPattern(context), LAUNCH_GRID_RANK(launchGridRank) {}
+
+  LogicalResult
+  matchAndRewrite(triton::GetProgramIdOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto axis = op.getAxis();
+    assert(axis < LAUNCH_GRID_RANK && "program_id expects "
+                                      "axis to be either 0, "
+                                      "1, or 2");
+
+    auto func = op->getParentOfType<FunctionOpInterface>();
+    auto numArgs = func.getNumArguments();
+    auto id = func.getArgument(numArgs - LAUNCH_GRID_RANK + axis);
+
+    rewriter.replaceOp(op, id);
+    return success();
+  }
+};
+
+// Remove all Meta ops except for AddPtr which is handled by AddPtrConverter.
+// Use benefit == 10 to ensure that this pattern always takes precedence over
+// other patterns.
+struct MetaOpConverter : public RewritePattern {
+private:
+  // UseAnalysis will tag operations whose results are used only as meta-data
+  // with "MetaUse" tag.
+  bool isMetaUse(Operation *op) const { return op->hasAttr("MetaUse"); }
+
+public:
+  MetaOpConverter(MLIRContext *context)
+      : RewritePattern(MatchAnyOpTypeTag(), /*benefit=*/10, context) {}
+
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const final {
+
+    if (isa<triton::AddPtrOp>(op)) {
+      return rewriter.notifyMatchFailure(op,
+                                         "AddPtrOp will be handled separately");
+    }
+
+    if (isMetaUse(op)) {
+      rewriter.eraseOp(op);
+      return success();
+    }
+
+    return rewriter.notifyMatchFailure(op, "requires meta ops");
+  }
+};
+
+// Convert a pair of cmpf and select to either min or max.
+// Leave the pattern as simple as possible because triton has plans to emit
+// min and max directly.
+struct MinMaxConverter : public OpRewritePattern<arith::CmpFOp> {
+  using OpRewritePattern<arith::CmpFOp>::OpRewritePattern;
+
+  MinMaxConverter(MLIRContext *context)
+      : OpRewritePattern<arith::CmpFOp>(context, /*benefit=*/10) {}
+
+  LogicalResult matchAndRewrite(arith::CmpFOp cmpOp,
+                                PatternRewriter &rewriter) const final {
+    if (!cmpOp.getResult().hasOneUse()) {
+      return failure();
+    }
+    auto selectOp =
+        dyn_cast<arith::SelectOp>(*cmpOp.getResult().getUsers().begin());
+    if (!selectOp) {
+      return failure();
+    }
+
+    if (!(cmpOp.getResult() == selectOp.getCondition() &&
+          cmpOp.getLhs() == selectOp.getTrueValue() &&
+          cmpOp.getRhs() == selectOp.getFalseValue())) {
+      return failure();
+    }
+
+    auto pred = cmpOp.getPredicate();
+    auto loc = cmpOp.getLoc();
+    if (pred == arith::CmpFPredicate::OGT) {
+      rewriter.replaceOpWithNewOp<arith::MaxFOp>(selectOp, cmpOp.getLhs(),
+                                                 cmpOp.getRhs());
+    } else if (pred == arith::CmpFPredicate::OLT) {
+      rewriter.replaceOpWithNewOp<arith::MinFOp>(selectOp, cmpOp.getLhs(),
+                                                 cmpOp.getRhs());
+    } else {
+      llvm_unreachable("Unhandled predicate");
+    }
+
+    rewriter.eraseOp(cmpOp);
+
+    return success();
+  }
+};
+
+struct DenseConstantConverter : public OpConversionPattern<arith::ConstantOp> {
+  using OpConversionPattern<arith::ConstantOp>::OpConversionPattern;
+  LogicalResult
+  matchAndRewrite(arith::ConstantOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto attr = cast<DenseElementsAttr>(op.getValue());
+    auto loc = op.getLoc();
+
+    auto splatConst = rewriter.create<arith::ConstantOp>(
+        loc, attr.getSplatValue<Attribute>(), attr.getElementType());
+
+    auto init = rewriter.create<tensor::EmptyOp>(
+        loc, cast<RankedTensorType>(op.getResult().getType()).getShape(),
+        attr.getElementType());
+
+    rewriter.replaceOpWithNewOp<linalg::FillOp>(op, ValueRange{splatConst},
+                                                ValueRange{init});
+
+    return success();
+  }
+};
+
+} // namespace
+
+void mlir::triton::populateTritonToLinalgCanonicalizationPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add<MinMaxConverter>(patterns.getContext());
+}
+
+void mlir::triton::populateTritonToLinalgConversionPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns,
+    unsigned int launchGridRank) {
+  populateFunctionOpInterfaceTypeConversionPattern<triton::FuncOp>(
+      patterns, typeConverter);
+  patterns.add<MetaOpConverter>(patterns.getContext());
+  patterns.add<StoreConverter>(patterns.getContext());
+  patterns.add<AddPtrConverter>(patterns.getContext());
+  patterns.add<GetProgramIDConverter>(patterns.getContext(), launchGridRank);
+  patterns.add<YieldConverter>(patterns.getContext());
+  patterns.add<LoadConverter>(patterns.getContext());
+  patterns.add<LoopConverter>(patterns.getContext());
+  patterns.add<BroadcastConverter>(patterns.getContext());
+  patterns.add<TransposeConverter>(patterns.getContext());
+  patterns.add<MakeRangeConverter>(patterns.getContext());
+  patterns.add<ExpandDimsConverter>(patterns.getContext());
+  patterns.add<BitcastConverter>(patterns.getContext());
+  patterns.add<AssertConverter>(patterns.getContext());
+  patterns.add<MatmulConverter>(patterns.getContext());
+  patterns.add<SplatConverter>(patterns.getContext());
+  patterns.add<ReduceConverter>(patterns.getContext());
+  patterns.add<DenseConstantConverter>(patterns.getContext());
+
+  // Note: the ordering here matters!
+  // MetaOpConverter has PatternBenefit == 10 which should take precedence over
+  // these linalg patterns, but to be safe, add these patterns last so that they
+  // will be tried last. Incorrect ordering or having MetaOpConverter has lower
+  // PatternBenefit will result in element-wise meta ops being converted to
+  // linalg.generic ops.
+  linalg::populateElementwiseToLinalgConversionPatterns(patterns);
+}

--- a/lib/Conversion/TritonToLinalg/TritonToLinalgPass.cpp
+++ b/lib/Conversion/TritonToLinalg/TritonToLinalgPass.cpp
@@ -1,0 +1,232 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (c) Triton Project Contributors.
+//
+//===----------------------------------------------------------------------===//
+
+#include "triton/Analysis/UseAnalysis.h"
+#include "triton/Conversion/TritonToLinalg/TritonToLinalg.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "triton-to-linalg"
+
+using namespace mlir;
+using namespace triton;
+
+#define GEN_PASS_CLASSES
+#include "triton/Conversion/TritonToLinalg/Passes.h.inc"
+
+namespace {
+
+class TritonTypeConverter : public TypeConverter {
+public:
+  TritonTypeConverter() {
+    // The order of type conversion is important: later ones are tried earlier.
+    addConversion([](Type type) { return type; });
+    addConversion([](triton::PointerType ptrType) {
+      return UnrankedMemRefType::get(ptrType.getPointeeType(), 0);
+    });
+    addConversion([](TensorType tensorType) -> Type {
+      auto elemType = tensorType.getElementType();
+      if (auto ptrType = elemType.dyn_cast<triton::PointerType>()) {
+        elemType = ptrType.getPointeeType();
+      }
+      return MemRefType::get(tensorType.getShape(), elemType);
+    });
+  }
+};
+
+struct TritonToLinalgPass : public TritonToLinalgBase<TritonToLinalgPass> {
+
+  static unsigned int constexpr LAUNCH_GRID_RANK = 3;
+
+  // Add additional I32 arguments to represent program
+  // ID, one for each dimension of the launch grid
+  static void addProgramId(triton::FuncOp func) {
+    OpBuilder b(func);
+
+    auto origFuncType = func.getFunctionType();
+    auto origInputTypes = origFuncType.getInputs();
+    SmallVector<Type> newInputTypes(origInputTypes);
+    newInputTypes.append(LAUNCH_GRID_RANK, b.getI32Type());
+
+    auto newFuncType =
+        b.getFunctionType(newInputTypes, origFuncType.getResults());
+
+    func.setFunctionType(newFuncType);
+
+    // Add empty attributes for each new argument if needed
+    if (func.getAllArgAttrs()) {
+      SmallVector<DictionaryAttr> newArgAttrs;
+      func.getAllArgAttrs(newArgAttrs);
+      newArgAttrs.append(LAUNCH_GRID_RANK, DictionaryAttr());
+      func.setAllArgAttrs(newArgAttrs);
+    }
+
+    // Add the corresponding arguments to function body
+    for (unsigned int i = 0; i < LAUNCH_GRID_RANK; i++) {
+      func.getBody().front().addArgument(b.getI32Type(), func.getLoc());
+    }
+  }
+
+public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<func::FuncDialect, arith::ArithDialect, math::MathDialect,
+                    linalg::LinalgDialect, AffineDialect, scf::SCFDialect,
+                    tensor::TensorDialect, bufferization::BufferizationDialect,
+                    memref::MemRefDialect>();
+  }
+
+  void runOnOperation() override {
+    auto moduleOp = getOperation();
+
+    {
+      RewritePatternSet patterns(&getContext());
+      populateTritonToLinalgCanonicalizationPatterns(patterns);
+      if (failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns)))) {
+        signalPassFailure();
+      }
+    }
+
+    moduleOp.walk([this](triton::FuncOp op) {
+      if (failed(runUseAnalysis(op))) {
+        signalPassFailure();
+      }
+    });
+
+    RewritePatternSet patterns(&getContext());
+    ConversionTarget target(getContext());
+    TritonTypeConverter tritonTypeConverter;
+
+    target.addLegalDialect<
+        func::FuncDialect, arith::ArithDialect, math::MathDialect,
+        linalg::LinalgDialect, AffineDialect, scf::SCFDialect,
+        cf::ControlFlowDialect, tensor::TensorDialect,
+        bufferization::BufferizationDialect, memref::MemRefDialect>();
+
+    target.addLegalOp<ModuleOp>();
+
+    target.addIllegalDialect<triton::TritonDialect>();
+
+    // triton.reduce will be lowered to linalg.reduce. Unfortunately, mlir
+    // inserts the ops inside triton.reduce's region BEFORE triton.reduce
+    // itself, so the conversion algorithm will visit triton.reduce_return
+    // first. Without marking this op as legal, the conversion process will fail
+    // because there's no legalization pattern for triton.reduce_return.
+    target.addLegalOp<triton::ReduceReturnOp>();
+
+    target.addLegalOp<triton::ReturnOp>();
+
+    // Update function signature to use memrefs
+    target.addDynamicallyLegalOp<triton::FuncOp>([&](triton::FuncOp op) {
+      return tritonTypeConverter.isSignatureLegal(op.getFunctionType());
+    });
+
+    // Lower dense constant to linalg.fill
+    target.addDynamicallyLegalOp<arith::ConstantOp>([](arith::ConstantOp op) {
+      if (!isa<RankedTensorType>(op.getResult().getType())) {
+        return true;
+      }
+
+      if (auto denseAttr = dyn_cast<DenseElementsAttr>(op.getValue())) {
+        if (denseAttr.isSplat() &&
+            isa<FloatType, IntegerType>(denseAttr.getElementType())) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    target.addDynamicallyLegalOp<scf::ForOp, scf::YieldOp>([](Operation *op) {
+      return llvm::all_of(op->getOperandTypes(), [](Type t) {
+        if (isa<triton::PointerType>(t)) {
+          return false;
+        }
+        if (auto shapedType = dyn_cast<ShapedType>(t)) {
+          return shapedType.getElementType().isIntOrFloat();
+        }
+        assert(t.isIntOrIndexOrFloat());
+        return true;
+      });
+    });
+
+    target.addDynamicallyLegalDialect<arith::ArithDialect, math::MathDialect>(
+        [](Operation *op) {
+          if (op->hasAttr("MetaUse")) {
+            return false;
+          }
+
+          if (isa<arith::ConstantOp>(op)) {
+            return true;
+          }
+
+          bool operateOnTensors =
+              llvm::all_of(op->getOperandTypes(), [](Type type) {
+                return type.isa<RankedTensorType>();
+              });
+
+          return !operateOnTensors;
+        });
+
+    triton::populateTritonToLinalgConversionPatterns(
+        tritonTypeConverter, patterns, LAUNCH_GRID_RANK);
+
+    for (auto func : getOperation().getOps<triton::FuncOp>())
+      addProgramId(func);
+
+    if (failed(applyFullConversion(moduleOp, target, std::move(patterns))))
+      signalPassFailure();
+
+    // Convert tt.func and tt.return into func's counterparts
+    moduleOp.walk([&](triton::FuncOp func) {
+      OpBuilder builder(func);
+
+      auto name = func.getName();
+      auto type = func.getFunctionType();
+
+      SmallVector<DictionaryAttr> argAttrs, resAttrs;
+      func.getAllArgAttrs(argAttrs);
+      func.getAllResultAttrs(resAttrs);
+
+      auto funcFunc = builder.create<func::FuncOp>(func.getLoc(), name, type);
+      funcFunc.setAllArgAttrs(argAttrs);
+      funcFunc.setAllResultAttrs(resAttrs);
+
+      auto &funcFuncBody = funcFunc.getBody();
+      auto &funcBody = func.getBody();
+
+      IRMapping map;
+      funcBody.cloneInto(&funcFuncBody, map);
+
+      for (Block &block : funcFuncBody.getBlocks()) {
+        auto term = block.getTerminator();
+        builder.setInsertionPoint(term);
+        builder.create<func::ReturnOp>(func.getLoc(), term->getOperands());
+        term->erase();
+      }
+      func.erase();
+    });
+
+    // Erase dead code and fold constants created during lowering
+    PassManager pm(&getContext(), moduleOp.getOperationName());
+    pm.addPass(createCanonicalizerPass());
+    if (failed(runPipeline(pm, getOperation()))) {
+      signalPassFailure();
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> triton::createTritonToLinalgPass() {
+  return std::make_unique<TritonToLinalgPass>();
+}

--- a/test/Conversion/TritonToLinalg/addptr_2d_example.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_2d_example.mlir
@@ -1,0 +1,69 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : !tt.ptr<bf16>,
+    %arg3 : i32
+  )
+  {
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32} : tensor<4xi32>
+    // offset = 0, size = 4, stride = 1
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    // offset = [0,0], size = [4,1], stride = [1,0]
+    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [1,0]
+    %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+    %offset3 = arith.addi %2, %arg3splat : tensor<4x256xi32>
+    // offset = [%arg3,0], size = [4,256], stride = [1,0]
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32}: tensor<256xi32>
+    // offset = 0, size = 256, stride = 1
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    // offset = [0,0], size = [1,256], stride = [0,1]
+    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,1]
+    %6 = arith.constant 5 : i32
+    %splat6 = tt.splat %6 : (i32) -> tensor<4x256xi32>
+    %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,5]
+    %7 = arith.addi %offset3, %scale5: tensor<4x256xi32>
+    // offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>
+    %11 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %12 = tt.addptr %11, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg1, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %13 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>
+    %14 = arith.addf %10, %13 : tensor<4x256xbf16>
+    %15 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %16 = tt.addptr %15, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg2, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    tt.store %16, %14 : tensor<4x256xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: memref<*xbf16>, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK:           %[[VAL_7:.*]] = arith.constant 5 : index
+// CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_8]]], sizes: [4, 256], strides: [1, %[[VAL_7]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy %[[VAL_9]], %[[VAL_10]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           %[[VAL_11:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<4x256xbf16>
+// CHECK:           %[[VAL_12:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_12]]], sizes: [4, 256], strides: [1, %[[VAL_7]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_14:.*]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy %[[VAL_13]], %[[VAL_14]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           %[[VAL_15:.*]] = bufferization.to_tensor %[[VAL_14]] restrict writable : memref<4x256xbf16>
+// CHECK:           %[[VAL_16:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_11]], %[[VAL_15]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs(%[[VAL_11]] : tensor<4x256xbf16>) {
+// CHECK:           ^bb0(%[[VAL_17:.*]]: bf16, %[[VAL_18:.*]]: bf16, %[[VAL_19:.*]]: bf16):
+// CHECK:             %[[VAL_20:.*]] = arith.addf %[[VAL_17]], %[[VAL_18]] : bf16
+// CHECK:             linalg.yield %[[VAL_20]] : bf16
+// CHECK:           } -> tensor<4x256xbf16>
+// CHECK:           %[[VAL_21:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_22:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: {{\[}}%[[VAL_21]]], sizes: [4, 256], strides: [1, %[[VAL_7]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_23:.*]], %[[VAL_22]] : memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_add_value.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_add_value.mlir
@@ -1,0 +1,68 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32,
+  %arg3 : i32
+  )
+  {
+  %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+  // offset = 0, size = 4, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+  // offset = [0,0], size = [4,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [1,0]
+  %arg2splat = tt.splat %arg2 : (i32) -> tensor<4x256xi32>
+  %offset2 = arith.addi %2, %arg2splat : tensor<4x256xi32>
+  // offset = [%arg2,0], size = [4,256], stride = [1,0]
+  %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+  %offset3 = arith.addi %offset2, %arg3splat : tensor<4x256xi32>
+  // offset = [%arg2+%arg3,0], size = [4,256], stride = [1,0]
+  %c10 = arith.constant 10 : i32
+  %c10splat = tt.splat %c10 : (i32) -> tensor<4x256xi32>
+  %offset4 = arith.addi %offset3, %c10splat : tensor<4x256xi32>
+  // offset = [%arg2+%arg3+10,0], size = [4,256], stride = [1,0]
+  %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+  // offset = 0, size = 256, stride = 1
+  %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+  // offset = [0,0], size = [1,256], stride = [0,1]
+  %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<4x256xi32>
+  %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [0,6]
+  %7 = arith.addi %offset4, %scale5: tensor<4x256xi32>
+  // offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
+  %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>,tensor<4x256xi32>
+  // source = %arg0, offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
+  %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %11 = tt.addptr %10, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+  // source = %arg1, offset = [%arg2+%arg3+10, 0], size = [4, 256], stride = [1, 6]
+  %12 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<4x256xbf16>
+  tt.store %11, %12 : tensor<4x256xbf16>
+  tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 6 : index
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 10 : index
+// CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_10:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_11:.*]] = arith.addi %[[VAL_9]], %[[VAL_10]] : index
+// CHECK:           %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_12]]], sizes: [4, 256], strides: [1, %[[VAL_7]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_14:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_15:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_16:.*]] = arith.addi %[[VAL_14]], %[[VAL_15]] : index
+// CHECK:           %[[VAL_17:.*]] = arith.addi %[[VAL_16]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_18:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_17]]], sizes: [4, 256], strides: [1, %[[VAL_7]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_19:.*]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy %[[VAL_13]], %[[VAL_19]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           %[[VAL_20:.*]] = bufferization.to_tensor %[[VAL_19]] restrict writable : memref<4x256xbf16>
+// CHECK:           memref.tensor_store %[[VAL_20]], %[[VAL_18]] : memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_for_accumulation.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_for_accumulation.mlir
@@ -1,0 +1,93 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : !tt.ptr<bf16>,
+    %arg3 : i32,
+    %arg4 : i32
+  )
+  {
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+    // offset = 0, size = 4, stride = 1
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    // offset = [0,0], size = [4,1], stride = [1,0]
+    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [1,0]
+    %arg3splat = tt.splat %arg3 : (i32) -> tensor<4x256xi32>
+    %offset3 = arith.addi %2, %arg3splat : tensor<4x256xi32>
+    // offset = [%arg3,0], size = [4,256], stride = [1,0]
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+    // offset = 0, size = 256, stride = 1
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    // offset = [0,0], size = [1,256], stride = [0,1]
+    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,1]
+    %c5 = arith.constant 5 : i32
+    %splat6 = tt.splat %c5 : (i32) -> tensor<4x256xi32>
+    // scalar = 5
+    %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32> // Why we never called the conversion function for the inputs here?
+    // offset = [0,0], size = [4,256], stride = [0,5]
+    %7 = arith.addi %offset3, %scale5: tensor<4x256xi32> // Why we never called the conversion function for the inputs here?
+    // offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>> // Why is the input unknown
+    %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %19 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16> // this will be replaced with a memref.copy
+    %11 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %12 = tt.addptr %11, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg1, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %sum_out, %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%sum_iter = %19, %ptr_iter = %12) -> (tensor<4x256xbf16>, tensor<4x256x!tt.ptr<bf16>>) {
+        %20 = tt.load %ptr_iter {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+        %sum = arith.addf %sum_iter, %20 : tensor<4x256xbf16>
+        // pointer updates
+        %17 = tt.splat %i_c3 : (i32) -> tensor<4x256xi32>
+        // offset: [3, 0], size = [4, 256], stride [0, 0]
+        %ptr = tt.addptr %ptr_iter, %17 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+        // source: %arg1, offset = [%arg3+%i, 0], size = [4, 256], stride = [1, 5]
+        scf.yield %sum, %ptr : tensor<4x256xbf16>, tensor<4x256x!tt.ptr<bf16>>
+    }
+    %15 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %16 = tt.addptr %15, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg2, offset = [%arg3, 0], size = [4, 256], stride = [1, 5]
+    tt.store %16, %sum_out : tensor<4x256xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: memref<*xbf16>, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 5 : index
+// CHECK-DAG:           %[[VAL_9:.*]] = arith.constant 1 : index
+// CHECK-DAG:           %[[VAL_10:.*]] = arith.constant 3 : index
+// CHECK-DAG:           %[[VAL_11:.*]] = arith.constant 12 : index
+// CHECK-DAG:           %[[VAL_12:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_14:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_13]]], sizes: [4, 256], strides: [1, %[[VAL_8]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_15:.*]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy %[[VAL_14]], %[[VAL_15]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           %[[VAL_16:.*]] = bufferization.to_tensor %[[VAL_15]] restrict writable : memref<4x256xbf16>
+// CHECK:           %[[VAL_17:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_18:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_17]]], sizes: [4, 256], strides: {{\[}}%[[VAL_9]], %[[VAL_8]]] : memref<*xbf16> to memref<4x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK:           %[[VAL_19:.*]]:4 = scf.for %[[VAL_20:.*]] = %[[VAL_12]] to %[[VAL_11]] step %[[VAL_10]] iter_args(%[[VAL_21:.*]] = %[[VAL_16]], %[[VAL_22:.*]] = %[[VAL_18]], %[[VAL_23:.*]] = %[[VAL_17]], %[[VAL_24:.*]] = %[[VAL_12]]) -> (tensor<4x256xbf16>, memref<4x256xbf16, strided<[?, ?], offset: ?>>, index, index) {
+// CHECK:             %[[VAL_25:.*]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:             memref.copy %[[VAL_22]], %[[VAL_25]] : memref<4x256xbf16, strided<[?, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:             %[[VAL_26:.*]] = bufferization.to_tensor %[[VAL_25]] restrict writable : memref<4x256xbf16>
+// CHECK:             %[[VAL_27:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_21]], %[[VAL_26]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs(%[[VAL_21]] : tensor<4x256xbf16>) {
+// CHECK:             ^bb0(%[[VAL_28:.*]]: bf16, %[[VAL_29:.*]]: bf16, %[[VAL_30:.*]]: bf16):
+// CHECK:               %[[VAL_31:.*]] = arith.addf %[[VAL_28]], %[[VAL_29]] : bf16
+// CHECK:               linalg.yield %[[VAL_31]] : bf16
+// CHECK:             } -> tensor<4x256xbf16>
+// CHECK:             %[[VAL_32:.*]] = arith.addi %[[VAL_23]], %[[VAL_10]] : index
+// CHECK:             %[[VAL_33:.*]] = arith.addi %[[VAL_32]], %[[VAL_24]] : index
+// CHECK:             %[[VAL_34:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_33]]], sizes: [4, 256], strides: {{\[}}%[[VAL_9]], %[[VAL_8]]] : memref<*xbf16> to memref<4x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK:             scf.yield %[[VAL_35:.*]], %[[VAL_34]], %[[VAL_33]], %[[VAL_12]] : tensor<4x256xbf16>, memref<4x256xbf16, strided<[?, ?], offset: ?>>, index, index
+// CHECK:           }
+// CHECK:           %[[VAL_36:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_37:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: {{\[}}%[[VAL_36]]], sizes: [4, 256], strides: [1, %[[VAL_8]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_38:.*]]#0, %[[VAL_37]] : memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_for_expand_ptr.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_for_expand_ptr.mlir
@@ -1,0 +1,64 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>
+  )
+  {
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %1 = tt.make_range {end = 2048 : i32, start = 1024 : i32}:tensor<256xi32>
+    // source: null, sizes: 256, offsets: 1024, strides: 4
+    %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg0, sizes: 256, offsets: 1024, strides: 4
+    // gep operand is another gep' output, which is passed into the loop as varible, used after update
+    %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %2) -> (tensor<256x!tt.ptr<bf16>>) {
+      %6 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+      %7 = tt.expand_dims %6 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+      %8 = tt.broadcast %7 : (tensor<256x1xi32>) -> tensor<256x256xi32>
+      // sizes: [256, 256], offsets: [0, 0], strides: [1, 0]
+      %9 = tt.make_range {end = 512 : i32, start = 256 : i32} : tensor<256xi32>
+      %10 = tt.expand_dims %9 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+      %11 = tt.broadcast %10 : (tensor<1x256xi32>) -> tensor<256x256xi32>
+      // sizes: [256, 256], offsets: [0, 256], strides: [0, 1]
+      %12 = arith.addi %8, %11 : tensor<256x256xi32>
+      // sizes: [256, 256], offsets: [0, 256], strides: [1, 1]
+      %13 = tt.expand_dims %ptr {axis = 1 : i32} : (tensor<256x!tt.ptr<bf16>>) -> tensor<256x1x!tt.ptr<bf16>>
+      %14 = tt.broadcast %13 : (tensor<256x1x!tt.ptr<bf16>>) -> tensor<256x256x!tt.ptr<bf16>>
+      %15 = tt.addptr %14, %12 : tensor<256x256x!tt.ptr<bf16>>, tensor<256x256xi32>
+      // source: arg0, sizes: [256, 256], offsets: [1024 + i, 256], strides: [5, 1]
+      // perform load
+      %16 = tt.load %15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256x256xbf16>
+      tt.store %15, %16 : tensor<256x256xbf16>
+      // pointer updates
+      %17 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+      // sizes: 256, offsets: 3, strides: 0
+      %ptr_iter = tt.addptr %ptr, %17 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+      // source: arg0, sizes: 256, offsets: 1024 + i, strides: 4
+      scf.yield %ptr_iter : tensor<256x!tt.ptr<bf16>>
+    }
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_4:.*]] = arith.constant 5 : index
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 1024 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 0 : index
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 12 : index
+// CHECK-DAG:           %[[VAL_9:.*]] = arith.constant 3 : index
+// CHECK:           %[[VAL_10:.*]] = scf.for %[[VAL_11:.*]] = %[[VAL_7]] to %[[VAL_8]] step %[[VAL_9]] iter_args(%[[VAL_12:.*]] = %[[VAL_6]]) -> (index) {
+// CHECK:             %[[VAL_13:.*]] = arith.addi %[[VAL_12]], %[[VAL_5]] : index
+// CHECK:             %[[VAL_14:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_13]]], sizes: [256, 256], strides: {{\[}}%[[VAL_4]], 1] : memref<*xbf16> to memref<256x256xbf16, strided<[?, 1], offset: ?>>
+// CHECK:             %[[VAL_15:.*]] = memref.alloc() : memref<256x256xbf16>
+// CHECK:             memref.copy %[[VAL_14]], %[[VAL_15]] : memref<256x256xbf16, strided<[?, 1], offset: ?>> to memref<256x256xbf16>
+// CHECK:             %[[VAL_16:.*]] = bufferization.to_tensor %[[VAL_15]] restrict writable : memref<256x256xbf16>
+// CHECK:             memref.tensor_store %[[VAL_16]], %[[VAL_14]] : memref<256x256xbf16, strided<[?, 1], offset: ?>>
+// CHECK:             %[[VAL_17:.*]] = arith.addi %[[VAL_12]], %[[VAL_9]] : index
+// CHECK:             scf.yield %[[VAL_17]] : index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_for_more_init_args.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_for_more_init_args.mlir
@@ -1,0 +1,72 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>
+  )
+  {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c2 = arith.constant 2 : index
+    %c3 = arith.constant 3 : index
+    %c12 = arith.constant 12 : index
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %1 = tt.make_range {end = 2048 : i32, start = 1024 : i32}:tensor<256xi32>
+    // source: null, sizes: 256, offsets: 1024, strides: 4
+    %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg0, sizes: 256, offsets: 1024, strides: 4
+    %3 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %4 = tt.addptr %3, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg1, sizes: 256, offsets: 1024, strides: 4
+    %_arg2, %_ptr_ld, %_arg3, %_ptr_st, %_arg4 = scf.for %i = %c0 to %c12 step %c3 iter_args(%arg2 = %c1, %ptr_ld = %2, %arg3 = %c2, %ptr_st = %4, %arg4 = %c3) -> (index, tensor<256x!tt.ptr<bf16>>, index, tensor<256x!tt.ptr<bf16>>, index) {
+        // perform load
+        %5 = tt.load %ptr_ld {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+        tt.store %ptr_st, %5 : tensor<256xbf16>
+        // pointer updates
+        %cast3 = arith.index_cast %c3 : index to i32
+        %6 = tt.splat %cast3 : (i32) -> tensor<256xi32>
+        %ptr_ld_iter = tt.addptr %ptr_ld, %6 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+        // source: arg0, sizes: 256, offsets: 1024 + i*3, strides: 4
+        %arg2_iter = arith.addi %arg2, %c3 : index
+        %arg3_iter = arith.addi %arg3, %c3 : index
+        %arg4_iter = arith.addi %arg4, %c3 : index
+        %7 = arith.addi %arg2_iter, %arg3_iter : index
+        %8 = arith.addi %7, %arg4_iter : index
+        %cast8 = arith.index_cast %8 : index to i32
+        %9 = tt.splat %cast8 : (i32) -> tensor<256xi32>
+        %ptr_st_iter = tt.addptr %ptr_st, %9 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+        // source: arg1, sizes: 256, offsets: 1024 + loop-carry variable*i, strides: 4
+        scf.yield %arg2_iter, %ptr_ld_iter, %arg3_iter, %ptr_st_iter, %arg4_iter : index, tensor<256x!tt.ptr<bf16>>, index, tensor<256x!tt.ptr<bf16>>, index
+    }
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 4 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 1024 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 0 : index
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 1 : index
+// CHECK-DAG:           %[[VAL_9:.*]] = arith.constant 2 : index
+// CHECK-DAG:           %[[VAL_10:.*]] = arith.constant 3 : index
+// CHECK-DAG:           %[[VAL_11:.*]] = arith.constant 12 : index
+// CHECK:           %[[VAL_12:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_6]]], sizes: [256], strides: {{\[}}%[[VAL_5]]] : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:           %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_6]]], sizes: [256], strides: {{\[}}%[[VAL_5]]] : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:           %[[VAL_14:.*]]:7 = scf.for %[[VAL_15:.*]] = %[[VAL_7]] to %[[VAL_11]] step %[[VAL_10]] iter_args(%[[VAL_16:.*]] = %[[VAL_8]], %[[VAL_17:.*]] = %[[VAL_12]], %[[VAL_18:.*]] = %[[VAL_9]], %[[VAL_19:.*]] = %[[VAL_13]], %[[VAL_20:.*]] = %[[VAL_10]], %[[VAL_21:.*]] = %[[VAL_6]], %[[VAL_22:.*]] = %[[VAL_6]]) -> (index, memref<256xbf16, strided<[?], offset: ?>>, index, memref<256xbf16, strided<[?], offset: ?>>, index, index, index) {
+// CHECK:             %[[VAL_23:.*]] = memref.alloc() : memref<256xbf16>
+// CHECK:             memref.copy %[[VAL_17]], %[[VAL_23]] : memref<256xbf16, strided<[?], offset: ?>> to memref<256xbf16>
+// CHECK:             %[[VAL_24:.*]] = bufferization.to_tensor %[[VAL_23]] restrict writable : memref<256xbf16>
+// CHECK:             memref.tensor_store %[[VAL_24]], %[[VAL_19]] : memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:             %[[VAL_25:.*]] = arith.addi %[[VAL_21]], %[[VAL_10]] : index
+// CHECK:             %[[VAL_26:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_25]]], sizes: [256], strides: {{\[}}%[[VAL_5]]] : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:             %[[VAL_27:.*]] = arith.addi %[[VAL_16]], %[[VAL_10]] : index
+// CHECK:             %[[VAL_28:.*]] = arith.addi %[[VAL_18]], %[[VAL_10]] : index
+// CHECK:             %[[VAL_29:.*]] = arith.addi %[[VAL_20]], %[[VAL_10]] : index
+// CHECK:             %[[VAL_30:.*]] = arith.addi %[[VAL_27]], %[[VAL_28]] : index
+// CHECK:             %[[VAL_31:.*]] = arith.addi %[[VAL_30]], %[[VAL_29]] : index
+// CHECK:             %[[VAL_32:.*]] = arith.addi %[[VAL_22]], %[[VAL_31]] : index
+// CHECK:             %[[VAL_33:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_32]]], sizes: [256], strides: {{\[}}%[[VAL_5]]] : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:             scf.yield %[[VAL_27]], %[[VAL_26]], %[[VAL_28]], %[[VAL_33]], %[[VAL_29]], %[[VAL_25]], %[[VAL_32]] : index, memref<256xbf16, strided<[?], offset: ?>>, index, memref<256xbf16, strided<[?], offset: ?>>, index, index, index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_for_used_after_update.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_for_used_after_update.mlir
@@ -1,0 +1,98 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>
+  )
+  {
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %1 = tt.make_range {end = 2048 : i32, start = 1024 : i32}:tensor<256xi32>
+    // source: null, sizes: 256, offsets: 1024, strides: 4
+    %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg0, sizes: 256, offsets: 1024, strides: 4
+    // gep operand is another gep' output, which is passed into the loop as varible, used after update
+    %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %2) -> (tensor<256x!tt.ptr<bf16>>) {
+        // pointer updates
+        %4 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+        // sizes: 256, offsets: 3, strides: 0
+        %ptr_iter = tt.addptr %ptr, %4 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+        // source: arg0, sizes: 256, offsets: 1024 + i, strides: 4
+        // perform load
+        %3 = tt.load %ptr_iter {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+        tt.store %ptr_iter, %3 : tensor<256xbf16>
+        scf.yield %ptr_iter : tensor<256x!tt.ptr<bf16>>
+    }
+    // Expected output
+    // %offset_dim0 = arith.constant 1024                                                       <- insert instructions to initialize init arg(new)
+    // for iter_args (%offset_dim0_iter = %offset_dim0) {                                       <- replace varibles passed in as init arg (new)
+    //  %4 = %offset_dim0_iter + %c3                                                            <- replace gep of splat with add (already done)
+    //  %subview = memref.subview %arg0, [%4][256][4] : memref<> -> memref<>                    <- generate subview on getelementptr (already done)
+    //  ...
+    //  scf.yield %4                                                                            <- replace yielding an gep output with the corresponding dim variable (new)
+    // }
+    // TODO: examples below are not supported since scf.for does not support returning a tensor type
+    // Example 3, gep operand is a vector of i32, which is passed into the loop as variable, pointer updated using step, used after update
+    //%_ptr3 = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %1) -> (tensor<256xi32>) {
+    //    // offset update
+    //    %3 = tt.splat %c3 : (i32) -> tensor<256xi32>
+    //    %ptr_iter = arith.addi %3, %ptr : tensor<256xi32>
+    //    // generate pointer
+    //    %gep_ptr = tt.addptr %0, %ptr_iter : tensor<256x!tt.ptr<bf16>>
+    //    // perform load
+    //    %4 = tt.load %gep_ptr {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+    //    tt.store %gep_ptr, %4 : tensor<256xbf16>
+    //    scf.yield %ptr_iter : tensor<256xi32>
+    //}
+    // Expected output
+    // %offset_dim0 = arith.constant 1024                                                       <- insert instructions to initialize init arg(new)
+    // for iter_args (%offset_dim0_iter = %offset_dim0) {                                       <- replace varibles passed in as init arg (new)
+    //  %4 = %offset_dim0_iter + %c3                                                            <- replace gep of splat with add (already done)
+    //  %subview = memref.subview %arg0, [%offset_dim0_iter][256][4] : memref<> -> memref<>     <- generate subview on load (new)
+    //  ...
+    //  scf.yield %4                                                                            <- replace yielding an gep output with the corresponding dim variable (new)
+    // }
+    //// Example 4, gep operand is a vector of i32, which is passed into the loop as variable, pointer updated using step, used before update
+    //%_ptr4 = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %1) -> (tensor<256xi32>) {
+    //    // generate pointer
+    //    %gep_ptr = tt.addptr %0, %ptr : tensor<256x!tt.ptr<bf16>>
+    //
+    //    // perform load
+    //    %4 = tt.load %gep_ptr {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+    //    tt.store %gep_ptr, %4 : tensor<256xbf16>
+    //    // offset update
+    //    %3 = tt.splat %c3 : (i32) -> tensor<256xi32>
+    //    %ptr_iter = arith.addi %3, %ptr : tensor<256xi32>
+    //    scf.yield %ptr_iter : tensor<256xi32>
+    //}
+    // Expected output
+    // %offset_dim0 = arith.constant 1024                                                       <- insert instructions to initialize init arg(new)
+    // for iter_args (%offset_dim0_iter = %offset_dim0) {                                       <- replace varibles passed in as init arg (new)
+    //  %subview = memref.subview %arg0, [%offset_dim0_iter][256][4] : memref<> -> memref<>     <- generate subview on load (new)
+    //  ...
+    //  %4 = %offset_dim0_iter + %c3                                                            <- replace gep of splat with add (already done)
+    //  scf.yield %4                                                                            <- replace yielding an gep output with the corresponding dim variable (new)
+    // }
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_4:.*]] = arith.constant 4 : index
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 1024 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 12 : index
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 3 : index
+// CHECK:           %[[VAL_9:.*]] = scf.for %[[VAL_10:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] iter_args(%[[VAL_11:.*]] = %[[VAL_5]]) -> (index) {
+// CHECK:             %[[VAL_12:.*]] = arith.addi %[[VAL_11]], %[[VAL_8]] : index
+// CHECK:             %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_12]]], sizes: [256], strides: {{\[}}%[[VAL_4]]] : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:             %[[VAL_14:.*]] = memref.alloc() : memref<256xbf16>
+// CHECK:             memref.copy %[[VAL_13]], %[[VAL_14]] : memref<256xbf16, strided<[?], offset: ?>> to memref<256xbf16>
+// CHECK:             %[[VAL_15:.*]] = bufferization.to_tensor %[[VAL_14]] restrict writable : memref<256xbf16>
+// CHECK:             memref.tensor_store %[[VAL_15]], %[[VAL_13]] : memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:             scf.yield %[[VAL_12]] : index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_for_used_before_update.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_for_used_before_update.mlir
@@ -1,0 +1,55 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>
+  )
+  {
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %i_c3 = arith.constant 3 : i32
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %1 = tt.make_range {end = 2048 : i32, start = 1024 : i32}:tensor<256xi32>
+    // source: null, sizes: 256, offsets: 1024, strides: 4
+    %2 = tt.addptr %0, %1 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    // source: arg0, sizes: 256, offsets: 1024, strides: 4
+    // Example 2, gep operand is another gep's output, which is passed into the loop as varible, used before update
+    %_ptr2 = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr = %2) -> (tensor<256x!tt.ptr<bf16>>) {
+        // perform load
+        %3 = tt.load %ptr {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256xbf16>
+        tt.store %ptr, %3 : tensor<256xbf16>
+        // pointer updates
+        %4 = tt.splat %i_c3 : (i32) -> tensor<256xi32>
+        %ptr_iter = tt.addptr %ptr, %4 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+        scf.yield %ptr_iter : tensor<256x!tt.ptr<bf16>>
+    }
+    // Expected output
+    // %offset_dim0 = arith.constant 1024                                                       <- insert instructions to initialize init arg(new)
+    // for iter_args (%offset_dim0_iter = %offset_dim0) {                                       <- replace varibles passed in as init arg (new)
+    //  %subview = memref.subview %arg0, [%offset_dim0_iter][256][4] : memref<> -> memref<>     <- generate subview on load (new)
+    //  ...
+    //  %4 = %offset_dim0_iter + %c3                                                            <- replace gep of splat with add (already done)
+    //  scf.yield %4                                                                            <- replace yielding an gep output with the corresponding dim variable (new)
+    // }
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_4:.*]] = arith.constant 4 : index
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 1024 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 12 : index
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 3 : index
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_5]]], sizes: [256], strides: {{\[}}%[[VAL_4]]] : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:           %[[VAL_10:.*]]:2 = scf.for %[[VAL_11:.*]] = %[[VAL_6]] to %[[VAL_7]] step %[[VAL_8]] iter_args(%[[VAL_12:.*]] = %[[VAL_9]], %[[VAL_13:.*]] = %[[VAL_5]]) -> (memref<256xbf16, strided<[?], offset: ?>>, index) {
+// CHECK:             %[[VAL_14:.*]] = memref.alloc() : memref<256xbf16>
+// CHECK:             memref.copy %[[VAL_12]], %[[VAL_14]] : memref<256xbf16, strided<[?], offset: ?>> to memref<256xbf16>
+// CHECK:             %[[VAL_15:.*]] = bufferization.to_tensor %[[VAL_14]] restrict writable : memref<256xbf16>
+// CHECK:             memref.tensor_store %[[VAL_15]], %[[VAL_12]] : memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:             %[[VAL_16:.*]] = arith.addi %[[VAL_13]], %[[VAL_8]] : index
+// CHECK:             %[[VAL_17:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_16]]], sizes: [256], strides: {{\[}}%[[VAL_4]]] : memref<*xbf16> to memref<256xbf16, strided<[?], offset: ?>>
+// CHECK:             scf.yield %[[VAL_17]], %[[VAL_16]] : memref<256xbf16, strided<[?], offset: ?>>, index
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_loopback.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_loopback.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32
+  )
+  {
+  %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+  // offset = 0, size = 4, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+  // offset = [0,0], size = [4,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [1,0]
+  %arg2splat = tt.splat %arg2 : (i32) -> tensor<4x256xi32>
+  %offset2 = arith.addi %2, %arg2splat : tensor<4x256xi32>
+  // offset = [%arg2,0], size = [4,256], stride = [1,0]
+  %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+  // offset = 0, size = 256, stride = 1
+  %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+  // offset = [0,0], size = [1,256], stride = [0,1]
+  %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<4x256xi32>
+  %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
+  // offset = [0,0], size = [4,256], stride = [0,6]
+  %7 = arith.addi %offset2, %scale5: tensor<4x256xi32>
+  // offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
+  %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+  // source: arg0, offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
+  %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+  %11 = tt.addptr %10, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+  // source: arg1, offset = [%arg2, 0], size = [4, 256], stride = [1, 6]
+  %12 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+  tt.store %11, %12 : tensor<4x256xbf16>
+  tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK:           %[[VAL_6:.*]] = arith.constant 6 : index
+// CHECK:           %[[VAL_7:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_7]]], sizes: [4, 256], strides: [1, %[[VAL_6]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_10:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_9]]], sizes: [4, 256], strides: [1, %[[VAL_6]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_11:.*]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy %[[VAL_8]], %[[VAL_11]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           %[[VAL_12:.*]] = bufferization.to_tensor %[[VAL_11]] restrict writable : memref<4x256xbf16>
+// CHECK:           memref.tensor_store %[[VAL_12]], %[[VAL_10]] : memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_mul_const_const.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_mul_const_const.mlir
@@ -1,0 +1,48 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : i32
+  )
+  {
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = tt.make_range {end = 1024 : i32, start = 0 : i32}:tensor<1024xi32>
+    %2 = tt.splat %0 : (i32) -> tensor<1024xi32>
+    %3 = arith.addi %2, %1 : tensor<1024xi32>
+    //%3: splat(%0) + range(0, 1024)
+    //%3: offset = %0, size = 1024, stride = 1
+    // vector and scalar are both constant
+    %4 = tt.make_range {end = 4096 : i32, start = 2048 : i32}:tensor<1024xi32>
+    %c10 = arith.constant 10 : i32
+    %5 = tt.splat %c10 : (i32) -> tensor<1024xi32>
+    %6 = arith.muli %5, %4 : tensor<1024xi32>
+    //%6: splat(%c10)*range(2048, 4096);
+    //%6: offset = %c10*2048, size = 1024, stride = %c10*2
+    %7 = arith.addi %3, %6 : tensor<1024xi32>
+    //%7: offset = %c10*2048 + %0, size = 1024, stride = %c10*2+1
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
+    //source=%arg0 offset = %c10*2048 + pid0, size = 1024, stride = %c10*2+1
+    %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %11 = tt.addptr %10, %3 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
+    //source=%arg1, offset = pid0, size = 1024, stride = 1
+    %16 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xbf16>
+    tt.store %11, %16 : tensor<1024xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK:           %[[VAL_7:.*]] = arith.constant 20480 : index
+// CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_10:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_9]]], sizes: [1024], strides: {{\[}}21] : memref<*xbf16> to memref<1024xbf16, strided<[21], offset: ?>>
+// CHECK:           %[[VAL_11:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_12:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_11]]], sizes: [1024], strides: [1] : memref<*xbf16> to memref<1024xbf16, strided<[1], offset: ?>>
+// CHECK:           %[[VAL_13:.*]] = memref.alloc() : memref<1024xbf16>
+// CHECK:           memref.copy %[[VAL_10]], %[[VAL_13]] : memref<1024xbf16, strided<[21], offset: ?>> to memref<1024xbf16>
+// CHECK:           %[[VAL_14:.*]] = bufferization.to_tensor %[[VAL_13]] restrict writable : memref<1024xbf16>
+// CHECK:           memref.tensor_store %[[VAL_14]], %[[VAL_12]] : memref<1024xbf16, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_mul_value_const.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_mul_value_const.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : i32
+  )
+  {
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = tt.make_range {end = 1024 : i32, start = 0 : i32}:tensor<1024xi32>
+    %2 = tt.splat %0 : (i32) -> tensor<1024xi32>
+    %3 = arith.addi %2, %1 : tensor<1024xi32>
+    //%3: splat(%0) + range(0, 1024)
+    //%3: offset = %0, size = 1024, stride = 1
+    // vector is constant, scalar is value
+    %4 = tt.make_range {end = 4096 : i32, start = 2048 : i32}:tensor<1024xi32>
+    %5 = tt.splat %arg2 : (i32) -> tensor<1024xi32>
+    %6 = arith.muli %5, %4 : tensor<1024xi32>
+    //%6: splat(%arg2)*range(2048, 4096);
+    //%6: offset = %arg2*2048, size = 1024, stride = %arg2*2
+    %7 = arith.addi %3, %6 : tensor<1024xi32>
+    //%7: offset = %arg2*2048 + %0, size = 1024, stride = %arg2*2+1
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
+    //source=%arg0: offset = %arg2*2048 + pid0, size = 1024, stride = %arg2*2+1
+    %10 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<1024x!tt.ptr<bf16>>
+    %11 = tt.addptr %10, %3 : tensor<1024x!tt.ptr<bf16>>, tensor<1024xi32>
+    //source=%arg1: offset = pid0, size = 1024, stride = 1
+    %16 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xbf16>
+    tt.store %11, %16 : tensor<1024xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 1 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 2 : index
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 2048 : index
+// CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_10:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_11:.*]] = arith.muli %[[VAL_10]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_12:.*]] = arith.muli %[[VAL_10]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_9]], %[[VAL_11]] : index
+// CHECK:           %[[VAL_14:.*]] = arith.addi %[[VAL_12]], %[[VAL_6]] : index
+// CHECK:           %[[VAL_15:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_13]]], sizes: [1024], strides: {{\[}}%[[VAL_14]]] : memref<*xbf16> to memref<1024xbf16, strided<[?], offset: ?>>
+// CHECK:           %[[VAL_16:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_17:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_16]]], sizes: [1024], strides: [1] : memref<*xbf16> to memref<1024xbf16, strided<[1], offset: ?>>
+// CHECK:           %[[VAL_18:.*]] = memref.alloc() : memref<1024xbf16>
+// CHECK:           memref.copy %[[VAL_15]], %[[VAL_18]] : memref<1024xbf16, strided<[?], offset: ?>> to memref<1024xbf16>
+// CHECK:           %[[VAL_19:.*]] = bufferization.to_tensor %[[VAL_18]] restrict writable : memref<1024xbf16>
+// CHECK:           memref.tensor_store %[[VAL_19]], %[[VAL_17]] : memref<1024xbf16, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_nested.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_nested.mlir
@@ -1,0 +1,73 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : i32
+  )
+  {
+    %0 = tt.make_range {end = 4 : i32, start = 0 : i32}:tensor<4xi32>
+    // offset = 0, size = 4, stride = 1
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<4xi32>) -> tensor<4x1xi32>
+    // offset = [0,0], size = [4,1], stride = [1,0]
+    %2 = tt.broadcast %1 : (tensor<4x1xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [1,0]
+    %arg1splat = tt.splat %arg1 : (i32) -> tensor<4x256xi32>
+    %offset3 = arith.addi %2, %arg1splat : tensor<4x256xi32>
+    // offset = [%arg1,0], size = [4,256], stride = [1,0]
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32}:tensor<256xi32>
+    // offset = 0, size = 256, stride = 1
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    // offset = [0,0], size = [1,256], stride = [0,1]
+    %5 = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,1]
+    %6 = arith.constant 5 : i32
+    %splat6 = tt.splat %6 : (i32) -> tensor<4x256xi32>
+    %scale5 = arith.muli %5, %splat6 : tensor<4x256xi32>
+    // offset = [0,0], size = [4,256], stride = [0,5]
+    %7 = arith.addi %offset3, %scale5: tensor<4x256xi32>
+    // offset = [%arg1, 0], size = [4, 256], stride = [1, 5]
+    %8 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<4x256x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg1, 0], size = [4, 256], stride = [1, 5]
+    %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+    %12 = tt.addptr %9, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg1+%arg1, 0], size = [4, 256], stride = [2, 10]
+    %13 = tt.load %12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<4x256xbf16>
+    %14 = arith.addf %10, %13 : tensor<4x256xbf16>
+    %16 = tt.addptr %12, %7 : tensor<4x256x!tt.ptr<bf16>>, tensor<4x256xi32>
+    // source: %arg0, offset = [%arg1+%arg1+%arg1, 0], size = [4, 256], stride = [3, 15]
+    tt.store %16, %14 : tensor<4x256xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 15 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 5 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 10 : index
+// CHECK:           %[[VAL_8:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_8]]], sizes: [4, 256], strides: [1, %[[VAL_6]]] : memref<*xbf16> to memref<4x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy %[[VAL_9]], %[[VAL_10]] : memref<4x256xbf16, strided<[1, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           %[[VAL_11:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<4x256xbf16>
+// CHECK:           %[[VAL_12:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[VAL_14:.*]] = arith.addi %[[VAL_12]], %[[VAL_13]] : index
+// CHECK:           %[[VAL_15:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_14]]], sizes: [4, 256], strides: [2, %[[VAL_7]]] : memref<*xbf16> to memref<4x256xbf16, strided<[2, ?], offset: ?>>
+// CHECK:           %[[VAL_16:.*]] = memref.alloc() : memref<4x256xbf16>
+// CHECK:           memref.copy %[[VAL_15]], %[[VAL_16]] : memref<4x256xbf16, strided<[2, ?], offset: ?>> to memref<4x256xbf16>
+// CHECK:           %[[VAL_17:.*]] = bufferization.to_tensor %[[VAL_16]] restrict writable : memref<4x256xbf16>
+// CHECK:           %[[VAL_18:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_11]], %[[VAL_17]] : tensor<4x256xbf16>, tensor<4x256xbf16>) outs(%[[VAL_11]] : tensor<4x256xbf16>) {
+// CHECK:           ^bb0(%[[VAL_19:.*]]: bf16, %[[VAL_20:.*]]: bf16, %[[VAL_21:.*]]: bf16):
+// CHECK:             %[[VAL_22:.*]] = arith.addf %[[VAL_19]], %[[VAL_20]] : bf16
+// CHECK:             linalg.yield %[[VAL_22]] : bf16
+// CHECK:           } -> tensor<4x256xbf16>
+// CHECK:           %[[VAL_23:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[VAL_24:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[VAL_25:.*]] = arith.addi %[[VAL_23]], %[[VAL_24]] : index
+// CHECK:           %[[VAL_26:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[VAL_27:.*]] = arith.addi %[[VAL_25]], %[[VAL_26]] : index
+// CHECK:           %[[VAL_28:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_27]]], sizes: [4, 256], strides: [3, %[[VAL_5]]] : memref<*xbf16> to memref<4x256xbf16, strided<[3, ?], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_29:.*]], %[[VAL_28]] : memref<4x256xbf16, strided<[3, ?], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_reshape_broadcast.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_reshape_broadcast.mlir
@@ -1,0 +1,42 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+// TODO: expand this example to 3D
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>
+  )
+  {
+  %0 = tt.make_range {end = 1024 : i32, start = 512 : i32}:tensor<256xi32>
+  // offset = [512] size = 256, stride = 2
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  // offset = [512,0], size = [256,1], stride = [2,0]
+  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  // offset = [512,0], size = [256,128], stride = [2,0]
+  %5 = tt.make_range {end = 1408 : i32, start = 1024 : i32}:tensor<128xi32>
+  // offset = 1024, size = 128, stride = 3
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  // offset = [0,1024], size = [1,128], stride = [0,3]
+  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  // offset = [0,1024], size = [256,128], stride = [0,3]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
+  // offset = [0,6144], size = [256,128], stride = [0,18]
+  %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
+  // offset = [512,6144], size = [256,128], stride = [2,18]
+  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
+  %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
+  tt.store %18, %19 : tensor<256x128xbf16>
+  tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}6656], sizes: [256, 128], strides: [2, 18] : memref<*xbf16> to memref<256x128xbf16, strided<[2, 18], offset: 6656>>
+// CHECK:           %[[VAL_8:.*]] = memref.alloc() : memref<256x128xbf16>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_8]] : memref<256x128xbf16, strided<[2, 18], offset: 6656>> to memref<256x128xbf16>
+// CHECK:           %[[VAL_9:.*]] = bufferization.to_tensor %[[VAL_8]] restrict writable : memref<256x128xbf16>
+// CHECK:           memref.tensor_store %[[VAL_9]], %[[VAL_7]] : memref<256x128xbf16, strided<[2, 18], offset: 6656>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_scalar_broadcast.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_scalar_broadcast.mlir
@@ -1,0 +1,65 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    // source = arg1, offset = %1, size = 1, strides = 0
+    %3 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = arg1, offset = %1, size = 1024, strides = 0
+    %4 = tt.expand_dims %3 {axis = 1 : i32} : (tensor<1024x!tt.ptr<f32>>) -> tensor<1024x1x!tt.ptr<f32>>
+    // source = arg1, offset = [%1, 0], size = [1024, 1], strides = [0, 0]
+    %5 = tt.broadcast %4 : (tensor<1024x1x!tt.ptr<f32>>) -> tensor<1024x1024x!tt.ptr<f32>>
+    // source = arg1, offset = [%1, 0], size = [1024, 1024], strides = [0, 0]
+    %6 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // offset = 0, size = 1024, strides = 1
+    %7 = tt.expand_dims %6 {axis = 0 : i32} : (tensor<1024xi32>) -> tensor<1x1024xi32>
+    // offset = [0, 0], size = [1, 1024], strides = [0, 1]
+    %8 = tt.broadcast %7 : (tensor<1x1024xi32>) -> tensor<1024x1024xi32>
+    // offset = [0, 0], size = [1024, 1024], strides = [0, 1]
+    %9 = tt.make_range {end = 2048 : i32, start = 0 : i32} : tensor<1024xi32>
+    // offset = 0, size = 1024, strides = 2
+    %10 = tt.expand_dims %9 {axis = 1 : i32} : (tensor<1024xi32>) -> tensor<1024x1xi32>
+    // offset = [0, 0], size = [1024, 1], strides = [2, 0]
+    %11 = tt.broadcast %10 : (tensor<1024x1xi32>) -> tensor<1024x1024xi32>
+    // offset = [0, 0], size = [1024, 1024], strides = [2, 0]
+    %12 = arith.addi %8, %11 : tensor<1024x1024xi32>
+    // offset = [0, 0], size = [1024, 1024], strides = [2, 1]
+    %13 = tt.addptr %5, %12 : tensor<1024x1024x!tt.ptr<f32>>, tensor<1024x1024xi32>
+    // source = arg1, offset = [pid * %arg2, 0], size = [1024, 1024], strides = [2, 1]
+    %14 = tt.load %13 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024x1024xf32>
+    %17 = math.exp %14 : tensor<1024x1024xf32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = arg0, offset = pid+arg3, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = arg0, offset = pid+arg3, size = 1024, strides = 0
+    %21 = tt.expand_dims %20 {axis = 1 : i32} : (tensor<1024x!tt.ptr<f32>>) -> tensor<1024x1x!tt.ptr<f32>>
+    // source = arg0, offset = [pid+arg3, 0], size = [1024, 1], strides = [0, 0]
+    %22 = tt.broadcast %21 : (tensor<1024x1x!tt.ptr<f32>>) -> tensor<1024x1024x!tt.ptr<f32>>
+    // source = arg0, offset = [pid+arg3, 0], size = [1024, 1024], strides = [0, 0]
+    %23 = tt.addptr %22, %12 : tensor<1024x1024x!tt.ptr<f32>>, tensor<1024x1024xi32>
+    // source = arg0, offset = [pid+arg3, 0], size = [1024, 1024], strides = [2, 1]
+    tt.store %23, %17 : tensor<1024x1024xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_1:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32) {
+// CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : i32 to index
+// CHECK:           %[[VAL_10:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_9]]], sizes: [1024, 1024], strides: [2, 1] : memref<*xf32> to memref<1024x1024xf32, strided<[2, 1], offset: ?>>
+// CHECK:           %[[VAL_11:.*]] = memref.alloc() : memref<1024x1024xf32>
+// CHECK:           memref.copy %[[VAL_10]], %[[VAL_11]] : memref<1024x1024xf32, strided<[2, 1], offset: ?>> to memref<1024x1024xf32>
+// CHECK:           %[[VAL_12:.*]] = bufferization.to_tensor %[[VAL_11]] restrict writable : memref<1024x1024xf32>
+// CHECK:           %[[VAL_13:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_12]] : tensor<1024x1024xf32>) outs(%[[VAL_12]] : tensor<1024x1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_14:.*]]: f32, %[[VAL_15:.*]]: f32):
+// CHECK:             %[[VAL_16:.*]] = math.exp %[[VAL_14]] : f32
+// CHECK:             linalg.yield %[[VAL_16]] : f32
+// CHECK:           } -> tensor<1024x1024xf32>
+// CHECK:           %[[VAL_17:.*]] = arith.muli %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+// CHECK:           %[[VAL_19:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_18]]], sizes: [1024, 1024], strides: [2, 1] : memref<*xf32> to memref<1024x1024xf32, strided<[2, 1], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_20:.*]], %[[VAL_19]] : memref<1024x1024xf32, strided<[2, 1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_scalar_for.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_scalar_for.mlir
@@ -1,0 +1,70 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    // source = %arg1, offset = %1, size = 1, strides = 0
+    %cf0 = arith.constant 0.000000e+00 : f32
+    %tensor_cf0 = tt.splat %cf0 : (f32) -> tensor<1024xf32>
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %_ptr, %sum_out = scf.for %i = %c0 to %c12 step %c3 iter_args(%ptr_iter = %2, %sum_iter = %tensor_cf0) ->  (!tt.ptr<f32>, tensor<1024xf32>) {
+      %3 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+      // offset = 0, size = 1024, strides = 1
+      %4 = tt.splat %ptr_iter : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+      // source = %arg1, offset = %1, size = 1024, strides = 0
+      %5 = tt.addptr %4, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+      // source = %arg1, offset = %1, size = 1024, strides = 1
+      %8 = tt.load %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+      %9 = math.exp %8 : tensor<1024xf32>
+      %sum_next = arith.addf %sum_iter, %9 : tensor<1024xf32>
+      %cast_i = arith.index_cast %i : index to i32
+      %ptr_next = tt.addptr %ptr_iter, %cast_i : !tt.ptr<f32>, i32
+      // source = %arg1, offset = %1 + %i, size = 1, strides = 0
+      scf.yield %ptr_next, %sum_next : !tt.ptr<f32>, tensor<1024xf32>
+    }
+    %10 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %21 = tt.addptr %20, %10 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    tt.store %21, %sum_out : tensor<1024xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_1:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 3 : index
+// CHECK-DAG:           %[[VAL_9:.*]] = arith.constant 12 : index
+// CHECK-DAG:           %[[VAL_10:.*]] = arith.constant 0 : index
+// CHECK-DAG:           %[[VAL_11:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_14:.*]] = tensor.empty() : tensor<1024xf32>
+// CHECK:           %[[VAL_15:.*]] = linalg.fill ins(%[[VAL_11]] : f32) outs(%[[VAL_14]] : tensor<1024xf32>) -> tensor<1024xf32>
+// CHECK:           %[[VAL_12:.*]] = arith.muli %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : i32 to index
+// CHECK:           %[[VAL_16:.*]]:2 = scf.for %[[VAL_17:.*]] = %[[VAL_10]] to %[[VAL_9]] step %[[VAL_8]] iter_args(%[[VAL_18:.*]] = %[[VAL_15]], %[[VAL_19:.*]] = %[[VAL_13]]) -> (tensor<1024xf32>, index) {
+// CHECK:             %[[VAL_20:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_19]]], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:             %[[VAL_21:.*]] = memref.alloc() : memref<1024xf32>
+// CHECK:             memref.copy %[[VAL_20]], %[[VAL_21]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
+// CHECK:             %[[VAL_22:.*]] = bufferization.to_tensor %[[VAL_21]] restrict writable : memref<1024xf32>
+// CHECK:             %[[VAL_23:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[VAL_22]] : tensor<1024xf32>) outs(%[[VAL_22]] : tensor<1024xf32>) {
+// CHECK:             ^bb0(%[[VAL_24:.*]]: f32, %[[VAL_25:.*]]: f32):
+// CHECK:               %[[VAL_26:.*]] = math.exp %[[VAL_24]] : f32
+// CHECK:               linalg.yield %[[VAL_26]] : f32
+// CHECK:             } -> tensor<1024xf32>
+// CHECK:             %[[VAL_27:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_18]], %[[VAL_28:.*]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[VAL_18]] : tensor<1024xf32>) {
+// CHECK:             ^bb0(%[[VAL_29:.*]]: f32, %[[VAL_30:.*]]: f32, %[[VAL_31:.*]]: f32):
+// CHECK:               %[[VAL_32:.*]] = arith.addf %[[VAL_29]], %[[VAL_30]] : f32
+// CHECK:               linalg.yield %[[VAL_32]] : f32
+// CHECK:             } -> tensor<1024xf32>
+// CHECK:             %[[VAL_33:.*]] = arith.addi %[[VAL_19]], %[[VAL_17]] : index
+// CHECK:             scf.yield %[[VAL_34:.*]], %[[VAL_33]] : tensor<1024xf32>, index
+// CHECK:           }
+// CHECK:           %[[VAL_35:.*]] = arith.muli %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_36:.*]] = arith.index_cast %[[VAL_35]] : i32 to index
+// CHECK:           %[[VAL_37:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_36]]], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_38:.*]]#0, %[[VAL_37]] : memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_scalar_for_2d.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_scalar_for_2d.mlir
@@ -1,0 +1,92 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    %cf0 = arith.constant 0.000000e+00 : f32
+    %tensor_cf0 = tt.splat %cf0 : (f32) -> tensor<128x128xf32>
+    %c0 = arith.constant 0 : index
+    %c12 = arith.constant 12 : index
+    %c3 = arith.constant 3 : index
+    %sum_out, %_ptr = scf.for %i = %c0 to %c12 step %c3 iter_args(%sum_iter = %tensor_cf0,  %ptr_iter = %2) ->  (tensor<128x128xf32>, !tt.ptr<f32> ) {
+      %3 = tt.splat %ptr_iter : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+      // source = %arg1, offset = [%1, 0], size = [128, 128], strides = [0, 0]
+      %4 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+      %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+      %6 = tt.broadcast %5 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+      // offset = [0, 0], size = [128, 128], strides = [0, 1]
+      %7 = tt.make_range {end = 384 : i32, start = 128 : i32} : tensor<128xi32>
+      %8 = tt.expand_dims %7 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+      %9 = tt.broadcast %8 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+      // offset = [128, 0], size = [128, 128], strides = [2, 0]
+      %10 = arith.addi %6, %9 : tensor<128x128xi32>
+      // offset = [128, 0], size = [128, 128], strides = [2, 1]
+      %11 = tt.addptr %3, %10 : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+      // source = %arg1, offset = [%1 + 128, 0], size = [128, 128], strides = [2, 1]
+      %12 = tt.load %11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+      %17 = math.exp %12 : tensor<128x128xf32>
+      %sum_next = arith.addf %sum_iter, %17 : tensor<128x128xf32>
+      %cast_i = arith.index_cast %i : index to i32
+      %ptr_next = tt.addptr %ptr_iter, %cast_i : !tt.ptr<f32>, i32
+      // source = %arg1, offset = %1 + %i, size = 1, strides = 0
+      scf.yield %sum_next, %ptr_next : tensor<128x128xf32>, !tt.ptr<f32>
+    }
+    %4 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+    %6 = tt.broadcast %5 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+    // offset = [0, 0], size = [128, 128], strides = [0, 1]
+    %7 = tt.make_range {end = 384 : i32, start = 128 : i32} : tensor<128xi32>
+    %8 = tt.expand_dims %7 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %9 = tt.broadcast %8 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+    // offset = [128, 0], size = [128, 128], strides = [2, 0]
+    %10 = arith.addi %6, %9 : tensor<128x128xi32>
+    // offset = [128, 0], size = [128, 128], strides = [2, 1]
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = arg0, offset = %18, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    // source = arg0, offset = [%18, 0], size = [128, 128], strides = [0, 0]
+    %21 = tt.addptr %20, %10 : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+    // source = %arg0, offset = [%18 + 128, 0], size = [128, 128], strides = [2, 1]
+    tt.store %21, %sum_out : tensor<128x128xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_1:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 128 : index
+// CHECK-DAG:           %[[VAL_9:.*]] = arith.constant 3 : index
+// CHECK-DAG:           %[[VAL_10:.*]] = arith.constant 12 : index
+// CHECK-DAG:           %[[VAL_11:.*]] = arith.constant 0 : index
+// CHECK-DAG:           %[[VAL_12:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_15:.*]] = tensor.empty() : tensor<128x128xf32>
+// CHECK:           %[[VAL_16:.*]] = linalg.fill ins(%[[VAL_12]] : f32) outs(%[[VAL_15]] : tensor<128x128xf32>) -> tensor<128x128xf32>
+// CHECK:           %[[VAL_13:.*]] = arith.muli %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : i32 to index
+// CHECK:           %[[VAL_17:.*]]:2 = scf.for %[[VAL_18:.*]] = %[[VAL_11]] to %[[VAL_10]] step %[[VAL_9]] iter_args(%[[VAL_19:.*]] = %[[VAL_16]], %[[VAL_20:.*]] = %[[VAL_14]]) -> (tensor<128x128xf32>, index) {
+// CHECK:             %[[VAL_21:.*]] = arith.addi %[[VAL_20]], %[[VAL_8]] : index
+// CHECK:             %[[VAL_22:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_21]]], sizes: [128, 128], strides: [2, 1] : memref<*xf32> to memref<128x128xf32, strided<[2, 1], offset: ?>>
+// CHECK:             %[[VAL_23:.*]] = memref.alloc() : memref<128x128xf32>
+// CHECK:             memref.copy %[[VAL_22]], %[[VAL_23]] : memref<128x128xf32, strided<[2, 1], offset: ?>> to memref<128x128xf32>
+// CHECK:             %[[VAL_24:.*]] = bufferization.to_tensor %[[VAL_23]] restrict writable : memref<128x128xf32>
+// CHECK:             %[[VAL_25:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_24]] : tensor<128x128xf32>) outs(%[[VAL_24]] : tensor<128x128xf32>) {
+// CHECK:             ^bb0(%[[VAL_26:.*]]: f32, %[[VAL_27:.*]]: f32):
+// CHECK:               %[[VAL_28:.*]] = math.exp %[[VAL_26]] : f32
+// CHECK:               linalg.yield %[[VAL_28]] : f32
+// CHECK:             } -> tensor<128x128xf32>
+// CHECK:             %[[VAL_29:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_19]], %[[VAL_30:.*]] : tensor<128x128xf32>, tensor<128x128xf32>) outs(%[[VAL_19]] : tensor<128x128xf32>) {
+// CHECK:             ^bb0(%[[VAL_31:.*]]: f32, %[[VAL_32:.*]]: f32, %[[VAL_33:.*]]: f32):
+// CHECK:               %[[VAL_34:.*]] = arith.addf %[[VAL_31]], %[[VAL_32]] : f32
+// CHECK:               linalg.yield %[[VAL_34]] : f32
+// CHECK:             } -> tensor<128x128xf32>
+// CHECK:             %[[VAL_35:.*]] = arith.addi %[[VAL_20]], %[[VAL_18]] : index
+// CHECK:             scf.yield %[[VAL_36:.*]], %[[VAL_35]] : tensor<128x128xf32>, index
+// CHECK:           }
+// CHECK:           %[[VAL_37:.*]] = arith.muli %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_38:.*]] = arith.index_cast %[[VAL_37]] : i32 to index
+// CHECK:           %[[VAL_39:.*]] = arith.addi %[[VAL_38]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_40:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_39]]], sizes: [128, 128], strides: [2, 1] : memref<*xf32> to memref<128x128xf32, strided<[2, 1], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_41:.*]]#0, %[[VAL_40]] : memref<128x128xf32, strided<[2, 1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_scalar_loopback.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_scalar_loopback.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt --triton-to-linalg %s
+// XFAIL: *
+// Disable this test since we do not support scalar loads at the moment.
+
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32
+  )
+  {
+    %0 = tt.addptr %arg0, %arg2 : !tt.ptr<bf16>, i32
+    %1 = tt.addptr %arg1, %arg2 : !tt.ptr<bf16>, i32
+
+    // expected-error @below {{Scalar load is currently not supported}}
+    %10 = tt.load %0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: bf16
+    tt.store %1, %10 : bf16
+  tt.return
+  }
+}

--- a/test/Conversion/TritonToLinalg/addptr_scalar_nested.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_scalar_nested.mlir
@@ -1,0 +1,57 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    // source = arg1, offset = %1, size = 1, strides = 0
+    %3 = arith.muli %0, %arg3 : i32
+    %4 = tt.addptr %2, %3 : !tt.ptr<f32>, i32
+    // source = arg1, offset = %1+%3, size = 1, strides = 0
+    %5 = arith.muli %0, %arg4 : i32
+    %6 = tt.addptr %4, %5 : !tt.ptr<f32>, i32
+    // source = arg1, offset = %1+%3+%5, size = 1, strides = 0
+    %7 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // offset = 0, size = 1024, strides = 1
+    %8 = tt.splat %6 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = arg1, offset = %1, size = 1024, strides = 0
+    %9 = tt.addptr %8, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // source = arg1, offset = %1+%3+%5, size = 1024, strides = 1
+    %10 = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %17 = math.exp %10 : tensor<1024xf32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = arg0, offset = %18, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = arg0, offset = %18, size = 1024, strides = 0
+    %21 = tt.addptr %20, %7 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // source = arg0, offset = %18, size = 1024, strides = 1
+    tt.store %21, %17 : tensor<1024xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_1:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32) {
+// CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_9:.*]] = arith.muli %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_10:.*]] = arith.muli %[[VAL_5]], %[[VAL_4]] : i32
+// CHECK:           %[[VAL_11:.*]] = arith.index_cast %[[VAL_8]] : i32 to index
+// CHECK:           %[[VAL_12:.*]] = arith.index_cast %[[VAL_9]] : i32 to index
+// CHECK:           %[[VAL_13:.*]] = arith.addi %[[VAL_11]], %[[VAL_12]] : index
+// CHECK:           %[[VAL_14:.*]] = arith.index_cast %[[VAL_10]] : i32 to index
+// CHECK:           %[[VAL_15:.*]] = arith.addi %[[VAL_13]], %[[VAL_14]] : index
+// CHECK:           %[[VAL_16:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_15]]], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           %[[VAL_17:.*]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy %[[VAL_16]], %[[VAL_17]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
+// CHECK:           %[[VAL_18:.*]] = bufferization.to_tensor %[[VAL_17]] restrict writable : memref<1024xf32>
+// CHECK:           %[[VAL_19:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[VAL_18]] : tensor<1024xf32>) outs(%[[VAL_18]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_20:.*]]: f32, %[[VAL_21:.*]]: f32):
+// CHECK:             %[[VAL_22:.*]] = math.exp %[[VAL_20]] : f32
+// CHECK:             linalg.yield %[[VAL_22]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_23:.*]] = arith.muli %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_24:.*]] = arith.index_cast %[[VAL_23]] : i32 to index
+// CHECK:           %[[VAL_25:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_24]]], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_26:.*]], %[[VAL_25]] : memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_scalar_splat.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_scalar_splat.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    // source = %arg1, offset = %1, size = 1, strides = 0
+    %3 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // offset = 0, size = 1024, strides = 1
+    %4 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = %arg1, offset = %1, size = 1024, strides = 0
+    %5 = tt.addptr %4, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // source = %arg1, offset = %1, size = 1024, strides = 1
+    %8 = tt.load %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %17 = math.exp %8 : tensor<1024xf32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = %arg0, offset = %18, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    // source = %arg0, offset = %18, size = 1024, strides = 0
+    %21 = tt.addptr %20, %3 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // source = %arg0, offset = %18, size = 1024, strides = 1
+    tt.store %21, %17 : tensor<1024xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_1:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32) {
+// CHECK:           %[[VAL_8:.*]] = arith.muli %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : i32 to index
+// CHECK:           %[[VAL_10:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_9]]], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           %[[VAL_11:.*]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy %[[VAL_10]], %[[VAL_11]] : memref<1024xf32, strided<[1], offset: ?>> to memref<1024xf32>
+// CHECK:           %[[VAL_12:.*]] = bufferization.to_tensor %[[VAL_11]] restrict writable : memref<1024xf32>
+// CHECK:           %[[VAL_13:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[VAL_12]] : tensor<1024xf32>) outs(%[[VAL_12]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_14:.*]]: f32, %[[VAL_15:.*]]: f32):
+// CHECK:             %[[VAL_16:.*]] = math.exp %[[VAL_14]] : f32
+// CHECK:             linalg.yield %[[VAL_16]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_17:.*]] = arith.muli %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+// CHECK:           %[[VAL_19:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_18]]], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_20:.*]], %[[VAL_19]] : memref<1024xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/addptr_scalar_splat_2d.mlir
+++ b/test/Conversion/TritonToLinalg/addptr_scalar_splat_2d.mlir
@@ -1,0 +1,56 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel (%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    %3 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    // source = %arg1, offset = [%1, 0], size = [128, 128], strides = [0, 0]
+    %4 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+    %6 = tt.broadcast %5 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+    // offset = [0, 0], size = [128, 128], strides = [0, 1]
+    %7 = tt.make_range {end = 384 : i32, start = 128 : i32} : tensor<128xi32>
+    // offset = 128, size = 128, strides = 1
+    %8 = tt.expand_dims %7 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %9 = tt.broadcast %8 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+    // offset = [128, 0], size = [128, 128], strides = [2, 0]
+    %10 = arith.addi %6, %9 : tensor<128x128xi32>
+    // offset = [128, 0], size = [128, 128], strides = [2, 1]
+    %11 = tt.addptr %3, %10 : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+    // source = %arg1, offset = [%1 + 128, 0], size = [128, 128], strides = [2, 1]
+    %12 = tt.load %11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+    %17 = math.exp %12 : tensor<128x128xf32>
+    %18 = arith.muli %0, %arg3 : i32
+    %19 = tt.addptr %arg0, %18 : !tt.ptr<f32>, i32
+    // source = arg0, offset = %18, size = 1, strides = 0
+    %20 = tt.splat %19 : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    // source = arg0, offset = [%18, 0], size = [128, 128], strides = [0, 0]
+    %21 = tt.addptr %20, %10 : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+    // source = %arg0, offset = [%18 + 128, 0], size = [128, 128], strides = [2, 1]
+    tt.store %21, %17 : tensor<128x128xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_1:.*]]: memref<*xf32> {tt.divisibility = 16 : i32}, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32, %[[VAL_7:.*]]: i32) {
+// CHECK:           %[[VAL_8:.*]] = arith.constant 128 : index
+// CHECK:           %[[VAL_9:.*]] = arith.muli %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_10:.*]] = arith.index_cast %[[VAL_9]] : i32 to index
+// CHECK:           %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_12:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_11]]], sizes: [128, 128], strides: [2, 1] : memref<*xf32> to memref<128x128xf32, strided<[2, 1], offset: ?>>
+// CHECK:           %[[VAL_13:.*]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy %[[VAL_12]], %[[VAL_13]] : memref<128x128xf32, strided<[2, 1], offset: ?>> to memref<128x128xf32>
+// CHECK:           %[[VAL_14:.*]] = bufferization.to_tensor %[[VAL_13]] restrict writable : memref<128x128xf32>
+// CHECK:           %[[VAL_15:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_14]] : tensor<128x128xf32>) outs(%[[VAL_14]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0(%[[VAL_16:.*]]: f32, %[[VAL_17:.*]]: f32):
+// CHECK:             %[[VAL_18:.*]] = math.exp %[[VAL_16]] : f32
+// CHECK:             linalg.yield %[[VAL_18]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           %[[VAL_19:.*]] = arith.muli %[[VAL_5]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_20:.*]] = arith.index_cast %[[VAL_19]] : i32 to index
+// CHECK:           %[[VAL_21:.*]] = arith.addi %[[VAL_20]], %[[VAL_8]] : index
+// CHECK:           %[[VAL_22:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_21]]], sizes: [128, 128], strides: [2, 1] : memref<*xf32> to memref<128x128xf32, strided<[2, 1], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_23:.*]], %[[VAL_22]] : memref<128x128xf32, strided<[2, 1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/arith_not_ptr_arith.mlir
+++ b/test/Conversion/TritonToLinalg/arith_not_ptr_arith.mlir
@@ -1,0 +1,39 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %a : !tt.ptr<i32>,
+    %b : !tt.ptr<i32>
+  ) -> () {
+        // offset calculations
+        %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+        // a pointer
+        %8 = tt.splat %a : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+        %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
+        // b pointer
+        %18 = tt.splat %b : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+        %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
+        %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
+        %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
+        %5 = arith.addi %am, %bm : tensor<1024xi32>
+        tt.store %19, %5 : tensor<1024xi32>
+        tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xi32>, %[[VAL_1:.*]]: memref<*xi32>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK:           %[[VAL_5:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi32> to memref<1024xi32, strided<[1]>>
+// CHECK:           %[[VAL_6:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi32> to memref<1024xi32, strided<[1]>>
+// CHECK:           %[[VAL_7:.*]] = memref.alloc() : memref<1024xi32>
+// CHECK:           memref.copy %[[VAL_5]], %[[VAL_7]] : memref<1024xi32, strided<[1]>> to memref<1024xi32>
+// CHECK:           %[[VAL_8:.*]] = bufferization.to_tensor %[[VAL_7]] restrict writable : memref<1024xi32>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<1024xi32>
+// CHECK:           memref.copy %[[VAL_6]], %[[VAL_9]] : memref<1024xi32, strided<[1]>> to memref<1024xi32>
+// CHECK:           %[[VAL_10:.*]] = bufferization.to_tensor %[[VAL_9]] restrict writable : memref<1024xi32>
+// CHECK:           %[[VAL_11:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_8]], %[[VAL_10]] : tensor<1024xi32>, tensor<1024xi32>) outs(%[[VAL_8]] : tensor<1024xi32>) {
+// CHECK:           ^bb0(%[[VAL_12:.*]]: i32, %[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i32):
+// CHECK:             %[[VAL_15:.*]] = arith.addi %[[VAL_12]], %[[VAL_13]] : i32
+// CHECK:             linalg.yield %[[VAL_15]] : i32
+// CHECK:           } -> tensor<1024xi32>
+// CHECK:           memref.tensor_store %[[VAL_16:.*]], %[[VAL_6]] : memref<1024xi32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/bitcast.mlir
+++ b/test/Conversion/TritonToLinalg/bitcast.mlir
@@ -1,0 +1,43 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+
+module {
+  tt.func @kernel(%a : !tt.ptr<i32>, %b : !tt.ptr<f32>) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+
+    // a pointer
+    %8 = tt.splat %a : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+    %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
+
+    // b pointer
+    %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+
+    %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
+
+    // cast result before doing float add
+    %am_bitcast = tt.bitcast %am : tensor<1024xi32> -> tensor<1024xf32>
+
+
+    tt.store %19, %am_bitcast : tensor<1024xf32>
+    tt.return
+  }
+}
+
+// CHECK: module {
+// CHECK:   func.func @kernel(%arg0: memref<*xi32>, %arg1: memref<*xf32>, %arg2: i32, %arg3: i32, %arg4: i32) {
+// CHECK:   [[RC_:%.+]] = memref.reinterpret_cast %arg0 to offset: [0], sizes: [1024], strides: [1]{{.*}} : memref<*xi32> to memref<1024xi32, strided<[1]>>
+// CHECK:   [[RC_0_:%.+]] = memref.reinterpret_cast %arg1 to offset: [0], sizes: [1024], strides: [1]{{.*}} : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK:   [[ALLOC_:%.+]] = memref.alloc() : memref<1024xi32>
+// CHECK:   memref.copy [[RC_]], [[ALLOC_]] : memref<1024xi32, strided<[1]>> to memref<1024xi32>
+// CHECK:   [[VAR_0_:%.+]] = bufferization.to_tensor [[ALLOC_]] restrict writable : memref<1024xi32>
+// CHECK:   [[VAR_1_:%.+]] = tensor.empty() : tensor<1024xf32>
+// CHECK:   [[VAR_2_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_0_]] : tensor<1024xi32>) outs([[VAR_1_]] : tensor<1024xf32>) {
+// CHECK:   ^bb0(%in: i32, %out: f32):
+// CHECK:     [[VAR_5_:%.+]] = arith.bitcast %in : i32 to f32
+// CHECK:     linalg.yield [[VAR_5_]] : f32
+// CHECK:   } -> tensor<1024xf32>
+// CHECK:   memref.tensor_store [[VAR_2_]], [[RC_0_]] : memref<1024xf32, strided<[1]>>
+// CHECK:     return
+// CHECK:   }
+// CHECK: }

--- a/test/Conversion/TritonToLinalg/convert_1d_elemwise_arith_binary.mlir
+++ b/test/Conversion/TritonToLinalg/convert_1d_elemwise_arith_binary.mlir
@@ -1,0 +1,72 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %a : !tt.ptr<f32>,
+    %b : !tt.ptr<f32>,
+    %c : tensor<1024x!tt.ptr<f32>>
+  ) -> () {
+        %cst = arith.constant dense<true> : tensor<1024xi1>
+        // offset calculations
+        %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+        // a pointer
+        %8 = tt.splat %a : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+        %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+        // b pointer
+        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+        %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+        %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+        %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+        %1 = arith.addf %am, %bm : tensor<1024xf32>
+        %2 = arith.subf %1, %bm : tensor<1024xf32>
+        %3 = arith.mulf %2, %bm : tensor<1024xf32>
+        %4 = arith.divf %3, %bm : tensor<1024xf32>
+        %5 = arith.cmpf "oeq", %4, %bm : tensor<1024xf32>
+        %6 = arith.select %5, %am, %bm : tensor<1024xi1>, tensor<1024xf32>
+        tt.store %c, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+        tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32>, %[[VAL_1:.*]]: memref<*xf32>, %[[VAL_2:.*]]: memref<1024xf32>, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK:           %[[VAL_6:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy %[[VAL_6]], %[[VAL_8]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK:           %[[VAL_9:.*]] = bufferization.to_tensor %[[VAL_8]] restrict writable : memref<1024xf32>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_10]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK:           %[[VAL_11:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<1024xf32>
+// CHECK:           %[[VAL_12:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_9]], %[[VAL_11]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[VAL_9]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_13:.*]]: f32, %[[VAL_14:.*]]: f32, %[[VAL_15:.*]]: f32):
+// CHECK:             %[[VAL_16:.*]] = arith.addf %[[VAL_13]], %[[VAL_14]] : f32
+// CHECK:             linalg.yield %[[VAL_16]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_17:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_18:.*]], %[[VAL_11]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[VAL_18]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_19:.*]]: f32, %[[VAL_20:.*]]: f32, %[[VAL_21:.*]]: f32):
+// CHECK:             %[[VAL_22:.*]] = arith.subf %[[VAL_19]], %[[VAL_20]] : f32
+// CHECK:             linalg.yield %[[VAL_22]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_23:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_24:.*]], %[[VAL_11]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[VAL_24]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_25:.*]]: f32, %[[VAL_26:.*]]: f32, %[[VAL_27:.*]]: f32):
+// CHECK:             %[[VAL_28:.*]] = arith.mulf %[[VAL_25]], %[[VAL_26]] : f32
+// CHECK:             linalg.yield %[[VAL_28]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_29:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_30:.*]], %[[VAL_11]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[VAL_30]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_31:.*]]: f32, %[[VAL_32:.*]]: f32, %[[VAL_33:.*]]: f32):
+// CHECK:             %[[VAL_34:.*]] = arith.divf %[[VAL_31]], %[[VAL_32]] : f32
+// CHECK:             linalg.yield %[[VAL_34]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_35:.*]] = tensor.empty() : tensor<1024xi1>
+// CHECK:           %[[VAL_36:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_37:.*]], %[[VAL_11]] : tensor<1024xf32>, tensor<1024xf32>) outs(%[[VAL_35]] : tensor<1024xi1>) {
+// CHECK:           ^bb0(%[[VAL_38:.*]]: f32, %[[VAL_39:.*]]: f32, %[[VAL_40:.*]]: i1):
+// CHECK:             %[[VAL_41:.*]] = arith.cmpf oeq, %[[VAL_38]], %[[VAL_39]] : f32
+// CHECK:             linalg.yield %[[VAL_41]] : i1
+// CHECK:           } -> tensor<1024xi1>
+// CHECK:           %[[VAL_42:.*]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_43:.*]], %[[VAL_9]], %[[VAL_11]] : tensor<1024xi1>, tensor<1024xf32>, tensor<1024xf32>) outs(%[[VAL_9]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_44:.*]]: i1, %[[VAL_45:.*]]: f32, %[[VAL_46:.*]]: f32, %[[VAL_47:.*]]: f32):
+// CHECK:             %[[VAL_48:.*]] = arith.select %[[VAL_44]], %[[VAL_45]], %[[VAL_46]] : f32
+// CHECK:             linalg.yield %[[VAL_48]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           memref.tensor_store %[[VAL_49:.*]], %[[VAL_2]] : memref<1024xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_1d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/TritonToLinalg/convert_1d_elemwise_arith_ternary.mlir
@@ -1,0 +1,49 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %a : !tt.ptr<i1>,
+    %b : !tt.ptr<f32>,
+    %c : !tt.ptr<f32>,
+    %d : tensor<1024x!tt.ptr<f32>>
+  ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // a pointer
+    %8 = tt.splat %a : (!tt.ptr<i1>) -> tensor<1024x!tt.ptr<i1>>
+    %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<i1>>, tensor<1024xi32>
+    // b pointer
+    %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // c pointer
+    %28 = tt.splat %c : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %29 = tt.addptr %28, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi1>
+    %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %cm = tt.load %29 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %10 = arith.select %am, %bm, %cm : tensor<1024xi1>, tensor<1024xf32>
+    tt.store %d, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xi1>, %[[VAL_1:.*]]: memref<*xf32>, %[[VAL_2:.*]]: memref<*xf32>, %[[VAL_3:.*]]: memref<1024xf32>, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi1> to memref<1024xi1, strided<[1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<1024xi1>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_10]] : memref<1024xi1, strided<[1]>> to memref<1024xi1>
+// CHECK:           %[[VAL_11:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<1024xi1>
+// CHECK:           %[[VAL_12:.*]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy %[[VAL_8]], %[[VAL_12]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK:           %[[VAL_13:.*]] = bufferization.to_tensor %[[VAL_12]] restrict writable : memref<1024xf32>
+// CHECK:           %[[VAL_14:.*]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy %[[VAL_9]], %[[VAL_14]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK:           %[[VAL_15:.*]] = bufferization.to_tensor %[[VAL_14]] restrict writable : memref<1024xf32>
+// CHECK:           %[[VAL_16:.*]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins(%[[VAL_11]], %[[VAL_13]], %[[VAL_15]] : tensor<1024xi1>, tensor<1024xf32>, tensor<1024xf32>) outs(%[[VAL_13]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_17:.*]]: i1, %[[VAL_18:.*]]: f32, %[[VAL_19:.*]]: f32, %[[VAL_20:.*]]: f32):
+// CHECK:             %[[VAL_21:.*]] = arith.select %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : f32
+// CHECK:             linalg.yield %[[VAL_21]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           memref.tensor_store %[[VAL_22:.*]], %[[VAL_3]] : memref<1024xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_1d_elemwise_arith_unary.mlir
+++ b/test/Conversion/TritonToLinalg/convert_1d_elemwise_arith_unary.mlir
@@ -1,0 +1,88 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %f32ptr : !tt.ptr<f32>,
+    %intptr : !tt.ptr<i32>,
+    %f16ptr : !tt.ptr<f16>,
+    %save0 : tensor<1024x!tt.ptr<bf16>>,
+    %save1 : tensor<1024x!tt.ptr<f32>>,
+    %save2 : tensor<1024x!tt.ptr<f32>>,
+    %save3 : tensor<1024x!tt.ptr<f32>>,
+    %save4 : tensor<1024x!tt.ptr<f32>>
+  ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    // f32ptr pointer
+    %8 = tt.splat %f32ptr : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %0 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    // intptr pointer
+    %18 = tt.splat %intptr : (!tt.ptr<i32>) -> tensor<1024x!tt.ptr<i32>>
+    %19 = tt.addptr %18, %0 : tensor<1024x!tt.ptr<i32>>, tensor<1024xi32>
+    // f32ptr pointer
+    %28 = tt.splat %f16ptr : (!tt.ptr<f16>) -> tensor<1024x!tt.ptr<f16>>
+    %29 = tt.addptr %28, %0 : tensor<1024x!tt.ptr<f16>>, tensor<1024xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %aim = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xi32>
+    %bfm = tt.load %29 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf16>
+    %5 = arith.truncf %afm : tensor<1024xf32> to tensor<1024xbf16>
+    %6 = math.exp %afm : tensor<1024xf32>
+    %7 = arith.sitofp %aim : tensor<1024xi32> to tensor<1024xf32>
+    %10 = arith.extf %bfm : tensor<1024xf16> to tensor<1024xf32>
+    %11 = math.sqrt %afm : tensor<1024xf32>
+    tt.store %save0, %5 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xbf16>
+    tt.store %save1, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.store %save2, %7 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.store %save3, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.store %save4, %11 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32>, %[[VAL_1:.*]]: memref<*xi32>, %[[VAL_2:.*]]: memref<*xf16>, %[[VAL_3:.*]]: memref<1024xbf16>, %[[VAL_4:.*]]: memref<1024xf32>, %[[VAL_5:.*]]: memref<1024xf32>, %[[VAL_6:.*]]: memref<1024xf32>, %[[VAL_7:.*]]: memref<1024xf32>, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i32) {
+// CHECK:           %[[VAL_11:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf32> to memref<1024xf32, strided<[1]>>
+// CHECK:           %[[VAL_12:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [1024], strides: [1] : memref<*xi32> to memref<1024xi32, strided<[1]>>
+// CHECK:           %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: [0], sizes: [1024], strides: [1] : memref<*xf16> to memref<1024xf16, strided<[1]>>
+// CHECK:           %[[VAL_14:.*]] = memref.alloc() : memref<1024xf32>
+// CHECK:           memref.copy %[[VAL_11]], %[[VAL_14]] : memref<1024xf32, strided<[1]>> to memref<1024xf32>
+// CHECK:           %[[VAL_15:.*]] = bufferization.to_tensor %[[VAL_14]] restrict writable : memref<1024xf32>
+// CHECK:           %[[VAL_16:.*]] = memref.alloc() : memref<1024xi32>
+// CHECK:           memref.copy %[[VAL_12]], %[[VAL_16]] : memref<1024xi32, strided<[1]>> to memref<1024xi32>
+// CHECK:           %[[VAL_17:.*]] = bufferization.to_tensor %[[VAL_16]] restrict writable : memref<1024xi32>
+// CHECK:           %[[VAL_18:.*]] = memref.alloc() : memref<1024xf16>
+// CHECK:           memref.copy %[[VAL_13]], %[[VAL_18]] : memref<1024xf16, strided<[1]>> to memref<1024xf16>
+// CHECK:           %[[VAL_19:.*]] = bufferization.to_tensor %[[VAL_18]] restrict writable : memref<1024xf16>
+// CHECK:           %[[VAL_20:.*]] = tensor.empty() : tensor<1024xbf16>
+// CHECK:           %[[VAL_21:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[VAL_15]] : tensor<1024xf32>) outs(%[[VAL_20]] : tensor<1024xbf16>) {
+// CHECK:           ^bb0(%[[VAL_22:.*]]: f32, %[[VAL_23:.*]]: bf16):
+// CHECK:             %[[VAL_24:.*]] = arith.truncf %[[VAL_22]] : f32 to bf16
+// CHECK:             linalg.yield %[[VAL_24]] : bf16
+// CHECK:           } -> tensor<1024xbf16>
+// CHECK:           %[[VAL_25:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[VAL_15]] : tensor<1024xf32>) outs(%[[VAL_15]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_26:.*]]: f32, %[[VAL_27:.*]]: f32):
+// CHECK:             %[[VAL_28:.*]] = math.exp %[[VAL_26]] : f32
+// CHECK:             linalg.yield %[[VAL_28]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_29:.*]] = tensor.empty() : tensor<1024xf32>
+// CHECK:           %[[VAL_30:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[VAL_17]] : tensor<1024xi32>) outs(%[[VAL_29]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_31:.*]]: i32, %[[VAL_32:.*]]: f32):
+// CHECK:             %[[VAL_33:.*]] = arith.sitofp %[[VAL_31]] : i32 to f32
+// CHECK:             linalg.yield %[[VAL_33]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_34:.*]] = tensor.empty() : tensor<1024xf32>
+// CHECK:           %[[VAL_35:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[VAL_19]] : tensor<1024xf16>) outs(%[[VAL_34]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_36:.*]]: f16, %[[VAL_37:.*]]: f32):
+// CHECK:             %[[VAL_38:.*]] = arith.extf %[[VAL_36]] : f16 to f32
+// CHECK:             linalg.yield %[[VAL_38]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           %[[VAL_39:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins(%[[VAL_15]] : tensor<1024xf32>) outs(%[[VAL_15]] : tensor<1024xf32>) {
+// CHECK:           ^bb0(%[[VAL_40:.*]]: f32, %[[VAL_41:.*]]: f32):
+// CHECK:             %[[VAL_42:.*]] = math.sqrt %[[VAL_40]] : f32
+// CHECK:             linalg.yield %[[VAL_42]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           memref.tensor_store %[[VAL_43:.*]], %[[VAL_3]] : memref<1024xbf16>
+// CHECK:           memref.tensor_store %[[VAL_44:.*]], %[[VAL_4]] : memref<1024xf32>
+// CHECK:           memref.tensor_store %[[VAL_45:.*]], %[[VAL_5]] : memref<1024xf32>
+// CHECK:           memref.tensor_store %[[VAL_46:.*]], %[[VAL_6]] : memref<1024xf32>
+// CHECK:           memref.tensor_store %[[VAL_47:.*]], %[[VAL_7]] : memref<1024xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_2d_elemwise_arith_binary.mlir
+++ b/test/Conversion/TritonToLinalg/convert_2d_elemwise_arith_binary.mlir
@@ -1,0 +1,55 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %a : !tt.ptr<f32>,
+    %b : !tt.ptr<f32>,
+    %c : tensor<128x128x!tt.ptr<f32>>,
+    %d : tensor<128x128x!tt.ptr<f32>>
+  ) -> () {
+        // offset calculations
+        %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+        %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+        %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+        %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+        %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+        %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+        %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
+        // a pointer
+        %8 = tt.splat %a : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+        // b pointer
+        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+        %af = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+        %bf = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+        %res0 = arith.addf %af, %bf : tensor<128x128xf32>
+        %res1 = arith.subf %af, %bf : tensor<128x128xf32>
+        tt.store %c, %res0 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+        tt.store %d, %res1 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+        tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32>, %[[VAL_1:.*]]: memref<*xf32>, %[[VAL_2:.*]]: memref<128x128xf32>, %[[VAL_3:.*]]: memref<128x128xf32>, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_9]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK:           %[[VAL_10:.*]] = bufferization.to_tensor %[[VAL_9]] restrict writable : memref<128x128xf32>
+// CHECK:           %[[VAL_11:.*]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy %[[VAL_8]], %[[VAL_11]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK:           %[[VAL_12:.*]] = bufferization.to_tensor %[[VAL_11]] restrict writable : memref<128x128xf32>
+// CHECK:           %[[VAL_13:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_10]], %[[VAL_12]] : tensor<128x128xf32>, tensor<128x128xf32>) outs(%[[VAL_10]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0(%[[VAL_14:.*]]: f32, %[[VAL_15:.*]]: f32, %[[VAL_16:.*]]: f32):
+// CHECK:             %[[VAL_17:.*]] = arith.addf %[[VAL_14]], %[[VAL_15]] : f32
+// CHECK:             linalg.yield %[[VAL_17]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           %[[VAL_18:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_10]], %[[VAL_12]] : tensor<128x128xf32>, tensor<128x128xf32>) outs(%[[VAL_10]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0(%[[VAL_19:.*]]: f32, %[[VAL_20:.*]]: f32, %[[VAL_21:.*]]: f32):
+// CHECK:             %[[VAL_22:.*]] = arith.subf %[[VAL_19]], %[[VAL_20]] : f32
+// CHECK:             linalg.yield %[[VAL_22]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           memref.tensor_store %[[VAL_23:.*]], %[[VAL_2]] : memref<128x128xf32>
+// CHECK:           memref.tensor_store %[[VAL_24:.*]], %[[VAL_3]] : memref<128x128xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_2d_elemwise_arith_ternary.mlir
+++ b/test/Conversion/TritonToLinalg/convert_2d_elemwise_arith_ternary.mlir
@@ -1,0 +1,55 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+    tt.func @kernel(
+                        %a : !tt.ptr<i1>,
+                        %b : !tt.ptr<f32>,
+                        %c : !tt.ptr<f32>,
+                        %d : tensor<128x128x!tt.ptr<f32>>
+  ) -> () {
+        // offset calculations
+        %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+        %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+        %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+        %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+        %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+        %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+        %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
+        // a pointer
+        %8 = tt.splat %a : (!tt.ptr<i1>) -> tensor<128x128x!tt.ptr<i1>>
+        %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<i1>>, tensor<128x128xi32>
+        // b pointer
+        %18 = tt.splat %b : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+        // c pointer
+        %28 = tt.splat %c : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+        %29 = tt.addptr %28, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+        %am = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xi1>
+        %bm = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+        %cm = tt.load %29 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+        %100 = arith.select %am, %bm, %cm : tensor<128x128xi1>, tensor<128x128xf32>
+        tt.store %d, %100 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+        tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xi1>, %[[VAL_1:.*]]: memref<*xf32>, %[[VAL_2:.*]]: memref<*xf32>, %[[VAL_3:.*]]: memref<128x128xf32>, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xi1> to memref<128x128xi1, strided<[1, 1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<128x128xi1>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_10]] : memref<128x128xi1, strided<[1, 1]>> to memref<128x128xi1>
+// CHECK:           %[[VAL_11:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<128x128xi1>
+// CHECK:           %[[VAL_12:.*]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy %[[VAL_8]], %[[VAL_12]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK:           %[[VAL_13:.*]] = bufferization.to_tensor %[[VAL_12]] restrict writable : memref<128x128xf32>
+// CHECK:           %[[VAL_14:.*]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy %[[VAL_9]], %[[VAL_14]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK:           %[[VAL_15:.*]] = bufferization.to_tensor %[[VAL_14]] restrict writable : memref<128x128xf32>
+// CHECK:           %[[VAL_16:.*]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_11]], %[[VAL_13]], %[[VAL_15]] : tensor<128x128xi1>, tensor<128x128xf32>, tensor<128x128xf32>) outs(%[[VAL_13]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0(%[[VAL_17:.*]]: i1, %[[VAL_18:.*]]: f32, %[[VAL_19:.*]]: f32, %[[VAL_20:.*]]: f32):
+// CHECK:             %[[VAL_21:.*]] = arith.select %[[VAL_17]], %[[VAL_18]], %[[VAL_19]] : f32
+// CHECK:             linalg.yield %[[VAL_21]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           memref.tensor_store %[[VAL_22:.*]], %[[VAL_3]] : memref<128x128xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_2d_elemwise_arith_unary.mlir
+++ b/test/Conversion/TritonToLinalg/convert_2d_elemwise_arith_unary.mlir
@@ -1,0 +1,94 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %f32ptr : !tt.ptr<f32>,
+    %intptr : !tt.ptr<i32>,
+    %f16ptr : !tt.ptr<f16>,
+    %save0 : tensor<128x128x!tt.ptr<bf16>>,
+    %save1 : tensor<128x128x!tt.ptr<f32>>,
+    %save2 : tensor<128x128x!tt.ptr<f32>>,
+    %save3 : tensor<128x128x!tt.ptr<f32>>,
+    %save4 : tensor<128x128x!tt.ptr<f32>>
+  ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %moff = tt.broadcast %1 : (tensor<128x1xi32>) -> tensor<128x128xi32>
+    %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+    %koff = tt.broadcast %4 : (tensor<1x128xi32>) -> tensor<128x128xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<128x128xi32>
+    // f32ptr pointer
+    %8 = tt.splat %f32ptr : (!tt.ptr<f32>) -> tensor<128x128x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %mkoff : tensor<128x128x!tt.ptr<f32>>, tensor<128x128xi32>
+    // intptr pointer
+    %18 = tt.splat %intptr : (!tt.ptr<i32>) -> tensor<128x128x!tt.ptr<i32>>
+    %19 = tt.addptr %18, %mkoff : tensor<128x128x!tt.ptr<i32>>, tensor<128x128xi32>
+    // f16ptr pointer
+    %28 = tt.splat %f16ptr : (!tt.ptr<f16>) -> tensor<128x128x!tt.ptr<f16>>
+    %29 = tt.addptr %28, %mkoff : tensor<128x128x!tt.ptr<f16>>, tensor<128x128xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf32>
+    %aim = tt.load %19 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xi32>
+    %bfm = tt.load %29 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf16>
+    %5 = arith.truncf %afm : tensor<128x128xf32> to tensor<128x128xbf16>
+    %6 = math.exp %afm : tensor<128x128xf32>
+    %7 = arith.sitofp %aim : tensor<128x128xi32> to tensor<128x128xf32>
+    %10 = arith.extf %bfm : tensor<128x128xf16> to tensor<128x128xf32>
+    %11 = math.sqrt %afm : tensor<128x128xf32>
+    tt.store %save0, %5 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xbf16>
+    tt.store %save1, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+    tt.store %save2, %7 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+    tt.store %save3, %10 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+    tt.store %save4, %11 {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32>, %[[VAL_1:.*]]: memref<*xi32>, %[[VAL_2:.*]]: memref<*xf16>, %[[VAL_3:.*]]: memref<128x128xbf16>, %[[VAL_4:.*]]: memref<128x128xf32>, %[[VAL_5:.*]]: memref<128x128xf32>, %[[VAL_6:.*]]: memref<128x128xf32>, %[[VAL_7:.*]]: memref<128x128xf32>, %[[VAL_8:.*]]: i32, %[[VAL_9:.*]]: i32, %[[VAL_10:.*]]: i32) {
+// CHECK:           %[[VAL_11:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf32> to memref<128x128xf32, strided<[1, 1]>>
+// CHECK:           %[[VAL_12:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xi32> to memref<128x128xi32, strided<[1, 1]>>
+// CHECK:           %[[VAL_13:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: [0], sizes: [128, 128], strides: [1, 1] : memref<*xf16> to memref<128x128xf16, strided<[1, 1]>>
+// CHECK:           %[[VAL_14:.*]] = memref.alloc() : memref<128x128xf32>
+// CHECK:           memref.copy %[[VAL_11]], %[[VAL_14]] : memref<128x128xf32, strided<[1, 1]>> to memref<128x128xf32>
+// CHECK:           %[[VAL_15:.*]] = bufferization.to_tensor %[[VAL_14]] restrict writable : memref<128x128xf32>
+// CHECK:           %[[VAL_16:.*]] = memref.alloc() : memref<128x128xi32>
+// CHECK:           memref.copy %[[VAL_12]], %[[VAL_16]] : memref<128x128xi32, strided<[1, 1]>> to memref<128x128xi32>
+// CHECK:           %[[VAL_17:.*]] = bufferization.to_tensor %[[VAL_16]] restrict writable : memref<128x128xi32>
+// CHECK:           %[[VAL_18:.*]] = memref.alloc() : memref<128x128xf16>
+// CHECK:           memref.copy %[[VAL_13]], %[[VAL_18]] : memref<128x128xf16, strided<[1, 1]>> to memref<128x128xf16>
+// CHECK:           %[[VAL_19:.*]] = bufferization.to_tensor %[[VAL_18]] restrict writable : memref<128x128xf16>
+// CHECK:           %[[VAL_20:.*]] = tensor.empty() : tensor<128x128xbf16>
+// CHECK:           %[[VAL_21:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_15]] : tensor<128x128xf32>) outs(%[[VAL_20]] : tensor<128x128xbf16>) {
+// CHECK:           ^bb0(%[[VAL_22:.*]]: f32, %[[VAL_23:.*]]: bf16):
+// CHECK:             %[[VAL_24:.*]] = arith.truncf %[[VAL_22]] : f32 to bf16
+// CHECK:             linalg.yield %[[VAL_24]] : bf16
+// CHECK:           } -> tensor<128x128xbf16>
+// CHECK:           %[[VAL_25:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_15]] : tensor<128x128xf32>) outs(%[[VAL_15]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0(%[[VAL_26:.*]]: f32, %[[VAL_27:.*]]: f32):
+// CHECK:             %[[VAL_28:.*]] = math.exp %[[VAL_26]] : f32
+// CHECK:             linalg.yield %[[VAL_28]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           %[[VAL_29:.*]] = tensor.empty() : tensor<128x128xf32>
+// CHECK:           %[[VAL_30:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_17]] : tensor<128x128xi32>) outs(%[[VAL_29]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0(%[[VAL_31:.*]]: i32, %[[VAL_32:.*]]: f32):
+// CHECK:             %[[VAL_33:.*]] = arith.sitofp %[[VAL_31]] : i32 to f32
+// CHECK:             linalg.yield %[[VAL_33]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           %[[VAL_34:.*]] = tensor.empty() : tensor<128x128xf32>
+// CHECK:           %[[VAL_35:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_19]] : tensor<128x128xf16>) outs(%[[VAL_34]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0(%[[VAL_36:.*]]: f16, %[[VAL_37:.*]]: f32):
+// CHECK:             %[[VAL_38:.*]] = arith.extf %[[VAL_36]] : f16 to f32
+// CHECK:             linalg.yield %[[VAL_38]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           %[[VAL_39:.*]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_15]] : tensor<128x128xf32>) outs(%[[VAL_15]] : tensor<128x128xf32>) {
+// CHECK:           ^bb0(%[[VAL_40:.*]]: f32, %[[VAL_41:.*]]: f32):
+// CHECK:             %[[VAL_42:.*]] = math.sqrt %[[VAL_40]] : f32
+// CHECK:             linalg.yield %[[VAL_42]] : f32
+// CHECK:           } -> tensor<128x128xf32>
+// CHECK:           memref.tensor_store %[[VAL_43:.*]], %[[VAL_3]] : memref<128x128xbf16>
+// CHECK:           memref.tensor_store %[[VAL_44:.*]], %[[VAL_4]] : memref<128x128xf32>
+// CHECK:           memref.tensor_store %[[VAL_45:.*]], %[[VAL_5]] : memref<128x128xf32>
+// CHECK:           memref.tensor_store %[[VAL_46:.*]], %[[VAL_6]] : memref<128x128xf32>
+// CHECK:           memref.tensor_store %[[VAL_47:.*]], %[[VAL_7]] : memref<128x128xf32>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/convert_splat_float.mlir
+++ b/test/Conversion/TritonToLinalg/convert_splat_float.mlir
@@ -1,0 +1,23 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+    tt.func @kernel(%fin : f32,
+                    %bin : bf16,
+                    %save0 : tensor<1024x!tt.ptr<f32>>,
+                    %save1 : tensor<128x256x!tt.ptr<bf16>>) -> () {
+        %0 = tt.splat %fin : (f32) -> (tensor<1024xf32>)
+        %1 = tt.splat %bin : (bf16) -> (tensor<128x256xbf16>)
+        tt.store %save0, %0 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+        tt.store %save1, %1 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xbf16>
+        tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: bf16, %[[VAL_2:.*]]: memref<1024xf32>, %[[VAL_3:.*]]: memref<128x256xbf16>, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK:           %[[VAL_7:.*]] = tensor.empty() : tensor<1024xf32>
+// CHECK:           %[[VAL_8:.*]] = linalg.fill ins(%[[VAL_0]] : f32) outs(%[[VAL_7]] : tensor<1024xf32>) -> tensor<1024xf32>
+// CHECK:           %[[VAL_9:.*]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           %[[VAL_10:.*]] = linalg.fill ins(%[[VAL_1]] : bf16) outs(%[[VAL_9]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           memref.tensor_store %[[VAL_8]], %[[VAL_2]] : memref<1024xf32>
+// CHECK:           memref.tensor_store %[[VAL_10]], %[[VAL_3]] : memref<128x256xbf16>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/dot.mlir
+++ b/test/Conversion/TritonToLinalg/dot.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : !tt.ptr<bf16>
+  )
+  {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %c64 = arith.constant 128 : i32
+    %1 = tt.splat %c64 : (i32) -> tensor<128xi32>
+    %2 = arith.muli %0, %1 : tensor<128xi32>
+    %3 = tt.expand_dims %2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x64xi32>
+    %5 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
+    %7 = tt.broadcast %6 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %8 = arith.addi %4, %7 : tensor<128x64xi32>
+    %10 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %11 = tt.expand_dims %10 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+    %12 = tt.broadcast %11 : (tensor<256x1xi32>) -> tensor<256x64xi32>
+    %13 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %c256 = arith.constant 256 : i32
+    %14 = tt.splat %c256 : (i32) -> tensor<64xi32>
+    %15 = arith.muli %13, %14 : tensor<64xi32>
+    %16 = tt.expand_dims %15 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
+    %17 = tt.broadcast %16 : (tensor<1x64xi32>) -> tensor<256x64xi32>
+    %18 = arith.addi %12, %17 : tensor<256x64xi32>
+    %20 = tt.splat %c256 : (i32) -> tensor<128xi32>
+    %21 = arith.muli %0, %20 : tensor<128xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %23 = tt.broadcast %22 : (tensor<128x1xi32>) -> tensor<128x256xi32>
+    %24 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %25 = tt.broadcast %24 {axis = 0 : i32} : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %26 = arith.addi %23, %25 : tensor<128x256xi32>
+    %30 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %31 = tt.addptr %30, %8 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+    %32 = tt.load %31 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x64xbf16>
+    %40 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x64x!tt.ptr<bf16>>
+    %41 = tt.addptr %40, %18 : tensor<256x64x!tt.ptr<bf16>>, tensor<256x64xi32>
+    %42 = tt.load %41 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<256x64xbf16>
+    %43 = tt.trans %42 : (tensor<256x64xbf16>) -> tensor<64x256xbf16>
+    %50 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    %52 = tt.load %51 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x256xbf16>
+    %60 = tt.dot %32, %43, %52 {allowTF32 = false} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    tt.store %51, %60 : tensor<128x256xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: memref<*xbf16>, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 128 : index
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128, 64], strides: {{\[}}%[[VAL_7]], 1] : memref<*xbf16> to memref<128x64xbf16, strided<[?, 1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<128x64xbf16>
+// CHECK:           memref.copy %[[VAL_8]], %[[VAL_9]] : memref<128x64xbf16, strided<[?, 1]>> to memref<128x64xbf16>
+// CHECK:           %[[VAL_10:.*]] = bufferization.to_tensor %[[VAL_9]] restrict writable : memref<128x64xbf16>
+// CHECK:           %[[VAL_11:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [256, 64], strides: [1, %[[VAL_6]]] : memref<*xbf16> to memref<256x64xbf16, strided<[1, ?]>>
+// CHECK:           %[[VAL_12:.*]] = memref.alloc() : memref<256x64xbf16>
+// CHECK:           memref.copy %[[VAL_11]], %[[VAL_12]] : memref<256x64xbf16, strided<[1, ?]>> to memref<256x64xbf16>
+// CHECK:           %[[VAL_13:.*]] = bufferization.to_tensor %[[VAL_12]] restrict writable : memref<256x64xbf16>
+// CHECK:           %[[VAL_14:.*]] = tensor.empty() : tensor<64x256xbf16>
+// CHECK:           %[[VAL_15:.*]] = linalg.transpose ins(%[[VAL_13]] : tensor<256x64xbf16>) outs(%[[VAL_14]] : tensor<64x256xbf16>) permutation = [1, 0]
+// CHECK:           %[[VAL_16:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: [0], sizes: [128, 256], strides: {{\[}}%[[VAL_6]], 1] : memref<*xbf16> to memref<128x256xbf16, strided<[?, 1]>>
+// CHECK:           %[[VAL_17:.*]] = memref.alloc() : memref<128x256xbf16>
+// CHECK:           memref.copy %[[VAL_16]], %[[VAL_17]] : memref<128x256xbf16, strided<[?, 1]>> to memref<128x256xbf16>
+// CHECK:           %[[VAL_18:.*]] = bufferization.to_tensor %[[VAL_17]] restrict writable : memref<128x256xbf16>
+// CHECK:           %[[VAL_19:.*]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           %[[VAL_20:.*]] = linalg.matmul ins(%[[VAL_10]], %[[VAL_15]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs(%[[VAL_19]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           %[[VAL_21:.*]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_20]], %[[VAL_18]] : tensor<128x256xbf16>, tensor<128x256xbf16>) outs(%[[VAL_20]] : tensor<128x256xbf16>) {
+// CHECK:           ^bb0(%[[VAL_22:.*]]: bf16, %[[VAL_23:.*]]: bf16, %[[VAL_24:.*]]: bf16):
+// CHECK:             %[[VAL_25:.*]] = arith.addf %[[VAL_22]], %[[VAL_23]] : bf16
+// CHECK:             linalg.yield %[[VAL_25]] : bf16
+// CHECK:           } -> tensor<128x256xbf16>
+// CHECK:           memref.tensor_store %[[VAL_26:.*]], %[[VAL_16]] : memref<128x256xbf16, strided<[?, 1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/kernel-01-vector-add.mlir
+++ b/test/Conversion/TritonToLinalg/kernel-01-vector-add.mlir
@@ -1,0 +1,77 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+
+module {
+  tt.func public @add_kernel_01234(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: i32) {
+    %c1024_i32 = arith.constant 1024 : i32
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %c1024_i32 : i32
+    %2 = tt.make_range {end = 1024 : i32, start = 0 : i32} : tensor<1024xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<1024xi32>
+    %4 = arith.addi %3, %2 : tensor<1024xi32>
+    %5 = tt.splat %arg3 : (i32) -> tensor<1024xi32>
+    %6 = arith.cmpi slt, %4, %5 : tensor<1024xi32>
+    %7 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %8 = tt.addptr %7, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %9 = tt.load %8, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %10 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %11 = tt.addptr %10, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    %12 = tt.load %11, %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<1024xf32>
+    %13 = arith.addf %9, %12 : tensor<1024xf32>
+    %14 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<1024x!tt.ptr<f32>>
+    %15 = tt.addptr %14, %4 : tensor<1024x!tt.ptr<f32>>, tensor<1024xi32>
+    tt.store %15, %13, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<1024xf32>
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @add_kernel_01234
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_1024_:%.+]] = arith.constant 1024 : index
+// CHECK-DAG:       [[CST_1024_1_:%.+]] = arith.constant 1024 : i32
+// CHECK:           [[VAR_0_:%.+]] = arith.muli [[PARAM_4_]], [[CST_1024_1_]] : i32
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [1024], strides: [1]{{.*}} : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.addi [[VAR_2_]], [[CST_1024_]] : index
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_5_:%.+]] = arith.minsi [[VAR_3_]], [[VAR_4_]] : index
+// CHECK:           [[VAR_6_:%.+]] = arith.subi [[VAR_5_]], [[VAR_2_]] : index
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_6_]]{{.}} [1]{{.*}} : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_0_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_6_]]{{.}} [1] : memref<1024xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_]]_0 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_7_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<1024xf32>
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [1024], strides: [1]{{.*}} : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_1_:%.+]] = memref.alloc() : memref<1024xf32>
+// CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.addi [[VAR_9_]], [[CST_1024_]] : index
+// CHECK-DAG:       [[VAR_11_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_12_:%.+]] = arith.minsi [[VAR_10_]], [[VAR_11_]] : index
+// CHECK:           [[VAR_13_:%.+]] = arith.subi [[VAR_12_]], [[VAR_9_]] : index
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_13_]]{{.}} [1]{{.*}} : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_4_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_13_]]{{.}} [1] : memref<1024xf32> to memref<?xf32, strided<[1]>>
+// CHECK:           memref.copy [[VAR_subview_3_]], [[VAR_subview_4_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:           [[VAR_14_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<1024xf32>
+// CHECK:           [[VAR_15_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_7_]], [[VAR_14_]] : tensor<1024xf32>, tensor<1024xf32>) outs([[VAR_7_]] : tensor<1024xf32>) {
+// CHECK:           ^bb0([[in_1:%.+]]: f32, [[in_2:%.+]]: f32, [[out:%.+]]: f32):
+// CHECK:             [[VAR_22_:%.+]] = arith.addf [[in_1]], [[in_2]] : f32
+// CHECK:             linalg.yield [[VAR_22_]] : f32
+// CHECK:           } -> tensor<1024xf32>
+// CHECK:           [[VAR_16_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_16_]]{{.}}, sizes: [1024], strides: [1]{{.*}} : memref<*xf32> to memref<1024xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.addi [[VAR_17_]], [[CST_1024_]] : index
+// CHECK-DAG:       [[VAR_19_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_20_:%.+]] = arith.minsi [[VAR_18_]], [[VAR_19_]] : index
+// CHECK:           [[VAR_21_:%.+]] = arith.subi [[VAR_20_]], [[VAR_17_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_15_]][0] {{.}}[[VAR_21_]]{{.}} [1] : tensor<1024xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_6_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_21_]]{{.}} [1]{{.*}} : memref<1024xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           memref.tensor_store [[VAR_extracted_slice_]], [[VAR_subview_6_]] : memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/kernel-02-fused-softmax.mlir
+++ b/test/Conversion/TritonToLinalg/kernel-02-fused-softmax.mlir
@@ -1,0 +1,105 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+
+module {
+  tt.func public @softmax_kernel_012345(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: i32, %arg3: i32, %arg4: i32) {
+    %cst = arith.constant 0xFF800000 : f32
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %arg2 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    %3 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %4 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<128x!tt.ptr<f32>>
+    %5 = tt.addptr %4, %3 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    %6 = tt.splat %arg4 : (i32) -> tensor<128xi32>
+    %7 = arith.cmpi slt, %3, %6 : tensor<128xi32>
+    %8 = tt.splat %cst : (f32) -> tensor<128xf32>
+    %9 = tt.load %5, %7, %8 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xf32>
+    %10 = "tt.reduce"(%9) ({
+    ^bb0(%arg5: f32, %arg6: f32):
+      %21 = arith.cmpf ogt, %arg5, %arg6 : f32
+      %22 = arith.select %21, %arg5, %arg6 : f32
+      tt.reduce.return %22 : f32
+    }) {axis = 0 : i32} : (tensor<128xf32>) -> f32
+    %11 = tt.splat %10 : (f32) -> tensor<128xf32>
+    %12 = arith.subf %9, %11 : tensor<128xf32>
+    %13 = math.exp %12 : tensor<128xf32>
+    %14 = "tt.reduce"(%13) ({
+    ^bb0(%arg5: f32, %arg6: f32):
+      %21 = arith.addf %arg5, %arg6 : f32
+      tt.reduce.return %21 : f32
+    }) {axis = 0 : i32} : (tensor<128xf32>) -> f32
+    %15 = tt.splat %14 : (f32) -> tensor<128xf32>
+    %16 = arith.divf %13, %15 : tensor<128xf32>
+    %17 = arith.muli %0, %arg3 : i32
+    %18 = tt.addptr %arg0, %17 : !tt.ptr<f32>, i32
+    %19 = tt.splat %18 : (!tt.ptr<f32>) -> tensor<128x!tt.ptr<f32>>
+    %20 = tt.addptr %19, %3 : tensor<128x!tt.ptr<f32>>, tensor<128xi32>
+    tt.store %20, %16, %7 {cache = 1 : i32, evict = 1 : i32} : tensor<128xf32>
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @softmax_kernel_012345
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: i32, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0xFF800000 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = arith.muli [[PARAM_5_]], [[PARAM_2_]] : i32
+// CHECK:           [[VAR_1_:%.+]] = arith.index_cast [[VAR_0_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_1_]]{{.}}, sizes: [128], strides: [1]{{.*}} : memref<*xf32> to memref<128xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[RES_:%.+]] = memref.alloc() : memref<128xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:           [[VAR_3_:%.+]] = arith.minsi [[VAR_2_]], [[CST_128_]] : index
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_3_]]{{.}} [1]{{.*}} : memref<128xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_subview_1_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_3_]]{{.}} [1] : memref<128xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.cmpi slt, [[VAR_3_]], [[CST_128_]] : index
+// CHECK:           scf.if [[VAR_4_]] {
+// CHECK:             linalg.fill ins([[CST_0_]] : f32) outs([[RES_]] : memref<128xf32>)
+// CHECK:           }
+// CHECK:           memref.copy [[VAR_subview_]], [[VAR_subview_]]_1 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:       [[VAR_5_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128xf32>
+// CHECK-DAG:       [[VAR_6_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_]] into [[VAR_6_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_5_]] : tensor<128xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_1:%.+]]: f32, [[init_1:%.+]]: f32) {
+// CHECK:               [[VAR_19_:%.+]] = arith.maxf [[in_1]], [[init_1]] : f32
+// CHECK:               linalg.yield [[VAR_19_]] : f32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
+// CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<128xf32>
+// CHECK:           [[VAR_8_:%.+]] = linalg.fill ins([[VAR_extracted_]] : f32) outs([[VAR_7_]] : tensor<128xf32>) -> tensor<128xf32>
+// CHECK:           [[VAR_9_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_5_]], [[VAR_8_]] : tensor<128xf32>, tensor<128xf32>) outs([[VAR_5_]] : tensor<128xf32>) {
+// CHECK:           ^bb0([[in_1:%.+]]: f32, [[in_2:%.+]]: f32, [[out:%.+]]: f32):
+// CHECK:             [[VAR_19_1_:%.+]] = arith.subf [[in_1]], [[in_2]] : f32
+// CHECK:             linalg.yield [[VAR_19_1_]] : f32
+// CHECK:           } -> tensor<128xf32>
+// CHECK:           [[VAR_10_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel"]} ins([[VAR_9_]] : tensor<128xf32>) outs([[VAR_9_]] : tensor<128xf32>) {
+// CHECK:           ^bb0([[in_1:%.+]]: f32, [[out_1:%.+]]: f32):
+// CHECK:             [[VAR_19_2_:%.+]] = math.exp [[in_1]] : f32
+// CHECK:             linalg.yield [[VAR_19_2_]] : f32
+// CHECK:           } -> tensor<128xf32>
+// CHECK:           [[VAR_11_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_2_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_11_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_3_:%.+]] = linalg.reduce ins([[VAR_10_]] : tensor<128xf32>) outs([[VAR_inserted_2_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_1:%.+]]: f32, [[init_1:%.+]]: f32) {
+// CHECK:               [[VAR_19_3_:%.+]] = arith.addf [[in_1]], [[init_1]] : f32
+// CHECK:               linalg.yield [[VAR_19_3_]] : f32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_extracted_4_:%.+]] = tensor.extract [[VAR_reduced_3_]][] : tensor<f32>
+// CHECK-DAG:       [[VAR_12_:%.+]] = tensor.empty() : tensor<128xf32>
+// CHECK:           [[VAR_13_:%.+]] = linalg.fill ins([[VAR_extracted_4_]] : f32) outs([[VAR_12_]] : tensor<128xf32>) -> tensor<128xf32>
+// CHECK:           [[VAR_14_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_10_]], [[VAR_13_]] : tensor<128xf32>, tensor<128xf32>) outs([[VAR_10_]] : tensor<128xf32>) {
+// CHECK:           ^bb0([[in_1:%.+]]: f32, [[in_2:%.+]]: f32, [[out_1:%.+]]: f32):
+// CHECK:             [[VAR_19_4_:%.+]] = arith.divf [[in_1]], [[in_2]] : f32
+// CHECK:             linalg.yield [[VAR_19_4_]] : f32
+// CHECK:           } -> tensor<128xf32>
+// CHECK:           [[VAR_15_:%.+]] = arith.muli [[PARAM_5_]], [[PARAM_3_]] : i32
+// CHECK:           [[VAR_16_:%.+]] = arith.index_cast [[VAR_15_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_16_]]{{.}}, sizes: [128], strides: [1]{{.*}} : memref<*xf32> to memref<128xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:           [[VAR_18_:%.+]] = arith.minsi [[VAR_17_]], [[CST_128_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_14_]][0] {{.}}[[VAR_18_]]{{.}} [1] : tensor<128xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_6_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_18_]]{{.}} [1]{{.*}} : memref<128xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           memref.tensor_store [[VAR_extracted_slice_]], [[VAR_subview_6_]] : memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/kernel-03-matrix-multiplication.mlir
+++ b/test/Conversion/TritonToLinalg/kernel-03-matrix-multiplication.mlir
@@ -1,0 +1,217 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+
+module {
+  tt.func public @matmul_kernel_0123456789101112131415(%arg0: !tt.ptr<bf16>, %arg1: !tt.ptr<bf16>, %arg2: !tt.ptr<bf16>, %arg3: i32, %arg4: i32, %arg5: i32, %arg6: i32, %arg7: i32, %arg8: i32, %arg9: i32, %arg10: i32, %arg11: i32) {
+    %c63_i32 = arith.constant 63 : i32
+    %c255_i32 = arith.constant 255 : i32
+    %c127_i32 = arith.constant 127 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst = arith.constant 0.000000e+00 : f32
+    %c256_i32 = arith.constant 256 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.addi %arg3, %c127_i32 : i32
+    %2 = arith.divsi %1, %c128_i32 : i32
+    %3 = arith.addi %arg4, %c255_i32 : i32
+    %4 = arith.divsi %3, %c256_i32 : i32
+    %5 = arith.addi %arg5, %c63_i32 : i32
+    %6 = arith.divsi %5, %c64_i32 : i32
+    %7 = arith.muli %4, %c8_i32 : i32
+    %8 = arith.divsi %0, %7 : i32
+    %9 = arith.muli %8, %c8_i32 : i32
+    %10 = arith.subi %2, %9 : i32
+    %11 = arith.cmpi slt, %10, %c8_i32 : i32
+    %12 = arith.select %11, %10, %c8_i32 : i32
+    %13 = arith.remsi %0, %12 : i32
+    %14 = arith.addi %9, %13 : i32
+    %15 = arith.remsi %0, %7 : i32
+    %16 = arith.divsi %15, %12 : i32
+    %17 = arith.muli %14, %c128_i32 : i32
+    %18 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %19 = tt.splat %17 : (i32) -> tensor<128xi32>
+    %20 = arith.addi %19, %18 : tensor<128xi32>
+    %21 = arith.muli %16, %c256_i32 : i32
+    %22 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %23 = tt.splat %21 : (i32) -> tensor<256xi32>
+    %24 = arith.addi %23, %22 : tensor<256xi32>
+    %25 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %26 = tt.expand_dims %20 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %27 = tt.splat %arg6 : (i32) -> tensor<128x1xi32>
+    %28 = arith.muli %26, %27 : tensor<128x1xi32>
+    %29 = tt.expand_dims %25 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
+    %30 = tt.splat %arg7 : (i32) -> tensor<1x64xi32>
+    %31 = arith.muli %29, %30 : tensor<1x64xi32>
+    %32 = tt.broadcast %28 : (tensor<128x1xi32>) -> tensor<128x64xi32>
+    %33 = tt.broadcast %31 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %34 = arith.addi %32, %33 : tensor<128x64xi32>
+    %35 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %36 = tt.addptr %35, %34 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+    %37 = tt.expand_dims %25 {axis = 1 : i32} : (tensor<64xi32>) -> tensor<64x1xi32>
+    %38 = tt.splat %arg8 : (i32) -> tensor<64x1xi32>
+    %39 = arith.muli %37, %38 : tensor<64x1xi32>
+    %40 = tt.expand_dims %24 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %41 = tt.splat %arg9 : (i32) -> tensor<1x256xi32>
+    %42 = arith.muli %40, %41 : tensor<1x256xi32>
+    %43 = tt.broadcast %39 : (tensor<64x1xi32>) -> tensor<64x256xi32>
+    %44 = tt.broadcast %42 : (tensor<1x256xi32>) -> tensor<64x256xi32>
+    %45 = arith.addi %43, %44 : tensor<64x256xi32>
+    %46 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<64x256x!tt.ptr<bf16>>
+    %47 = tt.addptr %46, %45 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
+    %48 = tt.splat %cst : (f32) -> tensor<128x256xf32>
+    %49 = arith.muli %arg7, %c64_i32 : i32
+    %50 = tt.splat %49 : (i32) -> tensor<128x64xi32>
+    %51 = arith.muli %arg8, %c64_i32 : i32
+    %52 = tt.splat %51 : (i32) -> tensor<64x256xi32>
+    %53:3 = scf.for %arg12 = %c0_i32 to %6 step %c1_i32 iter_args(%arg13 = %48, %arg14 = %36, %arg15 = %47) -> (tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>)  : i32 {
+      %71 = tt.load %arg14 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xbf16>
+      %72 = tt.load %arg15 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xbf16>
+      %73 = tt.dot %71, %72, %48 {allowTF32 = true} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xf32>
+      %74 = arith.addf %arg13, %73 : tensor<128x256xf32>
+      %75 = tt.addptr %arg14, %50 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+      %76 = tt.addptr %arg15, %52 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
+      scf.yield %74, %75, %76 : tensor<128x256xf32>, tensor<128x64x!tt.ptr<bf16>>, tensor<64x256x!tt.ptr<bf16>>
+    }
+    %54 = arith.truncf %53#0 : tensor<128x256xf32> to tensor<128x256xbf16>
+    %55 = tt.splat %arg10 : (i32) -> tensor<128x1xi32>
+    %56 = arith.muli %55, %26 : tensor<128x1xi32>
+    %57 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x1x!tt.ptr<bf16>>
+    %58 = tt.addptr %57, %56 : tensor<128x1x!tt.ptr<bf16>>, tensor<128x1xi32>
+    %59 = tt.splat %arg11 : (i32) -> tensor<1x256xi32>
+    %60 = arith.muli %59, %40 : tensor<1x256xi32>
+    %61 = tt.broadcast %58 : (tensor<128x1x!tt.ptr<bf16>>) -> tensor<128x256x!tt.ptr<bf16>>
+    %62 = tt.broadcast %60 : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %63 = tt.addptr %61, %62 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    %64 = tt.splat %arg3 : (i32) -> tensor<128x1xi32>
+    %65 = arith.cmpi slt, %26, %64 : tensor<128x1xi32>
+    %66 = tt.splat %arg4 : (i32) -> tensor<1x256xi32>
+    %67 = arith.cmpi slt, %40, %66 : tensor<1x256xi32>
+    %68 = tt.broadcast %65 : (tensor<128x1xi1>) -> tensor<128x256xi1>
+    %69 = tt.broadcast %67 : (tensor<1x256xi1>) -> tensor<128x256xi1>
+    %70 = arith.andi %68, %69 : tensor<128x256xi1>
+    tt.store %63, %54, %70 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xbf16>
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @matmul_kernel_0123456789101112131415
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xbf16>, [[PARAM_1_:%.+]]: memref<*xbf16>, [[PARAM_2_:%.+]]: memref<*xbf16>, [[PARAM_3_:%.+]]: i32, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32, [[PARAM_12_:%.+]]: i32, [[PARAM_13_:%.+]]: i32, [[PARAM_14_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_128_:%.+]] = arith.constant 128 : index
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : index
+// CHECK-DAG:       [[CST_8_:%.+]] = arith.constant 8 : i32
+// CHECK-DAG:       [[CST_128_1_:%.+]] = arith.constant 128 : i32
+// CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_64_:%.+]] = arith.constant 64 : i32
+// CHECK-DAG:       [[CST_0_1_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_1_:%.+]] = arith.constant 1 : i32
+// CHECK-DAG:       [[CST_127_:%.+]] = arith.constant 127 : i32
+// CHECK-DAG:       [[CST_255_:%.+]] = arith.constant 255 : i32
+// CHECK-DAG:       [[CST_63_:%.+]] = arith.constant 63 : i32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<128x256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.addi [[PARAM_3_]], [[CST_127_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]] = arith.divsi [[VAR_2_]], [[CST_128_1_]] : i32
+// CHECK-DAG:       [[VAR_4_:%.+]] = arith.addi [[PARAM_4_]], [[CST_255_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.divsi [[VAR_4_]], [[CST_256_1_]] : i32
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.addi [[PARAM_5_]], [[CST_63_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_7_:%.+]] = arith.divsi [[VAR_6_]], [[CST_64_]] : i32
+// CHECK-DAG:       [[VAR_8_:%.+]] = arith.muli [[VAR_5_]], [[CST_8_]] : i32
+// CHECK:           [[VAR_9_:%.+]] = arith.divsi [[PARAM_12_]], [[VAR_8_]] : i32
+// CHECK:           [[VAR_10_:%.+]] = arith.muli [[VAR_9_]], [[CST_8_]] : i32
+// CHECK:           [[VAR_11_:%.+]] = arith.subi [[VAR_3_]], [[VAR_10_]] : i32
+// CHECK:           [[VAR_12_:%.+]] = arith.cmpi slt, [[VAR_11_]], [[CST_8_]] : i32
+// CHECK:           [[VAR_13_:%.+]] = arith.select [[VAR_12_]], [[VAR_11_]], [[CST_8_]] : i32
+// CHECK:           [[VAR_14_:%.+]] = arith.remsi [[PARAM_12_]], [[VAR_13_]] : i32
+// CHECK-DAG:       [[VAR_15_:%.+]] = arith.addi [[VAR_10_]], [[VAR_14_]] : i32
+// CHECK-DAG:       [[VAR_16_:%.+]] = arith.remsi [[PARAM_12_]], [[VAR_8_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.divsi [[VAR_16_]], [[VAR_13_]] : i32
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.muli [[VAR_15_]], [[CST_128_1_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_19_:%.+]] = arith.muli [[VAR_17_]], [[CST_256_1_]] : i32
+// CHECK-DAG:       [[VAR_20_:%.+]] = arith.index_cast [[VAR_18_]] : i32 to index
+// CHECK-DAG:       [[VAR_21_:%.+]] = arith.index_cast [[PARAM_6_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_22_:%.+]] = arith.muli [[VAR_20_]], [[VAR_21_]] : index
+// CHECK-DAG:       [[VAR_23_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK-DAG:       [[VAR_24_:%.+]] = arith.index_cast [[PARAM_8_]] : i32 to index
+// CHECK-DAG:       [[VAR_25_:%.+]] = arith.index_cast [[VAR_19_]] : i32 to index
+// CHECK-DAG:       [[VAR_26_:%.+]] = arith.index_cast [[PARAM_9_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_27_:%.+]] = arith.muli [[VAR_25_]], [[VAR_26_]] : index
+// CHECK-DAG:       [[VAR_28_:%.+]] = arith.muli [[PARAM_7_]], [[CST_64_]] : i32
+// CHECK-DAG:       [[VAR_29_:%.+]] = arith.muli [[PARAM_8_]], [[CST_64_]] : i32
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_22_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_21_]], [[VAR_23_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK:           [[VAR_reinterpret_cast_0_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_27_]]{{.}}, sizes: [64, 256], strides: {{.}}[[VAR_24_]], [[VAR_26_]]{{.}} : memref<*xbf16> to memref<64x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_30_:%.+]]:7 = scf.for [[VAR_arg15_:%.+]] = [[CST_0_1_]] to [[VAR_7_]] step [[CST_1_]] iter_args([[VAR_arg16_:%.+]] = [[VAR_1_]], [[VAR_arg17_:%.+]] = [[VAR_reinterpret_cast_]], [[VAR_arg18_:%.+]] = [[VAR_reinterpret_cast_]]_0, [[VAR_arg19_:%.+]] = [[VAR_22_]], [[VAR_arg20_:%.+]] = [[CST_0_]], [[VAR_arg21_:%.+]] = [[VAR_27_]], [[VAR_arg22_:%.+]] = [[CST_0_]]) -> (tensor<128x256xf32>, memref<128x64xbf16, strided<[?, ?], offset: ?>>, memref<64x256xbf16, strided<[?, ?], offset: ?>>, index, index, index, index)  : i32 {
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<128x64xbf16>
+// CHECK:             memref.copy [[VAR_arg17_]], [[RES_]] : memref<128x64xbf16, strided<[?, ?], offset: ?>> to memref<128x64xbf16>
+// CHECK-DAG:         [[VAR_52_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<128x64xbf16>
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<64x256xbf16>
+// CHECK:             memref.copy [[VAR_arg18_]], [[RES_1_]] : memref<64x256xbf16, strided<[?, ?], offset: ?>> to memref<64x256xbf16>
+// CHECK-DAG:         [[VAR_53_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<64x256xbf16>
+// CHECK-DAG:         [[VAR_54_:%.+]] = tensor.empty() : tensor<128x256xf32>
+// CHECK:             [[VAR_55_:%.+]] = linalg.matmul ins([[VAR_52_]], [[VAR_53_]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs([[VAR_54_]] : tensor<128x256xf32>) -> tensor<128x256xf32>
+// CHECK:             [[VAR_56_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_55_]], [[VAR_1_]] : tensor<128x256xf32>, tensor<128x256xf32>) outs([[VAR_55_]] : tensor<128x256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_64_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_64_]] : f32
+// CHECK:             } -> tensor<128x256xf32>
+// CHECK:             [[VAR_57_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg16_]], [[VAR_56_]] : tensor<128x256xf32>, tensor<128x256xf32>) outs([[VAR_arg16_]] : tensor<128x256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_64_1_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_64_1_]] : f32
+// CHECK:             } -> tensor<128x256xf32>
+// CHECK:             [[VAR_58_:%.+]] = arith.index_cast [[VAR_28_]] : i32 to index
+// CHECK:             [[VAR_59_:%.+]] = arith.addi [[VAR_arg19_]], [[VAR_58_]] : index
+// CHECK:             [[VAR_60_:%.+]] = arith.addi [[VAR_59_]], [[VAR_arg20_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_3_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_60_]]{{.}}, sizes: [128, 64], strides: {{.}}[[VAR_21_]], [[VAR_23_]]{{.}} : memref<*xbf16> to memref<128x64xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:         [[VAR_61_:%.+]] = arith.index_cast [[VAR_29_]] : i32 to index
+// CHECK:             [[VAR_62_:%.+]] = arith.addi [[VAR_arg21_]], [[VAR_61_]] : index
+// CHECK:             [[VAR_63_:%.+]] = arith.addi [[VAR_62_]], [[VAR_arg22_]] : index
+// CHECK:             [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_63_]]{{.}}, sizes: [64, 256], strides: {{.}}[[VAR_24_]], [[VAR_26_]]{{.}} : memref<*xbf16> to memref<64x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK:             scf.yield [[VAR_57_]], [[VAR_reinterpret_cast_3_]], [[VAR_reinterpret_cast_4_]], [[VAR_60_]], [[CST_0_]], [[VAR_63_]], [[CST_0_]] : tensor<128x256xf32>, memref<128x64xbf16, strided<[?, ?], offset: ?>>, memref<64x256xbf16, strided<[?, ?], offset: ?>>, index, index, index, index
+// CHECK:           }
+// CHECK:           [[VAR_31_:%.+]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           [[VAR_32_:%.+]] = linalg.generic {indexing_maps = [#map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_30_]]#0 : tensor<128x256xf32>) outs([[VAR_31_]] : tensor<128x256xbf16>) {
+// CHECK:           ^bb0([[in:.+]]: f32, [[out:.+]]: bf16):
+// CHECK:             [[VAR_52_1_:%.+]] = arith.truncf [[in]] : f32 to bf16
+// CHECK:             linalg.yield [[VAR_52_1_]] : bf16
+// CHECK:           } -> tensor<128x256xbf16>
+// CHECK-DAG:       [[VAR_33_:%.+]] = arith.index_cast [[PARAM_10_]] : i32 to index
+// CHECK-DAG:       [[VAR_34_:%.+]] = arith.index_cast [[VAR_18_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_35_:%.+]] = arith.muli [[VAR_34_]], [[VAR_33_]] : index
+// CHECK-DAG:       [[VAR_36_:%.+]] = arith.index_cast [[PARAM_11_]] : i32 to index
+// CHECK-DAG:       [[VAR_37_:%.+]] = arith.index_cast [[VAR_19_]] : i32 to index
+// CHECK:           [[VAR_38_:%.+]] = arith.muli [[VAR_37_]], [[VAR_36_]] : index
+// CHECK:           [[VAR_39_:%.+]] = arith.addi [[VAR_35_]], [[VAR_38_]] : index
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_39_]]{{.}}, sizes: [128, 256], strides: {{.}}[[VAR_33_]], [[VAR_36_]]{{.}} : memref<*xbf16> to memref<128x256xbf16, strided<[?, ?], offset: ?>>
+// CHECK-DAG:       [[VAR_40_:%.+]] = arith.index_cast [[VAR_18_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_41_:%.+]] = arith.addi [[VAR_40_]], [[CST_128_]] : index
+// CHECK-DAG:       [[VAR_42_:%.+]] = arith.index_cast [[PARAM_3_]] : i32 to index
+// CHECK:           [[VAR_43_:%.+]] = arith.minsi [[VAR_41_]], [[VAR_42_]] : index
+// CHECK-DAG:       [[VAR_44_:%.+]] = arith.subi [[VAR_43_]], [[VAR_40_]] : index
+// CHECK-DAG:       [[VAR_45_:%.+]] = arith.index_cast [[VAR_19_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_46_:%.+]] = arith.addi [[VAR_45_]], [[CST_256_]] : index
+// CHECK-DAG:       [[VAR_47_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:           [[VAR_48_:%.+]] = arith.minsi [[VAR_46_]], [[VAR_47_]] : index
+// CHECK-DAG:       [[VAR_49_:%.+]] = arith.subi [[VAR_48_]], [[VAR_45_]] : index
+// CHECK-DAG:       [[VAR_50_:%.+]] = arith.minsi [[VAR_44_]], [[CST_128_]] : index
+// CHECK:           [[VAR_51_:%.+]] = arith.minsi [[VAR_49_]], [[CST_256_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_32_]][0, 0] {{.}}[[VAR_50_]], [[VAR_51_]]{{.}} [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0, 0] {{.}}[[VAR_50_]], [[VAR_51_]]{{.}} [1, 1] : memref<128x256xbf16, strided<[?, ?], offset: ?>> to memref<?x?xbf16, strided<[?, ?], offset: ?>>
+// CHECK:           memref.tensor_store [[VAR_extracted_slice_]], [[VAR_subview_]] : memref<?x?xbf16, strided<[?, ?], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/kernel-05-layer-norm-dwdb.mlir
+++ b/test/Conversion/TritonToLinalg/kernel-05-layer-norm-dwdb.mlir
@@ -1,0 +1,189 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+
+module {
+  tt.func public @_layer_norm_bwd_dwdb_0123456(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: !tt.ptr<f32>, %arg4: i32, %arg5: i32) {
+    %c0_i32 = arith.constant 0 : i32
+    %c256_i32 = arith.constant 256 : i32
+    %cst = arith.constant 0.000000e+00 : f32
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %c256_i32 : i32
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %3 = tt.splat %1 : (i32) -> tensor<256xi32>
+    %4 = arith.addi %3, %2 : tensor<256xi32>
+    %5 = tt.splat %cst : (f32) -> tensor<256x256xf32>
+    %6 = tt.splat %arg4 : (i32) -> tensor<256x1xi32>
+    %7 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %8 = tt.splat %arg5 : (i32) -> tensor<1x256xi32>
+    %9 = arith.cmpi slt, %7, %8 : tensor<1x256xi32>
+    %10 = tt.broadcast %9 : (tensor<1x256xi1>) -> tensor<256x256xi1>
+    %11 = tt.splat %arg5 : (i32) -> tensor<256x1xi32>
+    %12 = tt.broadcast %7 : (tensor<1x256xi32>) -> tensor<256x256xi32>
+    %13 = tt.splat %arg0 : (!tt.ptr<f32>) -> tensor<256x256x!tt.ptr<f32>>
+    %14 = tt.splat %arg1 : (!tt.ptr<f32>) -> tensor<256x256x!tt.ptr<f32>>
+    %15:2 = scf.for %arg6 = %c0_i32 to %arg4 step %c256_i32 iter_args(%arg7 = %5, %arg8 = %5) -> (tensor<256x256xf32>, tensor<256x256xf32>)  : i32 {
+      %24 = tt.splat %arg6 : (i32) -> tensor<256xi32>
+      %25 = arith.addi %24, %2 : tensor<256xi32>
+      %26 = tt.expand_dims %25 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+      %27 = arith.cmpi slt, %26, %6 : tensor<256x1xi32>
+      %28 = tt.broadcast %27 : (tensor<256x1xi1>) -> tensor<256x256xi1>
+      %29 = arith.andi %28, %10 : tensor<256x256xi1>
+      %30 = arith.muli %26, %11 : tensor<256x1xi32>
+      %31 = tt.broadcast %30 : (tensor<256x1xi32>) -> tensor<256x256xi32>
+      %32 = arith.addi %31, %12 : tensor<256x256xi32>
+      %33 = tt.addptr %13, %32 : tensor<256x256x!tt.ptr<f32>>, tensor<256x256xi32>
+      %34 = tt.load %33, %29, %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x256xf32>
+      %35 = arith.addf %arg7, %34 : tensor<256x256xf32>
+      %36 = tt.addptr %14, %32 : tensor<256x256x!tt.ptr<f32>>, tensor<256x256xi32>
+      %37 = tt.load %36, %29, %5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x256xf32>
+      %38 = arith.addf %arg8, %37 : tensor<256x256xf32>
+      scf.yield %35, %38 : tensor<256x256xf32>, tensor<256x256xf32>
+    }
+    %16 = "tt.reduce"(%15#0) ({
+    ^bb0(%arg6: f32, %arg7: f32):
+      %24 = arith.addf %arg6, %arg7 : f32
+      tt.reduce.return %24 : f32
+    }) {axis = 0 : i32} : (tensor<256x256xf32>) -> tensor<256xf32>
+    %17 = "tt.reduce"(%15#1) ({
+    ^bb0(%arg6: f32, %arg7: f32):
+      %24 = arith.addf %arg6, %arg7 : f32
+      tt.reduce.return %24 : f32
+    }) {axis = 0 : i32} : (tensor<256x256xf32>) -> tensor<256xf32>
+    %18 = tt.splat %arg5 : (i32) -> tensor<256xi32>
+    %19 = arith.cmpi slt, %4, %18 : tensor<256xi32>
+    %20 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %21 = tt.addptr %20, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %21, %16, %19 {cache = 1 : i32, evict = 1 : i32} : tensor<256xf32>
+    %22 = tt.splat %arg3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %23 = tt.addptr %22, %4 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    tt.store %23, %17, %19 {cache = 1 : i32, evict = 1 : i32} : tensor<256xf32>
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-LABEL:  func.func @_layer_norm_bwd_dwdb_0123456
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: memref<*xf32>, [[PARAM_4_:%.+]]: i32, [[PARAM_5_:%.+]]: i32, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<256x256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<256x256xf32>) -> tensor<256x256xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_6_]], [[CST_256_1_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]]:2 = scf.for [[VAR_arg9_:%.+]] = [[CST_0_]] to [[PARAM_4_]] step [[CST_256_1_]] iter_args([[VAR_arg10_:%.+]] = [[VAR_1_]], [[VAR_arg11_:%.+]] = [[VAR_1_]]) -> (tensor<256x256xf32>, tensor<256x256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_20_:%.+]] = arith.index_cast [[VAR_arg9_]] : i32 to index
+// CHECK-DAG:         [[VAR_21_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_22_:%.+]] = arith.muli [[VAR_20_]], [[VAR_21_]] : index
+// CHECK-DAG:         [[VAR_23_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK:             [[VAR_24_:%.+]] = arith.addi [[VAR_22_]], [[VAR_23_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_24_]]{{.}}, sizes: [256, 256], strides: {{.}}[[VAR_21_]], 1] : memref<*xf32> to memref<256x256xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256x256xf32>
+// CHECK-DAG:         [[VAR_25_:%.+]] = arith.index_cast [[VAR_arg9_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_26_:%.+]] = arith.addi [[VAR_25_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_27_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:             [[VAR_28_:%.+]] = arith.minsi [[VAR_26_]], [[VAR_27_]] : index
+// CHECK-DAG:         [[VAR_29_:%.+]] = arith.subi [[VAR_28_]], [[VAR_25_]] : index
+// CHECK-DAG:         [[VAR_30_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_31_:%.+]] = arith.addi [[VAR_30_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_32_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:             [[VAR_33_:%.+]] = arith.minsi [[VAR_31_]], [[VAR_32_]] : index
+// CHECK-DAG:         [[VAR_34_:%.+]] = arith.subi [[VAR_33_]], [[VAR_30_]] : index
+// CHECK-DAG:         [[VAR_35_:%.+]] = arith.minsi [[VAR_29_]], [[CST_256_]] : index
+// CHECK:             [[VAR_36_:%.+]] = arith.minsi [[VAR_34_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_subview_5_:%.+]] = memref.subview [[VAR_reinterpret_cast_4_]][0, 0] {{.}}[[VAR_35_]], [[VAR_36_]]{{.}} [1, 1] : memref<256x256xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0, 0] {{.}}[[VAR_35_]], [[VAR_36_]]{{.}} [1, 1] : memref<256x256xf32> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK-DAG:         [[VAR_37_:%.+]] = arith.cmpi slt, [[VAR_35_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_38_:%.+]] = arith.cmpi slt, [[VAR_36_]], [[CST_256_]] : index
+// CHECK:             [[VAR_39_:%.+]] = arith.ori [[VAR_37_]], [[VAR_38_]] : i1
+// CHECK:             scf.if [[VAR_39_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_]] : memref<256x256xf32>)
+// CHECK:             }
+// CHECK:             memref.copy [[VAR_subview_5_]], [[VAR_subview_6_]] : memref<?x?xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK:             [[VAR_40_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256x256xf32>
+// CHECK:             [[VAR_41_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg10_]], [[VAR_40_]] : tensor<256x256xf32>, tensor<256x256xf32>) outs([[VAR_arg10_]] : tensor<256x256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_64_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_64_]] : f32
+// CHECK:             } -> tensor<256x256xf32>
+// CHECK-DAG:         [[VAR_42_:%.+]] = arith.index_cast [[VAR_arg9_]] : i32 to index
+// CHECK-DAG:         [[VAR_43_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_44_:%.+]] = arith.muli [[VAR_42_]], [[VAR_43_]] : index
+// CHECK-DAG:         [[VAR_45_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK:             [[VAR_46_:%.+]] = arith.addi [[VAR_44_]], [[VAR_45_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_46_]]{{.}}, sizes: [256, 256], strides: {{.}}[[VAR_43_]], 1] : memref<*xf32> to memref<256x256xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<256x256xf32>
+// CHECK-DAG:         [[VAR_47_:%.+]] = arith.index_cast [[VAR_arg9_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_48_:%.+]] = arith.addi [[VAR_47_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_49_:%.+]] = arith.index_cast [[PARAM_4_]] : i32 to index
+// CHECK:             [[VAR_50_:%.+]] = arith.minsi [[VAR_48_]], [[VAR_49_]] : index
+// CHECK-DAG:         [[VAR_51_:%.+]] = arith.subi [[VAR_50_]], [[VAR_47_]] : index
+// CHECK-DAG:         [[VAR_52_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_53_:%.+]] = arith.addi [[VAR_52_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_54_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:             [[VAR_55_:%.+]] = arith.minsi [[VAR_53_]], [[VAR_54_]] : index
+// CHECK-DAG:         [[VAR_56_:%.+]] = arith.subi [[VAR_55_]], [[VAR_52_]] : index
+// CHECK-DAG:         [[VAR_57_:%.+]] = arith.minsi [[VAR_51_]], [[CST_256_]] : index
+// CHECK:             [[VAR_58_:%.+]] = arith.minsi [[VAR_56_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0, 0] {{.}}[[VAR_57_]], [[VAR_58_]]{{.}} [1, 1] : memref<256x256xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[?, 1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_1_]][0, 0] {{.}}[[VAR_57_]], [[VAR_58_]]{{.}} [1, 1] : memref<256x256xf32> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK-DAG:         [[VAR_59_:%.+]] = arith.cmpi slt, [[VAR_57_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_60_:%.+]] = arith.cmpi slt, [[VAR_58_]], [[CST_256_]] : index
+// CHECK:             [[VAR_61_:%.+]] = arith.ori [[VAR_59_]], [[VAR_60_]] : i1
+// CHECK:             scf.if [[VAR_61_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_1_]] : memref<256x256xf32>)
+// CHECK:             }
+// CHECK:             memref.copy [[VAR_subview_9_]], [[VAR_subview_10_]] : memref<?x?xf32, strided<[?, 1], offset: ?>> to memref<?x?xf32, strided<[256, 1]>>
+// CHECK:             [[VAR_62_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256x256xf32>
+// CHECK:             [[VAR_63_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]} ins([[VAR_arg11_]], [[VAR_62_]] : tensor<256x256xf32>, tensor<256x256xf32>) outs([[VAR_arg11_]] : tensor<256x256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_64_1_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_64_1_]] : f32
+// CHECK:             } -> tensor<256x256xf32>
+// CHECK:             scf.yield [[VAR_41_]], [[VAR_63_]] : tensor<256x256xf32>, tensor<256x256xf32>
+// CHECK:           }
+// CHECK:           [[VAR_4_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_5_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_4_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_3_]]#0 : tensor<256x256xf32>) outs([[VAR_5_]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             ([[in_0:.+]]: f32, [[in_1:.+]]: f32) {
+// CHECK:               [[VAR_20_1_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_20_1_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_6_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_7_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_6_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           [[VAR_reduced_0_:%.+]] = linalg.reduce ins([[VAR_3_]]#1 : tensor<256x256xf32>) outs([[VAR_7_]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             ([[in_0:.+]]: f32, [[in_1:.+]]: f32) {
+// CHECK:               [[VAR_20_2_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_20_2_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_8_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_8_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_9_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_10_:%.+]] = arith.addi [[VAR_9_]], [[CST_256_]] : index
+// CHECK-DAG:       [[VAR_11_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:           [[VAR_12_:%.+]] = arith.minsi [[VAR_10_]], [[VAR_11_]] : index
+// CHECK:           [[VAR_13_:%.+]] = arith.subi [[VAR_12_]], [[VAR_9_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_reduced_]][0] {{.}}[[VAR_13_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_]][0] {{.}}[[VAR_13_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           memref.tensor_store [[VAR_extracted_slice_]], [[VAR_subview_]] : memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_14_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:       [[VAR_reinterpret_cast_1_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_14_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:       [[VAR_15_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_16_:%.+]] = arith.addi [[VAR_15_]], [[CST_256_]] : index
+// CHECK-DAG:       [[VAR_17_:%.+]] = arith.index_cast [[PARAM_5_]] : i32 to index
+// CHECK:           [[VAR_18_:%.+]] = arith.minsi [[VAR_16_]], [[VAR_17_]] : index
+// CHECK:           [[VAR_19_:%.+]] = arith.subi [[VAR_18_]], [[VAR_15_]] : index
+// CHECK-DAG:       [[VAR_extracted_slice_2_:%.+]] = tensor.extract_slice [[VAR_reduced_0_]][0] {{.}}[[VAR_19_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:       [[VAR_subview_3_:%.+]] = memref.subview [[VAR_reinterpret_cast_1_]][0] {{.}}[[VAR_19_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           memref.tensor_store [[VAR_extracted_slice_2_]], [[VAR_subview_3_]] : memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/kernel-05-layer-norm-fwd.mlir
+++ b/test/Conversion/TritonToLinalg/kernel-05-layer-norm-fwd.mlir
@@ -1,0 +1,313 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+
+module {
+  tt.func public @_layer_norm_fwd_fused_0123456789(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>, %arg2: !tt.ptr<f32>, %arg3: !tt.ptr<f32>, %arg4: !tt.ptr<f32>, %arg5: !tt.ptr<f32>, %arg6: i32, %arg7: i32, %arg8: f32) {
+    %c256_i32 = arith.constant 256 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %cst = arith.constant 1.000000e+00 : f32
+    %cst_0 = arith.constant 0.000000e+00 : f32
+    %0 = tt.get_program_id {axis = 0 : i32} : i32
+    %1 = arith.muli %0, %arg6 : i32
+    %2 = tt.addptr %arg1, %1 : !tt.ptr<f32>, i32
+    %3 = tt.addptr %arg0, %1 : !tt.ptr<f32>, i32
+    %4 = tt.splat %cst_0 : (f32) -> tensor<256xf32>
+    %5 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %6 = tt.splat %arg7 : (i32) -> tensor<256xi32>
+    %7 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %8 = scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32 iter_args(%arg10 = %4) -> (tensor<256xf32>)  : i32 {
+      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %33 = arith.addi %32, %5 : tensor<256xi32>
+      %34 = arith.cmpi slt, %33, %6 : tensor<256xi32>
+      %35 = tt.addptr %7, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %36 = tt.load %35, %34, %4 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %37 = arith.addf %arg10, %36 : tensor<256xf32>
+      scf.yield %37 : tensor<256xf32>
+    }
+    %9 = "tt.reduce"(%8) ({
+    ^bb0(%arg9: f32, %arg10: f32):
+      %32 = arith.addf %arg9, %arg10 : f32
+      tt.reduce.return %32 : f32
+    }) {axis = 0 : i32} : (tensor<256xf32>) -> f32
+    %10 = arith.sitofp %arg7 : i32 to f32
+    %11 = arith.divf %9, %10 : f32
+    %12 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %13 = tt.splat %arg7 : (i32) -> tensor<256xi32>
+    %14 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %15 = tt.splat %11 : (f32) -> tensor<256xf32>
+    %16 = scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32 iter_args(%arg10 = %4) -> (tensor<256xf32>)  : i32 {
+      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %33 = arith.addi %32, %12 : tensor<256xi32>
+      %34 = arith.cmpi slt, %33, %13 : tensor<256xi32>
+      %35 = tt.addptr %14, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %36 = tt.load %35, %34, %4 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %37 = arith.subf %36, %15 : tensor<256xf32>
+      %38 = arith.select %34, %37, %4 : tensor<256xi1>, tensor<256xf32>
+      %39 = arith.mulf %38, %38 : tensor<256xf32>
+      %40 = arith.addf %arg10, %39 : tensor<256xf32>
+      scf.yield %40 : tensor<256xf32>
+    }
+    %17 = "tt.reduce"(%16) ({
+    ^bb0(%arg9: f32, %arg10: f32):
+      %32 = arith.addf %arg9, %arg10 : f32
+      tt.reduce.return %32 : f32
+    }) {axis = 0 : i32} : (tensor<256xf32>) -> f32
+    %18 = arith.divf %17, %10 : f32
+    %19 = arith.addf %18, %arg8 : f32
+    %20 = math.sqrt %19 : f32
+    %21 = arith.divf %cst, %20 : f32
+    %22 = tt.addptr %arg4, %0 : !tt.ptr<f32>, i32
+    tt.store %22, %11 {cache = 1 : i32, evict = 1 : i32} : f32
+    %23 = tt.addptr %arg5, %0 : !tt.ptr<f32>, i32
+    tt.store %23, %21 {cache = 1 : i32, evict = 1 : i32} : f32
+    %24 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %25 = tt.splat %arg7 : (i32) -> tensor<256xi32>
+    %26 = tt.splat %arg2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %27 = tt.splat %arg3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %28 = tt.splat %3 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %29 = tt.splat %11 : (f32) -> tensor<256xf32>
+    %30 = tt.splat %21 : (f32) -> tensor<256xf32>
+    %31 = tt.splat %2 : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    scf.for %arg9 = %c0_i32 to %arg7 step %c256_i32  : i32 {
+      %32 = tt.splat %arg9 : (i32) -> tensor<256xi32>
+      %33 = arith.addi %32, %24 : tensor<256xi32>
+      %34 = arith.cmpi slt, %33, %25 : tensor<256xi32>
+      %35 = tt.addptr %26, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %36 = tt.load %35, %34 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %37 = tt.addptr %27, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %38 = tt.load %37, %34 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %39 = tt.addptr %28, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      %40 = tt.load %39, %34, %4 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256xf32>
+      %41 = arith.subf %40, %29 : tensor<256xf32>
+      %42 = arith.mulf %41, %30 : tensor<256xf32>
+      %43 = arith.mulf %42, %36 : tensor<256xf32>
+      %44 = arith.addf %43, %38 : tensor<256xf32>
+      %45 = tt.addptr %31, %33 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+      tt.store %45, %44, %34 {cache = 1 : i32, evict = 1 : i32} : tensor<256xf32>
+    }
+    tt.return
+  }
+}
+
+// CHECK-DAG:   [[MAP_0_:#.+]] = affine_map<(d0) -> (d0)>
+// CHECK-LABEL:  func.func @_layer_norm_fwd_fused_0123456789
+// CHECK-SAME:   ([[PARAM_0_:%.+]]: memref<*xf32>, [[PARAM_1_:%.+]]: memref<*xf32>, [[PARAM_2_:%.+]]: memref<*xf32>, [[PARAM_3_:%.+]]: memref<*xf32>, [[PARAM_4_:%.+]]: memref<*xf32>, [[PARAM_5_:%.+]]: memref<*xf32>, [[PARAM_6_:%.+]]: i32, [[PARAM_7_:%.+]]: i32, [[PARAM_8_:%.+]]: f32, [[PARAM_9_:%.+]]: i32, [[PARAM_10_:%.+]]: i32, [[PARAM_11_:%.+]]: i32) {
+// CHECK-DAG:       [[CST_256_:%.+]] = arith.constant 256 : index
+// CHECK-DAG:       [[CST_1_dot_000000_:%.+]] = arith.constant 1.000000e+00 : f32
+// CHECK-DAG:       [[CST_0_:%.+]] = arith.constant 0 : i32
+// CHECK-DAG:       [[CST_256_1_:%.+]] = arith.constant 256 : i32
+// CHECK-DAG:       [[CST_0_dot_000000_:%.+]] = arith.constant 0.000000e+00 : f32
+// CHECK-DAG:       [[VAR_0_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_1_:%.+]] = linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[VAR_0_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_2_:%.+]] = arith.muli [[PARAM_9_]], [[PARAM_6_]] : i32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_3_:%.+]] = scf.for [[VAR_arg12_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_1_]] iter_args([[VAR_arg13_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_25_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:         [[VAR_26_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
+// CHECK:             [[VAR_27_:%.+]] = arith.addi [[VAR_25_]], [[VAR_26_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_27_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[RES_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-DAG:         [[VAR_28_:%.+]] = arith.index_cast [[VAR_arg12_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_29_:%.+]] = arith.addi [[VAR_28_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_30_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_31_:%.+]] = arith.minsi [[VAR_29_]], [[VAR_30_]] : index
+// CHECK:             [[VAR_32_:%.+]] = arith.subi [[VAR_31_]], [[VAR_28_]] : index
+// CHECK-DAG:         [[VAR_subview_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_]][0] {{.}}[[VAR_32_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_:%.+]] = memref.subview [[RES_]][0] {{.}}[[VAR_32_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_33_:%.+]] = arith.cmpi slt, [[VAR_32_]], [[CST_256_]] : index
+// CHECK:             scf.if [[VAR_33_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_]] : memref<256xf32>)
+// CHECK:             }
+// CHECK:             memref.copy [[VAR_subview_]], [[VAR_subview_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_34_:%.+]] = bufferization.to_tensor [[RES_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_35_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg13_]], [[VAR_34_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg13_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_36_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_36_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             scf.yield [[VAR_35_]] : tensor<256xf32>
+// CHECK:           }
+// CHECK:           [[VAR_4_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_4_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_:%.+]] = linalg.reduce ins([[VAR_3_]] : tensor<256xf32>) outs([[VAR_inserted_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_0:.+]]: f32, [[in_1:.+]]: f32) {
+// CHECK:               [[VAR_25_1_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_25_1_]] : f32
+// CHECK:             }
+// CHECK-DAG:       [[VAR_extracted_:%.+]] = tensor.extract [[VAR_reduced_]][] : tensor<f32>
+// CHECK-DAG:       [[VAR_5_:%.+]] = arith.sitofp [[PARAM_7_]] : i32 to f32
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_6_:%.+]] = arith.divf [[VAR_extracted_]], [[VAR_5_]] : f32
+// CHECK-DAG:       [[VAR_7_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK:           [[VAR_8_:%.+]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs([[VAR_7_]] : tensor<256xi32>) {
+// CHECK:           ^bb0([[out:.+]]: i32):
+// CHECK:             [[VAR_25_2_:%.+]] = linalg.index 0 : index
+// CHECK:             [[VAR_26_1_:%.+]] = arith.index_cast [[VAR_25_2_]] : index to i32
+// CHECK:             linalg.yield [[VAR_26_1_]] : i32
+// CHECK:           } -> tensor<256xi32>
+// CHECK:           [[VAR_9_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK-DAG:       [[VAR_10_:%.+]] = linalg.fill ins([[PARAM_7_]] : i32) outs([[VAR_9_]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK-DAG:       [[VAR_11_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:       [[VAR_12_:%.+]] = linalg.fill ins([[VAR_6_]] : f32) outs([[VAR_11_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_13_:%.+]] = scf.for [[VAR_arg12_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_1_]] iter_args([[VAR_arg13_1_:%.+]] = [[VAR_1_]]) -> (tensor<256xf32>)  : i32 {
+// CHECK-DAG:         [[VAR_25_3_:%.+]] = tensor.empty() : tensor<256xi32>
+// CHECK:             [[VAR_26_2_:%.+]] = linalg.fill ins([[VAR_arg12_1_]] : i32) outs([[VAR_25_3_]] : tensor<256xi32>) -> tensor<256xi32>
+// CHECK:             [[VAR_27_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_26_2_]], [[VAR_8_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_26_2_]] : tensor<256xi32>) {
+// CHECK:             ^bb0([[in_0:.+]]: i32, [[in_1:.+]]: i32, [[out:.+]]: i32):
+// CHECK:               [[VAR_44_:%.+]] = arith.addi [[in_0]], [[in_1]] : i32
+// CHECK:               linalg.yield [[VAR_44_]] : i32
+// CHECK:             } -> tensor<256xi32>
+// CHECK:             [[VAR_28_1_:%.+]] = tensor.empty() : tensor<256xi1>
+// CHECK:             [[VAR_29_1_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_27_1_]], [[VAR_10_]] : tensor<256xi32>, tensor<256xi32>) outs([[VAR_28_1_]] : tensor<256xi1>) {
+// CHECK:             ^bb0([[in_0:.+]]: i32, [[in_1:.+]]: i32, [[out:.+]]: i1):
+// CHECK:               [[VAR_44_1_:%.+]] = arith.cmpi slt, [[in_0]], [[in_1]] : i32
+// CHECK:               linalg.yield [[VAR_44_1_]] : i1
+// CHECK:             } -> tensor<256xi1>
+// CHECK-DAG:         [[VAR_30_1_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:         [[VAR_31_1_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK:             [[VAR_32_1_:%.+]] = arith.addi [[VAR_30_1_]], [[VAR_31_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_1_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_32_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[RES_1_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-DAG:         [[VAR_33_1_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_34_1_:%.+]] = arith.addi [[VAR_33_1_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_35_1_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_36_1_:%.+]] = arith.minsi [[VAR_34_1_]], [[VAR_35_1_]] : index
+// CHECK:             [[VAR_37_:%.+]] = arith.subi [[VAR_36_1_]], [[VAR_33_1_]] : index
+// CHECK-DAG:         [[VAR_subview_1_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_1_]][0] {{.}}[[VAR_37_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_1_:%.+]] = memref.subview [[RES_1_]][0] {{.}}[[VAR_37_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_38_:%.+]] = arith.cmpi slt, [[VAR_37_]], [[CST_256_]] : index
+// CHECK:             scf.if [[VAR_38_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_1_]] : memref<256xf32>)
+// CHECK:             }
+// CHECK:             memref.copy [[VAR_subview_1_]], [[VAR_subview_1_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_39_:%.+]] = bufferization.to_tensor [[RES_1_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_40_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_39_]], [[VAR_12_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_39_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_44_2_:%.+]] = arith.subf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_44_2_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_41_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_29_1_]], [[VAR_40_]], [[VAR_1_]] : tensor<256xi1>, tensor<256xf32>, tensor<256xf32>) outs([[VAR_40_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: i1, [[in_1:.+]]: f32, [[in_2:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_44_3_:%.+]] = arith.select [[in_0]], [[in_1]], [[in_2]] : f32
+// CHECK:               linalg.yield [[VAR_44_3_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_42_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_41_]], [[VAR_41_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_41_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_44_4_:%.+]] = arith.mulf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_44_4_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_43_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_arg13_1_]], [[VAR_42_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_arg13_1_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_44_5_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_44_5_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             scf.yield [[VAR_43_]] : tensor<256xf32>
+// CHECK:           }
+// CHECK:           [[VAR_14_:%.+]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           [[VAR_inserted_1_:%.+]] = tensor.insert [[CST_0_dot_000000_]] into [[VAR_14_]][] : tensor<f32>
+// CHECK:           [[VAR_reduced_2_:%.+]] = linalg.reduce ins([[VAR_13_]] : tensor<256xf32>) outs([[VAR_inserted_1_]] : tensor<f32>) dimensions = [0]
+// CHECK:             ([[in_0:.+]]: f32, [[in_1:.+]]: f32) {
+// CHECK:               [[VAR_25_4_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_25_4_]] : f32
+// CHECK:             }
+// CHECK:           [[VAR_extracted_3_:%.+]] = tensor.extract [[VAR_reduced_2_]][] : tensor<f32>
+// CHECK:           [[VAR_15_:%.+]] = arith.divf [[VAR_extracted_3_]], [[VAR_5_]] : f32
+// CHECK:           [[VAR_16_:%.+]] = arith.addf [[VAR_15_]], [[PARAM_8_]] : f32
+// CHECK:           [[VAR_17_:%.+]] = math.sqrt [[VAR_16_]] : f32
+// CHECK-DAG:       [[VAR_18_:%.+]] = arith.divf [[CST_1_dot_000000_]], [[VAR_17_]] : f32
+// CHECK-DAG:       [[VAR_19_:%.+]] = arith.index_cast [[PARAM_9_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_:%.+]] = memref.reinterpret_cast [[PARAM_4_]] to offset: {{.}}[[VAR_19_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_6_]], [[VAR_reinterpret_cast_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_20_:%.+]] = arith.index_cast [[PARAM_9_]] : i32 to index
+// CHECK:           [[VAR_reinterpret_cast_4_:%.+]] = memref.reinterpret_cast [[PARAM_5_]] to offset: {{.}}[[VAR_20_]]{{.}}, sizes: [1], strides: [1] : memref<*xf32> to memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           affine.store [[VAR_18_]], [[VAR_reinterpret_cast_4_]][0] : memref<1xf32, strided<[1], offset: ?>>
+// CHECK:           [[VAR_21_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK-DAG:       [[VAR_22_:%.+]] = linalg.fill ins([[VAR_6_]] : f32) outs([[VAR_21_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK-DAG:       [[VAR_23_:%.+]] = tensor.empty() : tensor<256xf32>
+// CHECK:           [[VAR_24_:%.+]] = linalg.fill ins([[VAR_18_]] : f32) outs([[VAR_23_]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           scf.for [[VAR_arg12_1_:%.+]] = [[CST_0_]] to [[PARAM_7_]] step [[CST_256_1_]]  : i32 {
+// CHECK:             [[VAR_25_5_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK-DAG:         [[VAR_reinterpret_cast_5_2_:%.+]] = memref.reinterpret_cast [[PARAM_2_]] to offset: {{.}}[[VAR_25_5_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[RES_2_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-DAG:         [[VAR_26_3_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_27_2_:%.+]] = arith.addi [[VAR_26_3_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_28_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_29_2_:%.+]] = arith.minsi [[VAR_27_2_]], [[VAR_28_2_]] : index
+// CHECK:             [[VAR_30_2_:%.+]] = arith.subi [[VAR_29_2_]], [[VAR_26_3_]] : index
+// CHECK-DAG:         [[VAR_subview_2_:%.+]] = memref.subview [[VAR_reinterpret_cast_5_2_]][0] {{.}}[[VAR_30_2_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_6_2_:%.+]] = memref.subview [[RES_2_]][0] {{.}}[[VAR_30_2_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_2_]], [[VAR_subview_2_]]_6 : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_31_2_:%.+]] = bufferization.to_tensor [[RES_2_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_32_2_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_reinterpret_cast_7_:%.+]] = memref.reinterpret_cast [[PARAM_3_]] to offset: {{.}}[[VAR_32_2_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[RES_3_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-DAG:         [[VAR_33_2_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_34_2_:%.+]] = arith.addi [[VAR_33_2_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_35_2_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_36_2_:%.+]] = arith.minsi [[VAR_34_2_]], [[VAR_35_2_]] : index
+// CHECK:             [[VAR_37_1_:%.+]] = arith.subi [[VAR_36_2_]], [[VAR_33_2_]] : index
+// CHECK-DAG:         [[VAR_subview_9_:%.+]] = memref.subview [[VAR_reinterpret_cast_7_]][0] {{.}}[[VAR_37_1_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_10_:%.+]] = memref.subview [[RES_3_]][0] {{.}}[[VAR_37_1_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK:             memref.copy [[VAR_subview_9_]], [[VAR_subview_10_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_38_1_:%.+]] = bufferization.to_tensor [[RES_3_]] restrict writable : memref<256xf32>
+// CHECK-DAG:         [[VAR_39_1_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:         [[VAR_40_1_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK:             [[VAR_41_1_:%.+]] = arith.addi [[VAR_39_1_]], [[VAR_40_1_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_11_:%.+]] = memref.reinterpret_cast [[PARAM_0_]] to offset: {{.}}[[VAR_41_1_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[RES_4_:%.+]] = memref.alloc() : memref<256xf32>
+// CHECK-DAG:         [[VAR_42_1_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_43_1_:%.+]] = arith.addi [[VAR_42_1_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_44_6_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_45_:%.+]] = arith.minsi [[VAR_43_1_]], [[VAR_44_6_]] : index
+// CHECK:             [[VAR_46_:%.+]] = arith.subi [[VAR_45_]], [[VAR_42_1_]] : index
+// CHECK-DAG:         [[VAR_subview_13_:%.+]] = memref.subview [[VAR_reinterpret_cast_11_]][0] {{.}}[[VAR_46_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_subview_14_:%.+]] = memref.subview [[RES_4_]][0] {{.}}[[VAR_46_]]{{.}} [1] : memref<256xf32> to memref<?xf32, strided<[1]>>
+// CHECK-DAG:         [[VAR_47_:%.+]] = arith.cmpi slt, [[VAR_46_]], [[CST_256_]] : index
+// CHECK:             scf.if [[VAR_47_]] {
+// CHECK:               linalg.fill ins([[CST_0_dot_000000_]] : f32) outs([[RES_4_]] : memref<256xf32>)
+// CHECK:             }
+// CHECK:             memref.copy [[VAR_subview_13_]], [[VAR_subview_14_]] : memref<?xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1]>>
+// CHECK:             [[VAR_48_:%.+]] = bufferization.to_tensor [[RES_4_]] restrict writable : memref<256xf32>
+// CHECK:             [[VAR_49_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_48_]], [[VAR_22_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_48_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_61_:%.+]] = arith.subf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_61_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_50_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_49_]], [[VAR_24_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_49_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_61_1_:%.+]] = arith.mulf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_61_1_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_51_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_50_]], [[VAR_31_2_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_50_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_61_2_:%.+]] = arith.mulf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_61_2_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK:             [[VAR_52_:%.+]] = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins([[VAR_51_]], [[VAR_38_1_]] : tensor<256xf32>, tensor<256xf32>) outs([[VAR_51_]] : tensor<256xf32>) {
+// CHECK:             ^bb0([[in_0:.+]]: f32, [[in_1:.+]]: f32, [[out:.+]]: f32):
+// CHECK:               [[VAR_61_3_:%.+]] = arith.addf [[in_0]], [[in_1]] : f32
+// CHECK:               linalg.yield [[VAR_61_3_]] : f32
+// CHECK:             } -> tensor<256xf32>
+// CHECK-DAG:         [[VAR_53_:%.+]] = arith.index_cast [[VAR_2_]] : i32 to index
+// CHECK-DAG:         [[VAR_54_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK:             [[VAR_55_:%.+]] = arith.addi [[VAR_53_]], [[VAR_54_]] : index
+// CHECK-DAG:         [[VAR_reinterpret_cast_15_:%.+]] = memref.reinterpret_cast [[PARAM_1_]] to offset: {{.}}[[VAR_55_]]{{.}}, sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1], offset: ?>>
+// CHECK-DAG:         [[VAR_56_:%.+]] = arith.index_cast [[VAR_arg12_1_]] : i32 to index
+// CHECK-NOT: separator of consecutive DAGs
+// CHECK-DAG:         [[VAR_57_:%.+]] = arith.addi [[VAR_56_]], [[CST_256_]] : index
+// CHECK-DAG:         [[VAR_58_:%.+]] = arith.index_cast [[PARAM_7_]] : i32 to index
+// CHECK:             [[VAR_59_:%.+]] = arith.minsi [[VAR_57_]], [[VAR_58_]] : index
+// CHECK:             [[VAR_60_:%.+]] = arith.subi [[VAR_59_]], [[VAR_56_]] : index
+// CHECK-DAG:         [[VAR_extracted_slice_:%.+]] = tensor.extract_slice [[VAR_52_]][0] {{.}}[[VAR_60_]]{{.}} [1] : tensor<256xf32> to tensor<?xf32>
+// CHECK-DAG:         [[VAR_subview_16_:%.+]] = memref.subview [[VAR_reinterpret_cast_15_]][0] {{.}}[[VAR_60_]]{{.}} [1] : memref<256xf32, strided<[1], offset: ?>> to memref<?xf32, strided<[1], offset: ?>>
+// CHECK:             memref.tensor_store [[VAR_extracted_slice_]], [[VAR_subview_16_]] : memref<?xf32, strided<[1], offset: ?>>
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/masked_ldst_1d.mlir
+++ b/test/Conversion/TritonToLinalg/masked_ldst_1d.mlir
@@ -1,0 +1,45 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32
+  )
+  {
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %ldptr = tt.addptr %0, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %stptr = tt.addptr %1, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %nans = arith.constant dense<0xFF80> : tensor<128xbf16>
+    %5 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %mask = arith.cmpi slt, %2, %5 : tensor<128xi32>
+    %buff = tt.load %ldptr, %mask, %nans {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
+    tt.store %stptr, %buff, %mask : tensor<128xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0xFF80 : bf16
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 128 : index
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<128xbf16>
+// CHECK:           %[[VAL_11:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_12:.*]] = arith.minsi %[[VAL_11]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_13:.*]] = memref.subview %[[VAL_8]][0] {{\[}}%[[VAL_12]]] [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           %[[VAL_14:.*]] = memref.subview %[[VAL_10]][0] {{\[}}%[[VAL_12]]] [1] : memref<128xbf16> to memref<?xbf16, strided<[1]>>
+// CHECK:           %[[VAL_15:.*]] = arith.cmpi slt, %[[VAL_12]], %[[VAL_7]] : index
+// CHECK:           scf.if %[[VAL_15]] {
+// CHECK:             linalg.fill ins(%[[VAL_6]] : bf16) outs(%[[VAL_10]] : memref<128xbf16>)
+// CHECK:           }
+// CHECK:           memref.copy %[[VAL_13]], %[[VAL_14]] : memref<?xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           %[[VAL_16:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<128xbf16>
+// CHECK:           %[[VAL_17:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_18:.*]] = arith.minsi %[[VAL_17]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_19:.*]] = tensor.extract_slice %[[VAL_16]][0] {{\[}}%[[VAL_18]]] [1] : tensor<128xbf16> to tensor<?xbf16>
+// CHECK:           %[[VAL_20:.*]] = memref.subview %[[VAL_9]][0] {{\[}}%[[VAL_18]]] [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           memref.tensor_store %[[VAL_19]], %[[VAL_20]] : memref<?xbf16, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/masked_ldst_2d.mlir
+++ b/test/Conversion/TritonToLinalg/masked_ldst_2d.mlir
@@ -1,0 +1,108 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32,
+  %arg3 : i32
+  )
+  {
+    // Mimic a scenario where the raw pointer points to a buffer with dimension (1024, 1024)
+    // in row-major, but the actual tensor size is (arg2, arg3).
+    // We are trying to load a 128x256 sub-buffer starting at (2, 3).
+    // The resulting memref:
+    //  offset = 3074
+    //  size[1] = 128
+    //  size[0] = 256
+    //  stride[0] = 1024
+    //  stride[1] = 1
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    // horizontal index
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %c2 = arith.constant 2 : i32
+    %c2tensor = tt.splat %c2 : (i32) -> tensor<128xi32>
+    %offset2 = arith.addi %2, %c2tensor : tensor<128xi32>
+    %3 = tt.expand_dims %offset2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x256xi32>
+    // vertical index
+    %5 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %c3 = arith.constant 3 : i32
+    %c3tensor = tt.splat %c3 : (i32) -> tensor<256xi32>
+    %offset5 = arith.addi %5, %c3tensor : tensor<256xi32>
+    %c1024 = arith.constant 1024 : i32
+    %c1024tensor = tt.splat %c1024 : (i32) -> tensor<256xi32>
+    %scale5 = arith.muli %offset5, %c1024tensor : tensor<256xi32>
+    %6 = tt.expand_dims %scale5 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %7 = tt.broadcast %6 : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    // combined index
+    %index = arith.addi %4, %7 : tensor<128x256xi32>
+    %ldptr = tt.addptr %0, %index : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    %stptr = tt.addptr %1, %index : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    // other value for masked load
+    %cnan = arith.constant 0xFF80 : bf16
+    %nans = tt.splat %cnan : (bf16) -> tensor<128x256xbf16>
+    // horizontal mask
+    %8 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %9 = arith.cmpi slt, %offset2, %8 : tensor<128xi32>
+    %10 = tt.expand_dims %9 {axis = 1 : i32} : (tensor<128xi1>) -> tensor<128x1xi1>
+    %11 = tt.broadcast %10 : (tensor<128x1xi1>) -> tensor<128x256xi1>
+    // vertical mask
+    %12 = tt.splat %arg3 : (i32) -> tensor<256xi32>
+    %13 = arith.cmpi slt, %offset5, %12 : tensor<256xi32>
+    %14 = tt.expand_dims %13 {axis = 0 : i32} : (tensor<256xi1>) -> tensor<1x256xi1>
+    %15 = tt.broadcast %14 : (tensor<1x256xi1>) -> tensor<128x256xi1>
+    // combined mask
+    %mask = arith.andi %11, %15 : tensor<128x256xi1>
+    // dim0 = min(%arg2, 128), dim1 = min(%arg3, 256)
+    // TODO: need reinterpret cast
+    %buff = tt.load %ldptr, %mask, %nans {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x256xbf16>
+    tt.store %stptr, %buff, %mask : tensor<128x256xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32, %[[VAL_6:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 3074 : index
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 1024 : index
+// CHECK-DAG:           %[[VAL_9:.*]] = arith.constant 3 : index
+// CHECK-DAG:           %[[VAL_10:.*]] = arith.constant 2 : index
+// CHECK-DAG:           %[[VAL_11:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_12:.*]] = arith.constant 128 : index
+// CHECK-DAG:           %[[VAL_13:.*]] = arith.constant 259 : index
+// CHECK-DAG:           %[[VAL_14:.*]] = arith.constant 130 : index
+// CHECK-DAG:           %[[VAL_15:.*]] = arith.constant 0xFF80 : bf16
+// CHECK:           %[[VAL_16:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: {{\[}}%[[VAL_7]]], sizes: [128, 256], strides: [1, %[[VAL_8]]] : memref<*xbf16> to memref<128x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_17:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}%[[VAL_7]]], sizes: [128, 256], strides: [1, %[[VAL_8]]] : memref<*xbf16> to memref<128x256xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_18:.*]] = memref.alloc() : memref<128x256xbf16>
+// CHECK:           %[[VAL_19:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_20:.*]] = arith.minsi %[[VAL_19]], %[[VAL_14]] : index
+// CHECK:           %[[VAL_21:.*]] = arith.subi %[[VAL_20]], %[[VAL_10]] : index
+// CHECK:           %[[VAL_22:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_23:.*]] = arith.minsi %[[VAL_22]], %[[VAL_13]] : index
+// CHECK:           %[[VAL_24:.*]] = arith.subi %[[VAL_23]], %[[VAL_9]] : index
+// CHECK:           %[[VAL_25:.*]] = arith.minsi %[[VAL_21]], %[[VAL_12]] : index
+// CHECK:           %[[VAL_26:.*]] = arith.minsi %[[VAL_24]], %[[VAL_11]] : index
+// CHECK:           %[[VAL_27:.*]] = memref.subview %[[VAL_16]][0, 0] {{\[}}%[[VAL_25]], %[[VAL_26]]] [1, 1] : memref<128x256xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           %[[VAL_28:.*]] = memref.subview %[[VAL_18]][0, 0] {{\[}}%[[VAL_25]], %[[VAL_26]]] [1, 1] : memref<128x256xbf16> to memref<?x?xbf16, strided<[256, 1]>>
+// CHECK:           %[[VAL_29:.*]] = arith.cmpi slt, %[[VAL_25]], %[[VAL_12]] : index
+// CHECK:           %[[VAL_30:.*]] = arith.cmpi slt, %[[VAL_26]], %[[VAL_11]] : index
+// CHECK:           %[[VAL_31:.*]] = arith.ori %[[VAL_29]], %[[VAL_30]] : i1
+// CHECK:           scf.if %[[VAL_31]] {
+// CHECK:             linalg.fill ins(%[[VAL_15]] : bf16) outs(%[[VAL_18]] : memref<128x256xbf16>)
+// CHECK:           }
+// CHECK:           memref.copy %[[VAL_27]], %[[VAL_28]] : memref<?x?xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[256, 1]>>
+// CHECK:           %[[VAL_32:.*]] = bufferization.to_tensor %[[VAL_18]] restrict writable : memref<128x256xbf16>
+// CHECK:           %[[VAL_33:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_34:.*]] = arith.minsi %[[VAL_33]], %[[VAL_14]] : index
+// CHECK:           %[[VAL_35:.*]] = arith.subi %[[VAL_34]], %[[VAL_10]] : index
+// CHECK:           %[[VAL_36:.*]] = arith.index_cast %[[VAL_3]] : i32 to index
+// CHECK:           %[[VAL_37:.*]] = arith.minsi %[[VAL_36]], %[[VAL_13]] : index
+// CHECK:           %[[VAL_38:.*]] = arith.subi %[[VAL_37]], %[[VAL_9]] : index
+// CHECK:           %[[VAL_39:.*]] = arith.minsi %[[VAL_35]], %[[VAL_12]] : index
+// CHECK:           %[[VAL_40:.*]] = arith.minsi %[[VAL_38]], %[[VAL_11]] : index
+// CHECK:           %[[VAL_41:.*]] = tensor.extract_slice %[[VAL_32]][0, 0] {{\[}}%[[VAL_39]], %[[VAL_40]]] [1, 1] : tensor<128x256xbf16> to tensor<?x?xbf16>
+// CHECK:           %[[VAL_42:.*]] = memref.subview %[[VAL_17]][0, 0] {{\[}}%[[VAL_39]], %[[VAL_40]]] [1, 1] : memref<128x256xbf16, strided<[1, ?], offset: ?>> to memref<?x?xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           memref.tensor_store %[[VAL_41]], %[[VAL_42]] : memref<?x?xbf16, strided<[1, ?], offset: ?>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/masked_ldst_sitofp_other.mlir
+++ b/test/Conversion/TritonToLinalg/masked_ldst_sitofp_other.mlir
@@ -1,0 +1,47 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : i32
+  )
+  {
+    %0 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %1 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %2 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %ldptr = tt.addptr %0, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %stptr = tt.addptr %1, %2 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %c7_i32 = arith.constant 7 : i32
+    %splat_c7_i32 = tt.splat %c7_i32 : (i32) -> tensor<128xi32>
+    %splat_c7_bf16 = arith.sitofp %splat_c7_i32 : tensor<128xi32> to tensor<128xbf16>
+    %5 = tt.splat %arg2 : (i32) -> tensor<128xi32>
+    %mask = arith.cmpi slt, %2, %5 : tensor<128xi32>
+    %buff = tt.load %ldptr, %mask, %splat_c7_bf16 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
+    tt.store %stptr, %buff, %mask : tensor<128xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 7.000000e+00 : bf16
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 128 : index
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<128xbf16>
+// CHECK:           %[[VAL_11:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_12:.*]] = arith.minsi %[[VAL_11]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_13:.*]] = memref.subview %[[VAL_8]][0] {{\[}}%[[VAL_12]]] [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           %[[VAL_14:.*]] = memref.subview %[[VAL_10]][0] {{\[}}%[[VAL_12]]] [1] : memref<128xbf16> to memref<?xbf16, strided<[1]>>
+// CHECK:           %[[VAL_15:.*]] = arith.cmpi slt, %[[VAL_12]], %[[VAL_7]] : index
+// CHECK:           scf.if %[[VAL_15]] {
+// CHECK:             linalg.fill ins(%[[VAL_6]] : bf16) outs(%[[VAL_10]] : memref<128xbf16>)
+// CHECK:           }
+// CHECK:           memref.copy %[[VAL_13]], %[[VAL_14]] : memref<?xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           %[[VAL_16:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<128xbf16>
+// CHECK:           %[[VAL_17:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_18:.*]] = arith.minsi %[[VAL_17]], %[[VAL_7]] : index
+// CHECK:           %[[VAL_19:.*]] = tensor.extract_slice %[[VAL_16]][0] {{\[}}%[[VAL_18]]] [1] : tensor<128xbf16> to tensor<?xbf16>
+// CHECK:           %[[VAL_20:.*]] = memref.subview %[[VAL_9]][0] {{\[}}%[[VAL_18]]] [1] : memref<128xbf16, strided<[1]>> to memref<?xbf16, strided<[1]>>
+// CHECK:           memref.tensor_store %[[VAL_19]], %[[VAL_20]] : memref<?xbf16, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/reducemax_32_256_bf16.mlir
+++ b/test/Conversion/TritonToLinalg/reducemax_32_256_bf16.mlir
@@ -1,0 +1,58 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<bf16>,
+        %res : tensor<256x16x!tt.ptr<bf16>>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<32xi32>
+    %ws = arith.muli %ct256, %0 : tensor<32xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<32xi32>) -> tensor<32x1xi32>
+    %m2 = tt.broadcast %1 : (tensor<32x1xi32>) -> tensor<32x256xi32>
+    %100 = tt.expand_dims %m2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
+    %moff = tt.broadcast %100 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %33 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %34 = tt.expand_dims %33 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %k2 = tt.broadcast %34 : (tensor<1x256xi32>) -> tensor<32x256xi32>
+    %200 = tt.expand_dims %k2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
+    %koff = tt.broadcast %200 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %23 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %24 = tt.expand_dims %23 {axis = 0 : i32} : (tensor<16xi32>) -> tensor<1x16xi32>
+    %n2 = tt.broadcast %24 : (tensor<1x16xi32>) -> tensor<256x16xi32>
+    %300 = tt.expand_dims %n2 {axis = 0 : i32} : (tensor<256x16xi32>) -> tensor<1x256x16xi32>
+    %noff = tt.broadcast %300 : (tensor<1x256x16xi32>) -> tensor<32x256x16xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<32x256x16xi32>
+    %mknoff = arith.addi %mkoff, %noff : tensor<32x256x16xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<32x256x16x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %mknoff : tensor<32x256x16x!tt.ptr<bf16>>, tensor<32x256x16xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x256x16xbf16>
+    %6 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.cmpf ogt, %arg5, %arg6 : bf16
+      %22 = arith.select %21, %arg5, %arg6 : bf16
+      tt.reduce.return %22 : bf16
+    }) {axis = 0 : i32} : (tensor<32x256x16xbf16>) -> tensor<256x16xbf16>
+    tt.store %res, %6 {cache = 1 : i32, evict = 1 : i32} : tensor<256x16xbf16>
+    tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<256x16xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0xFF80 : bf16
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [32, 256, 16], strides: {{\[}}%[[VAL_5]], 1, 1] : memref<*xbf16> to memref<32x256x16xbf16, strided<[?, 1, 1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.alloc() : memref<32x256x16xbf16>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_8]] : memref<32x256x16xbf16, strided<[?, 1, 1]>> to memref<32x256x16xbf16>
+// CHECK:           %[[VAL_9:.*]] = bufferization.to_tensor %[[VAL_8]] restrict writable : memref<32x256x16xbf16>
+// CHECK:           %[[VAL_10:.*]] = tensor.empty() : tensor<256x16xbf16>
+// CHECK:           %[[VAL_11:.*]] = linalg.fill ins(%[[VAL_6]] : bf16) outs(%[[VAL_10]] : tensor<256x16xbf16>) -> tensor<256x16xbf16>
+// CHECK:           %[[VAL_12:.*]] = linalg.reduce ins(%[[VAL_9]] : tensor<32x256x16xbf16>) outs(%[[VAL_11]] : tensor<256x16xbf16>) dimensions = [0]
+// CHECK:             (%[[VAL_13:.*]]: bf16, %[[VAL_14:.*]]: bf16) {
+// CHECK:               %[[VAL_15:.*]] = arith.maxf %[[VAL_13]], %[[VAL_14]] : bf16
+// CHECK:               linalg.yield %[[VAL_15]] : bf16
+// CHECK:             }
+// CHECK:           memref.tensor_store %[[VAL_12]], %[[VAL_1]] : memref<256x16xbf16>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/reducesum_512_256_bf16_axis0.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_512_256_bf16_axis0.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<bf16>,
+        %res : !tt.ptr<bf16>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ws = arith.muli %ct256, %0 : tensor<512xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<512x256x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<bf16>>, tensor<512x256xi32>
+    // res pointer
+    %18 = tt.splat %res : (!tt.ptr<bf16>) -> tensor<256x!tt.ptr<bf16>>
+    %19 = tt.addptr %18, %3 : tensor<256x!tt.ptr<bf16>>, tensor<256xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xbf16>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.addf %arg5, %arg6 : bf16
+      tt.reduce.return %21 : bf16
+    }) {axis = 0 : i32} : (tensor<512x256xbf16>) -> tensor<256xbf16>
+    tt.store %19, %5 : tensor<256xbf16>
+    tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [512, 256], strides: {{\[}}%[[VAL_5]], 1] : memref<*xbf16> to memref<512x256xbf16, strided<[?, 1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [256], strides: [1] : memref<*xbf16> to memref<256xbf16, strided<[1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<512x256xbf16>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_9]] : memref<512x256xbf16, strided<[?, 1]>> to memref<512x256xbf16>
+// CHECK:           %[[VAL_10:.*]] = bufferization.to_tensor %[[VAL_9]] restrict writable : memref<512x256xbf16>
+// CHECK:           %[[VAL_11:.*]] = tensor.empty() : tensor<256xbf16>
+// CHECK:           %[[VAL_12:.*]] = linalg.fill ins(%[[VAL_6]] : bf16) outs(%[[VAL_11]] : tensor<256xbf16>) -> tensor<256xbf16>
+// CHECK:           %[[VAL_13:.*]] = linalg.reduce ins(%[[VAL_10]] : tensor<512x256xbf16>) outs(%[[VAL_12]] : tensor<256xbf16>) dimensions = [0]
+// CHECK:             (%[[VAL_14:.*]]: bf16, %[[VAL_15:.*]]: bf16) {
+// CHECK:               %[[VAL_16:.*]] = arith.addf %[[VAL_14]], %[[VAL_15]] : bf16
+// CHECK:               linalg.yield %[[VAL_16]] : bf16
+// CHECK:             }
+// CHECK:           memref.tensor_store %[[VAL_13]], %[[VAL_8]] : memref<256xbf16, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/reducesum_512_256_bf16_axis1.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_512_256_bf16_axis1.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<bf16>,
+        %res : !tt.ptr<bf16>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ws = arith.muli %ct256, %0 : tensor<512xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<512x256x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<bf16>>, tensor<512x256xi32>
+    // res pointer
+    %18 = tt.splat %res : (!tt.ptr<bf16>) -> tensor<512x!tt.ptr<bf16>>
+    %19 = tt.addptr %18, %0 : tensor<512x!tt.ptr<bf16>>, tensor<512xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xbf16>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.addf %arg5, %arg6 : bf16
+      tt.reduce.return %21 : bf16
+    }) {axis = 1 : i32} : (tensor<512x256xbf16>) -> tensor<512xbf16>
+    tt.store %19, %5 : tensor<512xbf16>
+    tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [512, 256], strides: {{\[}}%[[VAL_5]], 1] : memref<*xbf16> to memref<512x256xbf16, strided<[?, 1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [512], strides: [1] : memref<*xbf16> to memref<512xbf16, strided<[1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<512x256xbf16>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_9]] : memref<512x256xbf16, strided<[?, 1]>> to memref<512x256xbf16>
+// CHECK:           %[[VAL_10:.*]] = bufferization.to_tensor %[[VAL_9]] restrict writable : memref<512x256xbf16>
+// CHECK:           %[[VAL_11:.*]] = tensor.empty() : tensor<256x512xbf16>
+// CHECK:           %[[VAL_12:.*]] = linalg.transpose ins(%[[VAL_10]] : tensor<512x256xbf16>) outs(%[[VAL_11]] : tensor<256x512xbf16>) permutation = [1, 0]
+// CHECK:           %[[VAL_13:.*]] = tensor.empty() : tensor<512xbf16>
+// CHECK:           %[[VAL_14:.*]] = linalg.fill ins(%[[VAL_6]] : bf16) outs(%[[VAL_13]] : tensor<512xbf16>) -> tensor<512xbf16>
+// CHECK:           %[[VAL_15:.*]] = linalg.reduce ins(%[[VAL_12]] : tensor<256x512xbf16>) outs(%[[VAL_14]] : tensor<512xbf16>) dimensions = [0]
+// CHECK:             (%[[VAL_16:.*]]: bf16, %[[VAL_17:.*]]: bf16) {
+// CHECK:               %[[VAL_18:.*]] = arith.addf %[[VAL_16]], %[[VAL_17]] : bf16
+// CHECK:               linalg.yield %[[VAL_18]] : bf16
+// CHECK:             }
+// CHECK:           memref.tensor_store %[[VAL_15]], %[[VAL_8]] : memref<512xbf16, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/reducesum_512_256_f32_axis0.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_512_256_f32_axis0.mlir
@@ -1,0 +1,51 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<f32>,
+        %res : !tt.ptr<f32>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ws = arith.muli %ct256, %0 : tensor<512xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<f32>) -> tensor<512x256x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<f32>>, tensor<512x256xi32>
+    // res pointer
+    %18 = tt.splat %res : (!tt.ptr<f32>) -> tensor<256x!tt.ptr<f32>>
+    %19 = tt.addptr %18, %3 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xf32>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: f32, %arg6: f32):
+      %21 = arith.addf %arg5, %arg6 : f32
+      tt.reduce.return %21 : f32
+    }) {axis = 0 : i32} : (tensor<512x256xf32>) -> tensor<256xf32>
+    tt.store %19, %5 : tensor<256xf32>
+    tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32>, %[[VAL_1:.*]]: memref<*xf32>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [512, 256], strides: {{\[}}%[[VAL_5]], 1] : memref<*xf32> to memref<512x256xf32, strided<[?, 1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [256], strides: [1] : memref<*xf32> to memref<256xf32, strided<[1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<512x256xf32>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_9]] : memref<512x256xf32, strided<[?, 1]>> to memref<512x256xf32>
+// CHECK:           %[[VAL_10:.*]] = bufferization.to_tensor %[[VAL_9]] restrict writable : memref<512x256xf32>
+// CHECK:           %[[VAL_11:.*]] = tensor.empty() : tensor<256xf32>
+// CHECK:           %[[VAL_12:.*]] = linalg.fill ins(%[[VAL_6]] : f32) outs(%[[VAL_11]] : tensor<256xf32>) -> tensor<256xf32>
+// CHECK:           %[[VAL_13:.*]] = linalg.reduce ins(%[[VAL_10]] : tensor<512x256xf32>) outs(%[[VAL_12]] : tensor<256xf32>) dimensions = [0]
+// CHECK:             (%[[VAL_14:.*]]: f32, %[[VAL_15:.*]]: f32) {
+// CHECK:               %[[VAL_16:.*]] = arith.addf %[[VAL_14]], %[[VAL_15]] : f32
+// CHECK:               linalg.yield %[[VAL_16]] : f32
+// CHECK:             }
+// CHECK:           memref.tensor_store %[[VAL_13]], %[[VAL_8]] : memref<256xf32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/reducesum_512_256_f32_axis1.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_512_256_f32_axis1.mlir
@@ -1,0 +1,53 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<f32>,
+        %res : !tt.ptr<f32>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 512 : i32, start = 0 : i32} : tensor<512xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<512xi32>
+    %ws = arith.muli %ct256, %0 : tensor<512xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<512xi32>) -> tensor<512x1xi32>
+    %moff = tt.broadcast %1 : (tensor<512x1xi32>) -> tensor<512x256xi32>
+    %3 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %4 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %koff = tt.broadcast %4 : (tensor<1x256xi32>) -> tensor<512x256xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<512x256xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<f32>) -> tensor<512x256x!tt.ptr<f32>>
+    %9 = tt.addptr %8, %mkoff : tensor<512x256x!tt.ptr<f32>>, tensor<512x256xi32>
+    // res pointer
+    %18 = tt.splat %res : (!tt.ptr<f32>) -> tensor<512x!tt.ptr<f32>>
+    %19 = tt.addptr %18, %0 : tensor<512x!tt.ptr<f32>>, tensor<512xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<512x256xf32>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: f32, %arg6: f32):
+      %21 = arith.addf %arg5, %arg6 : f32
+      tt.reduce.return %21 : f32
+    }) {axis = 1 : i32} : (tensor<512x256xf32>) -> tensor<512xf32>
+    tt.store %19, %5 : tensor<512xf32>
+    tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xf32>, %[[VAL_1:.*]]: memref<*xf32>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_5:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_7:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [512, 256], strides: {{\[}}%[[VAL_5]], 1] : memref<*xf32> to memref<512x256xf32, strided<[?, 1]>>
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [512], strides: [1] : memref<*xf32> to memref<512xf32, strided<[1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<512x256xf32>
+// CHECK:           memref.copy %[[VAL_7]], %[[VAL_9]] : memref<512x256xf32, strided<[?, 1]>> to memref<512x256xf32>
+// CHECK:           %[[VAL_10:.*]] = bufferization.to_tensor %[[VAL_9]] restrict writable : memref<512x256xf32>
+// CHECK:           %[[VAL_11:.*]] = tensor.empty() : tensor<256x512xf32>
+// CHECK:           %[[VAL_12:.*]] = linalg.transpose ins(%[[VAL_10]] : tensor<512x256xf32>) outs(%[[VAL_11]] : tensor<256x512xf32>) permutation = [1, 0]
+// CHECK:           %[[VAL_13:.*]] = tensor.empty() : tensor<512xf32>
+// CHECK:           %[[VAL_14:.*]] = linalg.fill ins(%[[VAL_6]] : f32) outs(%[[VAL_13]] : tensor<512xf32>) -> tensor<512xf32>
+// CHECK:           %[[VAL_15:.*]] = linalg.reduce ins(%[[VAL_12]] : tensor<256x512xf32>) outs(%[[VAL_14]] : tensor<512xf32>) dimensions = [0]
+// CHECK:             (%[[VAL_16:.*]]: f32, %[[VAL_17:.*]]: f32) {
+// CHECK:               %[[VAL_18:.*]] = arith.addf %[[VAL_16]], %[[VAL_17]] : f32
+// CHECK:               linalg.yield %[[VAL_18]] : f32
+// CHECK:             }
+// CHECK:           memref.tensor_store %[[VAL_15]], %[[VAL_8]] : memref<512xf32, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/reducesum_middle_dim.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_middle_dim.mlir
@@ -1,0 +1,58 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+    tt.func @kernel(%afloat : !tt.ptr<bf16>,
+        %res : !tt.ptr<bf16>,
+        %out: tensor<32x16x!tt.ptr<bf16>>
+    ) -> () {
+    // offset calculations
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32>
+    %c256 = arith.constant 256 : i32
+    %ct256 = tt.splat %c256 : (i32) -> tensor<32xi32>
+    %ws = arith.muli %ct256, %0 : tensor<32xi32>
+    %1 = tt.expand_dims %ws {axis = 1 : i32} : (tensor<32xi32>) -> tensor<32x1xi32>
+    %m2 = tt.broadcast %1 : (tensor<32x1xi32>) -> tensor<32x256xi32>
+    %100 = tt.expand_dims %m2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
+    %moff = tt.broadcast %100 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %33 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %34 = tt.expand_dims %33 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %k2 = tt.broadcast %34 : (tensor<1x256xi32>) -> tensor<32x256xi32>
+    %200 = tt.expand_dims %k2 {axis = 2 : i32} : (tensor<32x256xi32>) -> tensor<32x256x1xi32>
+    %koff = tt.broadcast %200 : (tensor<32x256x1xi32>) -> tensor<32x256x16xi32>
+    %23 = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+    %24 = tt.expand_dims %23 {axis = 0 : i32} : (tensor<16xi32>) -> tensor<1x16xi32>
+    %n2 = tt.broadcast %24 : (tensor<1x16xi32>) -> tensor<256x16xi32>
+    %300 = tt.expand_dims %n2 {axis = 0 : i32} : (tensor<256x16xi32>) -> tensor<1x256x16xi32>
+    %noff = tt.broadcast %300 : (tensor<1x256x16xi32>) -> tensor<32x256x16xi32>
+    %mkoff = arith.addi %moff, %koff : tensor<32x256x16xi32>
+    %mknoff = arith.addi %mkoff, %noff : tensor<32x256x16xi32>
+    // afloat pointer
+    %8 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<32x256x16x!tt.ptr<bf16>>
+    %9 = tt.addptr %8, %mknoff : tensor<32x256x16x!tt.ptr<bf16>>, tensor<32x256x16xi32>
+    %afm = tt.load %9 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<32x256x16xbf16>
+    %5 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.addf %arg5, %arg6 : bf16
+      tt.reduce.return %21 : bf16
+    }) {axis = 1 : i32} : (tensor<32x256x16xbf16>) -> tensor<32x16xbf16>
+    tt.store %out, %5 : tensor<32x16xbf16>
+    tt.return
+    }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: memref<32x16xbf16>, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[VAL_8:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [32, 256, 16], strides: {{\[}}%[[VAL_6]], 1, 1] : memref<*xbf16> to memref<32x256x16xbf16, strided<[?, 1, 1]>>
+// CHECK:           %[[VAL_9:.*]] = memref.alloc() : memref<32x256x16xbf16>
+// CHECK:           memref.copy %[[VAL_8]], %[[VAL_9]] : memref<32x256x16xbf16, strided<[?, 1, 1]>> to memref<32x256x16xbf16>
+// CHECK:           %[[VAL_10:.*]] = bufferization.to_tensor %[[VAL_9]] restrict writable : memref<32x256x16xbf16>
+// CHECK:           %[[VAL_11:.*]] = tensor.empty() : tensor<32x16xbf16>
+// CHECK:           %[[VAL_12:.*]] = linalg.fill ins(%[[VAL_7]] : bf16) outs(%[[VAL_11]] : tensor<32x16xbf16>) -> tensor<32x16xbf16>
+// CHECK:           %[[VAL_13:.*]] = linalg.reduce ins(%[[VAL_10]] : tensor<32x256x16xbf16>) outs(%[[VAL_12]] : tensor<32x16xbf16>) dimensions = [1]
+// CHECK:             (%[[VAL_14:.*]]: bf16, %[[VAL_15:.*]]: bf16) {
+// CHECK:               %[[VAL_16:.*]] = arith.addf %[[VAL_14]], %[[VAL_15]] : bf16
+// CHECK:               linalg.yield %[[VAL_16]] : bf16
+// CHECK:             }
+// CHECK:           memref.tensor_store %[[VAL_13]], %[[VAL_2]] : memref<32x16xbf16>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/reducesum_scalar.mlir
+++ b/test/Conversion/TritonToLinalg/reducesum_scalar.mlir
@@ -1,0 +1,38 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(%afloat : !tt.ptr<bf16>, %res : !tt.ptr<bf16>)
+  {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %1 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
+    %2 = tt.addptr %1, %0 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
+    %afm = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
+    %3 = "tt.reduce"(%afm) ({
+    ^bb0(%arg5: bf16, %arg6: bf16):
+      %21 = arith.addf %arg5, %arg6 : bf16
+      tt.reduce.return %21 : bf16
+    }) {axis = 0 : i32} : (tensor<128xbf16>) -> bf16
+    tt.store %res, %3 : bf16
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK:           %[[VAL_5:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_6:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128], strides: [1] : memref<*xbf16> to memref<128xbf16, strided<[1]>>
+// CHECK:           %[[VAL_7:.*]] = memref.alloc() : memref<128xbf16>
+// CHECK:           memref.copy %[[VAL_6]], %[[VAL_7]] : memref<128xbf16, strided<[1]>> to memref<128xbf16>
+// CHECK:           %[[VAL_8:.*]] = bufferization.to_tensor %[[VAL_7]] restrict writable : memref<128xbf16>
+// CHECK:           %[[VAL_9:.*]] = bufferization.alloc_tensor() : tensor<f32>
+// CHECK:           %[[VAL_10:.*]] = tensor.insert %[[VAL_5]] into %[[VAL_9]][] : tensor<f32>
+// CHECK:           %[[VAL_11:.*]] = linalg.reduce ins(%[[VAL_8]] : tensor<128xbf16>) outs(%[[VAL_10]] : tensor<f32>) dimensions = [0]
+// CHECK:             (%[[VAL_12:.*]]: bf16, %[[VAL_13:.*]]: f32) {
+// CHECK:               %[[VAL_14:.*]] = arith.extf %[[VAL_12]] : bf16 to f32
+// CHECK:               %[[VAL_15:.*]] = arith.addf %[[VAL_14]], %[[VAL_13]] : f32
+// CHECK:               linalg.yield %[[VAL_15]] : f32
+// CHECK:             }
+// CHECK:           %[[VAL_16:.*]] = tensor.extract %[[VAL_11]][] : tensor<f32>
+// CHECK:           %[[VAL_17:.*]] = arith.truncf %[[VAL_16]] : f32 to bf16
+// CHECK:           %[[VAL_18:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [1], strides: [1] : memref<*xbf16> to memref<1xbf16, strided<[1]>>
+// CHECK:           affine.store %[[VAL_17]], %[[VAL_18]][0] : memref<1xbf16, strided<[1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/use_dot_opc.mlir
+++ b/test/Conversion/TritonToLinalg/use_dot_opc.mlir
@@ -1,0 +1,73 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+    %arg0 : !tt.ptr<bf16>,
+    %arg1 : !tt.ptr<bf16>,
+    %arg2 : !tt.ptr<bf16>
+  )
+  {
+    %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+    %c64 = arith.constant 128 : i32
+    %1 = tt.splat %c64 : (i32) -> tensor<128xi32>
+    %2 = arith.muli %0, %1 : tensor<128xi32>
+    %3 = tt.expand_dims %2 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %4 = tt.broadcast %3 : (tensor<128x1xi32>) -> tensor<128x64xi32>
+    %5 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<64xi32>) -> tensor<1x64xi32>
+    %7 = tt.broadcast %6 : (tensor<1x64xi32>) -> tensor<128x64xi32>
+    %8 = arith.addi %4, %7 : tensor<128x64xi32>
+    %10 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32>
+    %11 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %12 = tt.broadcast %11 : (tensor<1x256xi32>) -> tensor<64x256xi32>
+    %13 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32>
+    %c256 = arith.constant 256 : i32
+    %14 = tt.splat %c256 : (i32) -> tensor<64xi32>
+    %15 = arith.muli %13, %14 : tensor<64xi32>
+    %16 = tt.expand_dims %15 {axis = 1 : i32} : (tensor<64xi32>) -> tensor<64x1xi32>
+    %17 = tt.broadcast %16 : (tensor<64x1xi32>) -> tensor<64x256xi32>
+    %18 = arith.addi %12, %17 : tensor<64x256xi32>
+    %20 = tt.splat %c256 : (i32) -> tensor<128xi32>
+    %21 = arith.muli %0, %20 : tensor<128xi32>
+    %22 = tt.expand_dims %21 {axis = 1 : i32} : (tensor<128xi32>) -> tensor<128x1xi32>
+    %23 = tt.broadcast %22 : (tensor<128x1xi32>) -> tensor<128x256xi32>
+    %24 = tt.expand_dims %10 {axis = 0 : i32} : (tensor<256xi32>) -> tensor<1x256xi32>
+    %25 = tt.broadcast %24 {axis = 0 : i32} : (tensor<1x256xi32>) -> tensor<128x256xi32>
+    %26 = arith.addi %23, %25 : tensor<128x256xi32>
+    %30 = tt.splat %arg0 : (!tt.ptr<bf16>) -> tensor<128x64x!tt.ptr<bf16>>
+    %31 = tt.addptr %30, %8 : tensor<128x64x!tt.ptr<bf16>>, tensor<128x64xi32>
+    %32 = tt.load %31 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<128x64xbf16>
+    %40 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<64x256x!tt.ptr<bf16>>
+    %41 = tt.addptr %40, %18 : tensor<64x256x!tt.ptr<bf16>>, tensor<64x256xi32>
+    %42 = tt.load %41 {cache = 1 : i32, evict = 1 : i32, isVolatile = false}: tensor<64x256xbf16>
+    %50 = tt.splat %arg2 : (!tt.ptr<bf16>) -> tensor<128x256x!tt.ptr<bf16>>
+    %51 = tt.addptr %50, %26 : tensor<128x256x!tt.ptr<bf16>>, tensor<128x256xi32>
+    %cf0 = arith.constant 0.0 : bf16
+    %71 = tt.splat %cf0 : (bf16) -> (tensor<128x256xbf16>)
+    %60 = tt.dot %32, %42, %71 {allowTF32 = false} : tensor<128x64xbf16> * tensor<64x256xbf16> -> tensor<128x256xbf16>
+    tt.store %51, %60 : tensor<128x256xbf16>
+    tt.store %51, %71 : tensor<128x256xbf16>
+    tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: memref<*xbf16>, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 256 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 128 : index
+// CHECK-DAG:           %[[VAL_8:.*]] = arith.constant 0.000000e+00 : bf16
+// CHECK:           %[[VAL_16:.*]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           %[[VAL_17:.*]] = linalg.fill ins(%[[VAL_8]] : bf16) outs(%[[VAL_16]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           %[[VAL_9:.*]] = memref.reinterpret_cast %[[VAL_0]] to offset: [0], sizes: [128, 64], strides: {{\[}}%[[VAL_7]], 1] : memref<*xbf16> to memref<128x64xbf16, strided<[?, 1]>>
+// CHECK:           %[[VAL_10:.*]] = memref.alloc() : memref<128x64xbf16>
+// CHECK:           memref.copy %[[VAL_9]], %[[VAL_10]] : memref<128x64xbf16, strided<[?, 1]>> to memref<128x64xbf16>
+// CHECK:           %[[VAL_11:.*]] = bufferization.to_tensor %[[VAL_10]] restrict writable : memref<128x64xbf16>
+// CHECK:           %[[VAL_12:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: [0], sizes: [64, 256], strides: {{\[}}%[[VAL_6]], 1] : memref<*xbf16> to memref<64x256xbf16, strided<[?, 1]>>
+// CHECK:           %[[VAL_13:.*]] = memref.alloc() : memref<64x256xbf16>
+// CHECK:           memref.copy %[[VAL_12]], %[[VAL_13]] : memref<64x256xbf16, strided<[?, 1]>> to memref<64x256xbf16>
+// CHECK:           %[[VAL_14:.*]] = bufferization.to_tensor %[[VAL_13]] restrict writable : memref<64x256xbf16>
+// CHECK:           %[[VAL_15:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: [0], sizes: [128, 256], strides: {{\[}}%[[VAL_6]], 1] : memref<*xbf16> to memref<128x256xbf16, strided<[?, 1]>>
+// CHECK:           %[[VAL_18:.*]] = tensor.empty() : tensor<128x256xbf16>
+// CHECK:           %[[VAL_19:.*]] = linalg.matmul ins(%[[VAL_11]], %[[VAL_14]] : tensor<128x64xbf16>, tensor<64x256xbf16>) outs(%[[VAL_18]] : tensor<128x256xbf16>) -> tensor<128x256xbf16>
+// CHECK:           memref.tensor_store %[[VAL_19]], %[[VAL_15]] : memref<128x256xbf16, strided<[?, 1]>>
+// CHECK:           memref.tensor_store %[[VAL_17]], %[[VAL_15]] : memref<128x256xbf16, strided<[?, 1]>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/use_end_chain.mlir
+++ b/test/Conversion/TritonToLinalg/use_end_chain.mlir
@@ -1,0 +1,91 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>
+  )
+  {
+  %0 = tt.make_range {end = 768 : i32, start = 512 : i32}:tensor<256xi32>
+  // offset = [512] size = 256, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  // offset = [512,0], size = [256,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  // offset = [512,0], size = [256,128], stride = [1,0]
+  %5 = tt.make_range {end = 1152 : i32, start = 1024 : i32}:tensor<128xi32>
+  // offset = 1024, size = 128, stride = 1
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  // offset = [0,1024], size = [1,128], stride = [0,1]
+  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  // offset = [0,1024], size = [256,128], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
+  // offset = [0,6144], size = [256,128], stride = [0,6]
+  %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
+  // offset = [512,6144], size = [256,128], stride = [1,6]
+  // mixed use
+  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
+  %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
+  tt.store %18, %19 : tensor<256x128xbf16>
+  %20 = arith.sitofp %14 : tensor<256x128xi32> to tensor<256x128xbf16>
+  tt.store %18, %20 : tensor<256x128xbf16>
+  tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_6:.*]] = arith.constant 6 : index
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 6 : i32
+// CHECK:           %[[VAL_30:.*]] = tensor.empty() : tensor<256x128xi32>
+// CHECK:           %[[VAL_31:.*]] = linalg.fill ins(%[[VAL_7]] : i32) outs(%[[VAL_30]] : tensor<256x128xi32>) -> tensor<256x128xi32>
+// CHECK:           %[[VAL_8:.*]] = tensor.empty() : tensor<256xi32>
+// CHECK:           %[[VAL_9:.*]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs(%[[VAL_8]] : tensor<256xi32>) {
+// CHECK:           ^bb0(%[[VAL_10:.*]]: i32):
+// CHECK:             %[[VAL_11:.*]] = linalg.index 0 : index
+// CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i32
+// CHECK:             linalg.yield %[[VAL_12]] : i32
+// CHECK:           } -> tensor<256xi32>
+// CHECK:           %[[VAL_13:.*]] = tensor.expand_shape %[[VAL_14:.*]] {{\[\[}}0, 1]] : tensor<256xi32> into tensor<256x1xi32>
+// CHECK:           %[[VAL_15:.*]] = tensor.empty() : tensor<256x128xi32>
+// CHECK:           %[[VAL_16:.*]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_13]] : tensor<256x1xi32>) outs(%[[VAL_15]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
+// CHECK:           ^bb0(%[[VAL_17:.*]]: i32, %[[VAL_18:.*]]: i32):
+// CHECK:             linalg.yield %[[VAL_17]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK:           %[[VAL_19:.*]] = tensor.empty() : tensor<128xi32>
+// CHECK:           %[[VAL_20:.*]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs(%[[VAL_19]] : tensor<128xi32>) {
+// CHECK:           ^bb0(%[[VAL_21:.*]]: i32):
+// CHECK:             %[[VAL_22:.*]] = linalg.index 0 : index
+// CHECK:             %[[VAL_23:.*]] = arith.index_cast %[[VAL_22]] : index to i32
+// CHECK:             linalg.yield %[[VAL_23]] : i32
+// CHECK:           } -> tensor<128xi32>
+// CHECK:           %[[VAL_24:.*]] = tensor.expand_shape %[[VAL_25:.*]] {{\[\[}}0, 1]] : tensor<128xi32> into tensor<1x128xi32>
+// CHECK:           %[[VAL_26:.*]] = tensor.empty() : tensor<256x128xi32>
+// CHECK:           %[[VAL_27:.*]] = linalg.generic {indexing_maps = [#map3, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_24]] : tensor<1x128xi32>) outs(%[[VAL_26]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 0>} {
+// CHECK:           ^bb0(%[[VAL_28:.*]]: i32, %[[VAL_29:.*]]: i32):
+// CHECK:             linalg.yield %[[VAL_28]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK:           %[[VAL_32:.*]] = linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_33:.*]], %[[VAL_31]] : tensor<256x128xi32>, tensor<256x128xi32>) outs(%[[VAL_33]] : tensor<256x128xi32>) {
+// CHECK:           ^bb0(%[[VAL_34:.*]]: i32, %[[VAL_35:.*]]: i32, %[[VAL_36:.*]]: i32):
+// CHECK:             %[[VAL_37:.*]] = arith.muli %[[VAL_34]], %[[VAL_35]] : i32
+// CHECK:             linalg.yield %[[VAL_37]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK:           %[[VAL_38:.*]] = linalg.generic {indexing_maps = [#map2, #map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_39:.*]], %[[VAL_40:.*]] : tensor<256x128xi32>, tensor<256x128xi32>) outs(%[[VAL_39]] : tensor<256x128xi32>) {
+// CHECK:           ^bb0(%[[VAL_41:.*]]: i32, %[[VAL_42:.*]]: i32, %[[VAL_43:.*]]: i32):
+// CHECK:             %[[VAL_44:.*]] = arith.addi %[[VAL_41]], %[[VAL_42]] : i32
+// CHECK:             linalg.yield %[[VAL_44]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK:           %[[VAL_45:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}6656], sizes: [256, 128], strides: [1, %[[VAL_6]]] : memref<*xbf16> to memref<256x128xbf16, strided<[1, ?], offset: 6656>>
+// CHECK:           %[[VAL_46:.*]] = memref.alloc() : memref<256x128xbf16>
+// CHECK:           memref.copy %[[VAL_45]], %[[VAL_46]] : memref<256x128xbf16, strided<[1, ?], offset: 6656>> to memref<256x128xbf16>
+// CHECK:           %[[VAL_47:.*]] = bufferization.to_tensor %[[VAL_46]] restrict writable : memref<256x128xbf16>
+// CHECK:           memref.tensor_store %[[VAL_47]], %[[VAL_45]] : memref<256x128xbf16, strided<[1, ?], offset: 6656>>
+// CHECK:           %[[VAL_48:.*]] = tensor.empty() : tensor<256x128xbf16>
+// CHECK:           %[[VAL_49:.*]] = linalg.generic {indexing_maps = [#map2, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_50:.*]] : tensor<256x128xi32>) outs(%[[VAL_48]] : tensor<256x128xbf16>) {
+// CHECK:           ^bb0(%[[VAL_51:.*]]: i32, %[[VAL_52:.*]]: bf16):
+// CHECK:             %[[VAL_53:.*]] = arith.sitofp %[[VAL_51]] : i32 to bf16
+// CHECK:             linalg.yield %[[VAL_53]] : bf16
+// CHECK:           } -> tensor<256x128xbf16>
+// CHECK:           memref.tensor_store %[[VAL_54:.*]], %[[VAL_45]] : memref<256x128xbf16, strided<[1, ?], offset: 6656>>
+// CHECK:           return
+// CHECK:         }

--- a/test/Conversion/TritonToLinalg/use_mid_chain.mlir
+++ b/test/Conversion/TritonToLinalg/use_mid_chain.mlir
@@ -1,0 +1,62 @@
+// RUN: triton-opt --triton-to-linalg %s | FileCheck %s
+module {
+  tt.func @kernel(
+  %arg0 : !tt.ptr<bf16>,
+  %arg1 : !tt.ptr<bf16>,
+  %arg2 : !tt.ptr<i32>
+  )
+  {
+  %0 = tt.make_range {end = 768 : i32, start = 512 : i32}:tensor<256xi32>
+  // offset = [512] size = 256, stride = 1
+  %1 = tt.expand_dims %0 {axis = 1 : i32} : (tensor<256xi32>) -> tensor<256x1xi32>
+  // offset = [512,0], size = [256,1], stride = [1,0]
+  %2 = tt.broadcast %1 : (tensor<256x1xi32>) -> tensor<256x128xi32>
+  // offset = [512,0], size = [256,128], stride = [1,0]
+  // mixed use
+  %5 = tt.make_range {end = 1152 : i32, start = 1024 : i32}:tensor<128xi32>
+  // offset = 1024, size = 128, stride = 1
+  %6 = tt.expand_dims %5 {axis = 0 : i32} : (tensor<128xi32>) -> tensor<1x128xi32>
+  // offset = [0,1024], size = [1,128], stride = [0,1]
+  %7 = tt.broadcast %6 : (tensor<1x128xi32>) -> tensor<256x128xi32>
+  // offset = [0,1024], size = [256,128], stride = [0,1]
+  %c6 = arith.constant 6 : i32
+  %splat6 = tt.splat %c6 : (i32) -> tensor<256x128xi32>
+  %scale7 = arith.muli %7, %splat6 : tensor<256x128xi32>
+  // offset = [0,6144], size = [256,128], stride = [0,6]
+  %14 = arith.addi %2, %scale7 : tensor<256x128xi32>
+  // offset = [512,6144], size = [256,128], stride = [1,6]
+  %17 = tt.splat %arg1 : (!tt.ptr<bf16>) -> tensor<256x128x!tt.ptr<bf16>>
+  %18 = tt.addptr %17, %14 : tensor<256x128x!tt.ptr<bf16>>, tensor<256x128xi32>
+  %19 = tt.load %18 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x128xbf16>
+  tt.store %18, %19 : tensor<256x128xbf16>
+  %20 = tt.splat %arg2 : (!tt.ptr<i32>) -> tensor<256x128x!tt.ptr<i32>>
+  %21 = tt.addptr %20, %14 : tensor<256x128x!tt.ptr<i32>>, tensor<256x128xi32>
+  tt.store %21, %2 : tensor<256x128xi32>
+  tt.return
+  }
+}
+// CHECK-LABEL:   func.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<*xbf16>, %[[VAL_1:.*]]: memref<*xbf16>, %[[VAL_2:.*]]: memref<*xi32>, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: i32) {
+// CHECK-DAG:           %[[VAL_7:.*]] = arith.constant 6 : index
+// CHECK:           %[[VAL_8:.*]] = tensor.empty() : tensor<256xi32>
+// CHECK:           %[[VAL_9:.*]] = linalg.generic {indexing_maps = [#map], iterator_types = ["parallel"]} outs(%[[VAL_8]] : tensor<256xi32>) {
+// CHECK:           ^bb0(%[[VAL_10:.*]]: i32):
+// CHECK:             %[[VAL_11:.*]] = linalg.index 0 : index
+// CHECK:             %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i32
+// CHECK:             linalg.yield %[[VAL_12]] : i32
+// CHECK:           } -> tensor<256xi32>
+// CHECK:           %[[VAL_13:.*]] = tensor.expand_shape %[[VAL_14:.*]] {{\[\[}}0, 1]] : tensor<256xi32> into tensor<256x1xi32>
+// CHECK:           %[[VAL_15:.*]] = tensor.empty() : tensor<256x128xi32>
+// CHECK:           %[[VAL_16:.*]] = linalg.generic {indexing_maps = [#map1, #map2], iterator_types = ["parallel", "parallel"]} ins(%[[VAL_13]] : tensor<256x1xi32>) outs(%[[VAL_15]] : tensor<256x128xi32>) attrs =  {broadcastDims = array<i64: 1>} {
+// CHECK:           ^bb0(%[[VAL_17:.*]]: i32, %[[VAL_18:.*]]: i32):
+// CHECK:             linalg.yield %[[VAL_17]] : i32
+// CHECK:           } -> tensor<256x128xi32>
+// CHECK:           %[[VAL_19:.*]] = memref.reinterpret_cast %[[VAL_1]] to offset: {{\[}}6656], sizes: [256, 128], strides: [1, %[[VAL_7]]] : memref<*xbf16> to memref<256x128xbf16, strided<[1, ?], offset: 6656>>
+// CHECK:           %[[VAL_20:.*]] = memref.alloc() : memref<256x128xbf16>
+// CHECK:           memref.copy %[[VAL_19]], %[[VAL_20]] : memref<256x128xbf16, strided<[1, ?], offset: 6656>> to memref<256x128xbf16>
+// CHECK:           %[[VAL_21:.*]] = bufferization.to_tensor %[[VAL_20]] restrict writable : memref<256x128xbf16>
+// CHECK:           memref.tensor_store %[[VAL_21]], %[[VAL_19]] : memref<256x128xbf16, strided<[1, ?], offset: 6656>>
+// CHECK:           %[[VAL_22:.*]] = memref.reinterpret_cast %[[VAL_2]] to offset: {{\[}}6656], sizes: [256, 128], strides: [1, %[[VAL_7]]] : memref<*xi32> to memref<256x128xi32, strided<[1, ?], offset: 6656>>
+// CHECK:           memref.tensor_store %[[VAL_23:.*]], %[[VAL_22]] : memref<256x128xi32, strided<[1, ?], offset: 6656>>
+// CHECK:           return
+// CHECK:         }


### PR DESCRIPTION
# Prototype for converting `triton` to `linalg`

## Introduction

I would like to share with the `triton` community this on-going work to add support for converting the triton dialect to the linalg dialect. This PR, which includes contributions from myself and my peers at Microsoft, introduces a prototype that supports `linalg` conversion for a limited number of scenarios. We hope folks will eventually be able to leverage this work in building new back-ends for `triton`.

## Usage

The pass is exposed via `triton-opt` and can be invoked by using the `--triton-to-linalg` flag like so:

```
triton-opt --triton-to-linalg %file
```

## Impact to the triton compiler

This PR introduces the `TritonToLinalg` pass and its related analyses. The new code is accessible only via `triton-opt`; it does not introduce any changes to the triton main compilation path.

## Implementation details

Even though a valid triton program can perform load and store in arbitrary memory locations, the prototype only supports lowering programs that have structured memory access patterns.

### Analyses

As part of the conversion process, there are three important analyses:

1. Pointer analysis:
    + This analysis is responsible for extracting structured memory access patterns from a `triton` program during load and store; it walks the IR and visits relevant instructions to build strided memory accesses in the `memref` dialect. The analysis is still in its early stage and does not support all scenarios.

2. Use analysis:
    + After "Pointer analysis", instructions that are part of memory address calculation will no longer be necessary in a triton program because their semantics have now been captured by `memref` operations representing strided memory accesses. To aid with removing these instructions safely, we perform `Use analysis` to mark which instructions are used *only* in address calculation (called `MetaUse`) or used in *both* address calculation and data manipulation (called `MixedUse`) operations. Those that are `MixedUse` are cloned and have their users adjusted accordingly with the goal of separating out the `MetaUse` ops so that they can be safely deleted.

3. Mask analysis:
    + This analysis is responsible for handling masked loads and stores.

### Conversion strategy

We introduce the `TritonToLinalg` pass that converts the `triton` dialect to the `linalg` dialect on *tensors*. This means the resulting IR is fully compatible with `linalg` tiling and fusion transformation passes. As mentioned in the `Pointer analysis`'s description, we do however have to deal with memref instructions at the load and store boundaries and have to convert them to tensors using `bufferization.to_tensor`. Here's a simple example of what the IR looks like:

```mlir
tt.func @kernel(%afloat : !tt.ptr<bf16>, %res : !tt.ptr<bf16>) {
  %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
  %1 = tt.splat %afloat : (!tt.ptr<bf16>) -> tensor<128x!tt.ptr<bf16>>
  %2 = tt.addptr %1, %0 : tensor<128x!tt.ptr<bf16>>, tensor<128xi32>
  %afm = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128xbf16>
  %3 = "tt.reduce"(%afm) ({
  ^bb0(%arg5: bf16, %arg6: bf16):
    %21 = arith.addf %arg5, %arg6 : bf16
    tt.reduce.return %21 : bf16
  }) {axis = 0 : i32} : (tensor<128xbf16>) -> bf16
  tt.store %res, %3 : bf16
  tt.return
}
```

after conversion:

```mlir
func.func @kernel(%arg0: memref<*xbf16>, %arg1: memref<*xbf16>, %arg2: i32, %arg3: i32, %arg4: i32) {
    %cst = arith.constant 0.000000e+00 : f32
    %reinterpret_cast = memref.reinterpret_cast %arg0 to offset: [0], sizes: [128], strides: [1] :
        memref<*xbf16> to memref<128xbf16, strided<[1]>>
    %alloc = memref.alloc() : memref<128xbf16>
    memref.copy %reinterpret_cast, %alloc : memref<128xbf16, strided<[1]>> to memref<128xbf16>
    %0 = bufferization.to_tensor %alloc restrict writable : memref<128xbf16>
    %1 = bufferization.alloc_tensor() : tensor<f32>
    %inserted = tensor.insert %cst into %1[] : tensor<f32>
    %reduced = linalg.reduce ins(%0 : tensor<128xbf16>) outs(%inserted : tensor<f32>) dimensions = [0]
      (%in: bf16, %init: f32) {
        %3 = arith.extf %in : bf16 to f32
        %4 = arith.addf %3, %init : f32
        linalg.yield %4 : f32
      }
    %extracted = tensor.extract %reduced[] : tensor<f32>
    %2 = arith.truncf %extracted : f32 to bf16
    %reinterpret_cast_0 = memref.reinterpret_cast %arg1 to offset: [0], sizes: [1], strides: [1] :
        memref<*xbf16> to memref<1xbf16, strided<[1]>>
    affine.store %2, %reinterpret_cast_0[0] : memref<1xbf16, strided<[1]>>
    return

}

```

Important details to note:

+ `tt.load` (together with all of its related address calculation instructions such as `tt.addptr` and `tt.splat`) are lowered to a combination of `memref.reinterpret_cast`, `memref.alloc`, and `memref.copy`. After the initialization of the local buffer, we convert the memref back to a tensor using `bufferization.to_tensor`; this op is automatically removed during bufferization.

+ `tt.store` lowers to a combination of `memref.reinterpret_cast` and either `affine.store` or `memref.tensor_store`:

```
%reinterpret_cast = memref.reinterpret_cast %arg2 to offset: [...] memref<*xf32> to memref<1024xf32>
%extracted_slice = tensor.extract_slice %15[0] [%21] [1] : tensor<1024xf32> to tensor<?xf32>
%subview = memref.subview %reinterpret_cast[0] [%21] [1] : memref<1024xf32> to memref<?xf32>
memref.tensor_store %extracted_slice, %subview : memref<?xf32>
```

+ element-wise `arith` and `math` operators are converted to their corresponding `linalg.generic` version.
+ `tt.dot` becomes `linalg.matmul`.
+ `tt.reduce` becomes `linalg.reduce`; known limitation: only support `addf` and `maxf` reduction in the reduction body for now.

### Testing

The prototype was tested on the following triton kernel examples:

1. vector addition
2. fused softmax
3. matrix multiplication
4. layer normalization
5. fused attention

In addition to testing on the tutorial kernels, I have also added many lit tests covering various scenarios.