### PR TITLE
[FRONTEND] Remove unnecessary replace in while op's after block

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -682,10 +682,6 @@ class CodeGenerator(ast.NodeVisitor):
                     yields.append(loop_defs[name])
             self.builder.create_yield_op([y.handle for y in yields])
 
-        # update global uses in while_op
-        for i, name in enumerate(names):
-            after_block.replace_use_in_block_with(init_args[i].handle, after_block.arg(i))
-
         # WhileOp defines new values, update the symbol table (lscope, local_defs)
         for i, name in enumerate(names):
             new_def = language.core.tensor(while_op.get_result(i), ret_types[i])


### PR DESCRIPTION
We've already updated the mapping between name and tensor before visiting each compound statement in the while op. As a result, any overwritten name gets up-to-date values updated in the while loop. And any unchanged livein names hold the original tensors.