### PR TITLE
[CMAKE] Add link dependency to dl for TritonLLVMIR.

### DIFF
--- a/lib/Target/LLVMIR/CMakeLists.txt
+++ b/lib/Target/LLVMIR/CMakeLists.txt
@@ -4,7 +4,9 @@ add_mlir_translation_library(TritonLLVMIR
         LINK_COMPONENTS
         Core
 
-        LINK_LIBS PUBLIC
+        LINK_LIBS
+        ${CMAKE_DL_LIBS}
+        PUBLIC
         MLIRArithToLLVM
         MLIRBuiltinToLLVMIRTranslation
         MLIRExecutionEngineUtils


### PR DESCRIPTION
That library makes use of the dladdr function, so it eventually needs to be linked with -ldl, which may not be done automatically. This commit adds a link dependency to `${CMAKE_DL_LIBS}`, which is CMake's way of specifying that library in a portable way.