### PR TITLE
Add additive attention mask support for FlashAttention

### DIFF
--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -23,10 +23,19 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par):
     sm_scale = 0.5
     dout = torch.randn_like(q)
     # reference implementation
-    M = torch.tril(torch.ones((N_CTX, N_CTX), device="cuda"))
-    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
     if causal:
-        p[:, :, M == 0] = float("-inf")
+        M = torch.triu(
+            torch.full(
+                # Cannot give dtype here due to BF16 incompatibility with torch<=2.0:
+                # RuntimeError: "triu_tril_cuda_template" not implemented for 'BFloat16'
+                (N_CTX, N_CTX), float('-inf'), device="cuda"),
+            diagonal=1,
+        ).to(dtype)
+    else:
+        M = torch.zeros((N_CTX, N_CTX), device="cuda", dtype=dtype)
+
+    p = torch.matmul(q, k.transpose(2, 3)) * sm_scale
+    p = p + M
     p = torch.softmax(p.float(), dim=-1).to(dtype)
     # p = torch.exp(p)
     ref_out = torch.matmul(p, v)


### PR DESCRIPTION
(Updated for FlashAttention-2.)

This adds support for optional additive attention masks to the FlashAttention kernel, enabling usage of ALiBi position embeddings with the Triton FlashAttention kernel. The implementation allows masks to be broadcast in any dimension. The usage of a constexpr that selects mask usage leads to full backward-compatibility (except that I did not insert the `mask` argument after `sequence_parallel`, although I can move that, of course), even considering performance if no mask is supplied.

This supports attention masks in any shapes between 1 and 4 dimensions. Any dimensions of size 1 are expanded to `[batch, nhead, seq_len_q, seq_len_k]`.
Depending on the shape, the attention mask is broadcast in the missing dimensions.

The masks work transparently with the `IS_CAUSAL` flag, where the mask is used if given but gives priority to `IS_CAUSAL`. This means for example if `causal=True` is given, the additive attention mask will never make the result non-causal.

I haven't updated the tutorial implementation with this since it seemed unfitting for a tutorial.

### Performance

On a 40GB A100, I reach  98–55 % performance in the non-causal forward pass when using a mask compared to not using one, 78–61 % in the causal forward pass, and 62–61 % in the backward pass. The values get worse as the sequence length increases, indicating that scaling in the sequence dimension when using the mask does not work so well.

<details>

<summary>Benchmarks</summary>

For runs that are `masked`, I used a causal mask with shape `[seq_len, seq_len]`. Note that I did no tuning on block sizes, number of warps, etc.

```
fused-attention-batch4-head48-d32-fwd:
     N_CTX      Triton     Flash-2
0   1024.0   99.792695  119.550929
1   2048.0  140.728315  136.184688
2   4096.0  147.558037  140.860409
3   8192.0  147.798234  141.462715
4  16384.0  147.342743  141.890673
fused-attention-batch4-head48-d32-fwd-masked:
     N_CTX      Triton     Flash-2
0   1024.0   97.026727  119.844292
1   2048.0  108.415044  136.084480
2   4096.0  111.815609  141.146063
3   8192.0   85.601567  142.710783
4  16384.0   81.323063  142.691578
fused-attention-batch4-head48-d32-fwd-causal:
     N_CTX      Triton     Flash-2
0   1024.0   82.320584   93.111912
1   2048.0  101.477992  119.153502
2   4096.0  112.601324  132.373686
3   8192.0  118.487554  138.178212
4  16384.0  121.473593  141.384384
fused-attention-batch4-head48-d32-fwd-causal-masked:
     N_CTX     Triton       Flash-2
0   1024.0  64.063979   92.668605
1   2048.0  79.065491  119.234299
2   4096.0  86.131246  132.393245
3   8192.0  73.626376  137.986429
4  16384.0  73.873162  141.468732
fused-attention-batch4-head48-d32-bwd:
     N_CTX     Triton     Flash-2
0   1024.0  66.163093   91.742602
1   2048.0  69.443098  111.485633
2   4096.0  74.048491  124.545976
3   8192.0  76.427802  130.971936
4  16384.0  78.143690  133.098730
fused-attention-batch4-head48-d32-bwd-masked:
     N_CTX     Triton     Flash-2
0   1024.0  40.410264   91.667270
1   2048.0  43.517003  111.461513
2   4096.0  46.030034  124.554674
3   8192.0  46.237564  131.203599
4  16384.0  46.934056  133.000807
fused-attention-batch4-head48-d32-bwd-seqparallel:
     N_CTX     Triton     Flash-2
0   1024.0  49.150620   91.667714
1   2048.0  54.392641  111.456156
2   4096.0  57.175038  124.533592
3   8192.0  57.684661  131.180096
4  16384.0  57.600431  131.692158
fused-attention-batch4-head48-d32-bwd-seqparallel-masked:
     N_CTX     Triton     Flash-2
0   1024.0  34.510287   91.651080
1   2048.0  37.738370  111.476871
2   4096.0  39.349908  124.458280
3   8192.0  39.702376  130.982332
4  16384.0  39.575782  133.112139
fused-attention-batch4-head48-d32-bwd-causal:
     N_CTX     Triton     Flash-2
0   1024.0  51.449924   64.805640
1   2048.0  61.277668   88.160691
2   4096.0  67.753134  106.858607
3   8192.0  72.545272  119.435274
4  16384.0  74.812593  126.844498
fused-attention-batch4-head48-d32-bwd-causal-masked:
     N_CTX     Triton     Flash-2
0   1024.0  31.536418   64.775626
1   2048.0  37.781047   88.174499
2   4096.0  42.392492  106.857709
3   8192.0  44.675565  119.425535
4  16384.0  46.117187  126.823140
fused-attention-batch4-head48-d32-bwd-causal-seqparallel:
     N_CTX     Triton     Flash-2
0   1024.0  36.892260   64.786334
1   2048.0  42.892722   88.173744
2   4096.0  46.484240  106.901241
3   8192.0  47.752703  119.388045
4  16384.0  47.850842  126.824703
fused-attention-batch4-head48-d32-bwd-causal-seqparallel-masked:
     N_CTX     Triton     Flash-2
0   1024.0  28.725072   64.788020
1   2048.0  33.329620   88.176808
2   4096.0  36.142402  106.863171
3   8192.0  37.157810  119.398741
4  16384.0  37.426767  126.822456
```

</details>