### PR TITLE
[FRONTEND] don't skip block_ptr rewrite on H100

### DIFF
--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -470,8 +470,8 @@ public:
 
   void runOnOperation() override {
     // Only rewrite if the hardware does not support
-    if (computeCapability >= 90)
-      return;
+    // if (computeCapability >= 90)
+    //   return;
 
     // NOTES(Chenggang): we don't use `ConversionPatternRewriter`, because
     // MLIR does not support one-multiple value mapping. For example, if we use


### PR DESCRIPTION
will be skipped again when proper codegen for TMAs exists