### PR TITLE
Add build instrs for running in a virtualenv.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,24 @@ pip install -U --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/
 
 ```
 git clone https://github.com/openai/triton.git;
-cd triton/python;
+cd triton;
+
 pip install cmake; # build-time dependency
-pip install -e .
+pip install -e python
 ```
 
+Or with a virtualenv:
 
+```
+git clone https://github.com/openai/triton.git;
+cd triton;
+
+python -m venv .venv --prompt triton;
+source .venv/bin/activate;
+
+pip install cmake; # build-time dependency
+pip install -e python
+```
 
 # Changelog
 


### PR DESCRIPTION
On my machine, when I try to `pip install cmake` outside a virtualenv,
it gets mad at me and tells me to use apt.  Which doesn't quite work for
some reason.  Anyway maybe this is simple to Python people, but perhaps
worth mentioning.  Especially because we have `.venv` in gitignore
already.
