### PR TITLE
[BACKEND] Fine-tune SharedMemoryObject definition and fix related problems

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -462,11 +462,12 @@ public:
     unsigned inVec = srcSharedLayout.getVec();
     unsigned minVec = std::min(outVec, inVec);
     unsigned outElems = triton::gpu::getTotalElemsPerThread(dstTy);
+    SmallVector<Value> offsetVals = {i32_val(0), i32_val(0)};
     assert(outElems == dstIndices.size());
 
-    DenseMap<unsigned, Value> sharedPtrs = getSwizzledSharedPtrs(
-        loc, outVec, dstTy, srcSharedLayout, srcElemTy, smemObj, rewriter,
-        smemObj.offsets, smemObj.strides);
+    DenseMap<unsigned, Value> sharedPtrs =
+        getSwizzledSharedPtrs(loc, outVec, dstTy, srcSharedLayout, srcElemTy,
+                              smemObj, rewriter, offsetVals, smemObj.strides);
     assert(outElems % minVec == 0 && "Unexpected number of elements");
     unsigned numVecs = outElems / minVec;
     auto wordTy = vec_ty(elemTy, minVec);


### PR DESCRIPTION
```
import triton
import triton.language as tl
import torch

ir = """
#blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
#shared = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1], hasLeadingOffset = false}>
module attributes {"triton_gpu.compute-capability" = 86 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
  tt.func public @read_slice_kernel_0d1d(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
    %cst = arith.constant dense<64> : tensor<64x1xi64, #blocked>
    %cst_0 = arith.constant dense<32> : tensor<32x1xi64, #blocked1>
    %cst_1 = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked1>
    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
    %1 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
    %2 = arith.extsi %0 : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> to tensor<64xi64, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
    %3 = arith.extsi %1 : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>> to tensor<64xi64, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
    %4 = tt.expand_dims %2 {axis = 1 : i32} : (tensor<64xi64, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<64x1xi64, #blocked>
    %5 = arith.muli %4, %cst : tensor<64x1xi64, #blocked>
    %6 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<64x1x!tt.ptr<f32, 1>, #blocked>
    %7 = tt.addptr %6, %5 : tensor<64x1x!tt.ptr<f32, 1>, #blocked>, tensor<64x1xi64, #blocked>
    %8 = tt.broadcast %7 : (tensor<64x1x!tt.ptr<f32, 1>, #blocked>) -> tensor<64x64x!tt.ptr<f32, 1>, #blocked>
    %9 = tt.expand_dims %3 {axis = 0 : i32} : (tensor<64xi64, #triton_gpu.slice<{dim = 0, parent = #blocked}>>) -> tensor<1x64xi64, #blocked>
    %10 = tt.broadcast %9 : (tensor<1x64xi64, #blocked>) -> tensor<64x64xi64, #blocked>
    %11 = tt.addptr %8, %10 : tensor<64x64x!tt.ptr<f32, 1>, #blocked>, tensor<64x64xi64, #blocked>
    %12 = tt.load %11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x64xf32, #blocked>
    %13 = triton_gpu.convert_layout %12 : (tensor<64x64xf32, #blocked>) -> tensor<64x64xf32, #shared>
    %14 = triton_gpu.extract_slice %13[32, 32] [32, 32] [1, 1] : tensor<64x64xf32, #shared> to tensor<32x32xf32, #shared>
    %15 = triton_gpu.convert_layout %14 : (tensor<32x32xf32, #shared>) -> tensor<32x32xf32, #blocked1>
    %16 = arith.addf %15, %cst_1 : tensor<32x32xf32, #blocked1>
    %17 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
    %18 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
    %19 = arith.extsi %17 : tensor<32xi32, #triton_gpu.slice<{dim = 1, parent = #blocked1}>> to tensor<32xi64, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>
    %20 = arith.extsi %18 : tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> to tensor<32xi64, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
    %21 = tt.expand_dims %19 {axis = 1 : i32} : (tensor<32xi64, #triton_gpu.slice<{dim = 1, parent = #blocked1}>>) -> tensor<32x1xi64, #blocked1>
    %22 = arith.muli %21, %cst_0 : tensor<32x1xi64, #blocked1>
    %23 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x1x!tt.ptr<f32, 1>, #blocked1>
    %24 = tt.addptr %23, %22 : tensor<32x1x!tt.ptr<f32, 1>, #blocked1>, tensor<32x1xi64, #blocked1>
    %25 = tt.broadcast %24 : (tensor<32x1x!tt.ptr<f32, 1>, #blocked1>) -> tensor<32x32x!tt.ptr<f32, 1>, #blocked1>
    %26 = tt.expand_dims %20 {axis = 0 : i32} : (tensor<32xi64, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>) -> tensor<1x32xi64, #blocked1>
    %27 = tt.broadcast %26 : (tensor<1x32xi64, #blocked1>) -> tensor<32x32xi64, #blocked1>
    %28 = tt.addptr %25, %27 : tensor<32x32x!tt.ptr<f32, 1>, #blocked1>, tensor<32x32xi64, #blocked1>
    tt.store %28, %16 {cache = 1 : i32, evict = 1 : i32} : tensor<32x32xf32, #blocked1>
    tt.return
  }
}
"""


import tempfile
with tempfile.NamedTemporaryFile(mode='w', suffix='.ttgir') as f:
    f.write(ir)
    f.flush()
    kernel = triton.compile(f.name)

x = torch.rand((64,64), dtype=torch.float32, device='cuda')
y = torch.empty((32,32), dtype=torch.float32, device='cuda')
grid = (1,1,1)
kernel[grid](x, y)
print(x[32:,32:],y)
assert torch.allclose(x[32:,32:], y)                            
```