### PR TITLE
Make sure `getAxisBlockStride` does not return 0

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -317,8 +317,9 @@ unsigned ScanLoweringHelper::getAxisBlockStride() {
   for (unsigned dim : order) {
     if (dim == getAxis())
       return stride;
-    stride *= type.getShape()[dim] /
-              (sizePerThreads[dim] * threadsPerWarp[dim] * warpsPerCTA[dim]);
+    stride *= std::max<unsigned int>(
+        1, type.getShape()[dim] /
+               (sizePerThreads[dim] * threadsPerWarp[dim] * warpsPerCTA[dim]));
   }
   llvm_unreachable("Axis not found in order");
 }

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -317,9 +317,9 @@ unsigned ScanLoweringHelper::getAxisBlockStride() {
   for (unsigned dim : order) {
     if (dim == getAxis())
       return stride;
-    stride *= std::max<unsigned int>(
-        1, type.getShape()[dim] /
-               (sizePerThreads[dim] * threadsPerWarp[dim] * warpsPerCTA[dim]));
+    stride *= ceil<unsigned int>(type.getShape()[dim], sizePerThreads[dim] *
+                                                           threadsPerWarp[dim] *
+                                                           warpsPerCTA[dim]);
   }
   llvm_unreachable("Axis not found in order");
 }

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1750,7 +1750,7 @@ scan_layouts = [
 ]
 
 
-@pytest.mark.parametrize("M, N", [[32, 32], [32, 64], [64, 32]])
+@pytest.mark.parametrize("M, N", [[32, 16], [32, 32], [32, 64], [64, 32]])
 @pytest.mark.parametrize("src_layout", scan_layouts)
 @pytest.mark.parametrize("axis", [0, 1])
 def test_scan_layouts(M, N, src_layout, axis, device):


### PR DESCRIPTION
This can happen when the CTA shape is larger than the tensor shape along the non-axis dim during scanOp lowering.