### PR TITLE
Improve docs for atomic and load/store operations.

### DIFF
--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -63,8 +63,6 @@ Memory Ops
 
     load
     store
-    atomic_cas
-    atomic_xchg
 
 
 Indexing Ops
@@ -129,10 +127,11 @@ Atomic Ops
     :toctree: generated
     :nosignatures:
 
-    atomic_cas
     atomic_add
+    atomic_cas
     atomic_max
     atomic_min
+    atomic_xchg
 
 
 Comparison ops

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1016,14 +1016,19 @@ def load(pointer, mask=None, other=None, boundary_check=tuple(), padding_option=
     """
     Return a tensor of data whose values are loaded from memory at location defined by `pointer`:
         (1) `pointer` could be a single element pointer, then a scalar will be loaded
+
             - `mask` and `other` must be scalar too
             - `other` is implicitly typecast to `pointer.dtype.element_ty`
             - `boundary_check` and `padding_option` must be empty
+
         (2) `pointer` could be element-wise tensor of pointers, in which case:
+
             - `mask` and `other` are implicitly broadcast to `pointer.shape`
             - `other` is implicitly typecast to `pointer.dtype.element_ty`
             - `boundary_check` and `padding_option` must be empty
+
         (3) `pointer` could be a block pointer defined by `make_block_ptr`, in which case:
+
             - `mask` and `other` must be None
             - `boundary_check` and `padding_option` can be specified to control the behavior of out-of-bound access
 
@@ -1062,14 +1067,20 @@ def store(pointer, value, mask=None, boundary_check=(), cache_modifier="", evict
     """
     Store a tensor of data into memory locations defined by `pointer`:
         (1) `pointer` could be a single element pointer, then a scalar will be stored
+
             - `mask` must be scalar too
             - `boundary_check` and `padding_option` must be empty
+
         (2) `pointer` could be element-wise tensor of pointers, in which case:
+
             - `mask` is implicitly broadcast to `pointer.shape`
             - `boundary_check` must be empty
+
         (3) or `pointer` could be a block pointer defined by `make_block_ptr`, in which case:
+
             - `mask` must be None
             - `boundary_check` can be specified to control the behavior of out-of-bound access
+
     `value` is implicitly broadcast to `pointer.shape` and typecast to `pointer.dtype.element_ty`.
 
     :param pointer: The memory location where the elements of `value` are stored


### PR DESCRIPTION
 - Move atomic_cas and atomic_xchg to "atomic ops" section of
   documentation.
 - Don't talk about the `cmp` operand for operations which don't have
   it.
 - Document the `sem` operand.
 - :code:`foo` and ``foo`` don't work inside a :type: annotation,
   apparently.  (They are rendered literally, instead of being treated
   as a formatting command.)  Get rid of them.
- Format the bulleted lists in the load/store operations as intended.
