### PR TITLE
[FRONTEND] New kernel launch API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,14 @@ pip install ninja cmake wheel; # build-time dependencies
 pip install -e python
 ```
 
-Or with a virtualenv:
+Or with a virtualenv using python3.8 (the minimum Python version supported by
+Triton):
 
 ```
 git clone https://github.com/openai/triton.git;
 cd triton;
 
-python -m venv .venv --prompt triton;
+python3.8 -m venv .venv --prompt triton;
 source .venv/bin/activate;
 
 pip install ninja cmake wheel; # build-time dependencies

--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -153,6 +153,7 @@ def test_jit_warmup_cache() -> None:
         torch.randn(32, dtype=torch.float32, device="cuda"),
         32,
     ]
+    # TODO: Update to new API.
     device = torch.cuda.current_device()
     assert len(kernel_add.cache[device]) == 0
     kernel_add.warmup(torch.float32, torch.float32, torch.float32, 32, grid=(1,))

--- a/python/triton/ops/blocksparse/matmul.py
+++ b/python/triton/ops/blocksparse/matmul.py
@@ -103,6 +103,7 @@ def sdd_matmul(a, b, trans_a, trans_b, trans_c, spdims, block, lut, widths, out=
         assert out.shape == (a.shape[0], lut.shape[0], block, block)
         c = out
     grid = [c.shape[1], 1, c.shape[0]]
+    # TODO: Update to new API.
     _sdd_kernel[grid](
         a, b, c,
         a.stride(0), a.stride(1), a.stride(3 if trans_a else 2), a.stride(2 if trans_a else 3),

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -32,6 +32,7 @@ class Autotuner(KernelInterface):
             'top_k': number of configs to bench
             'prune_num_stages_by'(optional): a function used to prune num_stages. It takes configs:List[Config] as its input, and returns pruned configs.
         """
+        super().__init__()
         if not configs:
             self.configs = [Config({}, num_warps=4, num_stages=2, num_ctas=1)]
         else:
@@ -95,6 +96,7 @@ class Autotuner(KernelInterface):
             return [float("inf"), float("inf"), float("inf")]
 
     def run(self, *args, **kwargs):
+        # TODO: Update this API.
         self.nargs = dict(zip(self.arg_names, args))
         if len(self.configs) > 1:
             all_args = {**self.nargs, **kwargs}

--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -118,13 +118,12 @@ def softmax(x):
     y = torch.empty_like(x)
     # Enqueue kernel. The 1D launch grid is simple: we have one kernel instance per row o
     # f the input matrix
-    softmax_kernel[(n_rows,)](
+    softmax_kernel.with_flags(num_warps=num_warps)[(n_rows,)](
         y,
         x,
         x.stride(0),
         y.stride(0),
         n_cols,
-        num_warps=num_warps,
         BLOCK_SIZE=BLOCK_SIZE,
     )
     return y

--- a/python/tutorials/05-layer-norm.py
+++ b/python/tutorials/05-layer-norm.py
@@ -249,9 +249,8 @@ class LayerNorm(torch.autograd.Function):
         # heuristics for number of warps
         num_warps = min(max(BLOCK_SIZE // 256, 1), 8)
         # enqueue kernel
-        _layer_norm_fwd_fused[(M,)](x_arg, y, weight, bias, mean, rstd,
-                                    x_arg.stride(0), N, eps,
-                                    BLOCK_SIZE=BLOCK_SIZE, num_warps=num_warps, num_ctas=1)
+        _layer_norm_fwd_fused.with_flags(num_warps=num_warps, num_ctas=1)[(M,)](
+            x_arg, y, weight, bias, mean, rstd, x_arg.stride(0), N, eps, BLOCK_SIZE=BLOCK_SIZE)
         ctx.save_for_backward(x, weight, bias, mean, rstd)
         ctx.BLOCK_SIZE = BLOCK_SIZE
         ctx.num_warps = num_warps
@@ -278,16 +277,16 @@ class LayerNorm(torch.autograd.Function):
         # also compute partial sums for DW and DB
         x_arg = x.reshape(-1, x.shape[-1])
         M, N = x_arg.shape
-        _layer_norm_bwd_dx_fused[(M,)](dx, dy, _dw, _db, x, w, b, m, v, locks,
-                                       x_arg.stride(0), N, ctx.eps,
-                                       BLOCK_SIZE_N=ctx.BLOCK_SIZE,
-                                       GROUP_SIZE_M=GROUP_SIZE_M,
-                                       num_warps=ctx.num_warps)
+        _layer_norm_bwd_dx_fused.with_flags(num_warps=ctx.num_warps)[(M,)](
+            dx, dy, _dw, _db, x, w, b, m, v, locks,
+            x_arg.stride(0), N, ctx.eps,
+            BLOCK_SIZE_N=ctx.BLOCK_SIZE,
+            GROUP_SIZE_M=GROUP_SIZE_M)
         grid = lambda meta: [triton.cdiv(N, meta['BLOCK_SIZE_N'])]
         # accumulate partial sums in separate kernel
-        _layer_norm_bwd_dwdb[grid](_dw, _db, dw, db, GROUP_SIZE_M, N,
-                                   BLOCK_SIZE_M=32,
-                                   BLOCK_SIZE_N=128, num_ctas=1)
+        _layer_norm_bwd_dwdb.with_flags(num_ctas=1)[grid](
+            _dw, _db, dw, db, GROUP_SIZE_M, N,
+            BLOCK_SIZE_M=32, BLOCK_SIZE_N=128)
         return dx, None, dw, db, None
 
 

--- a/python/tutorials/07-math-functions.py
+++ b/python/tutorials/07-math-functions.py
@@ -22,10 +22,10 @@ import triton.language as tl
 
 @triton.jit
 def asin_kernel(
-        x_ptr,
-        y_ptr,
-        n_elements,
-        BLOCK_SIZE: tl.constexpr,
+    x_ptr,
+    y_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
@@ -35,6 +35,7 @@ def asin_kernel(
     x = tl.math.asin(x)
     tl.store(y_ptr + offsets, x, mask=mask)
 
+
 # %%
 #  Using the default libdevice library path
 # -----------------------------------------
@@ -43,19 +44,16 @@ def asin_kernel(
 
 torch.manual_seed(0)
 size = 98432
-x = torch.rand(size, device='cuda')
-output_triton = torch.zeros(size, device='cuda')
+x = torch.rand(size, device="cuda")
+output_triton = torch.zeros(size, device="cuda")
 output_torch = torch.asin(x)
 assert x.is_cuda and output_triton.is_cuda
 n_elements = output_torch.numel()
-grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
+grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
 asin_kernel[grid](x, output_triton, n_elements, BLOCK_SIZE=1024)
 print(output_torch)
 print(output_triton)
-print(
-    f'The maximum difference between torch and triton is '
-    f'{torch.max(torch.abs(output_torch - output_triton))}'
-)
+print(f"The maximum difference between torch and triton is " f"{torch.max(torch.abs(output_torch - output_triton))}")
 
 # %%
 #  Customize the libdevice library path
@@ -63,11 +61,9 @@ print(
 # We can also customize the libdevice library path by passing the path to the `libdevice` library to the `asin` kernel.
 
 output_triton = torch.empty_like(x)
-asin_kernel[grid](x, output_triton, n_elements, BLOCK_SIZE=1024,
-                  extern_libs={'libdevice': '/usr/local/cuda/nvvm/libdevice/libdevice.10.bc'})
+asin_kernel.with_flags(extern_libs={"libdevice": "/usr/local/cuda/nvvm/libdevice/libdevice.10.bc"})[grid](
+    x, output_triton, n_elements, BLOCK_SIZE=1024
+)
 print(output_torch)
 print(output_triton)
-print(
-    f'The maximum difference between torch and triton is '
-    f'{torch.max(torch.abs(output_torch - output_triton))}'
-)
+print(f"The maximum difference between torch and triton is " f"{torch.max(torch.abs(output_torch - output_triton))}")


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. [FRONTEND] New kernel launch API.
    
    Previously compiler flags were passed in the same list of parameters as
    kernel arguments, as in
    
      my_kernel[grid](arg1, arg2, ..., num_warps=42).
    
    This is problematic for a variety of reasons, but perhaps principal
    among them is the fact that we cannot add new compiler flags without
    potentially breaking kernels that use the arg name that we now want to
    claim.
    
    In the new syntax, you write
    
      my_kernel.with_flags(num_warps=42)[grid](arg1, arg2, ...)
    
    In addition to fixing the problem of adding new compiler flags, this
    also plays nicer with Python type-checkers.  Previously, pylance would
    incorrectly report that `num_warps` was not an argument to the kernel
    function, whereas now `with_flags` explicitly declares all its
    parameters in a manner friendly to the type checker.
1. WIP: More changes for new kernel API.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #2580 👈 **YOU ARE HERE**


</git-pr-chain>



