### PR TITLE
Use ninja for builds.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,6 +74,7 @@ jobs:
           cd python
           python3 -m pip install --upgrade pip
           python3 -m pip install cmake==3.24
+          python3 -m pip install ninja
           python3 -m pip install --no-build-isolation -vvv '.[tests]'
           python3 -m pip install pytest-xdist
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pip install -U --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/
 ```
 git clone https://github.com/openai/triton.git;
 cd triton/python;
-pip install cmake; # build-time dependency
+pip install ninja cmake; # build-time dependencies
 pip install -e .
 ```
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=11.1.1"]
 
 [tool.autopep8]
 aggressive = 1

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 
 [build-system]
-requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=11.1.1"]
+requires = ["setuptools>=40.8.0", "wheel", "cmake>=3.18", "ninja>=1.11.1"]
 
 [tool.autopep8]
 aggressive = 1

--- a/python/setup.py
+++ b/python/setup.py
@@ -230,7 +230,7 @@ class CMakeBuild(build_ext):
         # python directories
         python_include_dir = sysconfig.get_path("platinclude")
         cmake_args = [
-            "-G", "Ninja", # Ninja is much faster than make
+            "-G", "Ninja",  # Ninja is much faster than make
             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
             "-DLLVM_ENABLE_WERROR=ON",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,

--- a/python/setup.py
+++ b/python/setup.py
@@ -229,8 +229,6 @@ class CMakeBuild(build_ext):
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         # python directories
-        print("ninja dir is:")
-        print(ninja_dir)
         python_include_dir = sysconfig.get_path("platinclude")
         cmake_args = [
             "-G", "Ninja",  # Ninja is much faster than make

--- a/python/setup.py
+++ b/python/setup.py
@@ -127,13 +127,10 @@ def get_thirdparty_packages(triton_cache_path):
 
 def download_and_copy(src_path, version, url_func):
     base_dir = os.path.dirname(__file__)
-    # src_path = "bin/ptxas"
-    # version = "12.1.105"
     arch = platform.machine()
     if arch == "x86_64":
         arch = "64"
     url = url_func(arch, version)
-    # url = f"https://conda.anaconda.org/nvidia/label/cuda-12.1.1/linux-{arch}/cuda-nvcc-{version}-0.tar.bz2"
     dst_prefix = os.path.join(base_dir, "triton")
     dst_suffix = os.path.join("third_party", "cuda", src_path)
     dst_path = os.path.join(dst_prefix, dst_suffix)
@@ -233,6 +230,7 @@ class CMakeBuild(build_ext):
         # python directories
         python_include_dir = sysconfig.get_path("platinclude")
         cmake_args = [
+            "-G", "Ninja", # Ninja is much faster than make
             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
             "-DLLVM_ENABLE_WERROR=ON",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,

--- a/python/setup.py
+++ b/python/setup.py
@@ -216,6 +216,7 @@ class CMakeBuild(build_ext):
 
     def build_extension(self, ext):
         lit_dir = shutil.which('lit')
+        ninja_dir = shutil.which('ninja')
         user_home = os.getenv("HOME") or os.getenv("USERPROFILE") or \
             os.getenv("HOMEPATH") or None
         if not user_home:
@@ -228,9 +229,12 @@ class CMakeBuild(build_ext):
         if not os.path.exists(self.build_temp):
             os.makedirs(self.build_temp)
         # python directories
+        print("ninja dir is:")
+        print(ninja_dir)
         python_include_dir = sysconfig.get_path("platinclude")
         cmake_args = [
             "-G", "Ninja",  # Ninja is much faster than make
+            "-DCMAKE_MAKE_PROGRAM=" + ninja_dir,  # Pass explicit path to ninja otherwise cmake may cache a temporary path
             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON",
             "-DLLVM_ENABLE_WERROR=ON",
             "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=" + extdir,


### PR DESCRIPTION
I noticed that I was not getting much parallelism when building Triton
on my local machine.  After switching from make to ninja, I get a whole
lot more parallelism, and the from-scratch build runs much faster.

On my local machine, I ran:

  $ rm -rf python/build; time pip install -e python

 - Before(make):   999.11s user 124.67s system  484% cpu 3:51.90 total
 - After (ninja): 1539.75s user 187.06s system 2052% cpu 1:24.14 total

On my machine (granted, I have a lot of cores), the speedup is
(3 * 60 + 51) / (1 * 60 + 24) = 2.7x.
