### PR TITLE
[BACKEND] Remove invalid indexCast ops

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -404,7 +404,7 @@ struct GetProgramIdOpConversion
     sreg.append(1, 'x' + op.getAxisAsInt()); // 0 -> 'x', 1 -> 'y', 2 -> 'z'
 
     Value programId = getSRegValue(rewriter, loc, sreg);
-    rewriter.replaceOpWithNewOp<arith::IndexCastOp>(op, i32_ty, programId);
+    rewriter.replaceOp(op, programId);
     return success();
   }
 };
@@ -431,7 +431,7 @@ struct GetNumProgramsOpConversion
     sreg.append(1, 'x' + op.getAxis()); // 0 -> 'x', 1 -> 'y', 2 -> 'z'
 
     Value numPrograms = getSRegValue(rewriter, loc, sreg);
-    rewriter.replaceOpWithNewOp<arith::IndexCastOp>(op, i32_ty, numPrograms);
+    rewriter.replaceOp(op, numPrograms);
     return success();
   }
 };

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -295,10 +295,7 @@ Value getSRegValue(OpBuilder &b, Location loc, const std::string &sRegStr) {
   auto *sRegOpr = builder.newConstantOperand(sRegStr);
   mov(destOpr, sRegOpr);
   Value val = builder.launch(b, loc, b.getIntegerType(32), false);
-
-  auto cast = b.create<UnrealizedConversionCastOp>(
-      loc, TypeRange{b.getIntegerType(32)}, ValueRange{val});
-  return cast.getResult(0);
+  return val;
 }
 
 Value addStringToModule(Location loc, ConversionPatternRewriter &rewriter,


### PR DESCRIPTION
This was causing the IR to fail verification in the intermediate steps. Also remove another unnecessary cast.