### PR TITLE
Implement dot for int8 on Turing

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -171,6 +171,115 @@ inline static const std::map<TensorCoreType, std::string> mmaInstrPtxAmpere = {
      "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16"},
 };
 
+static void callMmaTuringInt8(PTXBuilder& builder, unsigned m,
+                              unsigned n, unsigned k,
+                              mlir::triton::PTXInstr& mma,
+                              unsigned numMmaRets, unsigned colsPerThread,
+                              int numCPackedElem, ValueTableV2& ha,
+                              ValueTableV2& hb, const SmallVector<Value>& fc) {
+  auto retArgs1 = builder.newListOperand(numMmaRets/2, "=r");
+  auto retArgs2 = builder.newListOperand(numMmaRets/2, "=r");
+  auto cArgs1 = builder.newListOperand();
+  for (int i = 0; i < numMmaRets/2; ++i) {
+    cArgs1->listAppend(builder.newOperand(
+    fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+        std::to_string(i)));
+    // reuse the output registers
+  }
+  auto cArgs2 = builder.newListOperand();
+  for (int i = numMmaRets/2; i < numMmaRets; ++i) {
+    cArgs2->listAppend(builder.newOperand(
+        fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+        std::to_string(i)));
+    // reuse the output registers
+  }
+  auto aArgs1 = builder.newListOperand({
+      {ha[{m, k}], "r"},
+  });
+  auto bArgs1 = builder.newListOperand({
+      {hb[{n, k}], "r"},
+  });
+  auto aArgs2 = builder.newListOperand({
+      {ha[{m, k + 1}], "r"},
+  });
+  auto bArgs2 = builder.newListOperand({
+      {hb[{n, k + 1}], "r"}
+  });
+  auto aArgs3 = builder.newListOperand({
+      {ha[{m + 1, k}], "r"},
+  });
+  auto bArgs3 = builder.newListOperand({
+      {hb[{n, k}], "r"},
+  });
+  auto aArgs4 = builder.newListOperand({
+      {ha[{m + 1, k + 1}], "r"},
+  });
+  auto bArgs4 = builder.newListOperand({
+      {hb[{n, k + 1}], "r"}
+  });
+  mma(retArgs1, aArgs1, bArgs1, cArgs1);
+  mma(retArgs1, aArgs2, bArgs2, cArgs1);
+  mma(retArgs2, aArgs3, bArgs3, cArgs2);
+  mma(retArgs2, aArgs4, bArgs4, cArgs2);
+}
+
+static void callMmaTuringFp16(PTXBuilder& builder, unsigned m,
+                              unsigned n, unsigned k,
+                              mlir::triton::PTXInstr& mma,
+                              unsigned numMmaRets, unsigned colsPerThread,
+                              int numCPackedElem, ValueTableV2& ha,
+                              ValueTableV2& hb, const SmallVector<Value>& fc,
+                              bool isAccF16) {
+  auto retArgs = builder.newListOperand(numMmaRets,
+                                        isAccF16 ? "=r" : "=f");
+  auto cArgs = builder.newListOperand();
+  for (int i = 0; i < numMmaRets; ++i) {
+    cArgs->listAppend(builder.newOperand(
+        fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+        std::to_string(i)));
+    // reuse the output registers
+  }
+  auto aArgs1 = builder.newListOperand({
+      {ha[{m, k}], "r"},
+      {ha[{m + 1, k}], "r"},
+  });
+  auto bArgs1 = builder.newListOperand({{hb[{n, k}], "r"}});
+  auto aArgs2 = builder.newListOperand({
+      {ha[{m, k + 1}], "r"},
+      {ha[{m + 1, k + 1}], "r"},
+  });
+  auto bArgs2 = builder.newListOperand({{hb[{n, k + 1}], "r"}});
+  mma(retArgs, aArgs1, bArgs1, cArgs);
+  mma(retArgs, aArgs2, bArgs2, cArgs);
+}
+
+static void callMmaAmpere(PTXBuilder& builder, unsigned m,
+                          unsigned n, unsigned k,
+                          mlir::triton::PTXInstr& mma,
+                          unsigned numMmaRets, unsigned colsPerThread,
+                          int numCPackedElem, ValueTableV2& ha,
+                          ValueTableV2& hb, const SmallVector<Value>& fc,
+                          bool isAccF16, bool isIntMMA) {
+  auto retArgs = builder.newListOperand(numMmaRets,
+                                        isIntMMA || isAccF16 ? "=r" : "=f");
+  auto cArgs = builder.newListOperand();
+  for (int i = 0; i < numMmaRets; ++i) {
+    cArgs->listAppend(builder.newOperand(
+        fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+        std::to_string(i)));
+    // reuse the output registers
+  }
+  auto aArgs = builder.newListOperand({
+      {ha[{m, k}], "r"},
+      {ha[{m + 1, k}], "r"},
+      {ha[{m, k + 1}], "r"},
+      {ha[{m + 1, k + 1}], "r"},
+  });
+  auto bArgs =
+      builder.newListOperand({{hb[{n, k}], "r"}, {hb[{n, k + 1}], "r"}});
+  mma(retArgs, aArgs, bArgs, cArgs);
+}
+
 LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
                          ConversionPatternRewriter &rewriter, Location loc,
                          Value a, Value b, Value c, Value d, Value loadedA,
@@ -219,87 +328,16 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
     bool isIntMMA = dTensorTy.getElementType().isInteger(32);
     bool isAccF16 = dTensorTy.getElementType().isF16();
 
-    if (isTuring && isIntMMA) {    // Turing int8
-      auto retArgs1 = builder.newListOperand(numMmaRets/2, "=r");
-      auto retArgs2 = builder.newListOperand(numMmaRets/2, "=r");
-      auto cArgs1 = builder.newListOperand();
-      for (int i = 0; i < numMmaRets/2; ++i) {
-        cArgs1->listAppend(builder.newOperand(
-            fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
-            std::to_string(i)));
-        // reuse the output registers
-      }
-      auto cArgs2 = builder.newListOperand();
-      for (int i = numMmaRets/2; i < numMmaRets; ++i) {
-        cArgs2->listAppend(builder.newOperand(
-            fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
-            std::to_string(i)));
-        // reuse the output registers
-      }
-      auto aArgs1 = builder.newListOperand({
-          {ha[{m, k}], "r"},
-      });
-      auto bArgs1 = builder.newListOperand({
-          {hb[{n, k}], "r"},
-      });
-      auto aArgs2 = builder.newListOperand({
-          {ha[{m, k + 1}], "r"},
-      });
-      auto bArgs2 = builder.newListOperand({
-          {hb[{n, k + 1}], "r"}
-      });
-      auto aArgs3 = builder.newListOperand({
-          {ha[{m + 1, k}], "r"},
-      });
-      auto bArgs3 = builder.newListOperand({
-          {hb[{n, k}], "r"},
-      });
-      auto aArgs4 = builder.newListOperand({
-          {ha[{m + 1, k + 1}], "r"},
-      });
-      auto bArgs4 = builder.newListOperand({
-          {hb[{n, k + 1}], "r"}
-      });
-      mma(retArgs1, aArgs1, bArgs1, cArgs1);
-      mma(retArgs1, aArgs2, bArgs2, cArgs1);
-      mma(retArgs2, aArgs3, bArgs3, cArgs2);
-      mma(retArgs2, aArgs4, bArgs4, cArgs2);
-    } else {
-      auto retArgs = builder.newListOperand(numMmaRets,
-                                            isIntMMA || isAccF16 ? "=r" : "=f");
-      auto cArgs = builder.newListOperand();
-      for (int i = 0; i < numMmaRets; ++i) {
-        cArgs->listAppend(builder.newOperand(
-            fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
-            std::to_string(i)));
-        // reuse the output registers
-      }
-      if (isTuring) {    // Turing fp16
-        auto aArgs1 = builder.newListOperand({
-            {ha[{m, k}], "r"},
-            {ha[{m + 1, k}], "r"},
-        });
-        auto bArgs1 = builder.newListOperand({
-            {hb[{n, k}], "r"},
-        });
-        auto aArgs2 = builder.newListOperand({
-            {ha[{m, k + 1}], "r"},
-            {ha[{m + 1, k + 1}], "r"},
-        });
-        auto bArgs2 = builder.newListOperand({{hb[{n, k + 1}], "r"}});
-        mma(retArgs, aArgs1, bArgs1, cArgs);
-        mma(retArgs, aArgs2, bArgs2, cArgs);
-      } else {           // Ampere
-        auto aArgs = builder.newListOperand({
-            {ha[{m, k}], "r"},
-            {ha[{m + 1, k}], "r"},
-            {ha[{m, k + 1}], "r"},
-            {ha[{m + 1, k + 1}], "r"},
-        });
-        auto bArgs =
-            builder.newListOperand({{hb[{n, k}], "r"}, {hb[{n, k + 1}], "r"}});
-        mma(retArgs, aArgs, bArgs, cArgs);
-      }
+    if (isTuring) {
+      if (isIntMMA)    // Turing int8
+        callMmaTuringInt8(builder, m, n, k, mma, numMmaRets, colsPerThread,
+                          numCPackedElem, ha, hb, fc);
+      else             // Turing fp16
+        callMmaTuringFp16(builder, m, n, k, mma, numMmaRets, colsPerThread,
+                          numCPackedElem, ha, hb, fc, isAccF16);
+    } else {           // Ampere
+      callMmaAmpere(builder, m, n, k, mma, numMmaRets, colsPerThread,
+                    numCPackedElem, ha, hb, fc, isAccF16, isIntMMA);
     }
 
     Value mmaOut =

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -171,26 +171,25 @@ inline static const std::map<TensorCoreType, std::string> mmaInstrPtxAmpere = {
      "mma.sync.aligned.m16n8k16.row.col.f16.f16.f16.f16"},
 };
 
-static void callMmaTuringInt8(PTXBuilder& builder, unsigned m,
-                              unsigned n, unsigned k,
-                              mlir::triton::PTXInstr& mma,
+static void callMmaTuringInt8(PTXBuilder &builder, unsigned m, unsigned n,
+                              unsigned k, mlir::triton::PTXInstr &mma,
                               unsigned numMmaRets, unsigned colsPerThread,
-                              int numCPackedElem, ValueTableV2& ha,
-                              ValueTableV2& hb, const SmallVector<Value>& fc) {
-  auto retArgs1 = builder.newListOperand(numMmaRets/2, "=r");
-  auto retArgs2 = builder.newListOperand(numMmaRets/2, "=r");
+                              int numCPackedElem, ValueTableV2 &ha,
+                              ValueTableV2 &hb, const SmallVector<Value> &fc) {
+  auto retArgs1 = builder.newListOperand(numMmaRets / 2, "=r");
+  auto retArgs2 = builder.newListOperand(numMmaRets / 2, "=r");
   auto cArgs1 = builder.newListOperand();
-  for (int i = 0; i < numMmaRets/2; ++i) {
-    cArgs1->listAppend(builder.newOperand(
-    fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
-        std::to_string(i)));
+  for (int i = 0; i < numMmaRets / 2; ++i) {
+    cArgs1->listAppend(
+        builder.newOperand(fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+                           std::to_string(i)));
     // reuse the output registers
   }
   auto cArgs2 = builder.newListOperand();
-  for (int i = numMmaRets/2; i < numMmaRets; ++i) {
-    cArgs2->listAppend(builder.newOperand(
-        fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
-        std::to_string(i)));
+  for (int i = numMmaRets / 2; i < numMmaRets; ++i) {
+    cArgs2->listAppend(
+        builder.newOperand(fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+                           std::to_string(i)));
     // reuse the output registers
   }
   auto aArgs1 = builder.newListOperand({
@@ -202,9 +201,7 @@ static void callMmaTuringInt8(PTXBuilder& builder, unsigned m,
   auto aArgs2 = builder.newListOperand({
       {ha[{m, k + 1}], "r"},
   });
-  auto bArgs2 = builder.newListOperand({
-      {hb[{n, k + 1}], "r"}
-  });
+  auto bArgs2 = builder.newListOperand({{hb[{n, k + 1}], "r"}});
   auto aArgs3 = builder.newListOperand({
       {ha[{m + 1, k}], "r"},
   });
@@ -214,29 +211,25 @@ static void callMmaTuringInt8(PTXBuilder& builder, unsigned m,
   auto aArgs4 = builder.newListOperand({
       {ha[{m + 1, k + 1}], "r"},
   });
-  auto bArgs4 = builder.newListOperand({
-      {hb[{n, k + 1}], "r"}
-  });
+  auto bArgs4 = builder.newListOperand({{hb[{n, k + 1}], "r"}});
   mma(retArgs1, aArgs1, bArgs1, cArgs1);
   mma(retArgs1, aArgs2, bArgs2, cArgs1);
   mma(retArgs2, aArgs3, bArgs3, cArgs2);
   mma(retArgs2, aArgs4, bArgs4, cArgs2);
 }
 
-static void callMmaTuringFp16(PTXBuilder& builder, unsigned m,
-                              unsigned n, unsigned k,
-                              mlir::triton::PTXInstr& mma,
+static void callMmaTuringFp16(PTXBuilder &builder, unsigned m, unsigned n,
+                              unsigned k, mlir::triton::PTXInstr &mma,
                               unsigned numMmaRets, unsigned colsPerThread,
-                              int numCPackedElem, ValueTableV2& ha,
-                              ValueTableV2& hb, const SmallVector<Value>& fc,
+                              int numCPackedElem, ValueTableV2 &ha,
+                              ValueTableV2 &hb, const SmallVector<Value> &fc,
                               bool isAccF16) {
-  auto retArgs = builder.newListOperand(numMmaRets,
-                                        isAccF16 ? "=r" : "=f");
+  auto retArgs = builder.newListOperand(numMmaRets, isAccF16 ? "=r" : "=f");
   auto cArgs = builder.newListOperand();
   for (int i = 0; i < numMmaRets; ++i) {
-    cArgs->listAppend(builder.newOperand(
-        fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
-        std::to_string(i)));
+    cArgs->listAppend(
+        builder.newOperand(fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+                           std::to_string(i)));
     // reuse the output registers
   }
   auto aArgs1 = builder.newListOperand({
@@ -253,20 +246,19 @@ static void callMmaTuringFp16(PTXBuilder& builder, unsigned m,
   mma(retArgs, aArgs2, bArgs2, cArgs);
 }
 
-static void callMmaAmpere(PTXBuilder& builder, unsigned m,
-                          unsigned n, unsigned k,
-                          mlir::triton::PTXInstr& mma,
+static void callMmaAmpere(PTXBuilder &builder, unsigned m, unsigned n,
+                          unsigned k, mlir::triton::PTXInstr &mma,
                           unsigned numMmaRets, unsigned colsPerThread,
-                          int numCPackedElem, ValueTableV2& ha,
-                          ValueTableV2& hb, const SmallVector<Value>& fc,
+                          int numCPackedElem, ValueTableV2 &ha,
+                          ValueTableV2 &hb, const SmallVector<Value> &fc,
                           bool isAccF16, bool isIntMMA) {
-  auto retArgs = builder.newListOperand(numMmaRets,
-                                        isIntMMA || isAccF16 ? "=r" : "=f");
+  auto retArgs =
+      builder.newListOperand(numMmaRets, isIntMMA || isAccF16 ? "=r" : "=f");
   auto cArgs = builder.newListOperand();
   for (int i = 0; i < numMmaRets; ++i) {
-    cArgs->listAppend(builder.newOperand(
-        fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
-        std::to_string(i)));
+    cArgs->listAppend(
+        builder.newOperand(fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+                           std::to_string(i)));
     // reuse the output registers
   }
   auto aArgs = builder.newListOperand({
@@ -329,13 +321,13 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
     bool isAccF16 = dTensorTy.getElementType().isF16();
 
     if (isTuring) {
-      if (isIntMMA)    // Turing int8
+      if (isIntMMA) // Turing int8
         callMmaTuringInt8(builder, m, n, k, mma, numMmaRets, colsPerThread,
                           numCPackedElem, ha, hb, fc);
-      else             // Turing fp16
+      else // Turing fp16
         callMmaTuringFp16(builder, m, n, k, mma, numMmaRets, colsPerThread,
                           numCPackedElem, ha, hb, fc, isAccF16);
-    } else {           // Ampere
+    } else { // Ampere
       callMmaAmpere(builder, m, n, k, mma, numMmaRets, colsPerThread,
                     numCPackedElem, ha, hb, fc, isAccF16, isIntMMA);
     }

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -145,6 +145,9 @@ inline static const std::map<TensorCoreType, std::string> mmaInstrPtxTuring = {
     {TensorCoreType::FP32_FP16_FP16_FP32,
      "mma.sync.aligned.m16n8k8.row.col.f32.f16.f16.f32"},
 
+    {TensorCoreType::INT32_INT8_INT8_INT32,
+     "mma.sync.aligned.m8n8k16.row.col.satfinite.s32.s8.s8.s32"},
+
     {TensorCoreType::FP16_FP16_FP16_FP16,
      "mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16"},
 };
@@ -215,42 +218,90 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
     // using =r for float32 works but leads to less readable ptx.
     bool isIntMMA = dTensorTy.getElementType().isInteger(32);
     bool isAccF16 = dTensorTy.getElementType().isF16();
-    auto retArgs =
-        builder.newListOperand(numMmaRets, isIntMMA || isAccF16 ? "=r" : "=f");
-    auto cArgs = builder.newListOperand();
-    for (int i = 0; i < numMmaRets; ++i) {
-      cArgs->listAppend(builder.newOperand(
-          fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
-          std::to_string(i)));
-      // reuse the output registers
-    }
 
-    if (isTuring) {
+    if (isTuring && isIntMMA) {    // Turing int8
+      auto retArgs1 = builder.newListOperand(numMmaRets/2, "=r");
+      auto retArgs2 = builder.newListOperand(numMmaRets/2, "=r");
+      auto cArgs1 = builder.newListOperand();
+      for (int i = 0; i < numMmaRets/2; ++i) {
+        cArgs1->listAppend(builder.newOperand(
+            fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+            std::to_string(i)));
+        // reuse the output registers
+      }
+      auto cArgs2 = builder.newListOperand();
+      for (int i = numMmaRets/2; i < numMmaRets; ++i) {
+        cArgs2->listAppend(builder.newOperand(
+            fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+            std::to_string(i)));
+        // reuse the output registers
+      }
       auto aArgs1 = builder.newListOperand({
           {ha[{m, k}], "r"},
-          {ha[{m + 1, k}], "r"},
       });
       auto bArgs1 = builder.newListOperand({
           {hb[{n, k}], "r"},
       });
       auto aArgs2 = builder.newListOperand({
           {ha[{m, k + 1}], "r"},
-          {ha[{m + 1, k + 1}], "r"},
       });
-      auto bArgs2 = builder.newListOperand({{hb[{n, k + 1}], "r"}});
-      mma(retArgs, aArgs1, bArgs1, cArgs);
-      mma(retArgs, aArgs2, bArgs2, cArgs);
-    } else {
-      auto aArgs = builder.newListOperand({
-          {ha[{m, k}], "r"},
+      auto bArgs2 = builder.newListOperand({
+          {hb[{n, k + 1}], "r"}
+      });
+      auto aArgs3 = builder.newListOperand({
           {ha[{m + 1, k}], "r"},
-          {ha[{m, k + 1}], "r"},
+      });
+      auto bArgs3 = builder.newListOperand({
+          {hb[{n, k}], "r"},
+      });
+      auto aArgs4 = builder.newListOperand({
           {ha[{m + 1, k + 1}], "r"},
       });
-      auto bArgs =
-          builder.newListOperand({{hb[{n, k}], "r"}, {hb[{n, k + 1}], "r"}});
-      mma(retArgs, aArgs, bArgs, cArgs);
+      auto bArgs4 = builder.newListOperand({
+          {hb[{n, k + 1}], "r"}
+      });
+      mma(retArgs1, aArgs1, bArgs1, cArgs1);
+      mma(retArgs1, aArgs2, bArgs2, cArgs1);
+      mma(retArgs2, aArgs3, bArgs3, cArgs2);
+      mma(retArgs2, aArgs4, bArgs4, cArgs2);
+    } else {
+      auto retArgs = builder.newListOperand(numMmaRets,
+                                            isIntMMA || isAccF16 ? "=r" : "=f");
+      auto cArgs = builder.newListOperand();
+      for (int i = 0; i < numMmaRets; ++i) {
+        cArgs->listAppend(builder.newOperand(
+            fc[(m * colsPerThread + 4 * n) / numCPackedElem + i],
+            std::to_string(i)));
+        // reuse the output registers
+      }
+      if (isTuring) {    // Turing fp16
+        auto aArgs1 = builder.newListOperand({
+            {ha[{m, k}], "r"},
+            {ha[{m + 1, k}], "r"},
+        });
+        auto bArgs1 = builder.newListOperand({
+            {hb[{n, k}], "r"},
+        });
+        auto aArgs2 = builder.newListOperand({
+            {ha[{m, k + 1}], "r"},
+            {ha[{m + 1, k + 1}], "r"},
+        });
+        auto bArgs2 = builder.newListOperand({{hb[{n, k + 1}], "r"}});
+        mma(retArgs, aArgs1, bArgs1, cArgs);
+        mma(retArgs, aArgs2, bArgs2, cArgs);
+      } else {           // Ampere
+        auto aArgs = builder.newListOperand({
+            {ha[{m, k}], "r"},
+            {ha[{m + 1, k}], "r"},
+            {ha[{m, k + 1}], "r"},
+            {ha[{m + 1, k + 1}], "r"},
+        });
+        auto bArgs =
+            builder.newListOperand({{hb[{n, k}], "r"}, {hb[{n, k + 1}], "r"}});
+        mma(retArgs, aArgs, bArgs, cArgs);
+      }
     }
+
     Value mmaOut =
         builder.launch(rewriter, loc, getMmaRetType(mmaType, op.getContext()));
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2473,10 +2473,10 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
             assert re.search(r'[mma|wgmma.mma_async].sync.aligned.m\d+n\d+k16(?:.row.col)?.f16.f16.f16', ptx)
     elif in_dtype == 'int8':
         if capability[0] == 7 and capability[1] == 5:  # Turing
-          assert 'mma.sync.aligned.m8n8k16.row.col.satfinite.s32.s8.s8.s32' in ptx
+            assert 'mma.sync.aligned.m8n8k16.row.col.satfinite.s32.s8.s8.s32' in ptx
         else:
-          assert 'wgmma.mma_async.sync.aligned' in ptx or\
-              'mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32' in ptx
+            assert 'wgmma.mma_async.sync.aligned' in ptx or\
+                'mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32' in ptx
 
 
 @pytest.mark.parametrize('in_dtype', ['float32'])

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2256,7 +2256,7 @@ def test_permute(dtype_str, shape, perm, num_ctas, device):
                                            [32, 32, 128, 16],
                                            [128, 128, 64, 2],
                                            [64, 128, 128, 2]]
-                          for allow_tf32 in [True]
+                          for allow_tf32 in [True, False]
                           for col_a in [True, False]
                           for col_b in [True, False]
                           for in_dtype, out_dtype in [('int8', 'int8'),
@@ -2282,12 +2282,12 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
     if capability[0] < 7:
         pytest.skip("Only test tl.dot() on devices with sm >= 70")
     if capability[0] < 8:
-        if in_dtype == 'int8':
-            pytest.skip("Only test int8 on devices with sm >= 80")
-        elif allow_tf32:
+        if capability[1] == 0 and in_dtype == 'int8':
+            pytest.skip("Only test int8 on devices with sm >= 75")
+        if allow_tf32:
             pytest.skip("Only test tf32 on devices with sm >= 80")
     if capability[0] == 7:
-        if (M, N, K, num_warps) == (128, 256, 32, 8):
+        if (M, N, K, num_warps) in [(128, 256, 32, 8), (64, 128, 128, 4), (64, 128, 128, 2)]:
             pytest.skip("shared memory out of resource")
         if out_dtype == 'float16':
             # TODO: support out_dtype=float16 for tl.dot on V100
@@ -2472,8 +2472,11 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
         else:
             assert re.search(r'[mma|wgmma.mma_async].sync.aligned.m\d+n\d+k16(?:.row.col)?.f16.f16.f16', ptx)
     elif in_dtype == 'int8':
-        assert 'wgmma.mma_async.sync.aligned' in ptx or\
-            'mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32' in ptx
+        if capability[0] == 7 and capability[1] == 5:  # Turing
+          assert 'mma.sync.aligned.m8n8k16.row.col.satfinite.s32.s8.s8.s32' in ptx
+        else:
+          assert 'wgmma.mma_async.sync.aligned' in ptx or\
+              'mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32' in ptx
 
 
 @pytest.mark.parametrize('in_dtype', ['float32'])


### PR DESCRIPTION
Replace a single mma.sync.aligned.m16n8k32.row.col.satfinite.s32.s8.s8.s32 instruction that is used on Ampere with 4 x mma.sync.aligned.m8n8k16.row.col.satfinite.s32.s8.s8.s32 instructions for Turing

Extracted the Turing-int8, Turing-fp16 and Ampere to separate functions.

Somehow I messed up with my previous PR, so just open a new one.