### PR TITLE
[CI] disable pypy wheel

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,8 +46,8 @@ jobs:
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           export CIBW_BEFORE_BUILD="pip install cmake;"
-          export CIBW_SKIP="{cp,pp}{35,36}-*"
-          export CIBW_BUILD="{cp,pp}3*-manylinux_x86_64"
+          export CIBW_SKIP="{cp}{35,36}-*"
+          export CIBW_BUILD="{cp}3*-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse
 
       - name: Install Azure CLI

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -53,6 +53,7 @@
 #include <fstream>
 #include <optional>
 #include <pybind11/buffer_info.h>
+#include <pybind11/embed.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -53,7 +53,6 @@
 #include <fstream>
 #include <optional>
 #include <pybind11/buffer_info.h>
-#include <pybind11/embed.h>
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>


### PR DESCRIPTION
emitting warnings from C++ code requires "#include pybind11/exec.h" which is not compatible with pypy. I think using the python interpreter form C++ is a bad idea in general... but we probably don't care much about pypy wheels anyway