### PR TITLE
Add NVGPU Depends to TritonGPU

### DIFF
--- a/lib/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/lib/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -4,6 +4,8 @@ add_mlir_dialect_library(TritonGPUIR
   Types.cpp
 
   DEPENDS
+  NVGPUTableGen
+  NVGPUAttrDefsIncGen
   TritonGPUTableGen
   TritonGPUAttrDefsIncGen
 


### PR DESCRIPTION
NVGPU dialect is part of the TritonGPU IR and the `TritonGPU/IR/Dialect.cpp` includes some NVGPU dialect files as follows. 

```C++
#include "triton/Dialect/NVGPU/IR/Dialect.h"
#include "triton/Dialect/NVGPU/IR/Dialect.cpp.inc"
```

So it makes sense to ensure the `TritonGPUIR` depends on `NVGPU` explicitly just like this PR does. 

In addition, it might trigger a compilation dependency issue as follows w/o this PR if another backend intends to integrate at the TritonGPU IR level.

```
In file included from /project/include/triton/Dialect/TritonGPU/IR/Dialect.h:10,
                 from /project/include/triton/Analysis/Utility.h:7,
                 from /project/lib/Dialect/TritonGPU/IR/Dialect.cpp:7:
/project/include/triton/Dialect/NVGPU/IR/Dialect.h:32:10: fatal error: triton/Dialect/NVGPU/IR/Dialect.h.inc: No such file or directory
   32 | #include "triton/Dialect/NVGPU/IR/Dialect.h.inc"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

cc @EikanWang @chengjunlu 