### PR TITLE
[OPTIMIZER] Fix Warp Specialized kernel launch failure

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/WSPipeline.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/WSPipeline.cpp
@@ -173,6 +173,10 @@ scf::ForOp appendPipelineIdxToLoopArgs(scf::ForOp forOp, int numStages,
     initValue = parentForOp.getBody()->getArguments().back();
     Value numSteps = builder.createWithAgentIds<arith::SubIOp>(
         loc, forOp.getUpperBound(), forOp.getLowerBound());
+    auto one = builder.createWithAgentIds<arith::ConstantIntOp>(loc, 1, 32);
+    numSteps = builder.createWithAgentIds<arith::AddIOp>(loc, numSteps,
+                                                         forOp.getStep());
+    numSteps = builder.createWithAgentIds<arith::SubIOp>(loc, numSteps, one);
     numSteps = builder.createWithAgentIds<arith::DivUIOp>(loc, numSteps,
                                                           forOp.getStep());
     initValue =

--- a/python/test/unit/hopper/test_persistent_warp_specialized_gemm.py
+++ b/python/test/unit/hopper/test_persistent_warp_specialized_gemm.py
@@ -701,6 +701,7 @@ def full_static_persistent_matmul_kernel(
                                  # bad from cublas-important-layers
                                  [4096, 1, 1024, False, False],
                                  [2048, 204, 1000, True, False],
+                                 [16, 524288, 32, False, True],
                              ]
                              for out_dtype in ['float16', 'float32']
                              for use_tma_store in [False, True]


### PR DESCRIPTION
For warp specialized persistent kernel, the instruction sequence for Warp Groups are
```
// warp group 0
for wave in 0..num_waves:
    idx = wave * num_inner_loop_steps;
    for k_tile_idx in 0..num_k_tiles:
        mbarrier.wait EB[idx];
        W0;
        mbarrier.arrive FB[idx];
        idx++;
```
```
// warp group 1
for wave in 0..num_waves:
    idx = wave * num_inner_loop_steps;
    for k_tile_idx in 0..num_k_tiles:
        mbarrier.wait FB[idx];
        R0;
        mbarrier.arrive EB[idx];
        idx++;
```
then this would form a sequence of morally-strong relations W0 -> R0 -> W1 -> R1 in causality order.
But if GEMM K is small than K-TileShape, then the num_inner_loop_steps of persistent kernel is 0. The buffer id and mbarrier id will always be 0 in this case. And it may form W0 -> W1 -> R0 -> R1 order, which is contradicts with the atomicity --
"If a read R precedes an overlapping write W in causality order, then R cannot read from W."