### PR TITLE
[BACKEND] Fix build error assignment of `BroadcastOp` in conditional

### DIFF
--- a/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
+++ b/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
@@ -143,7 +143,8 @@ struct MoveBroadcastAfterElementwisePattern
     auto operands = op->getOperands();
     triton::BroadcastOp broadcastOp;
     for (auto operand : operands) {
-      if (broadcastOp = operand.getDefiningOp<triton::BroadcastOp>()) {
+      broadcastOp = operand.getDefiningOp<triton::BroadcastOp>();
+      if (broadcastOp) {
         break;
       }
     }


### PR DESCRIPTION
Fix for current build error on main by assigning before if conditional: 
```shell
      /usr/local/home/kooljblack/Code/triton/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp:146:23: error: using the result of an assignment as a condition without parentheses [-Werror,-Wparentheses]
            if (broadcastOp = operand.getDefiningOp<triton::BroadcastOp>()) {
                ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      /usr/local/home/kooljblack/Code/triton/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp:146:23: note: place parentheses around the assignment to silence this warning
            if (broadcastOp = operand.getDefiningOp<triton::BroadcastOp>()) {
                            ^
                (                                                         )
      /usr/local/home/kooljblack/Code/triton/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp:146:23: note: use '==' to turn this assignment into an equality comparison
            if (broadcastOp = operand.getDefiningOp<triton::BroadcastOp>()) {
                            ^
                            ==
      1 error generated.
```