### PR TITLE
Add timeouts to github actions.

### DIFF
--- a/.github/workflows/compare-artifacts.yml
+++ b/.github/workflows/compare-artifacts.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   Compare-artifacts:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   Build-Documentation:
     runs-on: [self-hosted, A100]
+    timeout-minutes: 5
 
     steps:
       - name: Checkout branch

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,6 +18,7 @@ env:
 jobs:
   Runner-Preparation:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     outputs:
       matrix-required: ${{ steps.set-matrix.outputs.matrix-required }}
       matrix-optional: ${{ steps.set-matrix.outputs.matrix-optional }}
@@ -38,6 +39,7 @@ jobs:
     needs: Runner-Preparation
 
     runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
 
     strategy:
       matrix:
@@ -173,6 +175,7 @@ jobs:
 
   Compare-artifacts:
     needs: Integration-Tests
+    timeout-minutes: 5
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -20,6 +20,7 @@ jobs:
   build:
     name: Build on ${{ matrix.config.runner }}
     runs-on: ${{ matrix.config.runs_on }}
+    timeout-minutes: 240  # 4 hours
 
     strategy:
       fail-fast: true

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -24,6 +24,7 @@ jobs:
   Integration-Tests-Shared-Middle-Layer:
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -67,6 +68,7 @@ jobs:
 
   Integration-Tests-AMD:
     needs: Runner-Preparation
+    timeout-minutes: 20
     if: false
 
     runs-on: ${{ matrix.runner }}
@@ -118,6 +120,7 @@ jobs:
 
   Integration-Tests-Intel:
     needs: Runner-Preparation
+    timeout-minutes: 20
     if: false
 
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/torch-inductor-tests.yml
+++ b/.github/workflows/torch-inductor-tests.yml
@@ -18,6 +18,7 @@ jobs:
 
   Integration-Tests:
     needs: Runner-Preparation
+    timeout-minutes: 240  # 4 hours
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,6 +7,7 @@ on:
 jobs:
 
   Build-Wheels:
+    timeout-minutes: 60
 
     runs-on: [self-hosted, CPU]
     permissions:


### PR DESCRIPTION
I was hogging the H100 machine today with a build that ran forever.  As
penance, I've added timeouts to all our actions.  I set the timeouts to
be roughly 2x as long as a job normally takes.
