### PR TITLE
Fix predicate for store tiled op

### DIFF
--- a/lib/Conversion/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/lib/Conversion/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -437,7 +437,7 @@ public:
 
     PTXBuilder ptxBuilder;
     if (dimSize == 2) {
-      auto ptxAsm = "cp.async.bulk.tensor.2d.global.shared::cta.bulk_group"
+      auto ptxAsm = "@$4 cp.async.bulk.tensor.2d.global.shared::cta.bulk_group"
                     "[$0, {$2, $3}], [$1];";
       auto &ptxInstr = *ptxBuilder.create<PTXInstr>(ptxAsm);
 

--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -749,7 +749,7 @@ struct StoreAsyncOpConversion
         typeConverter->convertType(rewriter.getI8Type()), 3);
 
     auto threadId = getThreadId(rewriter, loc);
-    Value pred = icmp_eq(urem(threadId, i32_val(32)), i32_val(0));
+    Value pred = int_val(1, 1);
 
     auto llCoord = getTypeConverter()->unpackLLElements(loc, llDst, rewriter,
                                                         dst.getType());


### PR DESCRIPTION
The predicate of Store Tiled op was not set which caused a lot of perf drop due to duplicated memory traffic in epilogue.