### PR TITLE
[Hopper] Update CGA->CTA tiling heuristic and add support for persistent kernels to improve performance of warp specialized kernels with NUM_CTAS>1

### DIFF
--- a/include/triton/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/include/triton/Dialect/NVGPU/IR/NVGPUOps.td
@@ -248,6 +248,11 @@ def NVGPU_ClusterCTAIdOp : NVGPU_Op<"cluster_id", [Pure]> {
   let assemblyFormat = "attr-dict";
 }
 
+def NVGPU_CanonicalWarpIdOp : NVGPU_Op<"canonical_warp_id", [Pure]> {
+  let results = (outs I32:$result);
+  let assemblyFormat = "attr-dict";
+}
+
 def NVGPU_RegAllocOp : NVGPU_Op<"reg_alloc", []> {
   let arguments = (ins I32Attr: $regCount);
   let assemblyFormat = "operands attr-dict `:` type(operands)";

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -199,6 +199,15 @@ def TTNG_GetClusterCTAIdOp : TTNG_Op<"get_cluster_cta_id", [Pure]> {
   let assemblyFormat = "attr-dict `:` type($result)";
 }
 
+def TTNG_GetCanonicalWarpId : TTNG_Op<"get_canonical_warp_id", [Pure]> {
+  let description = [{
+    Returns the one dimensional warpId when it's used for producing warp uniform values.
+  }];
+
+  let results = (outs I32:$result);
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
 def TTNG_NamedBarrierArriveOp : TTNG_Op<"bar_arrive", []> {
   let summary = "named barrier arrive";
 

--- a/lib/Conversion/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/lib/Conversion/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -78,6 +78,23 @@ const std::string Cluster_Cta_Id_Op = "{\n"
                                       "mad.lo.u32 a1, a2, a4, a1;     \n"
                                       "mad.lo.u32 $0, a1, a3, a0;     \n"
                                       "}";
+const std::string Canonical_Warp_Id_Op =
+    "{\n"
+    ".reg .u32 a<5>;              \n"
+    "mov.u32 a0, %tid.x;          \n" // x
+    "mov.u32 a1, %tid.y;          \n" // y
+    "mov.u32 a2, %tid.z;          \n" // z
+    "mov.u32 a3, %ntid.x;         \n" // nx
+    "mov.u32 a4, %ntid.y;         \n" // ny
+    "mad.lo.u32 a1, a2, a4, a1;   \n"
+    "mad.lo.u32 a0, a1, a3, a0;   \n"
+    "shr.u32 a0, a0, 5;           \n"
+    ".reg .b32         %tmp<3>;   \n"
+    "mov.u32   %tmp0, -1;         \n"
+    "mov.u32   %tmp1, 31;         \n"
+    "mov.u32   %tmp2, 0;          \n"
+    "shfl.sync.idx.b32         $0, a0, %tmp2, %tmp1, %tmp0;           \n"
+    "}";
 
 bool isNumber(const std::string &s) {
   return !s.empty() && std::find_if(s.begin(), s.end(), [](unsigned char c) {
@@ -1106,6 +1123,8 @@ public:
         context, Sts64_Op, Constraints(), Constraints({"r", "r", "r"}));
     patterns.add<NVGPUOpGenericPattern<ttn::ClusterCTAIdOp>>(
         context, Cluster_Cta_Id_Op, Constraints({"=r"}), Constraints());
+    patterns.add<NVGPUOpGenericPattern<ttn::CanonicalWarpIdOp>>(
+        context, Canonical_Warp_Id_Op, Constraints({"=r"}), Constraints());
     patterns.add<NVGPUOpGenericPattern<ttn::WGMMADescCreateOp>>(
         context, Wgmma_Desc_Create_op, Constraints({"=l"}),
         Constraints({"l", "l"}));

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVM.cpp
@@ -599,6 +599,20 @@ struct GetThreadIdOpConversion : public ConvertTritonGPUOpToLLVMPattern<
   }
 };
 
+struct GetCanonicalWarpIdConversion
+    : public ConvertTritonGPUOpToLLVMPattern<
+          triton::nvidia_gpu::GetCanonicalWarpId> {
+  using ConvertTritonGPUOpToLLVMPattern<
+      triton::nvidia_gpu::GetCanonicalWarpId>::ConvertTritonGPUOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::GetCanonicalWarpId op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(op, GetCanonicalWarpId(rewriter, op->getLoc()));
+    return success();
+  }
+};
+
 struct GetClusterCTAIdOpConversion
     : public ConvertTritonGPUOpToLLVMPattern<
           triton::nvidia_gpu::GetClusterCTAIdOp> {
@@ -854,6 +868,7 @@ void populateTritonGPUToLLVMPatterns(
   patterns.add<GetProgramIdOpConversion>(typeConverter, benefit);
   patterns.add<GetNumProgramsOpConversion>(typeConverter, benefit);
   patterns.add<GetThreadIdOpConversion>(typeConverter, benefit);
+  patterns.add<GetCanonicalWarpIdConversion>(typeConverter, benefit);
   patterns.add<GetClusterCTAIdOpConversion>(typeConverter, benefit);
   patterns.add<MakeRangeOpConversion>(typeConverter, indexCacheInfo, benefit);
   patterns.add<ReturnOpConversion>(typeConverter, benefit);

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -249,6 +249,12 @@ public:
     return tid;
   }
 
+  Value GetCanonicalWarpId(ConversionPatternRewriter &rewriter,
+                           Location loc) const {
+    return rewriter.create<triton::nvgpu::CanonicalWarpIdOp>(
+        loc, rewriter.getI32Type());
+  }
+
   Value getClusterCTAId(ConversionPatternRewriter &rewriter,
                         Location loc) const {
     return rewriter.create<triton::nvgpu::ClusterCTAIdOp>(

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/WSFeasibilityChecking.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/WSFeasibilityChecking.cpp
@@ -57,11 +57,6 @@ public:
                         "the unspecialized version...\n";
       });
     }
-    // TODO: remove it when unspecialzied kernel supports NUM_CTAS>1
-    if (mod->getAttrOfType<IntegerAttr>("triton_gpu.num-ctas").getInt() > 1 &&
-        wsSupported == 0)
-      llvm::report_fatal_error(
-          "Currently unspecialized kernel doesn't support NUM_CTAS > 1");
   }
 };
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/WSFeasibilityChecking.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/WSFeasibilityChecking.cpp
@@ -50,8 +50,6 @@ public:
     auto i32_ty = IntegerType::get(mod->getContext(), 32);
     mod->setAttr(ttng::TritonNvidiaGPUDialect::getWSSupportedAttrName(),
                  IntegerAttr::get(i32_ty, llvm::APInt(32, wsSupported)));
-    int num_ctas =
-        mod->getAttrOfType<IntegerAttr>("triton_gpu.num-ctas").getInt();
     if (wsSupported == 0) {
       mod->walk([](triton::FuncOp func) {
         llvm::errs() << "Warning: kernel \'" << func.getName()
@@ -60,7 +58,8 @@ public:
       });
     }
     // TODO: remove it when unspecialzied kernel supports NUM_CTAS>1
-    if (num_ctas > 1 && wsSupported == 0)
+    if (mod->getAttrOfType<IntegerAttr>("triton_gpu.num-ctas").getInt() > 1 &&
+        wsSupported == 0)
       llvm::report_fatal_error(
           "Currently unspecialized kernel doesn't support NUM_CTAS > 1");
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/WSMaterialization.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/WSMaterialization.cpp
@@ -470,7 +470,6 @@ void mutexSyncPingPang(Operation *parentOp, int numAgents, int &nameBarrierId,
     OpBuilder builder(getMutexRoleIdOp);
     numRoles = getMutexRoleIdOp.getNum();
     auto loc = getMutexRoleIdOp->getLoc();
-    // Value threadId = getThreadId(builder, loc);
     Value warpId = builder.create<ttng::GetCanonicalWarpId>(loc);
     assert(getMutexRoleIdOp->hasAttr("agent.num-warps"));
     int numWarps =

--- a/python/test/unit/hopper/test_persistent_warp_specialized_gemm.py
+++ b/python/test/unit/hopper/test_persistent_warp_specialized_gemm.py
@@ -790,6 +790,14 @@ def full_static_persistent_matmul_kernel(a_ptr, b_ptr, w_ptr, bias_ptr, z_ptr,  
         for use_tma_store in [False, True]
         for num_stages in [3, 4]
         for enable_ws in [True]
+    ] + [
+        # larger NUM_CTAS
+        [1024, 128, 64, 4, 8, 1300, 1800, 3000, False, False, 'none', 'float16', True, 5, True],
+        [512, 256, 64, 4, 8, 800, 30000, 10000, True, True, 'none', 'float16', True, 4, True],
+        [1024, 128, 64, 4, 8, 1800, 10000, 15000, True, True, 'none', 'float16', True, 5, True],
+        [512, 256, 64, 4, 8, 1300, 1800, 3000, False, False, 'none', 'float16', True, 5, True],
+        [128, 1024, 64, 4, 8, 800, 30000, 10000, True, True, 'none', 'float16', True, 5, True],
+        [512, 256, 64, 4, 8, 1800, 10000, 15000, True, True, 'none', 'float16', True, 5, True],
     ])
 @pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="Requires compute capability >= 9")
 def test_full_static_persistent_matmul_kernel(BLOCK_M, BLOCK_N, BLOCK_K, NUM_WARPS, NUM_CTAS, M, N, K, TRANS_A, TRANS_B,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -10,7 +10,7 @@ from . import semantic
 
 T = TypeVar('T')
 
-TRITON_MAX_TENSOR_NUMEL = 131072
+TRITON_MAX_TENSOR_NUMEL = 1048576
 
 TRITON_BUILTIN = "__triton_builtin__"
 

--- a/python/triton/runtime/backends/cuda.c
+++ b/python/triton/runtime/backends/cuda.c
@@ -487,7 +487,7 @@ static PyObject *getMaxActiveClusters(PyObject *self, PyObject *args) {
   CUDA_CHECK_AND_RETURN_NULL_ALLOW_THREADS(
       cuOccupancyMaxActiveClusters(&maxActiveClusters, func, &config));
   Py_END_ALLOW_THREADS;
-  return (PyObject *)Py_BuildValue("i", maxActiveClusters);
+  return PyLong_FromLong(maxActiveClusters);
 }
 
 static PyMethodDef ModuleMethods[] = {

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -63,6 +63,7 @@ class CudaUtils(object):
         self.cuMemAlloc = mod.cuMemAlloc
         self.cuMemcpyHtoD = mod.cuMemcpyHtoD
         self.cuMemFree = mod.cuMemFree
+        self.cu_occupancy_max_active_clusters = mod.cu_occupancy_max_active_clusters
 
 
 class CudaDriver(DriverBase):


### PR DESCRIPTION
- Improve the logics of determining splitM&splitN
- Add necessary support for persistent kernels with NUM_CTAS>1
- Add canonocal warp id query operation to help cse and licm before nvgpu2llvm pass.
- Add warning info for fallback of warp specialized kernels