### PR TITLE
[BACKEND] Add back dot.wait when generating async_dot

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/WSPipeline.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/WSPipeline.cpp
@@ -859,6 +859,8 @@ void buildAsyncComm(const DenseMap<Operation *, SmallVector<Channel *>> &map,
               loc, dotOp.getA(), dotOp.getB(), dotOp.getC(),
               dotOp.getAllowTF32(), dotOp.getMaxNumImpreciseAcc());
       dot.replaceAllUsesWith(dotAsync.getResult());
+      builder.createWithAgentIds<triton::nvidia_gpu::DotWaitOp>(
+          loc, dotAsync.getResult(), 1);
 
       // 1. insert ConsumerReleaseOp for DotAsyncOps
       Value cond = builder.createWithAgentIds<arith::CmpIOp>(

--- a/test/TritonGPU/wspipeline.mlir
+++ b/test/TritonGPU/wspipeline.mlir
@@ -22,9 +22,10 @@
 // CHECK: triton_gpu.extract_slice
 // CHECK: triton_gpu.extract_slice
 // CHECK: triton_nvidia_gpu.dot_async
+// CHECK: triton_nvidia_gpu.dot_wait {{.*}} pendings = 1
 // CHECK: triton_nvidia_gpu.consumer_release
 // CHECK: scf.yield
-// CHECK: triton_nvidia_gpu.dot_wait
+// CHECK: triton_nvidia_gpu.dot_wait {{.*}} pendings = 0
 // CHECK: async_agent = dense<1> : vector<1xi32>
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 4], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>


### PR DESCRIPTION
Based on discussion this is needed to make sure there is no race condition when reading shared memory.