### PR TITLE
[FRONTEND] Explicitly forbid `dot(.., out_dtype=bfloat16)`

### DIFF
--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1310,7 +1310,7 @@ def dot(lhs: tl.tensor,
         _0 = builder.get_int32(0)
         ret_scalar_ty = tl.int32
     elif out_dtype.is_bf16():
-        assert False, "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`"
+        raise ValueError("out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`")
     elif lhs.type.scalar.is_fp32() or lhs.type.scalar.is_bf16():
         _0 = builder.get_fp32(0)
         ret_scalar_ty = tl.float32

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1310,7 +1310,7 @@ def dot(lhs: tl.tensor,
         _0 = builder.get_int32(0)
         ret_scalar_ty = tl.int32
     elif out_dtype.is_bf16():
-        assert False, "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32 and cast with `.to(tl.bfloat16)`"
+        assert False, "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32/float16 and cast with `.to(tl.bfloat16)`"
     elif lhs.type.scalar.is_fp32() or lhs.type.scalar.is_bf16():
         _0 = builder.get_fp32(0)
         ret_scalar_ty = tl.float32

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1309,6 +1309,8 @@ def dot(lhs: tl.tensor,
         assert lhs.shape[1].value >= 32, "small blocks not supported!"
         _0 = builder.get_int32(0)
         ret_scalar_ty = tl.int32
+    elif out_dtype.is_bf16():
+        assert False, "out_dtype=bfloat16 is unsupported. Please use out_dtype=float32 and cast with `.to(tl.bfloat16)`"
     elif lhs.type.scalar.is_fp32() or lhs.type.scalar.is_bf16():
         _0 = builder.get_fp32(0)
         ret_scalar_ty = tl.float32


### PR DESCRIPTION
Fixes: https://github.com/openai/triton/issues/2302