### PR TITLE
Adjust benchmarking for quick kernels

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -80,6 +80,8 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None,
                 x.grad = None
         # we clear the L2 cache before each run
         cache.zero_()
+        # Necessary for accurate timings of quick kernels
+        torch.cuda._sleep(2000000)
         # record time of `fn`
         start_event[i].record()
         fn()


### PR DESCRIPTION
Running quick kernels on some hardware can result in the host overhead being caught in the timing as seen in the following script
```
import torch
import time


def benchmark(n_repeat, size, flush):
    start_event = [
        torch.cuda.Event(enable_timing=True) for i in range(n_repeat)
    ]
    end_event = [torch.cuda.Event(enable_timing=True) for i in range(n_repeat)]
    cache = torch.empty(int(512e6), dtype=torch.int8, device='cuda')

    tensor = torch.rand(size, device='cuda')
    torch.cuda.synchronize()

    for _ in range(10):
        tensor = tensor + 1

    torch.cuda.synchronize()
    stream = torch.cuda.current_stream()
    for i in range(n_repeat):
        if flush:
            cache.zero_()

        start_event[i].record(stream)
        tensor = tensor + 1
        end_event[i].record(stream)

    torch.cuda.synchronize()
    times = torch.tensor(
        [s.elapsed_time(e) for s, e in zip(start_event, end_event)]
    )
    mean = times.mean()
    std = times.std()
    minimum = times.min()
    print(f'mean: {mean} min: {minimum} std: {std}')


tensor = torch.rand(1, device='cuda')

benchmark(100, 1, False)
benchmark(100, 1, True)
```

This is especially noticeable when using fast flush as it can be significantly faster, dropping its secondary effect as a torch.cuda._sleep. 
This change forces a small buffer period which makes timings more accurate.