### PR TITLE
add mail function in backends test

### DIFF
--- a/.github/actions/sent-mail/action.yml
+++ b/.github/actions/sent-mail/action.yml
@@ -27,7 +27,7 @@ runs:
         server_address: ${{ inputs.server }}
         server_port: ${{ inputs.port }}
         username: ${{ inputs.user }}
-        password: ${{ inputs.pswd }}        
+        password: ${{ inputs.pswd }}
         subject: "Failure Notification - ${{ inputs.jobname }}"
         body: |
           Notification: ${{ inputs.jobname }} failed in backend test,

--- a/.github/actions/sent-mail/action.yml
+++ b/.github/actions/sent-mail/action.yml
@@ -1,0 +1,28 @@
+name: Email Step
+
+inputs:
+  jobname:
+    required: true
+  jobowner:
+    required: true
+  ghrepo:
+    required: true
+  ghrunid:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Email
+      uses: dawidd6/action-send-mail@v3
+      with:
+        server_address: smtp.gmail.com
+        server_port: 465
+        subject: "Failure Notification - ${{ inputs.jobname }}"
+        body: |
+          Notification: ${{ inputs.jobname }} failed in backend test,
+
+          For details pls see "github.com/${{ inputs.ghrepo }}/actions/runs/${{ inputs.ghrunid }}"
+        ignore_cert: true
+        to: ${{ inputs.jobowner }}
+        from: ghaction@example.com

--- a/.github/actions/sent-mail/action.yml
+++ b/.github/actions/sent-mail/action.yml
@@ -1,6 +1,14 @@
 name: Email Step
 
 inputs:
+  server:
+    required: true
+  port:
+    required: true
+  user:
+    required: true
+  pswd:
+    required: true
   jobname:
     required: true
   jobowner:
@@ -16,13 +24,14 @@ runs:
     - name: Email
       uses: dawidd6/action-send-mail@v3
       with:
-        server_address: smtp.gmail.com
-        server_port: 465
+        server_address: ${{ inputs.server }}
+        server_port: ${{ inputs.port }}
+        username: ${{ inputs.user }}
+        password: ${{ inputs.pswd }}        
         subject: "Failure Notification - ${{ inputs.jobname }}"
         body: |
           Notification: ${{ inputs.jobname }} failed in backend test,
 
           For details pls see "github.com/${{ inputs.ghrepo }}/actions/runs/${{ inputs.ghrunid }}"
-        ignore_cert: true
         to: ${{ inputs.jobowner }}
         from: github_action@github.com

--- a/.github/actions/sent-mail/action.yml
+++ b/.github/actions/sent-mail/action.yml
@@ -1,13 +1,8 @@
 name: Email Step
 
 inputs:
-  server:
-    required: true
-  port:
-    required: true
-  user:
-    required: true
-  pswd:
+  mailconnection:
+    description: Specify connection via URL,like smtp+starttls://user:password@server:port
     required: true
   jobname:
     required: true
@@ -24,10 +19,7 @@ runs:
     - name: Email
       uses: dawidd6/action-send-mail@v3
       with:
-        server_address: ${{ inputs.server }}
-        server_port: ${{ inputs.port }}
-        username: ${{ inputs.user }}
-        password: ${{ inputs.pswd }}
+        connection_url: ${{ inputs.mailconnection }}
         subject: "Failure Notification - ${{ inputs.jobname }}"
         body: |
           Notification: ${{ inputs.jobname }} failed in backend test,

--- a/.github/actions/sent-mail/action.yml
+++ b/.github/actions/sent-mail/action.yml
@@ -25,4 +25,4 @@ runs:
           For details pls see "github.com/${{ inputs.ghrepo }}/actions/runs/${{ inputs.ghrunid }}"
         ignore_cert: true
         to: ${{ inputs.jobowner }}
-        from: ghaction@example.com
+        from: github_action@github.com

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -53,7 +53,7 @@ jobs:
           python3 -m pip uninstall -y triton
           python3 setup.py build
           python3 -m pip install --no-build-isolation -vvv '.[tests]'
-    
+
       - name: Run shared middle-layer lit tests
         run: |
           python3 -m pip install lit
@@ -181,41 +181,40 @@ jobs:
     needs: [Integration-Tests-Shared-Middle-Layer, Integration-Tests-AMD, Integration-Tests-Intel]
     if: ${{ always() && github.repository == 'openai/triton' }}
     steps:
-      - uses: actions/checkout@v4    
+      - uses: actions/checkout@v4
       - name: Integration-Tests-Shared-Middle-Layer-Notify
-        if: ${{ needs.Integration-Tests-Shared-Middle-Layer.result != '' && needs.Integration-Tests-Shared-Middle-Layer.result == 'failure' }}        
+        if: ${{ needs.Integration-Tests-Shared-Middle-Layer.result != '' && needs.Integration-Tests-Shared-Middle-Layer.result == 'failure' }}
         uses: ./.github/actions/sent-mail
         with:
           server: ${{ secrets.MAIL_SERVER }}
           port: ${{ secrets.MAIL_SERVER_PORT }}
           user: ${{ secrets.MAIL_USERNAME }}
-          pswd: ${{ secrets.MAIL_PASSWORD }}          
+          pswd: ${{ secrets.MAIL_PASSWORD }}
           jobname: Integration-Tests-Shared-Middle-Layer
           jobowner: ${{ secrets.MAIL_MS_RECEIVERS }}
           ghrepo: ${{ github.repository }}
-          ghrunid: ${{ github.run_id }}   
+          ghrunid: ${{ github.run_id }}
       - name: Integration-Tests-AMD-Notify
-        if: ${{ needs.Integration-Tests-AMD.result != '' && needs.Integration-Tests-AMD.result == 'failure' }}        
+        if: ${{ needs.Integration-Tests-AMD.result != '' && needs.Integration-Tests-AMD.result == 'failure' }}
         uses: ./.github/actions/sent-mail
         with:
           server: ${{ secrets.MAIL_SERVER }}
           port: ${{ secrets.MAIL_SERVER_PORT }}
           user: ${{ secrets.MAIL_USERNAME }}
-          pswd: ${{ secrets.MAIL_PASSWORD }}          
+          pswd: ${{ secrets.MAIL_PASSWORD }}
           jobname: Integration-Tests-AMD
           jobowner: ${{ secrets.MAIL_AMD_RECEIVERS }}
           ghrepo: ${{ github.repository }}
           ghrunid: ${{ github.run_id }}
       - name: Integration-Tests-Intel-Notify
-        if: ${{ needs.Integration-Tests-Intel.result != '' && needs.Integration-Tests-Intel.result == 'failure' }}        
+        if: ${{ needs.Integration-Tests-Intel.result != '' && needs.Integration-Tests-Intel.result == 'failure' }}
         uses: ./.github/actions/sent-mail
         with:
           server: ${{ secrets.MAIL_SERVER }}
           port: ${{ secrets.MAIL_SERVER_PORT }}
           user: ${{ secrets.MAIL_USERNAME }}
-          pswd: ${{ secrets.MAIL_PASSWORD }}       
+          pswd: ${{ secrets.MAIL_PASSWORD }}
           jobname: Integration-Tests-Intel
           jobowner: ${{ secrets.MAIL_INTEL_RECEIVERS }}
           ghrepo: ${{ github.repository }}
           ghrunid: ${{ github.run_id }}
-

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -26,10 +26,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      ## set failure status to test mail function
-      - name: Set failure
-        run: exit 1
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -190,10 +186,7 @@ jobs:
         if: ${{ needs.Integration-Tests-Shared-Middle-Layer.result != '' && needs.Integration-Tests-Shared-Middle-Layer.result == 'failure' }}
         uses: ./.github/actions/sent-mail
         with:
-          server: ${{ secrets.MAIL_SERVER }}
-          port: ${{ secrets.MAIL_SERVER_PORT }}
-          user: ${{ secrets.MAIL_USERNAME }}
-          pswd: ${{ secrets.MAIL_PASSWORD }}
+          mailconnection: ${{secrets.MAIL_CONNECTION}}
           jobname: Integration-Tests-Shared-Middle-Layer
           jobowner: ${{ secrets.MAIL_MS_RECEIVERS }}
           ghrepo: ${{ github.repository }}
@@ -202,10 +195,7 @@ jobs:
         if: ${{ needs.Integration-Tests-AMD.result != '' && needs.Integration-Tests-AMD.result == 'failure' }}
         uses: ./.github/actions/sent-mail
         with:
-          server: ${{ secrets.MAIL_SERVER }}
-          port: ${{ secrets.MAIL_SERVER_PORT }}
-          user: ${{ secrets.MAIL_USERNAME }}
-          pswd: ${{ secrets.MAIL_PASSWORD }}
+          mailconnection: ${{secrets.MAIL_CONNECTION}}
           jobname: Integration-Tests-AMD
           jobowner: ${{ secrets.MAIL_AMD_RECEIVERS }}
           ghrepo: ${{ github.repository }}
@@ -214,10 +204,7 @@ jobs:
         if: ${{ needs.Integration-Tests-Intel.result != '' && needs.Integration-Tests-Intel.result == 'failure' }}
         uses: ./.github/actions/sent-mail
         with:
-          server: ${{ secrets.MAIL_SERVER }}
-          port: ${{ secrets.MAIL_SERVER_PORT }}
-          user: ${{ secrets.MAIL_USERNAME }}
-          pswd: ${{ secrets.MAIL_PASSWORD }}
+          mailconnection: ${{secrets.MAIL_CONNECTION}}
           jobname: Integration-Tests-Intel
           jobowner: ${{ secrets.MAIL_INTEL_RECEIVERS }}
           ghrepo: ${{ github.repository }}

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -11,7 +11,7 @@ on:
         default: amd@example.com
       intelowner:
         required: true
-        default: yudong.si@intel.com    
+        default: yudong.si@intel.com,jian.hui.li@intel.com
   push:
     branches: [main]
 
@@ -213,7 +213,7 @@ jobs:
         uses: ./.github/actions/sent-mail
         with:
           jobname: Integration-Tests-Intel
-          jobowner: ${{ inputs.amdowner }}
+          jobowner: ${{ inputs.intelowner }}
           ghrepo: ${{ github.repository }}
           ghrunid: ${{ github.run_id }}
 

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -2,6 +2,16 @@ name: Backend Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      msowner:
+        required: true
+        default: ms@example.com      
+      amdowner:
+        required: true
+        default: amd@example.com
+      intelowner:
+        required: true
+        default: yudong.si@intel.com    
   push:
     branches: [main]
 
@@ -175,3 +185,35 @@ jobs:
           conda activate triton-xpu-ci
           cd python/test/backend/third_party_backends
           python3 -m pytest --capture=tee-sys -rfs --verbose --backend xpu
+
+  Check-Backends-Tests-And-Notify:
+    runs-on: ubuntu-latest
+    needs: [Integration-Tests-Shared-Middle-Layer, Integration-Tests-AMD, Integration-Tests-Intel]
+    if: always()
+    steps:
+      - uses: actions/checkout@v4    
+      - name: Integration-Tests-Shared-Middle-Layer-Notify
+        if: ${{ needs.Integration-Tests-Shared-Middle-Layer.result != '' && needs.Integration-Tests-Shared-Middle-Layer.result == 'failure' }}        
+        uses: ./.github/actions/sent-mail
+        with:
+          jobname: Integration-Tests-Shared-Middle-Layer
+          jobowner: ${{ inputs.msowner }}
+          ghrepo: ${{ github.repository }}
+          ghrunid: ${{ github.run_id }}   
+      - name: Integration-Tests-AMD-Notify
+        if: ${{ needs.Integration-Tests-AMD.result != '' && needs.Integration-Tests-AMD.result == 'failure' }}        
+        uses: ./.github/actions/sent-mail
+        with:
+          jobname: Integration-Tests-AMD
+          jobowner: ${{ inputs.amdowner }}
+          ghrepo: ${{ github.repository }}
+          ghrunid: ${{ github.run_id }}
+      - name: Integration-Tests-Intel-Notify
+        if: ${{ needs.Integration-Tests-Intel.result != '' && needs.Integration-Tests-Intel.result == 'failure' }}        
+        uses: ./.github/actions/sent-mail
+        with:
+          jobname: Integration-Tests-Intel
+          jobowner: ${{ inputs.amdowner }}
+          ghrepo: ${{ github.repository }}
+          ghrunid: ${{ github.run_id }}
+

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -2,16 +2,6 @@ name: Backend Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      msowner:
-        required: true
-        default: ms@example.com      
-      amdowner:
-        required: true
-        default: amd@example.com
-      intelowner:
-        required: true
-        default: yudong.si@intel.com,jian.hui.li@intel.com
   push:
     branches: [main]
 
@@ -63,7 +53,7 @@ jobs:
           python3 -m pip uninstall -y triton
           python3 setup.py build
           python3 -m pip install --no-build-isolation -vvv '.[tests]'
-
+    
       - name: Run shared middle-layer lit tests
         run: |
           python3 -m pip install lit
@@ -196,24 +186,36 @@ jobs:
         if: ${{ needs.Integration-Tests-Shared-Middle-Layer.result != '' && needs.Integration-Tests-Shared-Middle-Layer.result == 'failure' }}        
         uses: ./.github/actions/sent-mail
         with:
+          server: ${{ secrets.MAIL_SERVER }}
+          port: ${{ secrets.MAIL_SERVER_PORT }}
+          user: ${{ secrets.MAIL_USERNAME }}
+          pswd: ${{ secrets.MAIL_PASSWORD }}          
           jobname: Integration-Tests-Shared-Middle-Layer
-          jobowner: ${{ inputs.msowner }}
+          jobowner: ${{ secrets.MAIL_MS_RECEIVERS }}
           ghrepo: ${{ github.repository }}
           ghrunid: ${{ github.run_id }}   
       - name: Integration-Tests-AMD-Notify
         if: ${{ needs.Integration-Tests-AMD.result != '' && needs.Integration-Tests-AMD.result == 'failure' }}        
         uses: ./.github/actions/sent-mail
         with:
+          server: ${{ secrets.MAIL_SERVER }}
+          port: ${{ secrets.MAIL_SERVER_PORT }}
+          user: ${{ secrets.MAIL_USERNAME }}
+          pswd: ${{ secrets.MAIL_PASSWORD }}          
           jobname: Integration-Tests-AMD
-          jobowner: ${{ inputs.amdowner }}
+          jobowner: ${{ secrets.MAIL_AMD_RECEIVERS }}
           ghrepo: ${{ github.repository }}
           ghrunid: ${{ github.run_id }}
       - name: Integration-Tests-Intel-Notify
         if: ${{ needs.Integration-Tests-Intel.result != '' && needs.Integration-Tests-Intel.result == 'failure' }}        
         uses: ./.github/actions/sent-mail
         with:
+          server: ${{ secrets.MAIL_SERVER }}
+          port: ${{ secrets.MAIL_SERVER_PORT }}
+          user: ${{ secrets.MAIL_USERNAME }}
+          pswd: ${{ secrets.MAIL_PASSWORD }}       
           jobname: Integration-Tests-Intel
-          jobowner: ${{ inputs.intelowner }}
+          jobowner: ${{ secrets.MAIL_INTEL_RECEIVERS }}
           ghrepo: ${{ github.repository }}
           ghrunid: ${{ github.run_id }}
 

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -179,7 +179,7 @@ jobs:
   Check-Backends-Tests-And-Notify:
     runs-on: ubuntu-latest
     needs: [Integration-Tests-Shared-Middle-Layer, Integration-Tests-AMD, Integration-Tests-Intel]
-    if: always()
+    if: ${{ always() && github.repository == 'openai/triton' }}
     steps:
       - uses: actions/checkout@v4    
       - name: Integration-Tests-Shared-Middle-Layer-Notify

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -26,6 +26,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      ## set failure status to test mail function
+      - name: Set failure
+        run: exit 1
+
       - name: Checkout
         uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR add mail function in backends test based on https://github.com/openai/triton/pull/2613

1. add `actions/sent-mail` for reuse step in workflow
2. use `if: always()` in `Check-Backends-Tests-And-Notify` to ensure runs anyway even backends test encounter exit

Also, I may need your help on clear following info:
`amdowner` `msowner` `intelowner` `server_port`and `server_address`