### PR TITLE
Attempt to fix nightly wheel build.

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,11 +30,6 @@ jobs:
             echo "new_commit=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang lld
-
       - name: Patch setup.py
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
@@ -45,15 +40,13 @@ jobs:
       - name: Build wheels
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
+          export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
           # At time of writing, the VM "only" has 32GB of RAM and OOMs while
           # building if we give it the default number of workers (2 * NUM_CPUs).
-          export MAX_JOBS=4
-          export TRITON_WHEEL_NAME="triton-nightly"
-          export TRITON_WHEEL_VERSION_SUFFIX="-$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")"
-          export TRITON_BUILD_WITH_CLANG_LLD=1
+          export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_WHEEL_NAME=triton-nightly TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_WHEEL_VERSION_SUFFIX=-$LATEST_DATE"
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
-          export CIBW_BEFORE_BUILD="pip install cmake;"
+          export CIBW_BEFORE_BUILD="pip install cmake; sudo apt-get update; sudo apt-get install -y clang lld"
           export CIBW_SKIP="cp{35,36}-*"
           export CIBW_BUILD="cp3*-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -46,7 +46,7 @@ jobs:
           export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_WHEEL_NAME=triton-nightly TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_WHEEL_VERSION_SUFFIX=-$LATEST_DATE"
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
-          export CIBW_BEFORE_BUILD="pip install cmake; yum install clang lld"
+          export CIBW_BEFORE_BUILD="pip install cmake; apt install clang lld"
           export CIBW_SKIP="cp{35,36}-*"
           export CIBW_BUILD="cp3*-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,15 +14,11 @@ jobs:
       contents: read
 
     steps:
-      - name: Set Swap Space
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
 
       - name: Checkout
         uses: actions/checkout@v3
 
-      # The LATEST_DATE here should be kept in sync with TRITON_WHEEL_VERSION_SUFFIX.
+      # The LATEST_DATE here should be kept in sync with the one in Patch setup.py
       - id: check-version
         name: Check latest version
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -14,11 +14,15 @@ jobs:
       contents: read
 
     steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Checkout
         uses: actions/checkout@v3
 
-      # The LATEST_DATE here should be kept in sync with the one in Patch setup.py
+      # The LATEST_DATE here should be kept in sync with TRITON_WHEEL_VERSION_SUFFIX.
       - id: check-version
         name: Check latest version
         run: |

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,6 +30,11 @@ jobs:
             echo "new_commit=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang lld
+
       - name: Patch setup.py
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
@@ -46,7 +51,7 @@ jobs:
           export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_WHEEL_NAME=triton-nightly TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_WHEEL_VERSION_SUFFIX=-$LATEST_DATE"
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
-          export CIBW_BEFORE_BUILD="pip install cmake; sudo apt-get update; sudo apt-get install -y clang lld"
+          export CIBW_BEFORE_BUILD="pip install cmake;"
           export CIBW_SKIP="cp{35,36}-*"
           export CIBW_BUILD="cp3*-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,7 +22,6 @@ jobs:
       - id: check-version
         name: Check latest version
         run: |
-          free -g
           export PACKAGE_DATE=$(python3 -m pip install --user --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/ --dry-run triton-nightly== |& grep -oP '(?<=, )[0-9\.]+dev[0-9]+(?=\))' | grep -oP '(?<=dev)[0-9]+')
           export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
           if cmp -s <(echo $PACKAGE_DATE) <(echo $LATEST_DATE); then
@@ -41,6 +40,9 @@ jobs:
       - name: Build wheels
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
+          # At time of writing, the VM "only" has 32GB of RAM and OOMs while
+          # building if we give it the default number of workers (2 * NUM_CPUs).
+          export MAX_JOBS=4
           export TRITON_WHEEL_NAME="triton-nightly"
           export TRITON_WHEEL_VERSION_SUFFIX="-$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")"
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,6 +30,11 @@ jobs:
             echo "new_commit=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Install prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang lld
+
       - name: Patch setup.py
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
@@ -45,6 +50,7 @@ jobs:
           export MAX_JOBS=4
           export TRITON_WHEEL_NAME="triton-nightly"
           export TRITON_WHEEL_VERSION_SUFFIX="-$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")"
+          export TRITON_BUILD_WITH_CLANG_LLD=1
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           export CIBW_BEFORE_BUILD="pip install cmake;"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,11 +30,6 @@ jobs:
             echo "new_commit=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install prerequisites
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang lld
-
       - name: Patch setup.py
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
@@ -51,7 +46,7 @@ jobs:
           export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_WHEEL_NAME=triton-nightly TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_WHEEL_VERSION_SUFFIX=-$LATEST_DATE"
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
-          export CIBW_BEFORE_BUILD="pip install cmake;"
+          export CIBW_BEFORE_BUILD="pip install cmake; yum install clang lld"
           export CIBW_SKIP="cp{35,36}-*"
           export CIBW_BUILD="cp3*-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,6 +15,13 @@ jobs:
 
     steps:
 
+      - name: Prune stale docker containers
+        run: |
+          # If cibuildwheel crashes (or, say, is OOM-killed), it leaves behind a
+          # docker container.  Eventually these consume all the disk space on
+          # this machine.
+          docker container prune -f
+
       - name: Checkout
         uses: actions/checkout@v3
 
@@ -41,12 +48,20 @@ jobs:
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
           export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
-          # At time of writing, the VM "only" has 32GB of RAM and OOMs while
-          # building if we give it the default number of workers (2 * NUM_CPUs).
-          export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_WHEEL_NAME=triton-nightly TRITON_BUILD_WITH_CLANG_LLD=1 TRITON_WHEEL_VERSION_SUFFIX=-$LATEST_DATE"
+          # Pass MAX_JOBS=4 because, at time of writing, the VM "only" has 32GB
+          # of RAM and OOMs while building if we give it the default number of
+          # workers (2 * NUM_CPUs).
+          #
+          # Sadly, I couldn't make TRITON_BUILD_WITH_CLANG_LLD=1 work.  The
+          # manylinux image has a relatively recent gcc (v10, released 2020),
+          # but its clang is ancient, v3.4, released in 2014 (!).  I tried
+          # installing the prebuilt clang 10 binary distributed by LLVM, and I
+          # quickly ran into Linux DLL hell.  I give up, for now.  Perhaps
+          # manylinux_x_y will save us; I didn't try.
+          export CIBW_ENVIRONMENT="MAX_JOBS=4 TRITON_WHEEL_NAME=triton-nightly TRITON_WHEEL_VERSION_SUFFIX=-$LATEST_DATE"
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
-          export CIBW_BEFORE_BUILD="pip install cmake; apt install clang lld"
+          export CIBW_BEFORE_BUILD="pip install cmake;"
           export CIBW_SKIP="cp{35,36}-*"
           export CIBW_BUILD="cp3*-manylinux_x86_64"
           python3 -m cibuildwheel python --output-dir wheelhouse

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Patch setup.py
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
-          sed -i 's/name\=\"triton\"/name="triton-nightly"/g' python/setup.py
-          export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
-          sed -i -r "s/version\=\"(.*)\"/version=\"\1-dev"$LATEST_DATE"\"/g" python/setup.py
           echo "" >> python/setup.cfg
           echo "[build_ext]" >> python/setup.cfg
           echo "base-dir=/project" >> python/setup.cfg
@@ -43,6 +40,8 @@ jobs:
       - name: Build wheels
         if: ${{ steps.check-version.outputs.new_commit == 'true' }}
         run: |
+          export TRITON_WHEEL_NAME="triton-nightly"
+          export TRITON_WHEEL_VERSION_SUFFIX="-$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")"
           export CIBW_MANYLINUX_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           #export CIBW_MANYLINUX_PYPY_X86_64_IMAGE="quay.io/pypa/manylinux2014_x86_64:latest"
           export CIBW_BEFORE_BUILD="pip install cmake;"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -22,6 +22,7 @@ jobs:
       - id: check-version
         name: Check latest version
         run: |
+          free -g
           export PACKAGE_DATE=$(python3 -m pip install --user --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/Triton-Nightly/pypi/simple/ --dry-run triton-nightly== |& grep -oP '(?<=, )[0-9\.]+dev[0-9]+(?=\))' | grep -oP '(?<=dev)[0-9]+')
           export LATEST_DATE=$(TZ=UTC0 git show --quiet --date='format-local:%Y%m%d%H%M%S' --format="%cd")
           if cmp -s <(echo $PACKAGE_DATE) <(echo $LATEST_DATE); then

--- a/README.md
+++ b/README.md
@@ -2,13 +2,12 @@
   <img src="https://cdn.openai.com/triton/assets/triton-logo.png" alt="Triton logo" width="88" height="100">
 </div>
 
-[![Wheels](https://github.com/openai/triton/actions/workflows/wheels.yml/badge.svg?branch=release/2.0.x)](https://github.com/openai/triton/actions/workflows/wheels.yml)
-
 We're hiring! If you are interested in working on Triton at OpenAI, we have roles open for [Compiler Engineers](https://openai.com/careers/software-engineer-triton-compiler) and [Kernel Engineers](https://openai.com/careers/kernel-engineer).
 
-**`Documentation`** |
+**`Documentation`** | **`Nightly Wheels`** |
 ------------------- |
-[![Documentation](https://github.com/openai/triton/actions/workflows/documentation.yml/badge.svg)](https://triton-lang.org/)
+[![Documentation](https://github.com/openai/triton/actions/workflows/documentation.yml/badge.svg)](https://triton-lang.org/) |
+[![Wheels](https://github.com/openai/triton/actions/workflows/wheels.yml/badge.svg?branch=release/2.0.x)](https://github.com/openai/triton/actions/workflows/wheels.yml)
 
 
 # Triton

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@
 
 We're hiring! If you are interested in working on Triton at OpenAI, we have roles open for [Compiler Engineers](https://openai.com/careers/software-engineer-triton-compiler) and [Kernel Engineers](https://openai.com/careers/kernel-engineer).
 
-**`Documentation`** | **`Nightly Wheels`** |
-------------------- |
-[![Documentation](https://github.com/openai/triton/actions/workflows/documentation.yml/badge.svg)](https://triton-lang.org/) |
-[![Wheels](https://github.com/openai/triton/actions/workflows/wheels.yml/badge.svg?branch=release/2.0.x)](https://github.com/openai/triton/actions/workflows/wheels.yml)
+| **`Documentation`** | **`Nightly Wheels`** |
+|-------------------- | -------------------- |
+| [![Documentation](https://github.com/openai/triton/actions/workflows/documentation.yml/badge.svg)](https://triton-lang.org/) | [![Wheels](https://github.com/openai/triton/actions/workflows/wheels.yml/badge.svg?branch=release/2.0.x)](https://github.com/openai/triton/actions/workflows/wheels.yml) |
 
 
 # Triton

--- a/python/setup.py
+++ b/python/setup.py
@@ -341,8 +341,8 @@ download_and_copy(
 )
 
 setup(
-    name="triton",
-    version="2.1.0",
+    name=os.environ.get("TRITON_WHEEL_NAME", "triton"),
+    version="2.1.0" + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", ""),
     author="Philippe Tillet",
     author_email="phil@openai.com",
     description="A language and compiler for custom Deep Learning operations",


### PR DESCRIPTION
This fixes three issues.

1. We had a clbuttic bug [1].  The wheel script was running `sed` over
setup.py and modifying all instances of `version=`.  But really it only
meant to modify the `version=` inside the setup() call.

    Fixed this by using explicit envvars.

2. The job would OOM during build, because the builder "only" has 32GB of RAM.  I limited parallelism to 4 jobs, and now it seems to work consistently.

3. The builder was running out of disk space due to stale docker containers.  AFAICT cibuildwheel normally deletes the container, but it doesn't if e.g. it crashes or OOMs.  Now we delete all the docker containers at the beginning of the build step.

The build step of the nightly build job now completes. 
 https://github.com/openai/triton/actions/runs/6857343607.  The full job doesn't complete successfully, but that seems to be because I'm building a branch, `No matching federated identity record found for presented assertion subject 'repo:openai/triton:ref:refs/heads/nightly-wheel'.`.

Not done in this PR:

1. I did not switch to clang+lld.  I tried, but manylinux2014 is (intentionally) super old, and the package manager ships with clang from 2014.  I wasn't able to get a newer clang working, though I didn't try super-hard.  At least their gcc is relatively up to date (from 2020).

2. I did not set up email/slack notifications for failed builds.  I'm waiting on OpenAI slack administrators to give me permission to set up a slack hook.

Fixes #2418.

[1] https://en.wikipedia.org/wiki/Scunthorpe_problem
