### PR TITLE
Remove unnecessary lit command from combine.mlir

### DIFF
--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -1,4 +1,3 @@
-// RUN: triton-opt %s -split-input-file -canonicalize -triton-combine
 // RUN: triton-opt %s -split-input-file -canonicalize -triton-combine | FileCheck %s
 
 // CHECK-LABEL: @test_combine_dot_add_pattern


### PR DESCRIPTION
The only difference between the two RUNs is `FileCheck`, which should be needed.