### PR TITLE
Switch pre-commit clang-format to v16.0.6.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
             ^docs/conf.py$
           )
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v14.0.6
+    rev: v16.0.6
     hooks:
       - id: clang-format
         stages: [commit, push, manual]


### PR DESCRIPTION
Google uses clang-format at LLVM HEAD.  clang-format's formatting is not
stable, so we want to minimize the difference between the pre-commit
clang-format and HEAD to minimize differences with Google's formatter.

In practice, it appears that there are no relevant changes to the
formatting, so this is a nop.  :shrug:

Tested by running `pre-commit run --all-files`.
