### PR TITLE
A little better vprintf for debugging

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -687,6 +687,12 @@ void vprintf(StringRef msg, ValueRange args,
   PrintOpConversion::llPrintf(msg, args, rewriter);
 }
 
+void vprintf(ConversionPatternRewriter &rewriter, StringRef msg,
+             const Value& args...) {
+  std::vector<Value> values{args};
+  vprintf(msg, values, rewriter);
+}
+
 void vprintf_array(Value thread, ArrayRef<Value> arr, std::string info,
                    std::string elem_repr, ConversionPatternRewriter &builder) {
   std::string fmt = info + " t-%d ";

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -43,6 +43,9 @@ namespace LLVM {
 void vprintf(StringRef msg, ValueRange args,
              ConversionPatternRewriter &rewriter);
 
+void vprintf(ConversionPatternRewriter &rewriter, StringRef msg,
+             const Value& args...);
+
 void vprintf_array(Value thread, ArrayRef<Value> arr, std::string info,
                    std::string elem_repr, ConversionPatternRewriter &builder);
 


### PR DESCRIPTION
Just as simple as

vprintf(rewriter, "a=%d, b=%d", a, b);

I used it to add runtime prints into the kernel while debugging the compiler.