### PR TITLE
[BACKEND] Fix layouts in nvgpu RewriteTensorPointer.

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/RewriteTensorPointer.cpp
@@ -169,63 +169,94 @@ public:
 
   void setEncoding(Attribute newLayout) { layout = newLayout; }
 
+  // Creates a tensor with the values [0, tensorShape[axis]) + offsets[axis]
+  // broadcasted to N dimensions along axis (i.e. so that
+  // result[.., <axis'th dim> i, ...] = offsets[axis] + i).
   Value getExpandedOffsetWithRange(OpBuilder &builder, const Location &loc,
-                                   unsigned i) {
-    if (cachedOffsetWithRange.count(i))
-      return cachedOffsetWithRange[i];
+                                   unsigned axis) {
+    if (cachedOffsetWithRange.count(axis))
+      return cachedOffsetWithRange[axis];
 
-    // Add range
-    auto indexI32RowType =
-        RankedTensorType::get({tensorShape[i]}, builder.getI32Type(), layout);
-    auto indexRowType =
-        RankedTensorType::get({tensorShape[i]}, builder.getI64Type(), layout);
-    Value splatOffset =
-        builder.create<tt::SplatOp>(loc, indexRowType, offsets[i]);
-    Value range = builder.create<tt::MakeRangeOp>(loc, indexI32RowType, 0,
-                                                  tensorShape[i]);
-    Value i64Range = builder.create<arith::ExtSIOp>(loc, indexRowType, range);
+    // Ultimately this will look like:
+    //
+    //   % base = create_range ... : tensor<N>
+    //   %a0 = expand_dims %base   : tensor<M, 1>
+    //   %a1 = broadcast %a0       : tensor<M, N>
+    //   %b0 = expand_dims %a1     : tensor<M, N, 1>
+    //   %b1 = broadcast %b1       : tensor<M, N, K>
+    //   ...
+    //
+    // The final result has layout this->layout.  When we subtract a dim, that's
+    // equivalent to taking a sliced layout, so e.g. the layout of %a0/%a1 is a
+    // slice of %b0/%b1's layout.
+    size_t rank = tensorShape.size();
+    auto ctx = loc.getContext();
 
-    // Expand dimensions
-    Value expandedResult =
-        builder.create<arith::AddIOp>(loc, splatOffset, i64Range);
-    for (int axis = 0; axis < tensorShape.size(); ++axis) {
-      if (axis == i)
-        continue;
+    // layouts[i] is the layout at the i'th step of the algorithm.  In the last
+    // step of the algorithm, we have this->layout.  Every step before that
+    // slices away one dimension, until we get to the first step, which has all
+    // but `axis` sliced away.  For example:
+    //   - Suppose rank = 4 and axis = 2.
+    //   - Then the layouts will be:
+    //
+    //     layouts[0] = slice(layouts[1], remove_dim=0), containing axes [2]
+    //     layouts[1] = slice(layouts[2], remove_dim=1), containing axes [0,2]
+    //     layouts[2] = slice(layouts[3], remove_dim=3), containing axes [0,1,2]
+    //     layouts[3] = layout, containing axes [0,1,2,3]
+    //
+    // The loop below implements this algorithm.
+    SmallVector<Attribute, 4> layouts;
+    layouts.resize(rank);
+    layouts[rank - 1] = layout;
+    size_t axisToRemove = rank - 1;
+    for (int64_t i = rank - 2; i >= 0; i--) {
+      if (axisToRemove == axis)
+        axisToRemove--;
 
-      if (layout) {
-        auto argEncoding = layout.cast<ttg::BlockedEncodingAttr>();
-        auto retSizePerThread = insertOne(argEncoding.getSizePerThread(), axis);
-        auto retThreadsPerWarp =
-            insertOne(argEncoding.getThreadsPerWarp(), axis);
-        auto retWarpsPerCTA = insertOne(argEncoding.getWarpsPerCTA(), axis);
-        auto retOrder = insertOrder(argEncoding.getOrder(), axis);
-
-        auto argCTALayout = argEncoding.getCTALayout();
-        auto retCTAsPerCGA = insertOne(argCTALayout.getCTAsPerCGA(), axis);
-        auto retCTASplitNum = insertOne(argCTALayout.getCTASplitNum(), axis);
-        auto retCTAOrder = insertOrder(argCTALayout.getCTAOrder(), axis);
-
-        auto retCTALayout = ttg::CTALayoutAttr::get(
-            loc.getContext(), retCTAsPerCGA, retCTASplitNum, retCTAOrder);
-
-        auto retEncoding = ttg::BlockedEncodingAttr::get(
-            loc.getContext(), retSizePerThread, retThreadsPerWarp,
-            retWarpsPerCTA, retOrder, retCTALayout);
-
-        auto newArgEncoding =
-            ttg::SliceEncodingAttr::get(loc.getContext(), axis, retEncoding);
-        auto newArgType = RankedTensorType::get(indexRowType.getShape(),
-                                                indexRowType.getElementType(),
-                                                newArgEncoding);
-        Value newArg = builder.create<ttg::ConvertLayoutOp>(loc, newArgType,
-                                                            expandedResult);
-        expandedResult = builder.create<tt::ExpandDimsOp>(loc, newArg, axis);
-      } else
-        expandedResult =
-            builder.create<tt::ExpandDimsOp>(loc, expandedResult, axis);
+      layouts[i] =
+          ttg::SliceEncodingAttr::get(ctx, axisToRemove, layouts[i + 1]);
+      axisToRemove--;
     }
 
-    return cachedOffsetWithRange[i] = expandedResult;
+    // Now that we know the layout at each step, we can do the multi-step
+    // broadcast.  Start with the base case.
+    auto baseTy = RankedTensorType::get({tensorShape[axis]},
+                                        builder.getI64Type(), layouts[0]);
+    auto baseTyI32 = RankedTensorType::get({tensorShape[axis]},
+                                           builder.getI32Type(), layouts[0]);
+    Value base = builder.create<arith::AddIOp>(
+        loc,
+        // tt::MakeRangeOp can only return i32, so we have to extend it to i64.
+        builder.create<arith::ExtSIOp>(
+            loc, baseTy,
+            builder.create<tt::MakeRangeOp>(loc, baseTyI32, 0,
+                                            tensorShape[axis])),
+        builder.create<tt::SplatOp>(loc, baseTy, offsets[axis]));
+
+    // Now incrementally build up the full result.
+    Value curTensor = base;
+    SmallVector<int64_t, 4> curShape = {tensorShape[axis]};
+    size_t curAxis = 0;
+    for (size_t i = 1; i < rank; i++) {
+      if (curAxis == axis)
+        curAxis++;
+
+      curShape.insert(curShape.begin() + curAxis, 1);
+      Value expanded =
+          builder.create<tt::ExpandDimsOp>(loc, curTensor, curAxis);
+
+      curShape[curAxis] = tensorShape[curAxis];
+      Value broadcasted = builder.create<tt::BroadcastOp>(
+          loc,
+          RankedTensorType::get(curShape, builder.getI64Type(), layouts[i]),
+          expanded);
+
+      curTensor = broadcasted;
+      curAxis++;
+    }
+
+    cachedOffsetWithRange[axis] = curTensor;
+    return curTensor;
   }
 
   Value generatePtr(OpBuilder &builder, const Location &loc) {

--- a/test/TritonGPU/rewrite-tensor-pointer2.mlir
+++ b/test/TritonGPU/rewrite-tensor-pointer2.mlir
@@ -1,0 +1,86 @@
+// RUN: triton-opt %s -tritongpu-rewrite-tensor-pointer | FileCheck %s
+
+#blocked = #triton_gpu.blocked<{
+    sizePerThread = [1, 1],
+    threadsPerWarp = [32, 1],
+    warpsPerCTA = [4, 1],
+    order = [0, 1],
+    CTAsPerCGA = [1, 1],
+    CTASplitNum = [1, 1],
+CTAOrder = [0, 1]}>
+
+#blocked1 = #triton_gpu.blocked<{
+    sizePerThread = [1, 1, 1, 1],
+    threadsPerWarp = [32, 1, 1, 1],
+    warpsPerCTA = [4, 1, 1, 1],
+    order = [0, 1, 2, 3],
+    CTAsPerCGA = [1, 1, 1, 1],
+    CTASplitNum = [1, 1, 1, 1],
+CTAOrder = [0, 1, 2, 3]}>
+
+module attributes {
+    "triton_gpu.compute-capability" = 80 : i32,
+    "triton_gpu.num-ctas" = 1 : i32,
+    "triton_gpu.num-warps" = 4 : i32
+} {
+
+// CHECK-LABEL: @test2D
+tt.func public @test2D(%base_ptr: !tt.ptr<f32, 1>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c32_i64 = arith.constant 32 : i64
+    // CHECK-DAG: tt.splat {{.*}} : (i64) -> tensor<16xi64, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    // CHECK-DAG: tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    // CHECK: tt.expand_dims {{.*}} {axis = 1 : i32} : (tensor<16xi64, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<16x1xi64, #blocked>
+    // CHECK: tt.broadcast {{.*}} : (tensor<16x1xi64, #blocked>) -> tensor<16x32xi64, #blocked>
+
+    // CHECK-DAG: tt.splat {{.*}} : (i64) -> tensor<32xi64, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+    // CHECK-DAG: tt.make_range {{.*}} : tensor<32xi32, #triton_gpu.slice<{dim = 0, parent = #blocked}>>
+    // CHECK: tt.expand_dims {{.*}} {axis = 0 : i32} : (tensor<32xi64, #triton_gpu.slice<{dim = 0, parent = #blocked}>>) -> tensor<1x32xi64, #blocked>
+    // CHECK: tt.broadcast {{.*}} : (tensor<1x32xi64, #blocked>) -> tensor<16x32xi64, #blocked>
+    %tensor_ptr = tt.make_tensor_ptr %base_ptr,
+      [%c16_i64, %c32_i64], // shape
+      [%c1_i64, %c1_i64], // strides
+      [%c0_i32, %c0_i32] // offsets
+      {order = array<i32: 1, 0>}:
+      !tt.ptr<tensor<16x32xf32, #blocked>, 1>
+    %tensor = tt.load %tensor_ptr
+      {cache = 1 : i32, evict = 1 : i32, isVolatile = false}:
+      !tt.ptr<tensor<16x32xf32, #blocked>, 1> -> tensor<16x32xf32, #blocked>
+    tt.return
+}
+
+// CHECK-LABEL: @test4D
+tt.func public @test4D(%base_ptr: !tt.ptr<f32, 1>) {
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c4_i64 = arith.constant 4 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %c16_i64 = arith.constant 16 : i64
+
+    // One run of the dim-expansion algorithm.  This pattern repeats four times,
+    // once for each dimension, but we only check one of them.
+    // CHECK-DAG: tt.make_range {end = 2 : i32, start = 0 : i32} : tensor<2xi32, #triton_gpu.slice<{dim = 1, parent = #triton_gpu.slice<{dim = 2, parent = #triton_gpu.slice<{dim = 3, parent = #blocked1}>}>}>>
+    // CHECK-DAG: tt.splat {{.*}} : (i64) -> tensor<2xi64, #triton_gpu.slice<{dim = 1, parent = #triton_gpu.slice<{dim = 2, parent = #triton_gpu.slice<{dim = 3, parent = #blocked1}>}>}>>
+    // CHECK: tt.expand_dims {{.*}} {axis = 1 : i32} : (tensor<2xi64, #triton_gpu.slice<{dim = 1, parent = #triton_gpu.slice<{dim = 2, parent = #triton_gpu.slice<{dim = 3, parent = #blocked1}>}>}>>) -> tensor<2x1xi64, #triton_gpu.slice<{dim = 2, parent = #triton_gpu.slice<{dim = 3, parent = #blocked1}>}>>
+    // CHECK: tt.broadcast {{.*}} : (tensor<2x1xi64, #triton_gpu.slice<{dim = 2, parent = #triton_gpu.slice<{dim = 3, parent = #blocked1}>}>>) -> tensor<2x4xi64, #triton_gpu.slice<{dim = 2, parent = #triton_gpu.slice<{dim = 3, parent = #blocked1}>}>>
+    // CHECK: tt.expand_dims {{.*}} {axis = 2 : i32} : (tensor<2x4xi64, #triton_gpu.slice<{dim = 2, parent = #triton_gpu.slice<{dim = 3, parent = #blocked1}>}>>) -> tensor<2x4x1xi64, #triton_gpu.slice<{dim = 3, parent = #blocked1}>>
+    // CHECK: tt.broadcast {{.*}} : (tensor<2x4x1xi64, #triton_gpu.slice<{dim = 3, parent = #blocked1}>>) -> tensor<2x4x8xi64, #triton_gpu.slice<{dim = 3, parent = #blocked1}>>
+    // CHECK: tt.expand_dims {{.*}} {axis = 3 : i32} : (tensor<2x4x8xi64, #triton_gpu.slice<{dim = 3, parent = #blocked1}>>) -> tensor<2x4x8x1xi64, #blocked1>
+    // CHECK: tt.broadcast {{.*}} : (tensor<2x4x8x1xi64, #blocked1>) -> tensor<2x4x8x16xi64, #blocked1>
+
+    %tensor_ptr = tt.make_tensor_ptr %base_ptr,
+      [%c2_i64, %c4_i64, %c8_i64, %c16_i64], // shape
+      [%c1_i64, %c1_i64, %c1_i64, %c1_i64], // strides
+      [%c0_i32, %c0_i32, %c0_i32, %c0_i32] // offsets
+      {order = array<i32: 3, 2, 1, 0>}:
+      !tt.ptr<tensor<2x4x8x16xf32, #blocked1>, 1>
+    %tensor = tt.load %tensor_ptr
+      {cache = 1 : i32, evict = 1 : i32, isVolatile = false}:
+      !tt.ptr<tensor<2x4x8x16xf32, #blocked1>, 1> -> tensor<2x4x8x16xf32, #blocked1>
+    tt.return
+}
+
+} // end module


### PR DESCRIPTION
<git-pr-chain>


[BACKEND] Fix layouts in nvgpu RewriteTensorPointer.

This pass was creating invalid IR.  In particular, it would create an
rank-N tensor with a rank-M layout, where N != M.

It "happened to work" because a later pass (probably remove layout
conversions?) was fixing it up.

Example of invalid IR: https://github.com/openai/triton/pull/2622#issuecomment-1803139094

This was caught by an IR-verifier rule I'm working on that specifically
checks that the rank of a layout matches that of its tensor.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #2634 👈 **YOU ARE HERE**
1. #2660
1. #2622


</git-pr-chain>








