### PR TITLE
[BUILD] Disable W503 in flake8 config.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,5 @@
 [flake8]
-ignore = E501,E701,E731
+# W503 (linebreak occurred before binary operator) seems to be enabled by
+# default, even though it goes against pep8 and is incompatible with W504
+# (linebreak occurred *after* binary operator).  Disable it.
+ignore = E501,E701,E731,W503


### PR DESCRIPTION
<git-pr-chain>


[BUILD] Disable W503 in flake8 config.

It seems that by default, flake8 warns on both "linebreak occurred before
binary operator" (W503) and "linebreak occurred *after* binary operator"
(W504).  You...kind of have to pick one of these.  :)

According to the docs, W503 is deprecated, so we disable that one.
https://www.flake8rules.com/rules/W503.html


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #2555 👈 **YOU ARE HERE**
1. #2556


</git-pr-chain>



