### PR TITLE
Add more perf-tests, new features to FA

### DIFF
--- a/python/test/regression/test_performance.py
+++ b/python/test/regression/test_performance.py
@@ -55,26 +55,39 @@ matmul_data = {
         (1024, 64, 1024): {'float16': 0.0692},
         (4096, 64, 4096): {'float16': 0.264},
         (8192, 64, 8192): {'float16': 0.452},
+        # Non pow 2 shapes
+        (1000, 200, 100): {'float16': 0.084},
+        (1000, 200, 700): {'float16': 0.084},
+        (994, 136, 402): {'float16': 0.084},
+        (995, 135, 409): {'float16': 0.084},
+        (99, 1357, 409): {'float16': 0.084},
     },
     # NOTE:
     # A100 in the CI server is slow-ish for some reason.
     # On some other servers, we are getting about 90% peak for 8kx8x8k float16
     'a100': {
-        (512, 512, 512): {'float16': 0.084, 'float32': 0.13, 'int8': 0.05},
-        (1024, 1024, 1024): {'float16': 0.332, 'float32': 0.35, 'int8': 0.169},
-        (2048, 2048, 2048): {'float16': 0.641, 'float32': 0.57, 'int8': 0.34},
-        (4096, 4096, 4096): {'float16': 0.785, 'float32': 0.75, 'int8': 0.46},
-        (8192, 8192, 8192): {'float16': 0.805, 'float32': 0.85, 'int8': 0.51},
+        # square
+        (512, 512, 512): {'float16': 0.084, 'float32': 0.12, 'int8': 0.05},
+        (1024, 1024, 1024): {'float16': 0.332, 'float32': 0.352, 'int8': 0.169},
+        (2048, 2048, 2048): {'float16': 0.598, 'float32': 0.522, 'int8': 0.34},
+        (4096, 4096, 4096): {'float16': 0.702, 'float32': 0.804, 'int8': 0.46},
+        (8192, 8192, 8192): {'float16': 0.829, 'float32': 0.917, 'int8': 0.51},
         # tall-skinny
-        (16, 1024, 1024): {'float16': 0.0077, 'float32': 0.0127, 'int8': 0.005},
-        (16, 4096, 4096): {'float16': 0.044, 'float32': 0.0457, 'int8': 0.0259},
-        (16, 8192, 8192): {'float16': 0.07, 'float32': 0.0648, 'int8': 0.0431},
-        (64, 1024, 1024): {'float16': 0.028, 'float32': 0.0509, 'int8': 0.0169},
-        (64, 4096, 4096): {'float16': 0.163, 'float32': 0.162, 'int8': 0.097},
-        (64, 8192, 8192): {'float16': 0.285, 'float32': 0.257, 'int8': 0.174},
-        (1024, 64, 1024): {'float16': 0.033, 'float32': 0.0458, 'int8': 0.017},
-        (4096, 64, 4096): {'float16': 0.16, 'float32': 0.177, 'int8': 0.102},
-        (8192, 64, 8192): {'float16': 0.254, 'float32': 0.230, 'int8': 0.177},
+        (16, 1024, 1024): {'float16': 0.008, 'float32': 0.009, 'int8': 0.005},
+        (16, 4096, 4096): {'float16': 0.036, 'float32': 0.038, 'int8': 0.026},
+        (16, 8192, 8192): {'float16': 0.056, 'float32': 0.061, 'int8': 0.043},
+        (64, 1024, 1024): {'float16': 0.038, 'float32': 0.047, 'int8': 0.017},
+        (64, 4096, 4096): {'float16': 0.143, 'float32': 0.162, 'int8': 0.097},
+        (64, 8192, 8192): {'float16': 0.232, 'float32': 0.257, 'int8': 0.174},
+        (1024, 64, 1024): {'float16': 0.003, 'float32': 0.004, 'int8': 0.017},
+        (4096, 64, 4096): {'float16': 0.14, 'float32': 0.122, 'int8': 0.102},
+        (8192, 64, 8192): {'float16': 0.207, 'float32': 0.23, 'int8': 0.177},
+        # Non pow 2 shapes
+        (1000, 200, 100): {'float16': 0.011, 'float32': 0.017, 'int8': 0.05},
+        (1000, 200, 700): {'float16': 0.027, 'float32': 0.047, 'int8': 0.05},
+        (994, 136, 402): {'float16': 0.015, 'float32': 0.024, 'int8': 0.05},
+        (995, 135, 409): {'float16': 0.015, 'float32': 0.025, 'int8': 0.05},
+        (99, 1357, 409): {'float16': 0.011, 'float32': 0.036, 'int8': 0.05}
     }
 }
 
@@ -82,10 +95,12 @@ matmul_data = {
 @pytest.mark.parametrize('M, N, K, dtype_str',
                          [(M, N, K, dtype_str)
                           for M, N, K in matmul_data[DEVICE_NAME].keys()
-                          for dtype_str in ['float16']])
+                          for dtype_str in ['float16', 'float32']])
 def test_matmul(M, N, K, dtype_str):
     if dtype_str in ['float32', 'int8'] and DEVICE_NAME != 'a100':
         pytest.skip('Only test float32 & int8 on a100')
+    if (M, N, K) in [(64, 4096, 4096), (64, 8192, 8192), (8192, 64, 8192)] and dtype_str == 'float32':
+        pytest.skip('Out of shared memory in float32')
     dtype = {'float16': torch.float16, 'float32': torch.float32, 'int8': torch.int8}[dtype_str]
     torch.manual_seed(0)
     ref_gpu_util = matmul_data[DEVICE_NAME][(M, N, K)][dtype_str]
@@ -126,32 +141,44 @@ def _add(x_ptr, y_ptr, output_ptr, n_elements,
 
 elementwise_data = {
     'v100': {
-        1024 * 16: 0.0219,
-        1024 * 64: 0.0791,
-        1024 * 256: 0.243,
-        1024 * 1024: 0.530,
-        1024 * 4096: 0.796,
-        1024 * 16384: 0.905,
-        1024 * 65536: 0.939,
+        1024 * 16: {'float16': 0.0219, 'float32': 0.010},
+        1024 * 64: {'float16': 0.0791, 'float32': 0.010},
+        1024 * 256: {'float16': 0.243, 'float32': 0.010},
+        1024 * 1024: {'float16': 0.530, 'float32': 0.010},
+        1024 * 4096: {'float16': 0.796, 'float32': 0.010},
+        1024 * 16384: {'float16': 0.905, 'float32': 0.010},
+        1024 * 65536: {'float16': 0.939, 'float32': 0.010},
+        # Non pow 2
+        1020 * 100: {'float16': 0.010, 'float32': 0.010},
+        995 * 125: {'float16': 0.010, 'float32': 0.010},
+        10003 * 7007: {'float16': 0.010, 'float32': 0.010},
     },
     'a100': {
-        1024 * 16: 0.010,
-        1024 * 64: 0.040,
-        1024 * 256: 0.132,
-        1024 * 1024: 0.353,
-        1024 * 4096: 0.605,
-        1024 * 16384: 0.758,
-        1024 * 65536: 0.850,
+        1024 * 16: {'float16': 0.010, 'bfloat16': 0.010, 'float32': 0.010},
+        1024 * 64: {'float16': 0.040, 'bfloat16': 0.010, 'float32': 0.010},
+        1024 * 256: {'float16': 0.132, 'bfloat16': 0.010, 'float32': 0.010},
+        1024 * 1024: {'float16': 0.353, 'bfloat16': 0.010, 'float32': 0.010},
+        1024 * 4096: {'float16': 0.605, 'bfloat16': 0.010, 'float32': 0.010},
+        1024 * 16384: {'float16': 0.758, 'bfloat16': 0.010, 'float32': 0.010},
+        1024 * 65536: {'float16': 0.850, 'bfloat16': 0.010, 'float32': 0.010},
+        # Non pow 2
+        1020 * 100: {'float16': 0.010, 'bfloat16': 0.010, 'float32': 0.010},
+        995 * 125: {'float16': 0.010, 'bfloat16': 0.010, 'float32': 0.010},
+        10003 * 7007: {'float16': 0.010, 'bfloat16': 0.010, 'float32': 0.010},
     }
 }
 
 
 @pytest.mark.parametrize('N', elementwise_data[DEVICE_NAME].keys())
-def test_elementwise(N):
+@pytest.mark.parametrize("dtype_str", ['float16', 'bfloat16', 'float32'])
+def test_elementwise(N, dtype_str):
     torch.manual_seed(0)
-    ref_gpu_util = elementwise_data[DEVICE_NAME][N]
+    if dtype_str in ['bfloat16'] and DEVICE_NAME != 'a100':
+        pytest.skip('Only test bfloat16 on a100')
+    dtype = {'float16': torch.float16, 'bfloat16': torch.bfloat16, 'float32': torch.float32}[dtype_str]
+    ref_gpu_util = elementwise_data[DEVICE_NAME][N][dtype_str]
     max_gpu_perf = get_dram_gbps()
-    z = torch.empty((N, ), dtype=torch.float16, device='cuda')
+    z = torch.empty((N, ), dtype=dtype, device='cuda')
     x = torch.randn_like(z)
     y = torch.randn_like(z)
     grid = lambda args: (triton.cdiv(N, args['BLOCK_SIZE']), )
@@ -169,29 +196,43 @@ def test_elementwise(N):
 
 flash_attention_data = {
     "a100": {
-        (4, 48, 4096, 64, 'forward', 'float16'): 0.37,
-        (4, 48, 4096, 64, 'backward', 'float16'): 0.25,
+        (4, 48, 4096, 64, False, 'forward', 'float16'): 0.39,
+        (4, 48, 4096, 64, False, 'backward', 'float16'): 0.252,
+        (4, 48, 4096, 64, False, 'forward', 'bfloat16'): 0.358,
+        (4, 48, 4096, 64, False, 'backward', 'bfloat16'): 0.243,
+        (4, 48, 1024, 16, False, 'forward', 'float32'): 0.092,
+        (4, 48, 1024, 16, False, 'backward', 'float32'): 0.118,
+        (4, 48, 4096, 64, True, 'forward', 'float16'): 0.39,
+        (4, 48, 4096, 64, True, 'backward', 'float16'): 0.175,
+        (4, 48, 4096, 64, True, 'forward', 'bfloat16'): 0.355,
+        (4, 48, 4096, 64, True, 'backward', 'bfloat16'): 0.168,
+        (4, 48, 1024, 16, True, 'forward', 'float32'): 0.092,
+        (4, 48, 1024, 16, True, 'backward', 'float32'): 0.087
     }
 }
 
 
 @pytest.mark.parametrize("Z, H, N_CTX, D_HEAD", [[4, 48, 4096, 64]])
+@pytest.mark.parametrize("seq_par", [True, False])
 @pytest.mark.parametrize("mode", ['forward', 'backward'])
-@pytest.mark.parametrize("dtype_str", ['float16'])
-def test_flash_attention(Z, H, N_CTX, D_HEAD, mode, dtype_str):
+@pytest.mark.parametrize("dtype_str", ['float16', 'bfloat16', 'float32'])
+def test_flash_attention(Z, H, N_CTX, D_HEAD, seq_par, mode, dtype_str):
     is_backward = mode == 'backward'
     capability = torch.cuda.get_device_capability()
     if capability[0] < 8:
         pytest.skip("Flash attention only supported for compute capability < 80")
     torch.manual_seed(20)
-    dtype = {'float16': torch.float16, 'float32': torch.float32, 'int8': torch.int8}[dtype_str]
+    dtype = {'float16': torch.float16, 'bfloat16': torch.bfloat16, 'float32': torch.float32}[dtype_str]
     # init data
+    if dtype_str == 'float32':
+        N_CTX = 1024
+        D_HEAD = 16
     q = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.1, std=0.2).requires_grad_()
     k = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.4, std=0.2).requires_grad_()
     v = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.3, std=0.2).requires_grad_()
     sm_scale = 0.2
     # benchmark
-    fn = lambda: triton.ops.attention(q, k, v, sm_scale)
+    fn = lambda: triton.ops.attention(q, k, v, sm_scale, seq_par)
     if is_backward:
         o = fn()
         do = torch.randn_like(o)
@@ -207,6 +248,6 @@ def test_flash_attention(Z, H, N_CTX, D_HEAD, mode, dtype_str):
     cur_sm_clock = nvsmi(['clocks.current.sm'])[0]
     max_gpu_perf = get_max_tensorcore_tflops(dtype, clock_rate=cur_sm_clock * 1e3)
     cur_gpu_util = cur_gpu_perf / max_gpu_perf
-    ref_gpu_util = flash_attention_data[DEVICE_NAME][(Z, H, N_CTX, D_HEAD, mode, dtype_str)]
+    ref_gpu_util = flash_attention_data[DEVICE_NAME][(Z, H, N_CTX, D_HEAD, seq_par, mode, dtype_str)]
     print_perf(ms, cur_gpu_util, ref_gpu_util)
     triton.testing.assert_close(cur_gpu_util, ref_gpu_util, atol=0.01, rtol=0.05)

--- a/python/triton/ops/flash_attention.py
+++ b/python/triton/ops/flash_attention.py
@@ -31,8 +31,8 @@ def _fwd_kernel(
     offs_n = tl.arange(0, BLOCK_N)
     offs_d = tl.arange(0, BLOCK_DMODEL)
     off_q = off_hz * stride_qh + offs_m[:, None] * stride_qm + offs_d[None, :] * stride_qk
-    off_k = off_hz * stride_qh + offs_n[None, :] * stride_kn + offs_d[:, None] * stride_kk
-    off_v = off_hz * stride_qh + offs_n[:, None] * stride_qm + offs_d[None, :] * stride_qk
+    off_k = off_hz * stride_kh + offs_n[None, :] * stride_kn + offs_d[:, None] * stride_kk
+    off_v = off_hz * stride_vh + offs_n[:, None] * stride_vk + offs_d[None, :] * stride_vn
     # Initialize pointers to Q, K, V
     q_ptrs = Q + off_q
     k_ptrs = K + off_k
@@ -48,7 +48,7 @@ def _fwd_kernel(
         # -- compute qk ----
         k = tl.load(k_ptrs)
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
-        qk += tl.dot(q, k)
+        qk += tl.dot(q, k, allow_tf32=True)
         qk *= sm_scale
         qk = tl.where(offs_m[:, None] >= (start_n + offs_n[None, :]), qk, float("-inf"))
         # compute new m
@@ -65,7 +65,7 @@ def _fwd_kernel(
         # update acc
         p = p.to(Q.dtype.element_ty)
         v = tl.load(v_ptrs)
-        acc += tl.dot(p, v)
+        acc += tl.dot(p, v, allow_tf32=True)
         # update m_i and l_i
         l_prev = l_curr
         m_prev = m_curr
@@ -108,8 +108,9 @@ def _bwd_preprocess(
 
 
 @jit
-def _bwd_kernel(
-    Q, K, V, sm_scale, Out, DO,
+def _bwd_kernel_one_col_block(
+    Q, K, V, sm_scale,
+    Out, DO,
     DQ, DK, DV,
     L, M,
     D,
@@ -117,84 +118,143 @@ def _bwd_kernel(
     stride_kz, stride_kh, stride_kn, stride_kk,
     stride_vz, stride_vh, stride_vk, stride_vn,
     Z, H, N_CTX,
-    num_block,
+    off_hz, start_n, num_block,
     BLOCK_M: tl.constexpr, BLOCK_DMODEL: tl.constexpr,
     BLOCK_N: tl.constexpr,
+    SEQUENCE_PARALLEL: tl.constexpr,
+):
+    lo = start_n * BLOCK_M
+    # initialize row/col offsets
+    offs_qm = lo + tl.arange(0, BLOCK_M)
+    offs_n = start_n * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_m = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+    # initialize pointers to value-like data
+    q_ptrs = Q + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+    k_ptrs = K + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
+    v_ptrs = V + (offs_n[:, None] * stride_vk + offs_k[None, :] * stride_vn)
+    do_ptrs = DO + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+    dq_ptrs = DQ + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
+    # pointer to row-wise quantities in value-like data
+    D_ptrs = D + off_hz * N_CTX
+    m_ptrs = M + off_hz * N_CTX
+    # initialize dv amd dk
+    dv = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    dk = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    # k and v stay in SRAM throughout
+    k = tl.load(k_ptrs)
+    v = tl.load(v_ptrs)
+    # loop over rows
+    for start_m in range(lo, num_block * BLOCK_M, BLOCK_M):
+        offs_m_curr = start_m + offs_m
+        # load q, k, v, do on-chip
+        q = tl.load(q_ptrs)
+        # recompute p = softmax(qk, dim=-1).T
+        # NOTE: `do` is pre-divided by `l`; no normalization here
+        qk = tl.dot(q, tl.trans(k), allow_tf32=True)
+        qk = tl.where(offs_m_curr[:, None] >= (offs_n[None, :]), qk, float("-inf"))
+        m = tl.load(m_ptrs + offs_m_curr)
+        p = tl.exp(qk * sm_scale - m[:, None])
+        # compute dv
+        do = tl.load(do_ptrs)
+        dv += tl.dot(tl.trans(p.to(Q.dtype.element_ty)), do, allow_tf32=True)
+        # compute dp = dot(v, do)
+        Di = tl.load(D_ptrs + offs_m_curr)
+        # dp = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32) - Di[:, None]
+        dp = tl.dot(do, tl.trans(v), allow_tf32=True)
+        # compute ds = p * (dp - delta[:, None])
+        ds = (p * (dp - Di[:, None]) * sm_scale).to(Q.dtype.element_ty)
+        # compute dk = dot(ds.T, q)
+        dk += tl.dot(tl.trans(ds), q, allow_tf32=True)
+        # compute dq
+        if not SEQUENCE_PARALLEL:
+            dq = tl.load(dq_ptrs)
+            dq += tl.dot(ds, k, allow_tf32=True)
+            tl.store(dq_ptrs, dq)
+        elif SEQUENCE_PARALLEL:
+            # dq = tl.dot(ds, k, allow_tf32=True)
+            dq = tl.trans(tl.dot(tl.trans(k), tl.trans(ds), allow_tf32=True))
+            tl.atomic_add(dq_ptrs, dq, sem='relaxed')
+
+        # increment pointers
+        dq_ptrs += BLOCK_M * stride_qm
+        q_ptrs += BLOCK_M * stride_qm
+        do_ptrs += BLOCK_M * stride_qm
+    # write-back
+    dv_ptrs = DV + (offs_n[:, None] * stride_vk + offs_k[None, :] * stride_vn)
+    dk_ptrs = DK + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
+    tl.store(dv_ptrs, dv)
+    tl.store(dk_ptrs, dk)
+
+
+@jit
+def _bwd_kernel(
+    # fmt: off
+    Q, K, V, sm_scale,
+    Out, DO,
+    DQ, DK, DV,
+    L, M,
+    D,
+    stride_qz, stride_qh, stride_qm, stride_qk,
+    stride_kz, stride_kh, stride_kn, stride_kk,
+    stride_vz, stride_vh, stride_vk, stride_vn,
+    Z, H, N_CTX,
+    BLOCK_M: tl.constexpr, BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    SEQUENCE_PARALLEL: tl.constexpr,
+    # fmt: on
 ):
     off_hz = tl.program_id(0)
     off_z = off_hz // H
     off_h = off_hz % H
     # offset pointers for batch/head
     Q += off_z * stride_qz + off_h * stride_qh
-    K += off_z * stride_qz + off_h * stride_qh
-    V += off_z * stride_qz + off_h * stride_qh
+    K += off_z * stride_kz + off_h * stride_kh
+    V += off_z * stride_vz + off_h * stride_vh
     DO += off_z * stride_qz + off_h * stride_qh
     DQ += off_z * stride_qz + off_h * stride_qh
-    DK += off_z * stride_qz + off_h * stride_qh
-    DV += off_z * stride_qz + off_h * stride_qh
-    for start_n in range(0, num_block):
-        lo = start_n * BLOCK_M
-        # initialize row/col offsets
-        offs_qm = lo + tl.arange(0, BLOCK_M)
-        offs_n = start_n * BLOCK_M + tl.arange(0, BLOCK_M)
-        offs_m = tl.arange(0, BLOCK_N)
-        offs_k = tl.arange(0, BLOCK_DMODEL)
-        # initialize pointers to value-like data
-        q_ptrs = Q + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
-        k_ptrs = K + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
-        v_ptrs = V + (offs_n[:, None] * stride_qm + offs_k[None, :] * stride_qk)
-        do_ptrs = DO + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
-        dq_ptrs = DQ + (offs_qm[:, None] * stride_qm + offs_k[None, :] * stride_qk)
-        # pointer to row-wise quantities in value-like data
-        D_ptrs = D + off_hz * N_CTX
-        m_ptrs = M + off_hz * N_CTX
-        # initialize dv amd dk
-        dv = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
-        dk = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
-        # k and v stay in SRAM throughout
-        k = tl.load(k_ptrs)
-        v = tl.load(v_ptrs)
-        # loop over rows
-        for start_m in range(lo, num_block * BLOCK_M, BLOCK_M):
-            offs_m_curr = start_m + offs_m
-            # load q, k, v, do on-chip
-            q = tl.load(q_ptrs)
-            # recompute p = softmax(qk, dim=-1).T
-            # NOTE: `do` is pre-divided by `l`; no normalization here
-            qk = tl.dot(q, tl.trans(k))
-            qk = tl.where(offs_m_curr[:, None] >= (offs_n[None, :]), qk, float("-inf"))
-            m = tl.load(m_ptrs + offs_m_curr)
-            p = tl.exp(qk * sm_scale - m[:, None])
-            # compute dv
-            do = tl.load(do_ptrs)
-            dv += tl.dot(tl.trans(p.to(Q.dtype.element_ty)), do)
-            # compute dp = dot(v, do)
-            Di = tl.load(D_ptrs + offs_m_curr)
-            dp = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32) - Di[:, None]
-            dp += tl.dot(do, tl.trans(v))
-            # compute ds = p * (dp - delta[:, None])
-            ds = p * dp * sm_scale
-            # compute dk = dot(ds.T, q)
-            dk += tl.dot(tl.trans(ds.to(Q.dtype.element_ty)), q)
-            # compute dq
-            dq = tl.load(dq_ptrs)
-            dq += tl.dot(ds.to(Q.dtype.element_ty), k)
-            tl.store(dq_ptrs, dq)
-            # increment pointers
-            dq_ptrs += BLOCK_M * stride_qm
-            q_ptrs += BLOCK_M * stride_qm
-            do_ptrs += BLOCK_M * stride_qm
-        # write-back
-        dv_ptrs = DV + (offs_n[:, None] * stride_qm + offs_k[None, :] * stride_qk)
-        dk_ptrs = DK + (offs_n[:, None] * stride_kn + offs_k[None, :] * stride_kk)
-        tl.store(dv_ptrs, dv)
-        tl.store(dk_ptrs, dk)
+    DK += off_z * stride_kz + off_h * stride_kh
+    DV += off_z * stride_vz + off_h * stride_vh
+
+    num_block_n = tl.cdiv(N_CTX, BLOCK_N)
+    if not SEQUENCE_PARALLEL:
+        for start_n in range(0, num_block_n):
+            _bwd_kernel_one_col_block(
+                Q, K, V, sm_scale, Out, DO,
+                DQ, DK, DV,
+                L, M,
+                D,
+                stride_qz, stride_qh, stride_qm, stride_qk,
+                stride_kz, stride_kh, stride_kn, stride_kk,
+                stride_vz, stride_vh, stride_vk, stride_vn,
+                Z, H, N_CTX,
+                off_hz, start_n, num_block_n,
+                BLOCK_M=BLOCK_M, BLOCK_DMODEL=BLOCK_DMODEL,
+                BLOCK_N=BLOCK_N,
+                SEQUENCE_PARALLEL=SEQUENCE_PARALLEL,
+            )
+    else:
+        start_n = tl.program_id(1)
+        _bwd_kernel_one_col_block(
+            Q, K, V, sm_scale, Out, DO,
+            DQ, DK, DV,
+            L, M,
+            D,
+            stride_qz, stride_qh, stride_qm, stride_qk,
+            stride_kz, stride_kh, stride_kn, stride_kk,
+            stride_vz, stride_vh, stride_vk, stride_vn,
+            Z, H, N_CTX,
+            off_hz, start_n, num_block_n,
+            BLOCK_M=BLOCK_M, BLOCK_DMODEL=BLOCK_DMODEL,
+            BLOCK_N=BLOCK_N,
+            SEQUENCE_PARALLEL=SEQUENCE_PARALLEL,
+        )
 
 
 class _attention(torch.autograd.Function):
 
     @staticmethod
-    def forward(ctx, q, k, v, sm_scale):
+    def forward(ctx, q, k, v, sm_scale, sequence_parallel=False):
         # only support for Ampere now
         capability = torch.cuda.get_device_capability()
         if capability[0] < 8:
@@ -228,12 +288,15 @@ class _attention(torch.autograd.Function):
         ctx.grid = grid
         ctx.sm_scale = sm_scale
         ctx.BLOCK_DMODEL = Lk
+        ctx.sequence_parallel = sequence_parallel
         return o
 
     @staticmethod
     def backward(ctx, do):
         BLOCK = 128
         q, k, v, o, l, m = ctx.saved_tensors
+        sequence_parallel = ctx.sequence_parallel
+        seq_len_kv = k.shape[2]
         do = do.contiguous()
         dq = torch.zeros_like(q, dtype=torch.float32)
         dk = torch.empty_like(k)
@@ -245,7 +308,7 @@ class _attention(torch.autograd.Function):
             do_scaled, delta,
             BLOCK_M=BLOCK, D_HEAD=ctx.BLOCK_DMODEL,
         )
-        _bwd_kernel[(ctx.grid[1],)](
+        _bwd_kernel[(ctx.grid[1], cdiv(seq_len_kv, BLOCK) if sequence_parallel else 1)](
             q, k, v, ctx.sm_scale,
             o, do_scaled,
             dq, dk, dv,
@@ -255,12 +318,13 @@ class _attention(torch.autograd.Function):
             k.stride(0), k.stride(1), k.stride(2), k.stride(3),
             v.stride(0), v.stride(1), v.stride(2), v.stride(3),
             q.shape[0], q.shape[1], q.shape[2],
-            ctx.grid[0],
             BLOCK_M=BLOCK, BLOCK_N=BLOCK,
-            BLOCK_DMODEL=ctx.BLOCK_DMODEL, num_warps=8,
+            BLOCK_DMODEL=ctx.BLOCK_DMODEL,
+            SEQUENCE_PARALLEL=sequence_parallel,
+            num_warps=8,
             num_stages=1,
         )
-        return dq, dk, dv, None
+        return dq, dk, dv, None, None
 
 
 attention = _attention.apply


### PR DESCRIPTION
Adding new tests across the board for float32, bfloat16, non-powers-of-2 shapes (to test masks), and tests on sequence parallel for atomics.  This also adds the sequence parallel features from https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/flash_attn_triton.py.
I am not sure about the best way to grab the baseline benchmarking numbers.  I have access to V100s and A100s, but I saw on the tests it mentions " # A100 in the CI server is slow-ish for some reason.
    # On some other servers, we are getting about 90% peak for 8kx8x8k float16".  Current plan is to run CI here and use those numbers for baseline, then match against my GPUs as a sanity check.