### PR TITLE
[Backend] fix a bug in lowering ExtractSliceOp from TritonGPU to LLVM

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -563,10 +563,13 @@ struct ExtractSliceOpConversion
     SmallVector<Value, 4> opOffsetVals;
     SmallVector<Value, 4> offsetVals;
     auto mixedOffsets = op.getMixedOffsets();
-    for (auto i = 0; i < mixedOffsets.size(); ++i) {
-      if (op.isDynamicOffset(i))
-        opOffsetVals.emplace_back(adaptor.getOffsets()[i]);
-      else
+    for (auto i = 0, j = 0; i < mixedOffsets.size(); ++i) {
+      if (op.isDynamicOffset(i)) {
+        // adaptor.getOffsets() returns list of variable offsets. the size of
+        // the list may not be the same as mixedOffsets
+        opOffsetVals.emplace_back(adaptor.getOffsets()[j]);
+        ++j;
+      } else
         opOffsetVals.emplace_back(i32_val(op.getStaticOffset(i)));
       offsetVals.emplace_back(add(smemObj.offsets[i], opOffsetVals[i]));
     }


### PR DESCRIPTION
```
import triton
import torch

ir = f"""
#blocked = #triton_gpu.blocked<{{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}}>
#blocked1 = #triton_gpu.blocked<{{sizePerThread = [1, 4], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}}>
#blocked2 = #triton_gpu.blocked<{{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}}>
#shared = #triton_gpu.shared<{{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1], hasLeadingOffset = false}}>
module attributes {{"triton_gpu.compute-capability" = 86 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32}} {{
  tt.func public @read_slice_kernel_0d1d(%arg0: !tt.ptr<f32, 1> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<f32, 1> {{tt.divisibility = 16 : i32}}) attributes {{noinline = false}} {{
    %cst = arith.constant dense<32> : tensor<32x1xi64, #blocked>
    %cst_0 = arith.constant dense<64> : tensor<64x1xi64, #blocked1>
    %c0_i32 = arith.constant 0 : i32
    %c64_i32 = arith.constant 64 : i32
    %c32_i32 = arith.constant 32 : i32
    %cst_1 = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked2>
    %0 = tt.make_range {{end = 64 : i32, start = 0 : i32}} : tensor<64xi32, #triton_gpu.slice<{{dim = 1, parent = #blocked1}}>>
    %1 = tt.make_range {{end = 64 : i32, start = 0 : i32}} : tensor<64xi32, #triton_gpu.slice<{{dim = 0, parent = #blocked1}}>>
    %2 = arith.extsi %0 : tensor<64xi32, #triton_gpu.slice<{{dim = 1, parent = #blocked1}}>> to tensor<64xi64, #triton_gpu.slice<{{dim = 1, parent = #blocked1}}>>
    %3 = arith.extsi %1 : tensor<64xi32, #triton_gpu.slice<{{dim = 0, parent = #blocked1}}>> to tensor<64xi64, #triton_gpu.slice<{{dim = 0, parent = #blocked1}}>>
    %4 = tt.expand_dims %2 {{axis = 1 : i32}} : (tensor<64xi64, #triton_gpu.slice<{{dim = 1, parent = #blocked1}}>>) -> tensor<64x1xi64, #blocked1>
    %5 = arith.muli %4, %cst_0 : tensor<64x1xi64, #blocked1>
    %6 = tt.splat %arg0 : (!tt.ptr<f32, 1>) -> tensor<64x1x!tt.ptr<f32, 1>, #blocked1>
    %7 = tt.addptr %6, %5 : tensor<64x1x!tt.ptr<f32, 1>, #blocked1>, tensor<64x1xi64, #blocked1>
    %8 = tt.broadcast %7 : (tensor<64x1x!tt.ptr<f32, 1>, #blocked1>) -> tensor<64x64x!tt.ptr<f32, 1>, #blocked1>
    %9 = tt.expand_dims %3 {{axis = 0 : i32}} : (tensor<64xi64, #triton_gpu.slice<{{dim = 0, parent = #blocked1}}>>) -> tensor<1x64xi64, #blocked1>
    %10 = tt.broadcast %9 : (tensor<1x64xi64, #blocked1>) -> tensor<64x64xi64, #blocked1>
    %11 = tt.addptr %8, %10 : tensor<64x64x!tt.ptr<f32, 1>, #blocked1>, tensor<64x64xi64, #blocked1>
    %12 = tt.load %11 {{cache = 1 : i32, evict = 1 : i32, isVolatile = false}} : tensor<64x64xf32, #blocked1>
    %13 = triton_gpu.convert_layout %12 : (tensor<64x64xf32, #blocked1>) -> tensor<64x64xf32, #shared>
    %14 = scf.for %arg2 = %c0_i32 to %c64_i32 step %c32_i32 iter_args(%arg3 = %cst_1) -> (tensor<32x32xf32, #blocked2>)  : i32 {{
      %29 = triton_gpu.extract_slice %13[0, %arg2] [32, 32] [1, 1] : tensor<64x64xf32, #shared> to tensor<32x32xf32, #shared>
      %30 = triton_gpu.convert_layout %29 : (tensor<32x32xf32, #shared>) -> tensor<32x32xf32, #blocked2>
      %31 = arith.addf %arg3, %30 : tensor<32x32xf32, #blocked2>
      scf.yield %31 : tensor<32x32xf32, #blocked2>
    }}
    %15 = scf.for %arg2 = %c0_i32 to %c64_i32 step %c32_i32 iter_args(%arg3 = %14) -> (tensor<32x32xf32, #blocked2>)  : i32 {{
      %29 = triton_gpu.extract_slice %13[32, %arg2] [32, 32] [1, 1] : tensor<64x64xf32, #shared> to tensor<32x32xf32, #shared>
      %30 = triton_gpu.convert_layout %29 : (tensor<32x32xf32, #shared>) -> tensor<32x32xf32, #blocked2>
      %31 = arith.addf %arg3, %30 : tensor<32x32xf32, #blocked2>
      scf.yield %31 : tensor<32x32xf32, #blocked2>
    }}
    %16 = tt.make_range {{end = 32 : i32, start = 0 : i32}} : tensor<32xi32, #triton_gpu.slice<{{dim = 1, parent = #blocked}}>>
    %17 = tt.make_range {{end = 32 : i32, start = 0 : i32}} : tensor<32xi32, #triton_gpu.slice<{{dim = 0, parent = #blocked}}>>
    %18 = arith.extsi %16 : tensor<32xi32, #triton_gpu.slice<{{dim = 1, parent = #blocked}}>> to tensor<32xi64, #triton_gpu.slice<{{dim = 1, parent = #blocked}}>>
    %19 = arith.extsi %17 : tensor<32xi32, #triton_gpu.slice<{{dim = 0, parent = #blocked}}>> to tensor<32xi64, #triton_gpu.slice<{{dim = 0, parent = #blocked}}>>
    %20 = tt.expand_dims %18 {{axis = 1 : i32}} : (tensor<32xi64, #triton_gpu.slice<{{dim = 1, parent = #blocked}}>>) -> tensor<32x1xi64, #blocked>
    %21 = arith.muli %20, %cst : tensor<32x1xi64, #blocked>
    %22 = tt.splat %arg1 : (!tt.ptr<f32, 1>) -> tensor<32x1x!tt.ptr<f32, 1>, #blocked>
    %23 = tt.addptr %22, %21 : tensor<32x1x!tt.ptr<f32, 1>, #blocked>, tensor<32x1xi64, #blocked>
    %24 = tt.broadcast %23 : (tensor<32x1x!tt.ptr<f32, 1>, #blocked>) -> tensor<32x32x!tt.ptr<f32, 1>, #blocked>
    %25 = tt.expand_dims %19 {{axis = 0 : i32}} : (tensor<32xi64, #triton_gpu.slice<{{dim = 0, parent = #blocked}}>>) -> tensor<1x32xi64, #blocked>
    %26 = tt.broadcast %25 : (tensor<1x32xi64, #blocked>) -> tensor<32x32xi64, #blocked>
    %27 = tt.addptr %24, %26 : tensor<32x32x!tt.ptr<f32, 1>, #blocked>, tensor<32x32xi64, #blocked>
    %28 = triton_gpu.convert_layout %15 : (tensor<32x32xf32, #blocked2>) -> tensor<32x32xf32, #blocked>
    tt.store %27, %28 {{cache = 1 : i32, evict = 1 : i32}} : tensor<32x32xf32, #blocked>
    tt.return
  }}
}}
"""

import tempfile
with tempfile.NamedTemporaryFile(mode='w', suffix='.ttgir') as f:
    f.write(ir)
    f.flush()
    kernel = triton.compile(f.name)

torch.manual_seed(0)
x = torch.rand((64, 64), dtype=torch.float32, device='cuda')
y = torch.empty((32, 32), dtype=torch.float32, device='cuda')
grid = (1,1,1)
kernel[grid](x, y)
y_ref = x[0:32, 0:32]
y_ref += x[32:, 0:32]
y_ref += x[0:32, 32:]
y_ref += x[32:, 32:]
assert torch.allclose(y, y_ref)
```