### PR TITLE
Fix GIL handling in error conditions

### DIFF
--- a/python/triton/compiler/make_launcher.py
+++ b/python/triton/compiler/make_launcher.py
@@ -116,7 +116,10 @@ static inline void gpuAssert(CUresult code, const char *file, int line)
       char err[1024] = {{0}};
       strcat(err, prefix);
       strcat(err, str);
+      PyGILState_STATE gil_state;
+      gil_state = PyGILState_Ensure();
       PyErr_SetString(PyExc_RuntimeError, err);
+      PyGILState_Release(gil_state);
    }}
 }}
 

--- a/python/triton/runtime/backends/cuda.c
+++ b/python/triton/runtime/backends/cuda.c
@@ -11,7 +11,10 @@ static inline void gpuAssert(CUresult code, const char *file, int line) {
     char err[1024] = {0};
     strcat(err, prefix);
     strcat(err, str);
+    PyGILState_STATE gil_state;
+    gil_state = PyGILState_Ensure();
     PyErr_SetString(PyExc_RuntimeError, err);
+    PyGILState_Release(gil_state);
   }
 }
 

--- a/python/triton/runtime/backends/hip.c
+++ b/python/triton/runtime/backends/hip.c
@@ -13,7 +13,10 @@ static inline void gpuAssert(hipError_t code, const char *file, int line) {
         const char *str = hipGetErrorString(code);
         char err[1024] = {0};
         snprintf(err, 1024, "%s Code: %d, Messsage: %s", prefix, code, str);
+        PyGILState_STATE gil_state;
+        gil_state = PyGILState_Ensure();
         PyErr_SetString(PyExc_RuntimeError, err);
+        PyGILState_Release(gil_state);
       }
     }
   }


### PR DESCRIPTION
The use of the opaque GIL state APIs should mean that the PyErr_SetString is now safe, regardless of whether the caller has the GIL or not.