### PR TITLE
[tiny] Allow explicitly specifying a libcuda source

### DIFF
--- a/python/triton/common/build.py
+++ b/python/triton/common/build.py
@@ -18,9 +18,9 @@ def is_hip():
 
 @functools.lru_cache()
 def libcuda_dirs():
-    env_libcuda_dir = os.getenv("LIBCUDA_DIR")
-    if env_libcuda_dir:
-        return [env_libcuda_dir]
+    env_libcuda_path = os.getenv("TRITON_LIBCUDA_PATH")
+    if env_libcuda_path:
+        return [env_libcuda_path]
 
     libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode()
     # each line looks like the following:

--- a/python/triton/common/build.py
+++ b/python/triton/common/build.py
@@ -18,6 +18,10 @@ def is_hip():
 
 @functools.lru_cache()
 def libcuda_dirs():
+    env_libcuda_dir = os.getenv("LIBCUDA_DIR")
+    if env_libcuda_dir:
+        return [env_libcuda_dir]
+
     libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode()
     # each line looks like the following:
     # libcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1


### PR DESCRIPTION
Depending on the setup, sometimes it's much easier to explicitly specify the libcuda source instead of having ldconfig look it up. I was debating between using CUDA_HOME or other more commonly used env setups, but made it extremely explicit for the PR -- happy to update to any other env / mechanism. Thanks!