### PR TITLE
[BACKEND] Fix invalid intermediate IR in GPU to LLVM

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -388,7 +388,7 @@ struct GetProgramIdOpConversion
 
     Value blockId =
         rewriter.create<::mlir::gpu::BlockIdOp>(loc, dims[op.getAxisAsInt()]);
-    rewriter.replaceOpWithNewOp<arith::TruncIOp>(op, i32_ty, blockId);
+    rewriter.replaceOpWithNewOp<arith::IndexCastOp>(op, i32_ty, blockId);
     return success();
   }
 
@@ -410,7 +410,7 @@ struct GetNumProgramsOpConversion
 
     Value blockId =
         rewriter.create<::mlir::gpu::GridDimOp>(loc, dims[op.getAxis()]);
-    rewriter.replaceOpWithNewOp<arith::TruncIOp>(op, i32_ty, blockId);
+    rewriter.replaceOpWithNewOp<arith::IndexCastOp>(op, i32_ty, blockId);
 
     return success();
   }

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -217,10 +217,9 @@ public:
   }
 
   Value getThreadId(ConversionPatternRewriter &rewriter, Location loc) const {
-    auto llvmIndexTy = this->getTypeConverter()->getIndexType();
     auto tid = rewriter.create<::mlir::gpu::ThreadIdOp>(
-        loc, rewriter.getIndexType(), ::mlir::gpu::Dimension::x);
-    return rewriter.create<arith::TruncIOp>(loc, i32_ty, tid);
+        loc, ::mlir::gpu::Dimension::x);
+    return rewriter.create<arith::IndexCastOp>(loc, i32_ty, tid);
   }
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
arith.trunc op is not allowed to use index type. This causes the IR to fail the verifier.
This doesn't cause a compilation failure as index are lowered to i32 in the same pass. 
However this creates intermediate IR that fails verifier which can make things harder to debug.