### PR TITLE
[WIP] Move the default num_warps and num_stage setting from JITFunction to triton.compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ include_directories(${PROJECT_BINARY_DIR}/include) # Tablegen'd files
 # link_directories(${LLVM_LIBRARY_DIR})
 add_subdirectory(include)
 add_subdirectory(lib)
-add_subdirectory(bin)
+#add_subdirectory(bin)
 
 # find_package(PythonLibs REQUIRED)
 set(TRITON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
@@ -273,6 +273,6 @@ if (${CODEGEN_BACKENDS_LEN} GREATER 0)
   endforeach()
 endif()
 
-add_subdirectory(test)
+#add_subdirectory(test)
 
-add_subdirectory(unittest)
+#add_subdirectory(unittest)

--- a/python/setup.py
+++ b/python/setup.py
@@ -93,7 +93,8 @@ def get_llvm_package_info():
 
 
 def get_thirdparty_packages(triton_cache_path):
-    packages = [get_pybind11_package_info(), get_llvm_package_info()]
+    # packages = [get_pybind11_package_info(), get_llvm_package_info()]
+    packages = []
     thirdparty_cmake_args = []
     for p in packages:
         package_root_dir = os.path.join(triton_cache_path, p.package)
@@ -266,7 +267,10 @@ class CMakeBuild(build_ext):
 
         env = os.environ.copy()
         cmake_dir = self.get_cmake_dir()
-        subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=cmake_dir, env=env)
+        # subprocess.check_call(["cmake", self.base_dir] + cmake_args, cwd=cmake_dir, env=env)
+        print(["cmake", self.base_dir] + cmake_args)
+        print(cmake_dir)
+        print(["cmake", "--build", "."] + build_args)
         subprocess.check_call(["cmake", "--build", "."] + build_args, cwd=cmake_dir)
 
 

--- a/python/triton/compiler/__init__.py
+++ b/python/triton/compiler/__init__.py
@@ -1,4 +1,4 @@
-from .compiler import CompiledKernel, compile, instance_descriptor
+from .compiler import CompiledKernel, compile, instance_descriptor, get_architecture_num_warps, get_architecture_num_stages
 from .errors import CompilationError
 
-__all__ = ["compile", "instance_descriptor", "CompiledKernel", "CompilationError"]
+__all__ = ["compile", "instance_descriptor", "CompiledKernel", "CompilationError", "get_architecture_num_warps", "get_architecture_num_stages"]


### PR DESCRIPTION
### Background
The Triton JITFunction set the default num_warps and num_stages for all device backends. It may not be best configuration for different device backends.

### Changes
Remove the default num_warps and num_stage in JITFunction. The triton.compile automatically chose the default value based on the device backends architecture information with proper setting.