### PR TITLE
[Build] Makes the link_libraries(stdc++fs) global for all targets in the CMake project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,13 @@ set(TRITON_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 
+# TODO: Figure out which target is sufficient to fix errors; triton is
+# apparently not enough. Currently set linking libstdc++fs for all targets
+# to support some old version GCC compilers like 8.3.0.
+if (NOT WIN32 AND NOT APPLE)
+  link_libraries(stdc++fs)
+endif()
+
 if(TRITON_BUILD_PYTHON_MODULE)
   add_library(triton SHARED ${PYTHON_SRC})
   set(TRITON_LIBRARIES
@@ -240,9 +247,6 @@ if(TRITON_BUILD_PYTHON_MODULE)
     target_link_libraries(triton ${LLVM_LIBRARIES} z
       ${TRITON_LIBRARIES}
     )
-    # TODO: Figure out which target is sufficient to fix errors; triton is
-    # apparently not enough
-    link_libraries(stdc++fs)
   endif()
 
   target_link_options(triton PRIVATE ${LLVM_LDFLAGS})


### PR DESCRIPTION
### Problem
The previous change still didn't link libstdc++fs into libtriton.so, which caused the runtime error: undefined symbol _ZNKSt10filesystem7__cxx114path11parent_pathEv
`link_libraries(stdc++fs)` should be placed before `add_library`.

### What this PR does
This PR Makes the link_libraries(stdc++fs) global for all targets in the CMake project. By doing so, we ensure that the stdc++fs library is consistently linked to all targets, addressing potential build issues on old linux OS like debian10 which uses GCC8.3.0 as the default C/C++ compiler.