### PR TITLE
[Build] Fix very minor compilation problems

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -21,8 +21,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "DotOpToLLVM.h"
-#include "Utility.h"
+#include "../DotOpToLLVM.h"
+#include "../Utility.h"
 
 using namespace mlir;
 using namespace mlir::triton;

--- a/python/triton/runtime/backends/cuda.c
+++ b/python/triton/runtime/backends/cuda.c
@@ -330,7 +330,7 @@ static PyObject *memFree(PyObject *self, PyObject *args) {
 // Helper function to convert a Python list to a cuuint64_t array
 static cuuint64_t *list_to_cuuint64_array(PyObject *listObj) {
   Py_ssize_t len = PyList_Size(listObj);
-  cuuint64_t *array = malloc(len * sizeof(cuuint64_t));
+  cuuint64_t *array = (cuuint64_t *)malloc(len * sizeof(cuuint64_t));
   for (Py_ssize_t i = 0; i < len; i++) {
     PyObject *item = PyList_GetItem(listObj, i);
     array[i] = (cuuint64_t)PyLong_AsUnsignedLongLong(item);
@@ -341,7 +341,7 @@ static cuuint64_t *list_to_cuuint64_array(PyObject *listObj) {
 // Helper function to convert a Python list to a cuuint32_t array
 static cuuint32_t *list_to_cuuint32_array(PyObject *listObj) {
   Py_ssize_t len = PyList_Size(listObj);
-  cuuint32_t *array = malloc(len * sizeof(cuuint32_t));
+  cuuint32_t *array = (cuuint32_t *)malloc(len * sizeof(cuuint32_t));
   for (Py_ssize_t i = 0; i < len; i++) {
     PyObject *item = PyList_GetItem(listObj, i);
     array[i] = (cuuint32_t)PyLong_AsUnsignedLong(item);


### PR DESCRIPTION
This PR fixes a few very minor compilation issues found in internal deployment at Meta.  It looks like nit-picking, but it'd be really appreciated if it could be addressed in OSS Triton (to reduce differences from OSS), and we believe these changes are not bad in general.  Neither performance nor functionality is affected by this PR.

1. Type cast in `python/triton/runtime/backends/cuda.c`. Implicit `void *` -> `cuuint{32,64}_t *` cast is not allowed by many compilers (with certain flags).  It'd be nice to add an explicit cast (like `backends/hip.c`).

2. Inconsistent include path specification in `lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/WGMMA.cpp`.  Unlike other `DotOpToLLVM/*.cpp`, include paths used in `WGMMA.cpp` are not relative.  This is problematic in some compilation settings since a compiler somehow needs to find headers in a parent directory.  It'd be great to use a relative path, like other source files in Triton.

cc: @yuguo68 
