### PR TITLE
Revert "Update integration-tests.yml"

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -162,6 +162,7 @@ jobs:
 
   Integration-Tests-Third-Party:
     needs: Runner-Preparation
+    if: false
 
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
reverts openai/triton#2310 as recent changes to Triton-IR have broken third-party backends