### PR TITLE
[BACKEND] Lower to PTX with `trap-unreachable`

### DIFF
--- a/lib/Target/PTX/PTXTranslation.cpp
+++ b/lib/Target/PTX/PTXTranslation.cpp
@@ -88,6 +88,7 @@ std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version) {
   opt.UnsafeFPMath = false;
   opt.NoInfsFPMath = false;
   opt.NoNaNsFPMath = true;
+  opt.TrapUnreachable = true;
   std::unique_ptr<llvm::TargetMachine> machine{target->createTargetMachine(
       module.getTargetTriple(), proc, features, opt, llvm::Reloc::PIC_,
       std::nullopt, llvm::CodeGenOpt::Aggressive)};


### PR DESCRIPTION
We've seen cases where the entire kernel is poisoned due to division-by-zero, resulting in a single `unreachable` instruction at the LLIR level. Emit this instruction as `trap` (instead of dropping it) so that the kernel doesn't run successfully without writing any outputs.