### PR TITLE
Fix PTX issues in bf16 / fp8_e4m3 conversion

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -185,9 +185,11 @@ const std::string Fp16_to_Fp8E4M3Nv = "{ \n"
 // Fp8E4M3 (x2) -> Fp16 (x2) (packed)
 const std::string Fp8E4M3Nv_to_Bf16 =
     "{                                       \n"
+    ".reg .b32 a;                            \n"
     ".reg .f16 a<2>;                         \n"
-    ".reg .bf16 b<2>;                        \n"
-    "cvt.rn.f16x2.e4m3x2 {a0, a1}, $1;       \n"
+    ".reg .b16 b<2>;                         \n"
+    "cvt.rn.f16x2.e4m3x2 a, $1;              \n"
+    "mov.b32 {a0, a1}, a;                    \n"
     "cvt.bf16.f16 b0, a0;                    \n"
     "cvt.bf16.f16 b1, a1;                    \n"
     "mov.b32 $0, {b0, b1};                   \n"
@@ -196,7 +198,7 @@ const std::string Fp8E4M3Nv_to_Bf16 =
 // Bf16 (x2) -> Fp8E4M3 (x2) (packed)
 const std::string Bf16_to_Fp8E4M3Nv =
     "{                                       \n"
-    ".reg .bf16 a<2>;                        \n"
+    ".reg .b16 a<2>;                         \n"
     ".reg .f32 b<2>;                         \n"
     "mov.b32 {a0, a1}, $1;                   \n"
     "cvt.f32.bf16 b0, a0;                    \n"


### PR DESCRIPTION
Fix bugs in https://github.com/openai/triton/pull/2415. cc @htyu 

Previously corresponding tests failed on H100 with latest torch version. It passed CI because CI doesn't use latest torch, so the tests were skipped.