### PR TITLE
Git ignore clangd and vscode index files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ docs/dialects/
 docs/getting-started/tutorials
 !python/tutorials/*.py
 !python/tutorials/*.rst
+
+# clangd index. (".clangd" is a config file now, thus trailing slash)
+.clangd/
+.cache
+/compile_commands.json
+.vscode
+.vs


### PR DESCRIPTION
Vscode or clangd can create indexing cache for symbol resolutions. Those files should be ignored by git.

I'm basically cloning what is done in the LLVM repo. 