### PR TITLE
Fix core.dtype.__repr__

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -275,7 +275,7 @@ class dtype:
         return self.name
 
     def __repr__(self):
-        return f'triton.language.{self.name}'
+        return f'triton.language.{str(self)}'
 
 
 class pointer_type(dtype):


### PR DESCRIPTION
Hi
`function_type` does not have a `name` field, which leads to an error when debugging with gdb.
