### PR TITLE
Fix xpu stages logic

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -388,12 +388,6 @@ def compile(fn, **kwargs):
         add_cuda_stages(arch, extern_libs, stages)
     elif device_type == "hip":
         _device_backend.add_stages(arch, extern_libs, stages, num_warps=num_warps, num_stages=num_stages)
-    elif device_type == "xpu":
-        stages["ttgir"] = (lambda path: parse_mlir_module(path, context),
-                           lambda src: optimize_ttgir(ttir_to_ttgir(src, num_warps, num_ctas, arch), num_stages, num_warps, num_ctas, arch, cluster_info, enable_warp_specialization, enable_persistent, optimize_epilogue))
-        stages["llir"] = (lambda path: Path(path).read_text(),
-                          lambda src: ttgir_to_llir(src, extern_libs, arch, tma_infos))
-        _device_backend.add_stages(arch, extern_libs, stages)
     else:
         # pass the user's configuration to the backend device.
         arch["num_warps"] = num_warps


### PR DESCRIPTION
XPU does not need to set the stages in compiler.py and relies on the setting of the following.
```Python
        arch["num_warps"] = num_warps
        arch["num_stages"] = num_stages
        arch["num_ctas"] = num_ctas
```

In view of this, this PR deletes the logic of explicitly setting the stages in the compiler.py.

cc @EikanWang , @chengjunlu 