### PR TITLE
[BACKEND] Enable pipelining for bwd attention pass on A100

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -160,6 +160,8 @@ static ttg::DotOperandEncodingAttr allTransitiveUsesHaveDotEncoding(Value val) {
     if (user->getNumResults() != 1)
       return nullptr;
     auto tensorType = user->getResult(0).getType().dyn_cast<RankedTensorType>();
+    if (!tensorType)
+      return nullptr;
     ttg::DotOperandEncodingAttr tempAttr;
     if (tensorType.getEncoding().isa<ttg::SharedEncodingAttr>()) {
       tempAttr = allTransitiveUsesHaveDotEncoding(user->getResult(0));

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -56,12 +56,9 @@ static void createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
       SmallVector<OpFoldResult>{int_attr(1), int_attr(sliceType.getShape()[0]),
                                 int_attr(sliceType.getShape()[1])},
       SmallVector<OpFoldResult>{int_attr(1), int_attr(1), int_attr(1)});
-  Operation *user = *loadOp.getResult().getUsers().begin();
-  auto convertLayout = llvm::cast<ttg::ConvertLayoutOp>(user);
   auto newCvt = builder.create<ttg::ConvertLayoutOp>(
-      convertLayout->getLoc(), convertLayout.getType(), extract.getResult());
-  convertLayout->replaceAllUsesWith(newCvt->getResults());
-  convertLayout->erase();
+      loadOp->getLoc(), loadOp.getType(), extract.getResult());
+  loadOp->replaceAllUsesWith(newCvt->getResults());
   loadOp.erase();
 
   // Fix up the yield op.
@@ -126,12 +123,9 @@ static void createTMALoad(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
       loc, mBarTy, barrierArray, extractIdx);
   builder.create<ttng::MBarrierWaitOp>(loc, barrierWait, phase);
 
-  Operation *user = *loadOp.getResult().getUsers().begin();
-  auto convertLayout = llvm::cast<ttg::ConvertLayoutOp>(user);
   auto newCvt = builder.create<ttg::ConvertLayoutOp>(
-      convertLayout->getLoc(), convertLayout.getType(), extract.getResult());
-  convertLayout->replaceAllUsesWith(newCvt->getResults());
-  convertLayout->erase();
+      loadOp->getLoc(), loadOp.getType(), extract.getResult());
+  loadOp->replaceAllUsesWith(newCvt->getResults());
   loadOp.erase();
 
   // Fix up the yield op.
@@ -148,69 +142,81 @@ static void createAsyncLoad(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
   }
 }
 
-// Return the transitive use of the load which is a dot operand.
-static Value loadDotOperand(tt::LoadOp loadOp, bool &hasMMAV3) {
-  // We only pipeline loads that have one covert_layout (to dot_op) use
-  // TODO: lift this constraint in the future
-  bool isCandidate = false;
-  if (!loadOp.getResult().hasOneUse())
-    return Value();
+namespace {
+struct LoadDotOperand {
+  LoadDotOperand(tt::LoadOp load,
+                 ttg::DotOperandEncodingAttr dotOperandEncoding)
+      : load(load), dotOperandEncoding(dotOperandEncoding) {}
+  tt::LoadOp load;
+  ttg::DotOperandEncodingAttr dotOperandEncoding;
+};
+} // namespace
 
-  Operation *use = *loadOp.getResult().getUsers().begin();
-  if (auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(use)) {
-    auto tensorType =
-        convertLayout.getResult().getType().cast<RankedTensorType>();
-    if (auto sharedEnc =
-            tensorType.getEncoding().dyn_cast<ttg::SharedEncodingAttr>()) {
-      if (sharedEnc.getHasLeadingOffset()) {
-        // MMA V3 case.
-        auto newOrder = sharedEnc.getOrder();
-        auto ty = loadOp.getType().cast<RankedTensorType>();
-        auto oldOrder = ttg::getOrder(ty.getEncoding());
-        if (newOrder[0] == oldOrder[0] || newOrder[1] == oldOrder[1]) {
-          // The operand of MMAv3 is in SharedEncoding and it's order should
-          // not be changed after FuseTranspositions Pass. So we only pipeline
-          // the load if the order of the loaded BlockedEncoding is the same
-          // as the order of the SharedEncoding it is converted to.
-          // TODO: remove this constraint once the LoadOp supports transpose
-          // fusion
-          hasMMAV3 = true;
-          return convertLayout.getResult();
+// If all the transitive uses of the given value have are used by a convert to
+// the same dot operand encoding, return the encoding. Otherwise return nullptr.
+static ttg::DotOperandEncodingAttr allTransitiveUsesHaveDotEncoding(Value val) {
+  ttg::DotOperandEncodingAttr attr;
+  for (Operation *user : val.getUsers()) {
+    if (user->getNumResults() != 1)
+      return nullptr;
+    auto tensorType = user->getResult(0).getType().dyn_cast<RankedTensorType>();
+    ttg::DotOperandEncodingAttr tempAttr;
+    if (tensorType.getEncoding().isa<ttg::SharedEncodingAttr>()) {
+      tempAttr = allTransitiveUsesHaveDotEncoding(user->getResult(0));
+    } else {
+      auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(user);
+      if (!convertLayout)
+        return nullptr;
+      auto tensorType =
+          convertLayout.getResult().getType().dyn_cast<RankedTensorType>();
+      if (!tensorType)
+        return nullptr;
+      tempAttr =
+          tensorType.getEncoding().dyn_cast<ttg::DotOperandEncodingAttr>();
+    }
+    if (!tempAttr || (attr != nullptr && attr != tempAttr))
+      return nullptr;
+    attr = tempAttr;
+  }
+  return attr;
+}
+
+// Return the transitive use of the load which is a dot operand.
+static std::optional<LoadDotOperand> loadDotOperand(tt::LoadOp loadOp,
+                                                    bool &hasMMAV3) {
+  bool isCandidate = false;
+  if (loadOp.getResult().hasOneUse()) {
+    Operation *use = *loadOp.getResult().getUsers().begin();
+    if (auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(use)) {
+      auto tensorType =
+          convertLayout.getResult().getType().cast<RankedTensorType>();
+      if (auto sharedEnc =
+              tensorType.getEncoding().dyn_cast<ttg::SharedEncodingAttr>()) {
+        if (sharedEnc.getHasLeadingOffset()) {
+          // MMA V3 case.
+          auto newOrder = sharedEnc.getOrder();
+          auto ty = loadOp.getType().cast<RankedTensorType>();
+          auto oldOrder = ttg::getOrder(ty.getEncoding());
+          if (newOrder[0] == oldOrder[0] || newOrder[1] == oldOrder[1]) {
+            // The operand of MMAv3 is in SharedEncoding and it's order should
+            // not be changed after FuseTranspositions Pass. So we only pipeline
+            // the load if the order of the loaded BlockedEncoding is the same
+            // as the order of the SharedEncoding it is converted to.
+            // TODO: remove this constraint once the LoadOp supports transpose
+            // fusion
+            hasMMAV3 = true;
+            return LoadDotOperand(loadOp, nullptr);
+          }
         }
       }
     }
   }
-  // Advance to the first conversion as long as the use resides in shared
-  // memory and it has a single use itself
-  while (use) {
-    if (use->getNumResults() != 1 || !use->getResult(0).hasOneUse())
-      break;
-    auto tensorType = use->getResult(0).getType().dyn_cast<RankedTensorType>();
-    if (!tensorType.getEncoding().isa<ttg::SharedEncodingAttr>())
-      break;
-    use = *use->getResult(0).getUsers().begin();
-  }
-
-  if (auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(use)) {
-    if (auto tensorType =
-            convertLayout.getResult().getType().dyn_cast<RankedTensorType>()) {
-      if (auto dotOpEnc = tensorType.getEncoding()
-                              .dyn_cast<ttg::DotOperandEncodingAttr>()) {
-        return convertLayout.getResult();
-      }
-    }
-  }
-  return Value();
+  ttg::DotOperandEncodingAttr attr =
+      allTransitiveUsesHaveDotEncoding(loadOp.getResult());
+  if (!attr)
+    return std::nullopt;
+  return LoadDotOperand(loadOp, attr);
 }
-
-namespace {
-struct LoadDotOperand {
-  LoadDotOperand(tt::LoadOp load, Value dotOperand)
-      : load(load), dotOperand(dotOperand) {}
-  tt::LoadOp load;
-  Value dotOperand;
-};
-} // namespace
 
 /// Collect loads to pipeline. Return success if we can pipeline this loop
 static void collectOpsToPipeline(scf::ForOp forOp,
@@ -250,33 +256,28 @@ static void collectOpsToPipeline(scf::ForOp forOp,
       }
       if (!candidate)
         continue;
-      Value dotOperand = loadDotOperand(loadOp, hasMMAV3);
-      if (!dotOperand)
+      std::optional<LoadDotOperand> loadWithDotOperand =
+          loadDotOperand(loadOp, hasMMAV3);
+      if (!loadWithDotOperand.has_value())
         continue;
-      ops.emplace_back(loadOp, dotOperand);
+      ops.push_back(loadWithDotOperand.value());
     }
   }
 }
 
 // Create an allocation that can old distance number of loadOp shapes.
-static Value createAlloc(scf::ForOp &forOp, tt::LoadOp loadOp, Value dotOperand,
+static Value createAlloc(scf::ForOp &forOp, tt::LoadOp loadOp,
+                         ttg::DotOperandEncodingAttr dotOpEnc,
                          unsigned distance) {
   OpBuilder builder(forOp);
   auto ty = loadOp.getType().cast<RankedTensorType>();
-  if (!loadOp.getResult().hasOneUse())
-    return Value();
   Attribute sharedEnc;
   auto CTALayout = ttg::getCTALayout(ty.getEncoding());
-  auto tensorType = dotOperand.getType().cast<RankedTensorType>();
-  if (auto dotOpEnc =
-          tensorType.getEncoding().dyn_cast<ttg::DotOperandEncodingAttr>()) {
-    auto convertLayout = dotOperand.getDefiningOp<ttg::ConvertLayoutOp>();
-    bool needTrans = dyn_cast_or_null<tt::TransOp>(
-        convertLayout->getOperand(0).getDefiningOp());
+  if (dotOpEnc) {
     unsigned bitWidth = ty.getElementType().getIntOrFloatBitWidth();
     sharedEnc = ttg::SharedEncodingAttr::get(
         ty.getContext(), dotOpEnc, ty.getShape(),
-        ttg::getOrder(ty.getEncoding()), CTALayout, bitWidth, needTrans);
+        ttg::getOrder(ty.getEncoding()), CTALayout, bitWidth);
   } else {
     // MMAv3
     sharedEnc = ttg::SharedEncodingAttr::get(ty.getContext(), ty.getShape(),
@@ -313,8 +314,8 @@ static void createAsynOps(scf::ForOp &forOp, ArrayRef<LoadDotOperand> loads,
   bool needsAsyncWait = false;
   for (const LoadDotOperand &loadOperand : loads) {
     tt::LoadOp loadOp = loadOperand.load;
-    Value dotOperand = loadOperand.dotOperand;
-    Value alloc = createAlloc(forOp, loadOp, dotOperand, numBuffers);
+    Value alloc =
+        createAlloc(forOp, loadOp, loadOperand.dotOperandEncoding, numBuffers);
     assert(alloc && "Failed to create alloc for the async load.");
     newOperands.push_back(alloc);
     asyncLoads.emplace_back(loadOp, alloc);

--- a/python/tutorials/06-fused-attention.py
+++ b/python/tutorials/06-fused-attention.py
@@ -488,9 +488,7 @@ class _attention(torch.autograd.Function):
         dv = torch.empty_like(v)
         BATCH, N_HEAD, N_CTX = q.shape[:3]
         PRE_BLOCK = 128
-        NUM_WARPS, NUM_STAGES = 4, 1
-        if torch.cuda.get_device_capability()[0] == 9:
-            NUM_STAGES = 5
+        NUM_WARPS, NUM_STAGES = 4, 5
         BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 32, 128, 128, 32
         BLK_SLICE_FACTOR = 2
         RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -494,3 +494,64 @@ tt.func @dep_arg_two_uses(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32},
   }
   tt.return %91#3 : tensor<128x128xf32, #C>
 }
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 4], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#mma = #triton_gpu.mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], instrShape = [16, 8]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1], hasLeadingOffset = false}>
+#shared1 = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1], hasLeadingOffset = false}>
+module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: tt.func @load_two_users
+  tt.func @load_two_users(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}) -> (tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>) {
+    %cst = arith.constant dense<0> : tensor<1x16xi32, #blocked>
+    %cst_0 = arith.constant dense<0> : tensor<128x1xi32, #blocked1>
+    %c0_i64 = arith.constant 0 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma>
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.addptr %arg0, %c0_i64 : !tt.ptr<f16, 1>, i64
+    %1 = tt.addptr %arg1, %c0_i64 : !tt.ptr<f16, 1>, i64
+    %2 = tt.splat %1 : (!tt.ptr<f16, 1>) -> tensor<128x1x!tt.ptr<f16, 1>, #blocked1>
+    %3 = tt.addptr %2, %cst_0 : tensor<128x1x!tt.ptr<f16, 1>, #blocked1>, tensor<128x1xi32, #blocked1>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : (tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>) -> tensor<1x64xi32, #blocked1>
+    %6 = tt.broadcast %3 : (tensor<128x1x!tt.ptr<f16, 1>, #blocked1>) -> tensor<128x64x!tt.ptr<f16, 1>, #blocked1>
+    %7 = tt.broadcast %5 : (tensor<1x64xi32, #blocked1>) -> tensor<128x64xi32, #blocked1>
+    %8 = tt.addptr %6, %7 : tensor<128x64x!tt.ptr<f16, 1>, #blocked1>, tensor<128x64xi32, #blocked1>
+    %9 = tt.load %8 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xf16, #blocked1>
+    %10 = tt.splat %0 : (!tt.ptr<f16, 1>) -> tensor<1x16x!tt.ptr<f16, 1>, #blocked>
+    %11 = tt.addptr %10, %cst : tensor<1x16x!tt.ptr<f16, 1>, #blocked>, tensor<1x16xi32, #blocked>
+    %12 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %13 = tt.expand_dims %12 {axis = 1 : i32} : (tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<64x1xi32, #blocked>
+    %14 = tt.broadcast %11 : (tensor<1x16x!tt.ptr<f16, 1>, #blocked>) -> tensor<64x16x!tt.ptr<f16, 1>, #blocked>
+    %15 = tt.broadcast %13 : (tensor<64x1xi32, #blocked>) -> tensor<64x16xi32, #blocked>
+    %16 = tt.addptr %14, %15 : tensor<64x16x!tt.ptr<f16, 1>, #blocked>, tensor<64x16xi32, #blocked>
+    // CHECK: triton_gpu.async_wait {num = 1 : i32}
+    // CHECK: scf.for
+    // CHECK:   tt.dot
+    // CHECK:   tt.dot
+    // CHECK:   triton_gpu.insert_slice_async
+    // CHECK:   triton_gpu.async_wait {num = 1 : i32}
+    // CHECK:   scf.yield
+    // CHECK: triton_gpu.async_wait {num = 0 : i32}
+
+    %17:2 = scf.for %arg2 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg3 = %cst_1, %arg4 = %cst_2) -> (tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>)  : i32 {
+      %18 = tt.load %16 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x16xf16, #blocked>
+      %19 = triton_gpu.convert_layout %9 : (tensor<128x64xf16, #blocked1>) -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+      %20 = triton_gpu.convert_layout %18 : (tensor<64x16xf16, #blocked>) -> tensor<64x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %21 = tt.dot %19, %20, %cst_1 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>
+      %22 = arith.truncf %21 : tensor<128x16xf32, #mma> to tensor<128x16xf16, #mma>
+      %23 = triton_gpu.convert_layout %22 : (tensor<128x16xf16, #mma>) -> tensor<128x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+      %24 = triton_gpu.convert_layout %18 : (tensor<64x16xf16, #blocked>) -> tensor<64x16xf16, #shared>
+      %25 = tt.trans %24 : (tensor<64x16xf16, #shared>) -> tensor<16x64xf16, #shared1>
+      %26 = triton_gpu.convert_layout %25 : (tensor<16x64xf16, #shared1>) -> tensor<16x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %27 = tt.dot %23, %26, %arg4 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<16x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x64xf32, #mma>
+      scf.yield %21, %27 : tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>
+    }
+    tt.return %17#0, %17#1 : tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>
+  }
+}

--- a/test/TritonGPU/matmul.mlir
+++ b/test/TritonGPU/matmul.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu -tritongpu-remove-layout-conversions -tritongpu-pipeline=num-stages=3 -test-print-allocation 2>&1 | FileCheck %s
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu -tritongpu-remove-layout-conversions -tritongpu-pipeline=num-stages=3 -canonicalize -test-print-allocation 2>&1 | FileCheck %s
 
 // CHECK: offset = 0, size = 32768
 // CHECK: offset = 32768, size = 32768


### PR DESCRIPTION
Improves performance from 129TF to 149TF on backward attention pass on A100.

This relax some pre-condition of pipelining and allow pipelining cases where a load is used in multiple dot ops.