### PR TITLE
[FRONTEND] Fix device_assert AttributeError

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1684,7 +1684,7 @@ def device_assert(cond, msg="", _builder=None):
     lineno = 0
     func_name = 'unknown'
     file_name = 'unknown'
-    if frame is not None:
+    if frame is not None and frame.f_back is not None:
         func_name = frame.f_code.co_name
         file_name = frame.f_back.f_code.co_filename
         # TODO: The line number currently indicates the line


### PR DESCRIPTION
Fixes https://github.com/openai/triton/issues/2628
TLDR is `frame.f_back` can be `None` if `frame` is the topmost frame. This happens when compile is called from child processes started with the `spawn` method