### PR TITLE
[TritonGPUToLLVM] Correct the usage of option passing

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Passes.td
+++ b/include/triton/Conversion/TritonGPUToLLVM/Passes.td
@@ -27,7 +27,7 @@ def ConvertTritonGPUToLLVM : Pass<"convert-triton-gpu-to-llvm", "mlir::ModuleOp"
         Option<"computeCapability", "compute-capability",
                "int32_t", /*default*/"80",
                "device compute capability">,
-        Option<"TmaMetadata", "tma-metadata",
+        Option<"tmaMetadata", "tma-metadata",
                "mlir::triton::gpu::TMAMetadataTy*", /*default*/"nullptr",
                "tma metadata to the runtime">,
         Option<"isROCM", "is-rocm",

--- a/include/triton/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.h
@@ -14,10 +14,12 @@ template <typename T> class OperationPass;
 
 namespace triton {
 
-std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonGPUToLLVMPass(
-    int computeCapability = 80,
-    mlir::triton::gpu::TMAMetadataTy *tmaMetadata = nullptr,
-    bool isROCM = false);
+#define GEN_PASS_DECL
+#include "triton/Conversion/TritonGPUToLLVM/Passes.h.inc"
+
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonGPUToLLVMPass();
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertTritonGPUToLLVMPass(const ConvertTritonGPUToLLVMOptions &options);
 
 } // namespace triton
 

--- a/lib/Target/LLVMIR/LLVMIRTranslation.cpp
+++ b/lib/Target/LLVMIR/LLVMIRTranslation.cpp
@@ -351,7 +351,7 @@ translateTritonGPUToLLVMIR(llvm::LLVMContext *llvmContext,
   pm.addPass(mlir::createConvertSCFToCFPass());
   pm.addPass(mlir::createConvertIndexToLLVMPass());
   pm.addPass(
-      createConvertTritonGPUToLLVMPass(computeCapability, &tmaInfos, isROCM));
+      createConvertTritonGPUToLLVMPass({computeCapability, &tmaInfos, isROCM}));
   pm.addPass(createConvertNVGPUToLLVMPass());
   pm.addPass(mlir::createArithToLLVMConversionPass());
   pm.addPass(mlir::createCanonicalizerPass());


### PR DESCRIPTION
For example, when given `--convert-triton-gpu-to-llvm="is-rocm=true"`, `ConvertTritonGPUToLLVMPass` should generate ROCM-compatible LLVM. Before this PR, transformation options passed in command line are not respected.