### PR TITLE
Ignore tutorials 09 and 10 when building documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,8 +100,8 @@ sphinx_gallery_conf = {
     'examples_dirs': '../python/tutorials/',
     'gallery_dirs': 'getting-started/tutorials',
     'filename_pattern': '',
-    # XXX: Temporarily disable fused attention tutorial on V100
-    'ignore_pattern': r'__init__\.py',
+    # Disable TMA tutorials, which don't build with sphinx_gallery
+    'ignore_pattern': r'(__init__\.py|09.*\.py|10.*\.py)',
     'within_subsection_order': FileNameSortKey,
     'reference_url': {
         'sphinx_gallery': None,


### PR DESCRIPTION
The documentation currently doesn't build.  If you ignore tutorials 09 and 10 (don't execute in sphinx gallery), it appears to work.

Fixes https://github.com/openai/triton/issues/2171