### PR TITLE
[BUILD] Make sure always build_ext first

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -13,6 +13,7 @@ from typing import NamedTuple
 
 from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
+from setuptools.command.build_py import build_py
 
 
 # Taken from https://github.com/pytorch/pytorch/blob/master/tools/setup_helpers/env.py
@@ -134,6 +135,11 @@ def download_and_copy_ptxas():
 
 
 # ---- cmake extension ----
+
+class CMakeBuildPy(build_py):
+    def run(self) -> None:
+        self.run_command('build_ext')
+        return super().run()
 
 
 class CMakeExtension(Extension):
@@ -266,7 +272,7 @@ setup(
     ],
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],
-    cmdclass={"build_ext": CMakeBuild},
+    cmdclass={"build_ext": CMakeBuild, "build_py": CMakeBuildPy},
     zip_safe=False,
     # for PyPI
     keywords=["Compiler", "Deep Learning"],


### PR DESCRIPTION
The third-party backend might install its python package to the `triton/third_party` python package during the build process. But the `build_py` could be executed before the `build_ext`, and then `build_py` would only copy the `packages` defined in the `setup.py` w/o the third-party related packages as the third-party backend has not been built, which is triggered by `build_ext`. Therefore, this PR refined the build order a little bit to ensure `build_ext` always happens before `build_py`.