### PR TITLE
[NFC] Create explicit conversion pattern for ExternElementwiseOp in TT->TTGPU pass

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -600,6 +600,24 @@ struct TritonScanReturnPattern
   }
 };
 
+struct TritonExternElementwisePattern
+    : public OpConversionPattern<triton::ExternElementwiseOp> {
+  using OpConversionPattern<triton::ExternElementwiseOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      triton::ExternElementwiseOp op,
+      typename triton::ExternElementwiseOp::Adaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type retType = this->getTypeConverter()->convertType(op.getType());
+    addNamedAttrs(
+        rewriter.replaceOpWithNewOp<triton::ExternElementwiseOp>(
+            op, retType, adaptor.getOperands(), op.getLibnameAttr(),
+            op.getLibpathAttr(), op.getSymbolAttr(), op.getPureAttr()),
+        adaptor.getAttributes());
+    return success();
+  }
+};
+
 struct TritonPrintPattern : public OpConversionPattern<triton::PrintOp> {
   using OpConversionPattern<triton::PrintOp>::OpConversionPattern;
 
@@ -692,9 +710,9 @@ void populateTritonPatterns(TritonGPUTypeConverter &typeConverter,
       TritonReduceReturnPattern, TritonScanPattern, TritonScanReturnPattern,
       TritonTransPattern, TritonExpandDimsPattern, TritonMakeRangePattern,
       TritonDotPattern, TritonLoadPattern, TritonStorePattern,
-      TritonGenericPattern<triton::ExternElementwiseOp>, TritonPrintPattern,
-      TritonAssertPattern, TritonAtomicRMWPattern, TritonFuncOpPattern,
-      TritonReturnOpPattern, TritonCallOpPattern>(typeConverter, context);
+      TritonExternElementwisePattern, TritonPrintPattern, TritonAssertPattern,
+      TritonAtomicRMWPattern, TritonFuncOpPattern, TritonReturnOpPattern,
+      TritonCallOpPattern>(typeConverter, context);
 }
 
 //

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -604,16 +604,16 @@ struct TritonExternElementwisePattern
     : public OpConversionPattern<triton::ExternElementwiseOp> {
   using OpConversionPattern<triton::ExternElementwiseOp>::OpConversionPattern;
 
-  LogicalResult matchAndRewrite(
-      triton::ExternElementwiseOp op,
-      typename triton::ExternElementwiseOp::Adaptor adaptor,
-      ConversionPatternRewriter &rewriter) const override {
+  LogicalResult
+  matchAndRewrite(triton::ExternElementwiseOp op,
+                  typename triton::ExternElementwiseOp::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
     Type retType = this->getTypeConverter()->convertType(op.getType());
-    addNamedAttrs(
-        rewriter.replaceOpWithNewOp<triton::ExternElementwiseOp>(
-            op, retType, adaptor.getOperands(), op.getLibnameAttr(),
-            op.getLibpathAttr(), op.getSymbolAttr(), op.getPureAttr()),
-        adaptor.getAttributes());
+    addNamedAttrs(rewriter.replaceOpWithNewOp<triton::ExternElementwiseOp>(
+                      op, retType, adaptor.getOperands(), op.getLibnameAttr(),
+                      op.getLibpathAttr(), op.getSymbolAttr(),
+                      op.getPureAttr()),
+                  adaptor.getAttributes());
     return success();
   }
 };


### PR DESCRIPTION
This is needed for forward-compatibility with MLIR that now has "inherent" and "discardable" attributes (https://mlir.llvm.org/OpenMeetings/2023-02-09-Properties.pdf) and the ExternElementwiseOp attrs do not propagate with the current `addNamedAttrs` implementation.