### PR TITLE
[BACKEND] Support MMA V3 with float16 accumulator

### DIFF
--- a/include/triton/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/include/triton/Dialect/NVGPU/IR/NVGPUOps.td
@@ -344,15 +344,6 @@ def NVGPU_Sts64Op : NVGPU_Op<"sts64", [MemoryEffects<[MemWrite]>]> {
   }];
 }
 
-def NVGPU_CvtPackOp : NVGPU_Op<"cvt_pack", []> {
-  let arguments = (ins AnyTypeOf<[F16, I16]>:$d0, AnyTypeOf<[F16, I16]>:$d1);
-  let results = (outs I32:$result);
-  let assemblyFormat = "operands attr-dict `:` type(operands) `->` type($result)";
-  string llvmBuilder = [{
-    $result = createCvtPack(builder, $d0, $d1);
-  }];
-}
-
 def NVGPU_ClusterCTAIdOp : NVGPU_Op<"cluster_id", [Pure]> {
   let results = (outs I32:$result);
   let assemblyFormat = "attr-dict";

--- a/lib/Dialect/NVGPU/ToLLVMIR/NVGPUToLLVMIR.cpp
+++ b/lib/Dialect/NVGPU/ToLLVMIR/NVGPUToLLVMIR.cpp
@@ -326,8 +326,7 @@ llvm::Value *createWGMMA(llvm::IRBuilderBase &builder, uint32_t m, uint32_t n,
   uint32_t asmOpIdx = 0;
 
   // Operand C
-  uint32_t numCRegs = m * n / 128;
-  assert(numCRegs == structTypeC->getStructNumElements());
+  uint32_t numCRegs = structTypeC->getStructNumElements();
   asmOs << "{";
   for (uint32_t i = 0; i < numCRegs; ++i) {
     argTypes.push_back(structTypeC->getElementType(i));
@@ -335,7 +334,7 @@ llvm::Value *createWGMMA(llvm::IRBuilderBase &builder, uint32_t m, uint32_t n,
     asmOs << "$" << asmOpIdx++ << (i == numCRegs - 1 ? "" : ",");
     // LLVM does not support `+` semantic, we must repeat the arguments for both
     // input and outputs
-    if (structTypeC->getElementType(0)->isFloatTy())
+    if (structTypeC->getElementType(i)->isFloatTy())
       conOs << "=f,";
     else
       conOs << "=r,";

--- a/lib/Dialect/NVGPU/ToLLVMIR/NVGPUToLLVMIR.cpp
+++ b/lib/Dialect/NVGPU/ToLLVMIR/NVGPUToLLVMIR.cpp
@@ -705,26 +705,6 @@ void createSts64(llvm::IRBuilderBase &builder, llvm::Value *offset,
   return;
 }
 
-llvm::Value *createCvtPack(llvm::IRBuilderBase &builder, llvm::Value *d0,
-                           llvm::Value *d1) {
-  std::string funcName("__nv_cvt_pack");
-
-  llvm::Type *retTy = builder.getInt32Ty();
-  llvm::SmallVector<llvm::Value *> args;
-  llvm::SmallVector<llvm::Type *> argTys;
-  auto i16Ty = builder.getInt16Ty();
-
-  argTys.push_back(i16Ty);
-  args.push_back(builder.CreateBitCast(d0, i16Ty));
-  argTys.push_back(i16Ty);
-  args.push_back(builder.CreateBitCast(d1, i16Ty));
-
-  auto *module = builder.GetInsertBlock()->getModule();
-  auto *func = dyn_cast<llvm::Function>(
-      getExternalFuncOP(module, funcName, retTy, argTys).getCallee());
-  return builder.CreateCall(func, args);
-}
-
 static llvm::Value *getSRegValue(llvm::IRBuilderBase &builder,
                                  llvm::StringRef name) {
   std::string ptxStr;

--- a/lib/Hopper/HopperHelpers.c
+++ b/lib/Hopper/HopperHelpers.c
@@ -501,12 +501,3 @@ __nv_offset_of_sts64(uint32_t threadIdx, uint32_t rowOfWarp, int32_t elemIdx,
 
   return offset;
 }
-
-__DEVICE__ __attribute__((__always_inline__)) uint32_t
-__nv_cvt_pack(uint16_t d0, uint16_t d1) {
-  uint32_t ret;
-  asm volatile("cvt.pack.sat.u16.s32 %0, %1, %2;\n"
-               : "=r"(ret)
-               : "r"(d0), "r"(d1));
-  return ret;
-}

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2139,9 +2139,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
         if out_dtype == 'float16':
             # TODO: support out_dtype=float16 for tl.dot on V100
             pytest.skip("Only test out_dtype=float16 on devices with sm >=80")
-    if capability[0] == 9 and out_dtype == 'float16':
-        # TODO: support out_dtype=float16 for tl.dot on H100
-        pytest.skip("Only test out_dtype=float16 on devices with sm<90")
 
     torch.backends.cuda.matmul.allow_tf32 = allow_tf32
 
@@ -2297,7 +2294,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
     elif in_dtype == 'float16' and out_dtype == tl.float32:
         assert re.search(r'[mma|wgmma.mma_async].sync.aligned.m\d+n\d+k16(?:.row.col)?.f32.f16.f16', ptx)
     elif in_dtype == 'float16' and out_dtype == tl.float16:
-        assert 'mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16' in ptx
+        assert re.search(r'[mma|wgmma.mma_async].sync.aligned.m\d+n\d+k16(?:.row.col)?.f16.f16.f16', ptx)
     elif in_dtype == 'int8':
         assert 'wgmma.mma_async.sync.aligned' in ptx or\
             'mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32' in ptx


### PR DESCRIPTION
Also fixes a bug exposed in convertLayout lowering for float16. We shouldn't be using cvt.pack.sat.u16.s32 to pack 16bits values as this needs to take a 32bits register. Also this prevented optimization at llvm ir level.