### PR TITLE
[BACKEND] To generalize TritonGPU dialect for GPU of different vendors

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Attributes.h
+++ b/include/triton/Dialect/TritonGPU/IR/Attributes.h
@@ -1,6 +1,8 @@
 #ifndef TRITON_DIALECT_TRITONGPU_IR_ATTRIBUTES_H_
 #define TRITON_DIALECT_TRITONGPU_IR_ATTRIBUTES_H_
 
+#include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
+
 #define GET_ATTRDEF_CLASSES
 #include "triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.h.inc"
 

--- a/include/triton/Dialect/TritonGPU/IR/CMakeLists.txt
+++ b/include/triton/Dialect/TritonGPU/IR/CMakeLists.txt
@@ -12,6 +12,8 @@ add_mlir_doc(TritonGPUOps TritonGPUOps dialects/ -gen-op-doc)
 add_public_tablegen_target(TritonGPUTableGen)
 
 set(LLVM_TARGET_DEFINITIONS TritonGPUAttrDefs.td)
+mlir_tablegen(TritonGPUAttrInterfaces.h.inc -gen-attr-interface-decls)
+mlir_tablegen(TritonGPUAttrInterfaces.cpp.inc -gen-attr-interface-defs)
 mlir_tablegen(TritonGPUAttrDefs.h.inc -gen-attrdef-decls)
 mlir_tablegen(TritonGPUAttrDefs.cpp.inc -gen-attrdef-defs)
 mlir_tablegen(OpsEnums.h.inc -gen-enum-decls)

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -8,10 +8,29 @@ include "triton/Dialect/Triton/IR/TritonInterfaces.td"
 //===----------------------------------------------------------------------===//
 // TritonGPU Attribute Definitions
 //===----------------------------------------------------------------------===//
+def TritonGPU_AttrTrait : AttrInterface<"TritonGPU_AttrTrait"> {
+  let cppNamespace = "::mlir::triton::gpu";
+
+  let methods = [
+
+    InterfaceMethod<"Return total element size per thread.",
+                    "unsigned",
+                    "getTotalElemsPerThread",
+                     (ins "ArrayRef<int64_t>":$tensorShape,
+                          "Type":$eltTy)>,
+
+    InterfaceMethod<"Return element size per thread in each dimension.",
+                    "SmallVector<unsigned>",
+                    "getElemsPerThread",
+                     (ins "ArrayRef<int64_t>":$tensorShape,
+                          "Type":$eltTy)>,
+  ];
+}
 
 class TritonGPU_Attr<string name, list<Trait> traits = [],
+                     Dialect dialect = TritonGPU_Dialect,
                      string baseCppClass = "::mlir::Attribute">
-  : AttrDef<TritonGPU_Dialect, name, traits, baseCppClass> {
+  : AttrDef<dialect, name, !listconcat([TritonGPU_AttrTrait], traits), baseCppClass> {
 
   let description = [{
 TritonGPU Tensors differ from usual tensors in that they contain a _layout_ attribute which determines
@@ -52,6 +71,17 @@ def CTALayoutAttr : TritonGPU_Attr<"CTALayout"> {
     ArrayRefParameter<"unsigned">:$CTASplitNum,
     ArrayRefParameter<"unsigned">:$CTAOrder
   );
+
+  let extraClassDeclaration = [{
+    SmallVector<unsigned> getElemsPerThread(ArrayRef<int64_t> shape, Type eltTy) const {
+      llvm::report_fatal_error(
+        "Unsupported getElemsPerThread in CTALayoutAttr.");
+    }
+    unsigned getTotalElemsPerThread(ArrayRef<int64_t> shape, Type eltTy) const {
+      llvm::report_fatal_error(
+        "Unsupported getTotalElemsPerThread in CTALayoutAttr.");
+    }
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -252,8 +282,69 @@ compared to 1*64 when the hasLeadingOffset is false.
 //===----------------------------------------------------------------------===//
 // Distributed Layout Encoding
 //===----------------------------------------------------------------------===//
+def DistributedEncodingTrait : AttrInterface<"DistributedEncodingTrait"> {
+  let cppNamespace = "::mlir::triton::gpu";
 
-class DistributedEncoding<string name> : TritonGPU_Attr<name> {
+  let description = [{
+The Distributed encodings describes the layout tensor L with the 4-level hierarchy multiple threads on GPU.
+It is abstracted from the top to the bottom as CTAs Per CGA->Warps Per CTA->Threads Per Warp->Values Per Thread.
+
+For CTAs Per CGA and Warps Per CTA level, the linear id is distributed contiguously with the shape and order.
+For example, for a shape/order pair defines a distribution layout
+shape = [4, 4]
+order = [0, 1] // The fastest-changing axis first
+->
+layout = [0  4  8  12]
+         [1  5  9  13]
+         [2  6  10 14]
+         [3  7  11 15]
+
+For the Threads Per Warp and Values Per Thread level, the linear id distribution is variant for each sub-class encoding.
+  }];
+
+  let methods = [
+    // Interface for the meta information about the multiple thread hierarchy.
+    InterfaceMethod<"Get the shape of the CTAs per CGA.",
+                    "SmallVector<unsigned>",
+                    "getCTAsPerCGA">,
+
+    InterfaceMethod<"Get the order of the CTAs per CGA. The fastest-changing axis first",
+                    "SmallVector<unsigned>",
+                    "getCTAOrder">,
+
+    InterfaceMethod<"Get the shape of the warps per CTA.",
+                    "SmallVector<unsigned>",
+                    "getWarpsPerCTA">,
+
+    InterfaceMethod<"Get the order of the warps per CTA. The fastest-changing axis first",
+                    "SmallVector<unsigned>",
+                    "getWarpOrder">,
+
+    InterfaceMethod<"Get the shape of the threads per warp",
+                    "SmallVector<unsigned>",
+                    "getThreadsPerWarp">,
+
+    InterfaceMethod<"Get the order of the threads per warp. The fastest-changing axis first",
+                    "SmallVector<unsigned>",
+                    "getThreadOrder">,
+
+    InterfaceMethod<"Get the shape of the values per thread.",
+                    "SmallVector<unsigned>",
+                    "getSizePerThread">,
+
+    InterfaceMethod<"Get the split number of CTAs per CGA to handle the partial of the shape in each dimension.",
+                    "SmallVector<unsigned>",
+                    "getCTASplitNum">,
+
+    InterfaceMethod<"Return shape per CTA tile.",
+                    "SmallVector<unsigned>",
+                    "getShapePerCTATile",
+                     (ins "ArrayRef<int64_t>":$tensorShape)>,
+  ];
+}
+
+class DistributedEncoding<string name, list<Trait> traits = [],
+                     Dialect dialect = TritonGPU_Dialect> : TritonGPU_Attr<name, !listconcat([DistributedEncodingTrait], traits), dialect> {
   let description = [{
 Distributed encodings have a layout function that is entirely characterized
 by a d-dimensional tensor L. Note that L doesn't need to have the same shape
@@ -277,7 +368,18 @@ L(A) = [ {0,8} , {1,9} , {2,10}, {3,11}, {0,8} , {1, 9} , {2, 10}, {3, 11},
          {4,12}, {5,13}, {6,14}, {7,15}, {4,12}, {5, 13}, {6, 14}, {7, 15} ]
   }];
 
-  let extraClassDeclaration = extraBaseClassDeclaration;
+  code extraDistributedDeclaration  = extraBaseClassDeclaration # [{
+    SmallVector<unsigned> getCTAsPerCGA() const;
+    SmallVector<unsigned> getCTAOrder() const;
+    SmallVector<unsigned> getCTASplitNum() const;
+    SmallVector<unsigned> getWarpsPerCTA() const;
+    SmallVector<unsigned> getWarpOrder() const;
+    SmallVector<unsigned> getThreadsPerWarp() const;
+    SmallVector<unsigned> getThreadOrder() const;
+
+    SmallVector<unsigned> getSizePerThread() const;
+    SmallVector<unsigned> getShapePerCTATile(ArrayRef<int64_t> tensorShape = ArrayRef<int64_t>()) const;
+  }];
 }
 
 //===----------------------------------------------------------------------===//
@@ -369,9 +471,9 @@ for
 
   let parameters = (
     ins
-    ArrayRefParameter<"unsigned">:$sizePerThread,
-    ArrayRefParameter<"unsigned">:$threadsPerWarp,
-    ArrayRefParameter<"unsigned">:$warpsPerCTA,
+    ArrayRefParameter<"unsigned">:$sizePerThread__,
+    ArrayRefParameter<"unsigned">:$threadsPerWarp__,
+    ArrayRefParameter<"unsigned">:$warpsPerCTA__,
     ArrayRefParameter<"unsigned">:$order, // the fastest-changing axis first
     "CTALayoutAttr":$CTALayout
   );
@@ -442,7 +544,7 @@ for
     }]>
   ];
 
-  let extraClassDeclaration = extraBaseClassDeclaration # [{
+  let extraClassDeclaration = extraDistributedDeclaration # [{
     SliceEncodingAttr squeeze(int axis);
   }];
 
@@ -453,8 +555,28 @@ for
 // MMA Layout Encoding
 //===----------------------------------------------------------------------===//
 // TODO: MMAv1 and MMAv2 should be two instances of the same class
+def MmaEncodingTrait : AttrInterface<"MmaEncodingTrait"> {
+  let cppNamespace = "::mlir::triton::gpu";
+  let methods = [
 
-def MmaEncodingAttr : DistributedEncoding<"MmaEncoding"> {
+    InterfaceMethod<"Return whether the layout support reduction op.", "bool",
+      "supportReduction">,
+
+    InterfaceMethod<"Return shape per CTA.", "SmallVector<unsigned>",
+      "getShapePerCTATileForDotOperands", (ins "ArrayRef<int64_t>":$tensorShape,
+                                               "unsigned":$opIdx)>,
+
+    InterfaceMethod<"Return total element size per thread for dot operands.", "unsigned",
+      "getTotalElemsPerThreadForOperands", (ins "ArrayRef<int64_t>":$tensorShape,
+                                                "Type":$eltTy,
+                                                "unsigned":$opIdx)>,
+
+    InterfaceMethod<"Return size per thread for dot operands.", "SmallVector<unsigned>",
+      "getSizePerThreadForOperands", (ins "unsigned":$opIdx)>,
+  ];
+}
+
+def MmaEncodingAttr : DistributedEncoding<"MmaEncoding", [MmaEncodingTrait]> {
   let mnemonic = "mma";
 
   let description = [{
@@ -541,7 +663,7 @@ For example, the matrix L corresponding to blockTileSize=[32,16] is:
     ins
     "unsigned":$versionMajor,
     "unsigned":$versionMinor,
-    ArrayRefParameter<"unsigned">:$warpsPerCTA,
+    ArrayRefParameter<"unsigned">:$warpsPerCTA__,
     "CTALayoutAttr":$CTALayout,
     ArrayRefParameter<"unsigned">:$instrShape
   );
@@ -610,7 +732,7 @@ For example, the matrix L corresponding to blockTileSize=[32,16] is:
     }]>
   ];
 
-  let extraClassDeclaration = extraBaseClassDeclaration # [{
+  let extraClassDeclaration = extraDistributedDeclaration # [{
     bool isVolta() const;
     bool isTuring() const;
     bool isAmpere() const;
@@ -624,6 +746,25 @@ For example, the matrix L corresponding to blockTileSize=[32,16] is:
     // Number of bits in versionMinor to hold the ID of the MMA encoding instance.
     // Here 5 bits can hold 32 IDs in a single module.
     static constexpr int numBitsToHoldMmaV1ID{5};
+
+    bool getMMAv1IsRow(int opIdx) const;
+    bool getMMAv1IsVec4(int opIdx) const;
+    int getMMAv1NumOuter(ArrayRef<int64_t> shape, int opIdx) const;
+    SmallVector<int> getMMAv1Rep(int opIdx) const;
+    SmallVector<int> getMMAv1ShapePerWarp(int opIdx) const;
+    int getMMAv1Vec(int opIdx) const;
+    SmallVector<int64_t> getMMAv2Rep(ArrayRef<int64_t> shape,
+                                     int bitwidth, int opIdx) const;
+
+    bool supportReduction() const {
+      if (isAmpere() || isHopper()) {
+        return true;
+      }
+      return false;
+    };
+    SmallVector<unsigned> getSizePerThreadForOperands(unsigned opIdx) const;
+    SmallVector<unsigned> getShapePerCTATileForDotOperands(ArrayRef<int64_t> shape, int opIdx) const;
+    unsigned getTotalElemsPerThreadForOperands(ArrayRef<int64_t> shape, Type eltTy, int opIdx) const;
   }];
 
   let hasCustomAssemblyFormat = 1;
@@ -657,7 +798,7 @@ def SliceEncodingAttr : DistributedEncoding<"SliceEncoding"> {
     "Attribute":$parent
   );
 
-  let extraClassDeclaration = extraBaseClassDeclaration # [{
+  let extraClassDeclaration = extraDistributedDeclaration # [{
     template<class T>
     SmallVector<T> paddedShape(ArrayRef<T> shape) const;
   }];
@@ -701,18 +842,7 @@ section 9.7.13.4.1 for more details.
   ];
 
   let hasCustomAssemblyFormat = 1;
-  let extraClassDeclaration = extraBaseClassDeclaration # [{
-    bool getMMAv1IsRow() const;
-    bool getMMAv1IsVec4() const;
-    SmallVector<int> getMMAv1Rep() const;
-    SmallVector<int> getMMAv1ShapePerWarp() const;
-    int getMMAv1Vec() const;
-    int getMMAv1NumOuter(ArrayRef<int64_t> shape) const;
-    //
-    SmallVector<int64_t> getMMAv2Rep(ArrayRef<int64_t> shape,
-                                     int bitwidth) const;
-
-  }];
+  let extraClassDeclaration = extraDistributedDeclaration;
 }
 
 #endif

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h
@@ -1,0 +1,6 @@
+#ifndef TRITON_GPU_DIALECT_INTERFACES_H
+#define TRITON_GPU_DIALECT_INTERFACES_H
+
+#include "triton/Dialect/TritonGPU/IR/TritonGPUAttrInterfaces.h.inc"
+
+#endif // TRITON_GPU_DIALECT_INTERFACES_H

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -403,9 +403,7 @@ private:
 
       if (needTrans) {
         // do transpose
-        auto aEncoding =
-            DotOperandEncodingAttr::get(mma.getContext(), 0, mma, 0);
-        int numM = aEncoding.getMMAv1NumOuter(shapePerCTA);
+        int numM = mma.getMMAv1NumOuter(shapePerCTA, 0);
         int numN = accumSizePerThread / numM;
 
         for (int r = 0; r < numM; r++) {
@@ -1021,7 +1019,7 @@ private:
           dotOperandLayout.getOpIdx(), rewriter, loc, src, dotOperandLayout,
           smemObj, getTypeConverter(), getThreadId(rewriter, loc));
     } else if (!isOuter && mmaLayout.isVolta() && isMMA) { // tensor core v1
-      bool isMMAv1Row = dotOperandLayout.getMMAv1IsRow();
+      bool isMMAv1Row = mmaLayout.getMMAv1IsRow(dotOperandLayout.getOpIdx());
       auto srcSharedLayout = src.getType()
                                  .cast<RankedTensorType>()
                                  .getEncoding()

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
@@ -572,7 +572,8 @@ Value loadArg(ConversionPatternRewriter &rewriter, Location loc, Value tensor,
   int mmaInstrM = 16, mmaInstrN = 8, mmaInstrK = 4 * 64 / bitwidth;
   int matShapeM = 8, matShapeN = 8, matShapeK = 2 * 64 / bitwidth;
 
-  auto numRep = encoding.getMMAv2Rep(shapePerCTA, bitwidth);
+  auto numRep =
+      mmaLayout.getMMAv2Rep(shapePerCTA, bitwidth, encoding.getOpIdx());
   int kWidth = encoding.getKWidth();
 
   auto warpsPerCTA = mmaLayout.getWarpsPerCTA();

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv1.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv1.cpp
@@ -63,15 +63,15 @@ LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   auto AShape = ATensorTy.getShape();
   auto BShape = BTensorTy.getShape();
 
-  bool isARow = ALayout.getMMAv1IsRow();
-  bool isBRow = BLayout.getMMAv1IsRow();
+  bool isARow = mmaLayout.getMMAv1IsRow(ALayout.getOpIdx());
+  bool isBRow = mmaLayout.getMMAv1IsRow(BLayout.getOpIdx());
   auto [isARow_, isBRow_, isAVec4_, isBVec4_, _] =
       mmaLayout.decodeVoltaLayoutStates();
   assert(isARow == isARow_);
   assert(isBRow == isBRow_);
 
-  unsigned numM = ALayout.getMMAv1NumOuter(AShape);
-  unsigned numN = BLayout.getMMAv1NumOuter(BShape);
+  unsigned numM = mmaLayout.getMMAv1NumOuter(AShape, ALayout.getOpIdx());
+  unsigned numN = mmaLayout.getMMAv1NumOuter(BShape, ALayout.getOpIdx());
   unsigned NK = AShape[1];
 
   auto has = extractLoadedOperand(adaptor.getA(), NK, rewriter, typeConverter,

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -287,12 +287,12 @@ LogicalResult convertDot(TritonGPUToLLVMTypeConverter *typeConverter,
   auto dShapePerCTA = triton::gpu::getShapePerCTA(dTensorTy);
 
   int bitwidth = aTensorTy.getElementType().getIntOrFloatBitWidth();
-  auto repA =
-      aTensorTy.getEncoding().cast<DotOperandEncodingAttr>().getMMAv2Rep(
-          aShapePerCTA, bitwidth);
-  auto repB =
-      bTensorTy.getEncoding().cast<DotOperandEncodingAttr>().getMMAv2Rep(
-          bShapePerCTA, bitwidth);
+  auto dotOpA = aTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
+  auto repA = dotOpA.getParent().cast<MmaEncodingAttr>().getMMAv2Rep(
+      aShapePerCTA, bitwidth, dotOpA.getOpIdx());
+  auto dotOpB = bTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
+  auto repB = dotOpB.getParent().cast<MmaEncodingAttr>().getMMAv2Rep(
+      bShapePerCTA, bitwidth, dotOpB.getOpIdx());
 
   assert(repA[1] == repB[0]);
   int repM = repA[0], repN = repB[1], repK = repA[1];

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMBase.h
@@ -926,13 +926,11 @@ private:
     Value _fpw1 = i32_val(fpw[1]);
 
     // A info
-    auto aEncoding = DotOperandEncodingAttr::get(ctx, 0, mmaLayout, 0);
-    auto aRep = aEncoding.getMMAv1Rep();
-    auto aSpw = aEncoding.getMMAv1ShapePerWarp();
+    auto aRep = mmaLayout.getMMAv1Rep(0);
+    auto aSpw = mmaLayout.getMMAv1ShapePerWarp(0);
     // B info
-    auto bEncoding = DotOperandEncodingAttr::get(ctx, 1, mmaLayout, 0);
-    auto bSpw = bEncoding.getMMAv1ShapePerWarp();
-    auto bRep = bEncoding.getMMAv1Rep();
+    auto bSpw = mmaLayout.getMMAv1ShapePerWarp(1);
+    auto bRep = mmaLayout.getMMAv1Rep(1);
 
     SmallVector<int, 2> rep({aRep[0], bRep[1]});
     SmallVector<int, 2> spw({aSpw[0], bSpw[1]});
@@ -986,15 +984,11 @@ private:
 
     // TODO: seems like the apttern below to get `rep`/`spw` appears quite often
     // A info
-    auto aEncoding =
-        DotOperandEncodingAttr::get(type.getContext(), 0, mmaLayout, 0);
-    auto aRep = aEncoding.getMMAv1Rep();
-    auto aSpw = aEncoding.getMMAv1ShapePerWarp();
+    auto aRep = mmaLayout.getMMAv1Rep(0);
+    auto aSpw = mmaLayout.getMMAv1ShapePerWarp(0);
     // B info
-    auto bEncoding =
-        DotOperandEncodingAttr::get(type.getContext(), 1, mmaLayout, 0);
-    auto bSpw = bEncoding.getMMAv1ShapePerWarp();
-    auto bRep = bEncoding.getMMAv1Rep();
+    auto bSpw = mmaLayout.getMMAv1ShapePerWarp(1);
+    auto bRep = mmaLayout.getMMAv1Rep(1);
 
     auto wpt = mmaLayout.getWarpsPerCTA();
     static constexpr std::array<int, 3> fpw{{2, 2, 1}};

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -148,11 +148,11 @@ struct TritonExpandDimsPattern
     auto retShape = argType.getShape().vec();
     retShape.insert(retShape.begin() + op.getAxis(), 1);
     // return encoding
-    auto retSizePerThread = argEncoding.getSizePerThread().vec();
+    auto retSizePerThread = argEncoding.getSizePerThread();
     retSizePerThread.insert(retSizePerThread.begin() + op.getAxis(), 1);
-    auto retThreadsPerWarp = argEncoding.getThreadsPerWarp().vec();
+    auto retThreadsPerWarp = argEncoding.getThreadsPerWarp();
     retThreadsPerWarp.insert(retThreadsPerWarp.begin() + op.getAxis(), 1);
-    auto retWarpsPerCTA = argEncoding.getWarpsPerCTA().vec();
+    auto retWarpsPerCTA = argEncoding.getWarpsPerCTA();
     retWarpsPerCTA.insert(retWarpsPerCTA.begin() + op.getAxis(), 1);
     SmallVector<unsigned, 4> retOrder(retShape.size());
     std::iota(retOrder.begin(), retOrder.end(), 0);
@@ -297,7 +297,7 @@ struct TritonCatPattern : public OpConversionPattern<triton::CatOp> {
     // constraint.
     auto newRetTotalElemsPerThread =
         nextPowOf2(lhsTotalElemsPerThread + rhsTotalElemsPerThread);
-    auto newRetSizePerThread = retSizePerThread.vec();
+    auto newRetSizePerThread = retSizePerThread;
     newRetSizePerThread[retOrder[0]] *=
         newRetTotalElemsPerThread / retTotalElemsPerThread;
     triton::gpu::BlockedEncodingAttr newRetEncoding =

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -305,6 +305,13 @@ private:
     res.insert(res.begin() + index, static_cast<T>(value));
     return res;
   }
+  template <typename T>
+  SmallVector<T> insertValue(const SmallVector<T> &vec, unsigned index,
+                             int value) const {
+    SmallVector<T> res(vec.begin(), vec.end());
+    res.insert(res.begin() + index, static_cast<T>(value));
+    return res;
+  }
 };
 
 std::unique_ptr<Pass> mlir::createTritonGPUOptimizeThreadLocalityPass() {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/RewriteTensorPointer.cpp
@@ -124,6 +124,13 @@ private:
     return res;
   }
 
+  template <typename T>
+  SmallVector<T> insertOne(const SmallVector<T> &vec, unsigned axis) const {
+    SmallVector<T> res(vec.begin(), vec.end());
+    res.insert(res.begin() + axis, 1);
+    return res;
+  }
+
   // Example:    order = [   0, 2, 1, 3], dim = 2
   //          resOrder = [2, 0, 3, 1, 4]
   SmallVector<unsigned> insertOrder(ArrayRef<unsigned> order,


### PR DESCRIPTION
This PR is for [Generalize TritonGPU dialect](https://github.com/openai/triton/issues/2639)
1.Add TritonGPU_AttrTrait, DistributedEncodingTrait and MmaEncodingTrait as the interface for other vendor to extend. 2.Move the NV special API like: MMAv1 and MMAv2 to MmaEncodingAttr from the DotOpEncodingAttr. Generalize the DotOpEncoding.