### PR TITLE
[RUNTIME] Filter out paths that don't exist in json group cache

### DIFF
--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -93,9 +93,8 @@ class FileCacheManager(CacheManager):
         result = {}
         for c in child_paths:
             p = self._make_path(c)
-            if not os.path.exists(p):
-                raise Exception(f"Group file {p} does not exist from group {grp_filename} ")
-            result[c] = p
+            if os.path.exists(p):
+                result[c] = p
         return result
 
     # Note a group of pushed files as being part of a group


### PR DESCRIPTION
I think there's no guarantee that `/tmp/triton/*/*.json` existing means that the corresponding `/tmp/triton/*/*.cubin` file also exists.