### PR TITLE
[BACKEND] Fix crash in reductions on i1

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -174,7 +174,7 @@ unsigned ReduceOpHelper::getScratchSizeInBytes() {
 
   unsigned bytesPerElem = 0;
   for (const auto &ty : srcElementTypes) {
-    bytesPerElem += ty.getIntOrFloatBitWidth() / 8;
+    bytesPerElem += ceil<unsigned>(ty.getIntOrFloatBitWidth(), 8);
   }
   return bytesPerElem * elems;
 }


### PR DESCRIPTION
`getScratchSizeInBytes` was assuming that the size of all types in bits is
a multiple of 8. If it is not, it would return 0. This caused a bug for boolean
(i1) type, where the reduction lowering would attempt to use shared memory,
which was not assigned to the op.

Fix this issue by setting the number of bytes per element to `ceil(bits / 8)`.