### PR TITLE
[FRONTEND] Reverting constexpr propagation on assignment.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3059,22 +3059,6 @@ def test_constexpr_scalar_shape(device):
     np.testing.assert_equal(to_numpy(x_tri), np.arange(0, 256) % 8)
 
 
-@triton.jit
-def static_assert_func():
-    tl.static_assert(tl.constexpr(False), "Assert is firing because the constexpr progation did not work properly")
-
-
-def test_constexpr_propagation():
-
-    @triton.jit
-    def _kernel(COND: tl.constexpr):
-        NEW_COND = COND
-        if NEW_COND:
-            static_assert_func()
-
-    _kernel[(1, )](False)
-
-
 # -------------
 # test call
 # -------------

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -426,9 +426,6 @@ class CodeGenerator(ast.NodeVisitor):
             raise UnsupportedLanguageConstruct(None, node, "simultaneous multiple assignment is not supported.")
         names = _names[0]
         values = self.visit(node.value)
-        if not isinstance(node.value, ast.Constant) and _is_constexpr(values):
-            self.set_value(names, values)
-            return
         if not _is_list_like(names):
             names = [names]
         if not _is_list_like(values):


### PR DESCRIPTION
Reverting part of [this](https://github.com/openai/triton/pull/2496) PR, due to [this](https://github.com/openai/triton/issues/2617) issue