### PR TITLE
[BACKEND] Decompose splat to shared memory

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -213,3 +213,15 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
     tt.return
   }
 }
+
+// -----
+
+#shared = #triton_gpu.shared<{vec = 4, perPhase = 1, maxPhase = 8, order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], hasLeadingOffset = true}>
+// CHECK-LABEL: splat_shared_layout
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @splat_shared_layout(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}) {
+    %0 = tt.load %arg0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : f32
+    %1 = tt.splat %0 : (f32) -> tensor<64x128xf32, #shared>
+    tt.return
+  }
+}


### PR DESCRIPTION
Implementing fix described here:
https://github.com/openai/triton/issues/2586#issuecomment-1791413591.

When there is a splat->shared, we get the following unreachable:
```
getElemsPerThread is not supported for shared layout
UNREACHABLE executed at lib/Dialect/TritonGPU/IR/Dialect.cpp:830!
```
This can happen on H100s when you splat a scalar to a dot op as described in https://github.com/openai/triton/issues/2586.

Decompose the splat->shared to splat->blocked->shared.