### PR TITLE
[FRONTEND] Fix benchmark plotting

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 from contextlib import contextmanager
+from typing import Any, Dict, List
 
 from . import language as tl
 from ._C.libtriton.triton import runtime
@@ -201,37 +202,41 @@ class Benchmark:
 
     def __init__(
         self,
-        x_names,
-        x_vals,
-        line_arg,
-        line_vals,
-        line_names,
-        plot_name,
-        args,
-        xlabel='',
-        ylabel='',
-        x_log=False,
-        y_log=False,
+        x_names: List[str],
+        x_vals: List[Any],
+        line_arg: str,
+        line_vals: List[Any],
+        line_names: List[str],
+        plot_name: str,
+        args: Dict[str, Any],
+        xlabel: str = '',
+        ylabel: str = '',
+        x_log: bool = False,
+        y_log: bool = False,
         color=None,
         styles=None,
     ):
         """
-        Constructor
+        Constructor.
+        x_vals can be a list of scalars or a list of tuples/lists. If x_vals is a list
+        of scalars and there are multiple x_names, all arguments will have the same value.
+        If x_vals is a list of tuples/lists, each element should have the same length as
+        x_names.
 
-        :param x_names: Name of the arguments that should appear on the x axis of the plot. If the list contains more than one element, all the arguments are assumed to have the same value.
+        :param x_names: Name of the arguments that should appear on the x axis of the plot.
         :type x_names: List[str]
         :param x_vals: List of values to use for the arguments in :code:`x_names`.
         :type x_vals: List[Any]
         :param line_arg: Argument name for which different values correspond to different lines in the plot.
         :type line_arg: str
         :param line_vals: List of values to use for the arguments in :code:`line_arg`.
-        :type line_vals: List[str]
+        :type line_vals: List[Any]
         :param line_names: Label names for the different lines.
         :type line_names: List[str]
         :param plot_name: Name of the plot.
         :type plot_name: str
-        :param args: List of arguments to remain fixed throughout the benchmark.
-        :type args: List[str]
+        :param args: Dictionary of keyword arguments to remain fixed throughout the benchmark.
+        :type args: Dict[str, Any]
         :param xlabel: Label for the x axis of the plot.
         :type xlabel: str, optional
         :param ylabel: Label for the y axis of the plot.
@@ -261,7 +266,7 @@ class Mark:
         self.fn = fn
         self.benchmarks = benchmarks
 
-    def _run(self, bench, save_path, show_plots, print_data):
+    def _run(self, bench: Benchmark, save_path: str, show_plots: bool, print_data: bool):
         import os
 
         import matplotlib.pyplot as plt
@@ -269,15 +274,17 @@ class Mark:
         y_mean = bench.line_names
         y_min = [f'{x}-min' for x in bench.line_names]
         y_max = [f'{x}-max' for x in bench.line_names]
-        x_names_str = str(bench.x_names)
-        df = pd.DataFrame(columns=[x_names_str] + y_mean + y_min + y_max)
+        x_names = list(bench.x_names)
+        df = pd.DataFrame(columns=x_names + y_mean + y_min + y_max)
         for x in bench.x_vals:
-            if not isinstance(x, list):
-                x = [x]
-            if len(x) == 1:
-                x = x * len(bench.x_names)
-            x_str = str(x)
-            x_args = {x_name: x_in for x_name, x_in in zip(bench.x_names, x)}
+            # x can be a single value or a sequence of values.
+            if not isinstance(x, (list, tuple)):
+                x = [x for _ in x_names]
+
+            if len(x) != len(x_names):
+                raise ValueError(f"Expected {len(x_names)} values, got {x}")
+            x_args = dict(zip(x_names, x))
+
             row_mean, row_min, row_max = [], [], []
             for y in bench.line_vals:
                 ret = self.fn(**x_args, **{bench.line_arg: y}, **bench.args)
@@ -288,23 +295,24 @@ class Mark:
                 row_mean += [y_mean]
                 row_min += [y_min]
                 row_max += [y_max]
-            df.loc[len(df)] = [x_str] + row_mean + row_min + row_max
+            df.loc[len(df)] = list(x) + row_mean + row_min + row_max
+
         if bench.plot_name:
             plt.figure()
             ax = plt.subplot()
-            x = x_names_str
+            # Plot first x value on x axis if there are multiple.
+            first_x = x_names[0]
             for i, y in enumerate(bench.line_names):
                 y_min, y_max = df[y + '-min'], df[y + '-max']
                 col = bench.styles[i][0] if bench.styles else None
                 sty = bench.styles[i][1] if bench.styles else None
-                ax.plot(df[x], df[y], label=y, color=col, ls=sty)
+                ax.plot(df[first_x], df[y], label=y, color=col, ls=sty)
                 if not y_min.isnull().all() and not y_max.isnull().all():
                     y_min = y_min.astype(float)
                     y_max = y_max.astype(float)
-                    ax.fill_between(df[x], y_min, y_max, alpha=0.15, color=col)
+                    ax.fill_between(df[first_x], y_min, y_max, alpha=0.15, color=col)
             ax.legend()
-            xlabel = bench.xlabel if bench.xlabel else " = ".join(bench.x_names)
-            ax.set_xlabel(xlabel)
+            ax.set_xlabel(bench.xlabel or first_x)
             ax.set_ylabel(bench.ylabel)
             # ax.set_title(bench.plot_name)
             ax.set_xscale("log" if bench.x_log else "linear")
@@ -313,7 +321,7 @@ class Mark:
                 plt.show()
             if save_path:
                 plt.savefig(os.path.join(save_path, f"{bench.plot_name}.png"))
-        df = df[[x_names_str] + bench.line_names]
+        df = df[x_names + bench.line_names]
         if print_data:
             print(bench.plot_name + ':')
             print(df)


### PR DESCRIPTION
# Summary
A [recent PR](https://github.com/openai/triton/pull/2036/files#diff-447aaa7319f4083423e0d1ce5ecbf440e7efe60b5bc527b38f82e982280b98d3) changed the behavior of `triton.testing.Benchmark`, causing the x-axis to be incorrect and the dataframe to contain strings instead of values.
This PR improves the behavior to correctly handle the single `x_name` use case while also supporting the new multiple `x_name` with different values use case. I also added some type annotations and updated the docstring for clarity.

# Testing
To test this I made one vanilla test case that fits the most common single `x_name` pattern, and another from [the use case added in the above-mentioned PR](https://github.com/openai/triton/pull/2036/files#diff-8230ecf751625890f518ea30c064b509c1275be1c3b990a3b621d48aaa854771R149-R174) that required supporting multiple `x_name`s with different values.

## Test code:
```
from testing import *

@perf_report(
    [
        Benchmark(
            x_names=["x"],
            x_vals=list(range(-10, 11)),
            line_arg="positive",
            line_vals=[True, False],
            line_names=["True", "False"],
            styles=[("blue", "-"), ("green", "-")],
            plot_name="foo",
            args={},
        )
    ]
)
def foo(x: float, positive: bool) -> tuple[float, float, float]:
    coeff = 2 if positive else -2
    y = x**2 + coeff * x + 1
    return y, y - 1, y + 1

foo.run(show_plots=True, print_data=True)

@perf_report(
    Benchmark(
        # argument names to use as an x-axis for the plot
        x_names=['M', 'N', 'K'],
        x_vals=[
            [2048, 512, 512],
            [2048, 1024, 1024],
            [2048, 2048, 2048],
            [2048, 4096, 4096],
            [2048, 8192, 8192]
        ],  # different possible values for `x_name`
        line_arg='provider',
        # argument name whose value corresponds to a different line in the plot
        # possible values for `line_arg``
        line_vals=['cublas', 'triton'],
        # label name for the lines
        line_names=["cuBLAS", "Triton"],
        # line styles
        styles=[('green', '-'), ('green', '--'),
                ('blue', '-'), ('blue', '--')],
        ylabel="TFLOPS",  # label name for the y-axis
        plot_name="matmul-performance",
        # name for the plot. Used also as a file name for saving the plot.
        args={},
    )
)
def bar(M, N, K, provider):
    return (M + N + K) * (1 + int(provider == "triton"))

bar.run(show_plots=True, print_data=True)
```

## Previous Behavior
![bad_foo](https://github.com/openai/triton/assets/8582453/f1ba8dbc-e77c-487a-a02a-f4b5f8556e39)
![bad_bar](https://github.com/openai/triton/assets/8582453/2f46e10d-b8b6-4d06-9b75-d20865d89002)

```
foo:
    ['x']  True  False
0   [-10]    81    121
1    [-9]    64    100
2    [-8]    49     81
3    [-7]    36     64
4    [-6]    25     49
5    [-5]    16     36
6    [-4]     9     25
7    [-3]     4     16
8    [-2]     1      9
9    [-1]     0      4
10    [0]     1      1
11    [1]     4      0
12    [2]     9      1
13    [3]    16      4
14    [4]    25      9
15    [5]    36     16
16    [6]    49     25
17    [7]    64     36
18    [8]    81     49
19    [9]   100     64
20   [10]   121     81
matmul-performance:
      ['M', 'N', 'K']  cuBLAS  Triton
0    [2048, 512, 512]    3072    6144
1  [2048, 1024, 1024]    4096    8192
2  [2048, 2048, 2048]    6144   12288
3  [2048, 4096, 4096]   10240   20480
4  [2048, 8192, 8192]   18432   36864
```

## New Behavior
![good_foo](https://github.com/openai/triton/assets/8582453/ac7b028c-933a-4e8a-abaa-e7c3d7c31aef)
![good_bar](https://github.com/openai/triton/assets/8582453/fdf104af-727d-45b2-bdcb-e91ae6d9e9cf)

```
foo:
     x  True  False
0  -10    81    121
1   -9    64    100
2   -8    49     81
3   -7    36     64
4   -6    25     49
5   -5    16     36
6   -4     9     25
7   -3     4     16
8   -2     1      9
9   -1     0      4
10   0     1      1
11   1     4      0
12   2     9      1
13   3    16      4
14   4    25      9
15   5    36     16
16   6    49     25
17   7    64     36
18   8    81     49
19   9   100     64
20  10   121     81
matmul-performance:
        M       N       K   cuBLAS   Triton
0  2048.0   512.0   512.0   3072.0   6144.0
1  2048.0  1024.0  1024.0   4096.0   8192.0
2  2048.0  2048.0  2048.0   6144.0  12288.0
3  2048.0  4096.0  4096.0  10240.0  20480.0
4  2048.0  8192.0  8192.0  18432.0  36864.0
```
