### PR TITLE
[FRONTEND] Fix a inspection warning

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -401,6 +401,9 @@ class constexpr:
     def __repr__(self) -> str:
         return f"constexpr[{self.value}]"
 
+    def __index__(self):
+        return self.value
+
     def __add__(self, other):
         return constexpr(self.value + other.value)
 


### PR DESCRIPTION
"Expected type 'SupportsIndex', got 'constexpr' instead" is no longer reported.