### PR TITLE
[BUILD] Export compile commands

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -211,6 +211,7 @@ class CMakeBuild(build_ext):
         # python directories
         python_include_dir = sysconfig.get_path("platinclude")
         cmake_args = [
+            "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
             "-DLLVM_ENABLE_WERROR=ON",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,
             "-DTRITON_BUILD_TUTORIALS=OFF",


### PR DESCRIPTION
This can be used by IDEs to figure out how to correctly compile individual sources and offer semantic code completion.