### PR TITLE
Add verifier for MakeRangeOp.

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -488,7 +488,6 @@ def TT_ExternElementwiseOp : TT_Op<"extern_elementwise", [Elementwise,
 //
 // Make Range Op
 //
-// TODO: should have ConstantLike as Trait
 def TT_MakeRangeOp : TT_Op<"make_range", [Pure]> {
     let summary = "make range";
 
@@ -498,6 +497,10 @@ def TT_MakeRangeOp : TT_Op<"make_range", [Pure]> {
         Values span from $start to $end (exclusive), with step = 1
     }];
 
+    // WARNING: MLIR generates getStart()/getEnd() functions which return
+    // uint32_t, even though these arguments are to be interpreted as *signed*
+    // int32 values.  If this matters, use get{Start,End}Attr().getInt(), which
+    // return int64_t.
     let arguments = (ins I32Attr:$start, I32Attr:$end);
 
     let results = (outs TT_IntTensor:$result);
@@ -505,6 +508,7 @@ def TT_MakeRangeOp : TT_Op<"make_range", [Pure]> {
     let assemblyFormat = "attr-dict `:` type($result)";
 
     let hasFolder = 1;
+    let hasVerifier = 1;
 }
 
 //

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -543,7 +543,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
   // CHECK-LABEL: basic_insert_slice_async_fallback
   tt.func @basic_insert_slice_async_fallback(%arg0: !tt.ptr<f16> {tt.divisibility = 1 : i32}) {
     %off0_ = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #slice2d1>
-    %off1_ = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<64xi32, #slice3d0>
+    %off1_ = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #slice3d0>
     %off0 = tt.expand_dims %off0_ {axis = 1 : i32} : (tensor<16xi32, #slice2d1>) -> tensor<16x1xi32, #block2>
     %off1 = tt.expand_dims %off1_ {axis = 0 : i32} : (tensor<64xi32, #slice3d0>) -> tensor<1x64xi32, #block3>
     %broadcast_off0_scalar = tt.broadcast %off0 : (tensor<16x1xi32, #block2>) -> tensor<16x64xi32, #block2>
@@ -582,7 +582,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
   // CHECK-LABEL: basic_insert_slice_async_v4
   tt.func @basic_insert_slice_async_v4(%arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) {
     %off0_ = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32, #slice2d1>
-    %off1_ = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<64xi32, #slice3d0>
+    %off1_ = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #slice3d0>
     %off0 = tt.expand_dims %off0_ {axis = 1 : i32} : (tensor<16xi32, #slice2d1>) -> tensor<16x1xi32, #block2>
     %off1 = tt.expand_dims %off1_ {axis = 0 : i32} : (tensor<64xi32, #slice3d0>) -> tensor<1x64xi32, #block3>
     %broadcast_off0_scalar = tt.broadcast %off0 : (tensor<16x1xi32, #block2>) -> tensor<16x64xi32, #block2>

--- a/test/Triton/verify-make-range.mlir
+++ b/test/Triton/verify-make-range.mlir
@@ -1,0 +1,35 @@
+// RUN: triton-opt --split-input-file %s --verify-diagnostics
+
+tt.func public @i64_tensor() {
+    // expected-error @+1 {{i32 elements}}
+    %a = tt.make_range { start = 0 : i32, end = 16 : i32 } : tensor<16xi64>
+    tt.return
+}
+
+// -----
+tt.func public @i32_scalar() {
+    // expected-error @+1 {{invalid kind of type}}
+    %a = tt.make_range { start = 0 : i32, end = 16 : i32 } : i32
+    tt.return
+}
+
+// -----
+tt.func public @_2d_tensor() {
+    // expected-error @+1 {{must be a 1D tensor}}
+    %a = tt.make_range { start = 0 : i32, end = 16 : i32 } : tensor<16x1xi32>
+    tt.return
+}
+
+// -----
+tt.func public @bad_start_end() {
+    // expected-error @+1 {{start must be less than or equal to end}}
+    %a = tt.make_range { start = 0 : i32, end = -16 : i32 } : tensor<16xi32>
+    tt.return
+}
+
+// -----
+tt.func public @bad_num_elems() {
+    // expected-error @+1 {{number of elements}}
+    %a = tt.make_range { start = 0 : i32, end = 32 : i32 } : tensor<16xi32>
+    tt.return
+}


### PR DESCRIPTION
<git-pr-chain>


Add verifier for MakeRangeOp.

Checks that the op returns a 1D tensor of i32s.

I also removed "TODO: should have ConstantLike as a trait" from the op.
AFAICT, ConstantLike should only be used for ops that we *always* want
to fold.  But we only want to fold MakeRangeOp when it's "small", in the
current implementation 1 element.  If I mark the op as ConstantLike, it
seems to get unconditionally folded, and fold() must always succeed
(otherwise MLIR asserts).


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #2660 👈 **YOU ARE HERE**
1. #2622


</git-pr-chain>




