### PR TITLE
Hot fix for AOT

### DIFF
--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -156,8 +156,6 @@ def test_compile_link_matmul():
 
         # link all desired configs
         h_files = glob.glob(os.path.join(tmp_dir, "*.h"))
-        print('h_files', h_files)
-        print(' '.join([sys.executable, linker_path] + h_files + ["-o", "kernel"]))
         subprocess.run([sys.executable, linker_path] + h_files + ["-o", "kernel"], check=True, cwd=tmp_dir)
 
         # compile test case

--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -131,7 +131,6 @@ def test_compile_link_matmul():
     np.random.seed(3)
 
     with tempfile.TemporaryDirectory() as tmp_dir:
-        tmp_dir = "/home/chunwei/project/triton/python/test/unit/tools/out2"
         kernel_path = os.path.join(tmp_dir, "kernel.py")
         with open(kernel_path, "w") as file:
             file.write(kernel_src)

--- a/python/test/unit/tools/test_aot.py
+++ b/python/test/unit/tools/test_aot.py
@@ -153,7 +153,7 @@ def test_compile_link_matmul():
             for hb in hints:
                 sig = f'*fp32:16, *{dtype}:16, *{dtype}:16, i32{ha}, 1, i32{hb}, 1, i32:16, 1, {BM}, {BN}, {BK}'
                 name = f"matmul_{dtype}x{dtype}_{BM}x{BN}x{BK}"
-                subprocess.run([sys.executable, compiler_path, "-n", "kernel", "--signature", sig, "--out-name", name, "-o", name, kernel_path], check=True, cwd=tmp_dir)
+                subprocess.run([sys.executable, compiler_path, "-n", "kernel", "--signature", sig, "--out-name", name, "-o", name, "-w", 1, kernel_path], check=True, cwd=tmp_dir)
 
         # link all desired configs
         h_files = glob.glob(os.path.join(tmp_dir, "*.h"))

--- a/python/triton/tools/compile.c
+++ b/python/triton/tools/compile.c
@@ -41,7 +41,7 @@ void load_{kernel_name}() {{
     void *bin = (void *)&CUBIN_NAME;
     int shared = {shared};
     CUDA_CHECK(cuModuleLoadData(&{kernel_name}_mod, bin));
-    CUDA_CHECK(cuModuleGetFunction(&{kernel_name}_func, {kernel_name}_mod, "{kernel_name}"));
+    CUDA_CHECK(cuModuleGetFunction(&{kernel_name}_func, {kernel_name}_mod, "{triton_kernel_name}"));
     // set dynamic shared memory if necessary
     int shared_optin;
     CUDA_CHECK(cuDeviceGetAttribute(&shared_optin, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, dev));

--- a/python/triton/tools/compile.c
+++ b/python/triton/tools/compile.c
@@ -54,11 +54,11 @@ void load_{kernel_name}() {{
 /*
 {kernel_docstring}
 */
-CUresult {kernel_name}(CUstream stream, unsigned int gX,unsigned int gY,unsigned int gZ,unsigned int numWarps, {signature}) {{
+CUresult {kernel_name}(CUstream stream, unsigned int gX, unsigned int gY, unsigned int gZ, {signature}) {{
     if ({kernel_name}_func == NULL)
        load_{kernel_name}();
     void *args[{num_args}] = {{ {arg_pointers} }};
     // TODO: shared memory
     if(gX * gY * gZ > 0)
-      return cuLaunchKernel({kernel_name}_func, gX, gY, gZ, numWarps * 32, 1, 1, {shared}, stream, args, NULL);
+      return cuLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * 32, 1, 1, {shared}, stream, args, NULL);
 }}

--- a/python/triton/tools/compile.h
+++ b/python/triton/tools/compile.h
@@ -12,4 +12,4 @@ void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
 // tt-linker: {kernel_name}:{signature}
 CUresult{kernel_name}(CUstream stream, unsigned int gX, unsigned int gY,
-                      unsigned int gZ, unsigned int numWarps, {signature});
+                      unsigned int gZ, {signature});

--- a/python/triton/tools/compile.h
+++ b/python/triton/tools/compile.h
@@ -11,5 +11,6 @@
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
 // tt-linker: {kernel_name}:{signature}
-CUresult{kernel_name}(CUstream stream, unsigned int gX, unsigned int gY,
-                      unsigned int gZ, {signature});
+CUresult{_placeholder} {kernel_name}(CUstream stream, unsigned int gX,
+                                     unsigned int gY, unsigned int gZ,
+                                     {signature});

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -107,6 +107,7 @@ if __name__ == "__main__":
         "num_args": len(arg_names),
         "kernel_docstring": "",
         "shared": ccinfo.shared,
+        "num_warps": args.num_warps,
     }
     for ext in ['h', 'c']:
         template_path = Path(__file__).parent / f"compile.{ext}"

--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -61,7 +61,6 @@ if __name__ == "__main__":
 
     # validate and parse signature
     signature = list(map(lambda s: s.strip(" "), args.signature.split(",")))
-    print('signature', signature)
 
     def hash_signature(signature: List[str]):
         m = hashlib.sha256()


### PR DESCRIPTION
This PR addresses the following issues encountered when using AOT kernels in our project:

1. When different signatures are set for the same Triton kernel, it can result in C functions with the same name. This is problematic because C does not support function overloading.

2. Currently, the AOT kernel always compiles with `num_warps=1`, as indicated [here](https://github.com/openai/triton/pull/1939/files#diff-293af646f671d3a895c453a8b175754e9d4ec4fc855bb939ffa4d6e9e91b07c6L83). However, the generated function includes a `numWarps` argument, which can cause errors when the specified value does not match.

To resolve these issues, this PR does the following modifications:

1. Adds an 8-char hash key as a suffix to the generated function's signature. This ensures that different function names are generated in C when the argument dtype or constexpr value or even hint differs since we hope these kernels could be used in one C/C++ library.

2. Introduces a new flag called `num-warps` that allows manual specification of the `numWarps` value for AOT. This change hardcodes the specified value into the generated kernel.c and removes the `numWarps` argument from the generated function.
