### PR TITLE
Switch yapf pre-commit back to public Google repo.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,8 +30,8 @@ repos:
             ^docs/conf.py$
           )
 
-  - repo: https://github.com/jlebar/yapf
-    rev: bf301f5ef7777e137b97219842629ca78eb5ef2a
+  - repo: https://github.com/google/yapf
+    rev: 6a92535967543aa979461fbe2da63a9b6f7dd595
     hooks:
       - id: yapf
         args: ["-p", "-i"]


### PR DESCRIPTION
Google has merged the custom change we were relying on, so we no longer need to use my branch.

Also I unthinkingly deleted the branch in my repo and broke things for @jsh_20, and anyone else who tried to install our pre-commits in the past two days.  I've restored the branch so people shouldn't hit this issue, but anyway it's better to be on mainline.
