### PR TITLE
[FRONTEND] add option to disable fp mul/add fusion

### DIFF
--- a/bin/triton-translate.cpp
+++ b/bin/triton-translate.cpp
@@ -102,6 +102,10 @@ LogicalResult tritonTranslateMain(int argc, char **argv,
       "", llvm::cl::desc("AMDGCN features. e.g. '+sramecc,-xnack'"),
       llvm::cl::value_desc("features"), llvm::cl::init("+sramecc,-xnack"));
 
+  static llvm::cl::opt<bool> enableFpFusion(
+      "enable-fp-fusion", llvm::cl::desc("Enables fusion of fadd/fmul"),
+      llvm::cl::init(true));
+
   llvm::InitLLVM y(argc, argv);
 
   registerAsmPrinterCLOptions();
@@ -135,7 +139,8 @@ LogicalResult tritonTranslateMain(int argc, char **argv,
     llvm::outs() << *llvmir << '\n';
   } else if (targetKind == "ptx") {
     llvm::outs() << ::triton::translateLLVMIRToPTX(*llvmir, SMArch.getValue(),
-                                                   ptxVersion.getValue());
+                                                   ptxVersion.getValue(),
+                                                   enableFpFusion.getValue());
   } else {
     llvm::errs() << "Error: Unknown target specified: " << targetKind << "\n";
     return failure();

--- a/include/triton/Target/PTX/PTXTranslation.h
+++ b/include/triton/Target/PTX/PTXTranslation.h
@@ -10,7 +10,8 @@ class Module;
 namespace triton {
 
 // Translate TritonGPU IR to PTX code.
-std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version);
+std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version,
+                                 bool enable_fp_fusion);
 
 } // namespace triton
 

--- a/lib/Target/PTX/PTXTranslation.cpp
+++ b/lib/Target/PTX/PTXTranslation.cpp
@@ -44,7 +44,8 @@ static bool findAndReplace(std::string &str, const std::string &begin,
   return true;
 }
 
-std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version) {
+std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version,
+                                 bool enable_fp_fusion) {
   // LLVM version in use may not officially support target hardware.
   // Supported versions for LLVM 14 are here:
   // https://github.com/llvm/llvm-project/blob/f28c006a5895fc0e329fe15fead81e37457cb1d1/clang/include/clang/Basic/BuiltinsNVPTX.def
@@ -84,7 +85,8 @@ std::string translateLLVMIRToPTX(llvm::Module &module, int cc, int version) {
   auto target =
       llvm::TargetRegistry::lookupTarget(module.getTargetTriple(), error);
   llvm::TargetOptions opt;
-  opt.AllowFPOpFusion = llvm::FPOpFusion::Fast;
+  if (enable_fp_fusion)
+    opt.AllowFPOpFusion = llvm::FPOpFusion::Fast;
   opt.UnsafeFPMath = false;
   opt.NoInfsFPMath = false;
   opt.NoNaNsFPMath = true;

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -1870,7 +1870,8 @@ void init_triton_translation(py::module &m) {
 
   m.def(
       "translate_llvmir_to_ptx",
-      [](const std::string llvmIR, int capability, int version) -> std::string {
+      [](const std::string llvmIR, int capability, int version,
+         bool enable_fp_fusion) -> std::string {
         py::gil_scoped_release allow_threads;
         // create LLVM module from C++
         llvm::LLVMContext context;
@@ -1885,75 +1886,77 @@ void init_triton_translation(py::module &m) {
               "lineno: " + std::to_string(error.getLineNo()));
         }
         // translate module to PTX
-        auto ptxCode =
-            triton::translateLLVMIRToPTX(*module, capability, version);
+        auto ptxCode = triton::translateLLVMIRToPTX(*module, capability,
+                                                    version, enable_fp_fusion);
         return ptxCode;
       },
       ret::take_ownership);
 
-  m.def(
-      "compile_ptx_to_cubin",
-      [](const std::string &ptxCode, const std::string &ptxasPath,
-         int capability) -> py::object {
-        std::string cubin;
-        {
-          py::gil_scoped_release allow_threads;
+  m.def("compile_ptx_to_cubin",
+        [](const std::string &ptxCode, const std::string &ptxasPath,
+           int capability, bool enable_fp_fusion) -> py::object {
+          std::string cubin;
+          {
+            py::gil_scoped_release allow_threads;
 
-          // compile ptx with ptxas
-          llvm::SmallString<64> fsrc;
-          llvm::SmallString<64> flog;
-          llvm::sys::fs::createTemporaryFile("compile-ptx-src", "", fsrc);
-          llvm::sys::fs::createTemporaryFile("compile-ptx-log", "", flog);
-          std::string fbin = std::string(fsrc) + ".o";
-          llvm::FileRemover logRemover(flog);
-          llvm::FileRemover binRemover(fbin);
-          const char *_fsrc = fsrc.c_str();
-          const char *_flog = flog.c_str();
-          const char *_fbin = fbin.c_str();
-          std::ofstream ofs(_fsrc);
-          ofs << ptxCode << std::endl;
-          ofs.close();
+            // compile ptx with ptxas
+            llvm::SmallString<64> fsrc;
+            llvm::SmallString<64> flog;
+            llvm::sys::fs::createTemporaryFile("compile-ptx-src", "", fsrc);
+            llvm::sys::fs::createTemporaryFile("compile-ptx-log", "", flog);
+            std::string fbin = std::string(fsrc) + ".o";
+            llvm::FileRemover logRemover(flog);
+            llvm::FileRemover binRemover(fbin);
+            const char *_fsrc = fsrc.c_str();
+            const char *_flog = flog.c_str();
+            const char *_fbin = fbin.c_str();
+            std::ofstream ofs(_fsrc);
+            ofs << ptxCode << std::endl;
+            ofs.close();
 
-          auto lineInfoOption =
-              triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO")
-                  ? ""
-                  : " -lineinfo";
-          auto capabilitySuffix = (capability == 90) ? "a " : " ";
-          auto outputFileName = std::string(_fsrc) + ".o";
-          auto logRedirect = " 2> " + std::string(_flog);
-          std::string cmd = ptxasPath + lineInfoOption + " -v --gpu-name=sm_" +
-                            std::to_string(capability) + capabilitySuffix +
-                            _fsrc + " -o " + outputFileName + logRedirect;
+            auto lineInfoOption =
+                triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO")
+                    ? ""
+                    : " -lineinfo";
+            auto fmadOption = enable_fp_fusion ? "" : " --fmad=false";
+            auto capabilitySuffix = (capability == 90) ? "a " : " ";
+            auto outputFileName = std::string(_fsrc) + ".o";
+            auto logRedirect = " 2> " + std::string(_flog);
+            std::string cmd = ptxasPath + lineInfoOption + fmadOption +
+                              " -v --gpu-name=sm_" +
+                              std::to_string(capability) + capabilitySuffix +
+                              _fsrc + " -o " + outputFileName + logRedirect;
 
-          int err = system(cmd.c_str());
-          if (err != 0) {
-            err >>= 8;
-            std::ifstream _log(_flog);
-            std::string log(std::istreambuf_iterator<char>(_log), {});
-            if (err == 255) {
-              throw std::runtime_error("Internal Triton PTX codegen error: \n" +
-                                       log);
-            } else if (err == 128 + SIGSEGV) {
-              throw std::runtime_error("Please run `ptxas " + fsrc.str().str() +
-                                       "` to confirm that this is a "
-                                       "bug in `ptxas`\n" +
-                                       log);
+            int err = system(cmd.c_str());
+            if (err != 0) {
+              err >>= 8;
+              std::ifstream _log(_flog);
+              std::string log(std::istreambuf_iterator<char>(_log), {});
+              if (err == 255) {
+                throw std::runtime_error(
+                    "Internal Triton PTX codegen error: \n" + log);
+              } else if (err == 128 + SIGSEGV) {
+                throw std::runtime_error("Please run `ptxas " +
+                                         fsrc.str().str() +
+                                         "` to confirm that this is a "
+                                         "bug in `ptxas`\n" +
+                                         log);
+              } else {
+                throw std::runtime_error("`ptxas` failed with error code " +
+                                         std::to_string(err) + ": \n" + log);
+              }
+              return {};
             } else {
-              throw std::runtime_error("`ptxas` failed with error code " +
-                                       std::to_string(err) + ": \n" + log);
+              llvm::FileRemover srcRemover(fsrc);
+              std::ifstream _cubin(_fbin, std::ios::binary);
+              cubin = std::string(std::istreambuf_iterator<char>(_cubin), {});
+              _cubin.close();
+              // Do not return here, exit the gil scope and return below
             }
-            return {};
-          } else {
-            llvm::FileRemover srcRemover(fsrc);
-            std::ifstream _cubin(_fbin, std::ios::binary);
-            cubin = std::string(std::istreambuf_iterator<char>(_cubin), {});
-            _cubin.close();
-            // Do not return here, exit the gil scope and return below
           }
-        }
-        py::bytes bytes(cubin);
-        return std::move(bytes);
-      });
+          py::bytes bytes(cubin);
+          return std::move(bytes);
+        });
 
   m.def("add_external_libs",
         [](mlir::ModuleOp &op, const std::vector<std::string> &names,

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -453,7 +453,7 @@ def _unwrap(tensor):
 
 builder = Builder()
 
-RESERVED_KWS = ['num_warps', 'num_stages', 'num_ctas', 'enable_warp_specialization']
+RESERVED_KWS = ['num_warps', 'num_stages', 'num_ctas', 'enable_warp_specialization', 'enable_fp_fusion']
 
 
 class GridExecutor:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -275,13 +275,13 @@ class JITFunction(KernelInterface[T]):
         constants = dict(zip(self.constexprs, constexpr_key))
         return constants
 
-    def _call_hook(self, key, signature, device, constants, num_warps, num_ctas, num_stages, enable_warp_specialization, extern_libs, configs):
+    def _call_hook(self, key, signature, device, constants, num_warps, num_ctas, num_stages, enable_warp_specialization, enable_fp_fusion, extern_libs, configs):
         if JITFunction.cache_hook is None:
             return False
         name = self.fn.__name__
         module = self.fn.__module__
         arg_reprs = ', '.join([f'{name}: {ty}' for name, ty in zip(self.arg_names, key[1])])
-        repr = f"{name}[num_warps={num_warps}, num_ctas={num_ctas}, num_stages={num_stages}, enable_warp_specialization={enable_warp_specialization}]({arg_reprs})"
+        repr = f"{name}[num_warps={num_warps}, num_ctas={num_ctas}, num_stages={num_stages}, enable_warp_specialization={enable_warp_specialization}, enable_fp_fusion={enable_fp_fusion}]({arg_reprs})"
         key = str(key)
 
         class LegacyCompiler:
@@ -291,7 +291,7 @@ class JITFunction(KernelInterface[T]):
                 pass
 
         kwargs = dict(signature=signature, device=device, constants=constants,
-                      num_warps=num_warps, num_ctas=num_ctas, num_stages=num_stages, enable_warp_specialization=enable_warp_specialization, extern_libs=extern_libs,
+                      num_warps=num_warps, num_ctas=num_ctas, num_stages=num_stages, enable_warp_specialization=enable_warp_specialization, enable_fp_fusion=enable_fp_fusion, extern_libs=extern_libs,
                       configs=configs)
 
         return JITFunction.cache_hook(key=key, repr=repr, fn=LegacyCompiler(module, name), compile={
@@ -345,7 +345,7 @@ class JITFunction(KernelInterface[T]):
         def regular_args_v(args_proxy):
             return [args_proxy[arg_name] for arg_name in regular_args]
 
-        def launcher_body(args_proxy, grid, num_warps, num_ctas, num_stages, enable_warp_specialization, extern_libs, stream, warmup, device, device_type):
+        def launcher_body(args_proxy, grid, num_warps, num_ctas, num_stages, enable_warp_specialization, enable_fp_fusion, extern_libs, stream, warmup, device, device_type):
             from ..compiler import (CompiledKernel, compile,
                                     get_arch_default_num_stages,
                                     get_arch_default_num_warps)
@@ -396,7 +396,7 @@ class JITFunction(KernelInterface[T]):
             if num_stages is None:
                 num_stages = get_arch_default_num_stages(device_type)
 
-            key = (version_key(), sig_key, constexpr_key, spec_key, num_warps, num_ctas, num_stages, enable_warp_specialization, self.debug)
+            key = (version_key(), sig_key, constexpr_key, spec_key, num_warps, num_ctas, num_stages, enable_warp_specialization, enable_fp_fusion, self.debug)
             if extern_libs is not None:
                 key = (key, tuple(extern_libs.items()))
 
@@ -424,8 +424,8 @@ class JITFunction(KernelInterface[T]):
                 for i, arg in constants.items():
                     if callable(arg):
                         raise TypeError(f"Callable constexpr at index {i} is not supported")
-                if not self._call_hook(key, signature, device, constants, num_warps, num_ctas, num_stages, enable_warp_specialization, extern_libs, configs):
-                    bin = compile(self, signature=signature, device=device, constants=constants, num_warps=num_warps, num_ctas=num_ctas, num_stages=num_stages, enable_warp_specialization=enable_warp_specialization, extern_libs=extern_libs, configs=configs, debug=self.debug, device_type=device_type)
+                if not self._call_hook(key, signature, device, constants, num_warps, num_ctas, num_stages, enable_warp_specialization, enable_fp_fusion, extern_libs, configs):
+                    bin = compile(self, signature=signature, device=device, constants=constants, num_warps=num_warps, num_ctas=num_ctas, num_stages=num_stages, enable_warp_specialization=enable_warp_specialization, enable_fp_fusion=enable_fp_fusion, extern_libs=extern_libs, configs=configs, debug=self.debug, device_type=device_type)
                     # Create tensormaps and append to args
                     args = bin.assemble_tensormap_to_arg(args)
                     if not warmup:
@@ -440,8 +440,8 @@ class JITFunction(KernelInterface[T]):
         args_signature = args_signature + ', ' if len(args_signature) > 0 else ''
         src = f"""
 import triton
-def {self.fn.__name__}({args_signature}grid=None, num_warps=None, num_ctas=1, num_stages=None, enable_warp_specialization=False, extern_libs=None, stream=None, warmup=False, device=None, device_type=None):
-    return launcher_body({{{args_map}}}, grid, num_warps, num_ctas, num_stages, enable_warp_specialization, extern_libs, stream, warmup, device, device_type)
+def {self.fn.__name__}({args_signature}grid=None, num_warps=None, num_ctas=1, num_stages=None, enable_warp_specialization=False, enable_fp_fusion=True, extern_libs=None, stream=None, warmup=False, device=None, device_type=None):
+    return launcher_body({{{args_map}}}, grid, num_warps, num_ctas, num_stages, enable_warp_specialization, enable_fp_fusion, extern_libs, stream, warmup, device, device_type)
 """
         scope = {"launcher_body": launcher_body}
         exec(src, scope)


### PR DESCRIPTION
By default, ptxas will enable fusion of mul/add to fma instructions. The backend was also being configured unconditionally to enable this on conversion from LLVM IR to PTX. This commit adds an option which can be used to disable the FP fusion behavior in both locations.