### PR TITLE
AxisInfoVisitor for LoadOp constancy calculation

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -469,8 +469,7 @@ public:
   }
 };
 
-class LoadOpAxisInfoVisitor final
-    : public AxisInfoVisitorImpl<triton::LoadOp> {
+class LoadOpAxisInfoVisitor final : public AxisInfoVisitorImpl<triton::LoadOp> {
 public:
   using AxisInfoVisitorImpl<triton::LoadOp>::AxisInfoVisitorImpl;
 
@@ -492,8 +491,8 @@ public:
       contiguity.push_back(1);
       divisibility.push_back(1);
       constancy.push_back(
-        gcd(ptrInfo.getConstancy(d),
-            maskInfo.has_value() ? maskInfo->getConstancy(d) : 0));
+          gcd(ptrInfo.getConstancy(d),
+              maskInfo.has_value() ? maskInfo->getConstancy(d) : 0));
     }
 
     return AxisInfo(contiguity, divisibility, constancy);

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -480,7 +480,10 @@ public:
     // If pointers and mask both have constancy properties, those properties
     // will also extend to output.
     AxisInfo ptrInfo = operands[0]->getValue();
-    AxisInfo maskInfo = operands[1]->getValue();
+    std::optional<AxisInfo> maskInfo;
+    if (operands.size() > 1) {
+      maskInfo = operands[1]->getValue();
+    }
     AxisInfo::DimVectorT contiguity;
     AxisInfo::DimVectorT divisibility;
     AxisInfo::DimVectorT constancy;
@@ -488,7 +491,9 @@ public:
     for (int d = 0; d < ptrInfo.getRank(); ++d) {
       contiguity.push_back(1);
       divisibility.push_back(1);
-      constancy.push_back(gcd(ptrInfo.getConstancy(d), maskInfo.getConstancy(d)));
+      constancy.push_back(
+        gcd(ptrInfo.getConstancy(d),
+            maskInfo.has_value() ? maskInfo->getConstancy(d) : 0));
     }
 
     return AxisInfo(contiguity, divisibility, constancy);

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -469,6 +469,32 @@ public:
   }
 };
 
+class LoadOpAxisInfoVisitor final
+    : public AxisInfoVisitorImpl<triton::LoadOp> {
+public:
+  using AxisInfoVisitorImpl<triton::LoadOp>::AxisInfoVisitorImpl;
+
+  AxisInfo
+  getAxisInfo(triton::LoadOp op,
+              ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
+    // If pointers and mask both have constancy properties, those properties
+    // will also extend to output.
+    AxisInfo ptrInfo = operands[0]->getValue();
+    AxisInfo maskInfo = operands[1]->getValue();
+    AxisInfo::DimVectorT contiguity;
+    AxisInfo::DimVectorT divisibility;
+    AxisInfo::DimVectorT constancy;
+
+    for (int d = 0; d < ptrInfo.getRank(); ++d) {
+      contiguity.push_back(1);
+      divisibility.push_back(1);
+      constancy.push_back(gcd(ptrInfo.getConstancy(d), maskInfo.getConstancy(d)));
+    }
+
+    return AxisInfo(contiguity, divisibility, constancy);
+  }
+};
+
 class ExpandDimsOpAxisInfoVisitor final
     : public AxisInfoVisitorImpl<triton::ExpandDimsOp> {
 public:
@@ -871,6 +897,7 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
                   MaxMinOpAxisInfoVisitor<arith::MaxUIOp>,
                   MaxMinOpAxisInfoVisitor<arith::MinSIOp>,
                   MaxMinOpAxisInfoVisitor<arith::MinUIOp>>();
+  visitors.append<LoadOpAxisInfoVisitor>();
 }
 
 void AxisInfoAnalysis::visitOperation(


### PR DESCRIPTION
If you call `result = load(x, mask)` where `x` and `mask` have some constancy properties, then you can infer some constancy properties for `result`.