### PR TITLE
[FRONTEND] Improve autotuner

### DIFF
--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -12,7 +12,7 @@ def test_kwargs():
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
 
-    @triton.autotune(configs=configs, key=['N'], rep=1)
+    @triton.autotune(configs=configs, key=['N'], warmup=1, rep=1)
     @triton.jit
     def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
         offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -30,7 +30,7 @@ def test_restore():
 
     configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
 
-    @triton.autotune(configs=configs, key=['N'], restore_value=['src'], rep=1)
+    @triton.autotune(configs=configs, key=['N'], restore_value=['src'], warmup=1, rep=1)
     @triton.jit
     def _kernel(src, N, BLOCK_SIZE: tl.constexpr):
         offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -68,6 +68,7 @@ def test_prune_configs(with_perf_model: bool):
         configs=configs,
         key=['N'],
         prune_configs_by=prune_configs_by,
+        warmup=1,
         rep=1
     )
     @triton.jit

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -64,13 +64,7 @@ def test_prune_configs(with_perf_model: bool):
     else:
         prune_configs_by = {'early_config_prune': early_config_prune}
 
-    @triton.autotune(
-        configs=configs,
-        key=['N'],
-        prune_configs_by=prune_configs_by,
-        warmup=1,
-        rep=1
-    )
+    @triton.autotune(configs=configs, key=['N'], prune_configs_by=prune_configs_by, warmup=1, rep=1)
     @triton.jit
     def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
         offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -2,6 +2,7 @@ import torch
 
 import triton
 import triton.language as tl
+import pytest
 
 
 def test_kwargs():
@@ -39,3 +40,44 @@ def test_restore():
     grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
     _kernel[grid](src, N)
     triton.testing.assert_close(src, torch.ones_like(src))
+
+
+@pytest.mark.parametrize('with_perf_model', [False, True])
+def test_prune_configs(with_perf_model: bool):
+    N = 1024
+    src = torch.empty(N, device='cuda')
+    dst = torch.empty(N, device='cuda')
+    records = {}
+
+    def early_config_prune(configs, named_args):
+        records['run_early_config_prune'] = True
+        return [configs[0]]
+
+    def perf_model(*args, **kwargs):
+        records['run_perf_model'] = True
+        return kwargs['BLOCK_SIZE']
+
+    configs = [triton.Config(kwargs={'BLOCK_SIZE': 32}), triton.Config(kwargs={'BLOCK_SIZE': 128})]
+
+    @triton.autotune(
+        configs=configs,
+        key=['N'],
+        prune_configs_by={
+            'early_config_prune': None if with_perf_model else early_config_prune,
+            'perf_model': perf_model if with_perf_model else None,
+            'top_k': 1,
+        },
+    )
+    @triton.jit
+    def _kernel(dst, src, N, BLOCK_SIZE: tl.constexpr):
+        offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+        x = tl.load(src + offsets, mask=offsets < N)
+        tl.store(dst + offsets, x, mask=offsets < N)
+
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
+    _kernel[grid](dst, src, N)
+    assert len(records) == 1
+    if with_perf_model:
+        assert records['run_perf_model']
+    else:
+        assert records['run_early_config_prune']

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -81,11 +81,11 @@ class Autotuner(KernelInterface):
             self.post_hook = _post_hook
 
         self.perf_model = None
-        self.top_k = 1.0
+        self.configs_top_k = 1.0
         self.early_config_prune = None
         if prune_configs_by:
             self.perf_model = prune_configs_by.get("perf_model", self.perf_model)
-            self.top_k = prune_configs_by.get("top_k", self.top_k)
+            self.configs_top_k = prune_configs_by.get("top_k", self.configs_top_k)
             self.early_config_prune = prune_configs_by.get("early_config_prune", self.early_config_prune)
 
         self.fn = fn

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -80,15 +80,13 @@ class Autotuner(KernelInterface):
 
             self.post_hook = _post_hook
 
-        # Prune configs
+        self.perf_model = None
+        self.top_k = 1.0
+        self.early_config_prune = None
         if prune_configs_by:
-            perf_model, top_k = prune_configs_by["perf_model"], prune_configs_by["top_k"]
-            if "early_config_prune" in prune_configs_by:
-                early_config_prune = prune_configs_by["early_config_prune"]
-        else:
-            perf_model, top_k, early_config_prune = None, None, None
-        self.perf_model, self.configs_top_k = perf_model, top_k
-        self.early_config_prune = early_config_prune
+            self.perf_model = prune_configs_by.get("perf_model", self.perf_model)
+            self.top_k = prune_configs_by.get("top_k", self.top_k)
+            self.early_config_prune = prune_configs_by.get("early_config_prune", self.early_config_prune)
 
         self.fn = fn
         self.warmup = warmup


### PR DESCRIPTION
- Reduce number of repetitions in the test
- Allow prune by `early_config_prune` without a perf model
- Cover early prune mode and prune by a perf model mode with tests