### PR TITLE
[FRONTEND] Add input dtypes to autotuning key

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -96,7 +96,11 @@ class Autotuner(KernelInterface):
             for name in self.arg_names:
                 if name in all_args:
                     _args.append(all_args[name])
-            key = tuple(_args[i] for i in self.key_idx)
+            key = [_args[i] for i in self.key_idx]
+            for arg in _args:
+                if hasattr(arg, "dtype"):
+                    key.append(str(arg.dtype))
+            key = tuple(key)
             if key not in self.cache:
                 # prune configs
                 pruned_configs = self.prune_configs(kwargs)


### PR DESCRIPTION
When input tensors' `dtype` changes, autotuning should (in general) be run again. At least two reasons for this:

1. The best-performing config on one `dtype` may not be the best for others (e.g., index `dtype` change from `i32` to `i64` may lead to heavier arithmetics).

2. A valid config for one `dtype` may be invalid for another (e.g., block sizes picked for `fp8` may be too large and lead to shared memory OOM with `fp32`).

Currently, input `dtype`s are not included in the autotining cache key, leading to the cached config on one input tensors' `dtype` be reused for all others. In this PR, the `dtype`s of all inputs having a `dtype` property are appended to the cache key. This should invalidate the cache on `dtype` change.