### PR TITLE
[BACKEND] Added paths to look for CUDA binaries

### DIFF
--- a/python/test/unit/runtime/test_cuda_paths.py
+++ b/python/test/unit/runtime/test_cuda_paths.py
@@ -1,0 +1,28 @@
+from unittest.mock import call, patch, Mock, ANY
+from triton.common.backend import _path_to_binary
+import pytest
+import os
+
+
+def test_cuda_paths():
+    env_vars = {"TRITON_PTXAS_PATH": "/nonexistent/ptax",
+                "CUDA_ROOT": "/nonexistent/cuda_root",
+                "CUDA_HOME": "/nonexistent/cuda_home",
+                "CUDA_PATH": "/nonexistent/cuda_path",
+                }
+
+    with patch.dict(os.environ, env_vars), \
+            patch('os.path.exists', return_value=False) as mocked_path_exists:
+        with pytest.raises(RuntimeError) as expected_exception:
+            _path_to_binary("x")
+
+        assert "Cannot find x" == str(expected_exception.value)
+
+    assert mocked_path_exists.call_count == len(env_vars) + 1  # third_party/bin/binary
+    mocked_path_exists.assert_has_calls([call("/nonexistent/ptax"),
+                                         ANY,
+                                         call("/nonexistent/cuda_root/bin/x"),
+                                         call("/nonexistent/cuda_home/bin/x"),
+                                         call("/nonexistent/cuda_path/bin/x"),])
+
+    assert "/third_party/cuda/bin/x" in mocked_path_exists.call_args_list[1].args[0]

--- a/python/triton/common/backend.py
+++ b/python/triton/common/backend.py
@@ -105,7 +105,10 @@ def _path_to_binary(binary: str):
     base_dir = os.path.join(os.path.dirname(__file__), os.pardir)
     paths = [
         os.environ.get("TRITON_PTXAS_PATH", ""),
-        os.path.join(base_dir, "third_party", "cuda", "bin", binary)
+        os.path.join(base_dir, "third_party", "cuda", "bin", binary),
+        os.path.join(os.environ.get("CUDA_ROOT", ""), "bin", binary),
+        os.path.join(os.environ.get("CUDA_HOME", ""), "bin", binary),
+        os.path.join(os.environ.get("CUDA_PATH", ""), "bin", binary),
     ]
 
     for p in paths:


### PR DESCRIPTION
Some tools, including LLVM, look for the CUDA binaries in the directories specified by the following environment variables: CUDA_ROOT, CUDA_HOME, and CUDA_PATH. Specifying TRITON_PTXAS_PATH is not sufficient because this environment variable contains a full path to the ptax binary, and the CUDA disassembler cannot be found in this case. This patch fixes the issue #2316.