### PR TITLE
Add cuobjdump and nvsisasm to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ venv.bak/
 cmake-build-*
 
 # Third-party binaries
+cuobjdump
+nvdisasm
 ptxas
 
 # Docs


### PR DESCRIPTION
Otherwise, these files show up in `git status` under
python/triton/third_party/cuda/bin/.
