### PR TITLE
Use clang+lld in CI builds.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,10 +73,10 @@ jobs:
         run: |
           cd python
           python3 -m pip install --upgrade pip
-          python3 -m pip install cmake==3.24
-          python3 -m pip install ninja
-          python3 -m pip install --no-build-isolation -vvv '.[tests]'
-          python3 -m pip install pytest-xdist
+          python3 -m pip install cmake==3.24 ninja pytest-xdist
+          sudo apt-get update -y
+          sudo apt-get install -y ccache clang lld
+          TRITON_BUILD_WITH_CLANG_LLD=true TRITON_BUILD_WITH_CCACHE=true python3 -m pip install --no-build-isolation -vvv '.[tests]'
 
       - name: Run lit tests
         if: ${{ env.BACKEND == 'CUDA'}}


### PR DESCRIPTION
<git-pr-chain>


Use clang+lld in CI builds.

This is significantly faster.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #2564 👈 **YOU ARE HERE**


</git-pr-chain>


