### PR TITLE
Allow user to adjust warmup and repetition time for autotuning

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -175,7 +175,7 @@ class Config:
         return ', '.join(res)
 
 
-def autotune(configs, key, prune_configs_by=None, reset_to_zero=None):
+def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, warmup=25, rep=100):
     """
     Decorator for auto-tuning a :code:`triton.jit`'d function.
 
@@ -206,9 +206,13 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None):
         'early_config_prune'(optional): a function used to do early prune (eg, num_stages). It takes configs:List[Config] as its input, and returns pruned configs.
     :param reset_to_zero: a list of argument names whose value will be reset to zero before evaluating any configs.
     :type reset_to_zero: list[str]
+    :param warmup: Warmup time (in ms) to pass to benchmarking, defaults to 25.
+    :type warmup: int
+    :param rep: Repetition time (in ms) to pass to benchmarking, defaults to 100.
+    :type rep: int
     """
     def decorator(fn):
-        return Autotuner(fn, fn.arg_names, configs, key, reset_to_zero, prune_configs_by)
+        return Autotuner(fn, fn.arg_names, configs, key, reset_to_zero, prune_configs_by, warmup, rep)
 
     return decorator
 


### PR DESCRIPTION
Adds an option to adjust warmup and repetition time for autotuning.  It should default to old values and have no effect on current kernels.  
This is useful for bigger kernels where runtime might be a sizable fraction 100ms and lead to less warmup and more variance during benchmarking.