### PR TITLE
Fixes a bug in `ConvertLayoutOp` canonicalization patterns.

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -103,7 +103,7 @@ unsigned getNumCTAs(Attribute layout);
 
 bool isaDistributedLayout(Attribute layout);
 
-bool isSharedEncoding(Value value);
+bool hasSharedEncoding(Value value);
 
 bool isExpensiveCat(CatOp cat, Attribute targetEncoding);
 

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -43,7 +43,7 @@ void SharedMemoryAliasAnalysis::visitOperation(
     } else if (isa<triton::nvidia_gpu::StoreAsyncOp>(op)) {
       aliasInfo = AliasInfo(operands[0]->getValue());
       pessimistic = false;
-    } else if (triton::gpu::isSharedEncoding(result)) {
+    } else if (triton::gpu::hasSharedEncoding(result)) {
       aliasInfo.insert(result);
       pessimistic = false;
     }

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -189,7 +189,7 @@ private:
     // XXX(Keren): Why this hard-coded alignment?
     size_t kAlignment = 8;
     for (Value result : op->getResults()) {
-      if (triton::gpu::isSharedEncoding(result)) {
+      if (triton::gpu::hasSharedEncoding(result)) {
         // Bytes could be a different value once we support padding or other
         // allocation policies.
         auto tensorType = result.getType().dyn_cast<RankedTensorType>();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -574,13 +574,21 @@ bool isaDistributedLayout(Attribute layout) {
          layout.isa<SliceEncodingAttr>();
 }
 
-bool isSharedEncoding(Value value) {
+template <typename T> bool hasEncoding(Value value) {
   auto type = value.getType();
   if (auto tensorType = type.dyn_cast<RankedTensorType>()) {
     auto encoding = tensorType.getEncoding();
-    return encoding && encoding.isa<triton::gpu::SharedEncodingAttr>();
+    return encoding && encoding.isa<T>();
   }
   return false;
+}
+
+bool hasSharedEncoding(Value value) {
+  return hasEncoding<triton::gpu::SharedEncodingAttr>(value);
+}
+
+bool hasDotOperandEncoding(Value value) {
+  return hasEncoding<triton::gpu::DotOperandEncodingAttr>(value);
 }
 
 bool isExpensiveCat(CatOp cat, Attribute targetEncoding) {
@@ -1597,6 +1605,15 @@ struct CanonicalizeConvertFromConvert
     if (auto view = dyn_cast<triton::ViewOp>(arg)) {
       if (isExpensiveView(view.getOperand().getType(), op.getType()))
         return failure();
+      // In TritonGPUToLLVM phase, ViewOp is converted to unpacking and packing
+      // operations, which requires the element type to match between unpacking
+      // and packing. However, part of values with dot operand encoding will be
+      // packed/unpacked as i32 elements instead of the underlying element type.
+      // To avoid errors, skip this folding when either the operand or result
+      // of view has a dot operand encoding.
+      if (hasDotOperandEncoding(op->getOperand(0)) ||
+          hasDotOperandEncoding(op->getResult(0)))
+        return failure();
       rewriter.replaceOpWithNewOp<triton::ViewOp>(
           op, op->getResult(0).getType(), view.getResult());
       return mlir::success();
@@ -1614,7 +1631,7 @@ struct CanonicalizeConvertFromConvert
     // cvt(alloc_tensor(x), type2) -> alloc_tensor(x, type2)
     auto alloc_tensor = dyn_cast<triton::gpu::AllocTensorOp>(arg);
     if (alloc_tensor) {
-      if (!triton::gpu::isSharedEncoding(op->getResult(0))) {
+      if (!triton::gpu::hasSharedEncoding(op->getResult(0))) {
         return mlir::failure();
       }
       rewriter.replaceOpWithNewOp<triton::gpu::AllocTensorOp>(
@@ -1624,7 +1641,7 @@ struct CanonicalizeConvertFromConvert
     // cvt(insert_slice(x), type2) -> insert_slice(cvt(x, type2))
     auto insert_slice = dyn_cast<triton::gpu::InsertSliceAsyncOp>(arg);
     if (insert_slice) {
-      if (!triton::gpu::isSharedEncoding(op->getResult(0))) {
+      if (!triton::gpu::hasSharedEncoding(op->getResult(0))) {
         return mlir::failure();
       }
       auto newType = op->getResult(0).getType().cast<RankedTensorType>();
@@ -1646,7 +1663,7 @@ struct CanonicalizeConvertFromConvert
     // cvt(extract_slice(x), type2) -> extract_slice(cvt(x, type2))
     auto extract_slice = dyn_cast<triton::gpu::ExtractSliceOp>(arg);
     if (extract_slice) {
-      if (!triton::gpu::isSharedEncoding(op->getResult(0))) {
+      if (!triton::gpu::hasSharedEncoding(op->getResult(0))) {
         return mlir::failure();
       }
       auto origType =
@@ -1676,13 +1693,13 @@ struct CanonicalizeConvertFromConvert
     // cvt(cvt(x, type1), type2) -> cvt(x, type2)
     if (llvm::isa<triton::gpu::ConvertLayoutOp>(arg)) {
       if (arg->getOperand(0).getDefiningOp() &&
-          !triton::gpu::isSharedEncoding(arg->getOperand(0)) &&
-          triton::gpu::isSharedEncoding(op.getOperand()) &&
-          !triton::gpu::isSharedEncoding(op.getResult())) {
+          !triton::gpu::hasSharedEncoding(arg->getOperand(0)) &&
+          triton::gpu::hasSharedEncoding(op.getOperand()) &&
+          !triton::gpu::hasSharedEncoding(op.getResult())) {
         return mlir::failure();
       }
-      if (triton::gpu::isSharedEncoding(op.getOperand()) &&
-          triton::gpu::isSharedEncoding(op.getResult())) {
+      if (triton::gpu::hasSharedEncoding(op.getOperand()) &&
+          triton::gpu::hasSharedEncoding(op.getResult())) {
         return mlir::failure();
       }
       auto srcType = op.getOperand().getType().cast<RankedTensorType>();

--- a/lib/Dialect/TritonGPU/IR/Traits.cpp
+++ b/lib/Dialect/TritonGPU/IR/Traits.cpp
@@ -7,7 +7,7 @@ mlir::OpTrait::impl::verifyResultsAreSharedEncoding(Operation *op) {
     return failure();
 
   for (auto result : op->getResults())
-    if (!triton::gpu::isSharedEncoding(result))
+    if (!triton::gpu::hasSharedEncoding(result))
       return op->emitOpError() << "requires all results to be shared encoding";
 
   return success();

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -172,7 +172,7 @@ LogicalResult Prefetcher::initialize() {
         break;
       rets.push_back(op->getOperand(0));
       if (auto cvt = dyn_cast_or_null<triton::gpu::ConvertLayoutOp>(op))
-        if (triton::gpu::isSharedEncoding(cvt.getOperand())) {
+        if (triton::gpu::hasSharedEncoding(cvt.getOperand())) {
           foundConvertFromShared = true;
           break;
         }

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -827,8 +827,8 @@ static LogicalResult getRematerializableSlice(
 
 static void backwardRematerialization(ConvertLayoutOp convertOp) {
   // we don't want to rematerialize any conversion to/from shared
-  if (triton::gpu::isSharedEncoding(convertOp.getResult()) ||
-      triton::gpu::isSharedEncoding(convertOp.getOperand()))
+  if (triton::gpu::hasSharedEncoding(convertOp.getResult()) ||
+      triton::gpu::hasSharedEncoding(convertOp.getOperand()))
     return;
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristics to accommodate fused attention
@@ -853,8 +853,8 @@ static void backwardRematerialization(ConvertLayoutOp convertOp) {
 // of the convert.
 static void hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp) {
   // we don't want to rematerialize any conversion to/from shared
-  if (triton::gpu::isSharedEncoding(convertOp.getResult()) ||
-      triton::gpu::isSharedEncoding(convertOp.getOperand()))
+  if (triton::gpu::hasSharedEncoding(convertOp.getResult()) ||
+      triton::gpu::hasSharedEncoding(convertOp.getOperand()))
     return;
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristics to accommodate fused attention

--- a/lib/Dialect/TritonNvidiaGPU/IR/Traits.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Traits.cpp
@@ -29,7 +29,7 @@ mlir::OpTrait::impl::verifySource1IsSharedEncoding(Operation *op) {
   if (failed(verifyAtLeastNOperands(op, 2)))
     return failure();
 
-  if (!mlir::triton::gpu::isSharedEncoding(op->getOperand(1)))
+  if (!mlir::triton::gpu::hasSharedEncoding(op->getOperand(1)))
     return op->emitOpError() << "requires operand 1 to be shared encoding";
 
   return success();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -71,7 +71,7 @@ private:
     if (op && isa<tt::DotOp, ttng::DotAsyncOp>(op))
       return false;
     // reach convertlayout
-    if (op && isa<ttg::ConvertLayoutOp>(op) && ttg::isSharedEncoding(operand))
+    if (op && isa<ttg::ConvertLayoutOp>(op) && ttg::hasSharedEncoding(operand))
       return true;
     // root and not BlockArgument
     if (!op && !isa<BlockArgument>(operand))

--- a/test/TritonGPU/canonicalize.mlir
+++ b/test/TritonGPU/canonicalize.mlir
@@ -37,7 +37,7 @@ tt.func @test_canonicalize_convert_expensive_view(%arg0: tensor<256x16xf32, #blo
 // -----
 
 // Test that the convert doesn't get combined with view if the either the
-// operand or result has a dot operand ecnoding.
+// operand or result has a dot operand encoding.
 // CHECK-LABEL: @test_canonicalize_convert_view_with_dot_operand_encoding
 // CHECK-SAME: (%[[ARG:.+]]: tensor<32x4x32xbf16
 //       CHECK:   %[[V:.+]] = tt.view %[[ARG]]

--- a/test/TritonGPU/canonicalize.mlir
+++ b/test/TritonGPU/canonicalize.mlir
@@ -32,3 +32,22 @@ tt.func @test_canonicalize_convert_expensive_view(%arg0: tensor<256x16xf32, #blo
     %r = tt.view %c : (tensor<256x16xf32, #blocked2>) -> tensor<4096xf32, #blocked1>
     tt.return %r : tensor<4096xf32, #blocked1>
 }
+
+
+// -----
+
+// Test that the convert doesn't get combined with view if the either the
+// operand or result has a dot operand ecnoding.
+// CHECK-LABEL: @test_canonicalize_convert_view_with_dot_operand_encoding
+// CHECK-SAME: (%[[ARG:.+]]: tensor<32x4x32xbf16
+//       CHECK:   %[[V:.+]] = tt.view %[[ARG]]
+//       CHECK:   %[[C:.+]] = triton_gpu.convert_layout %[[V]]
+//       CHECK:   tt.return %[[C]]
+#blocked3 = #triton_gpu.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [32, 1, 1], warpsPerCTA = [1, 1, 4], order = [0, 1, 2], CTAsPerCGA = [1, 1, 1], CTASplitNum = [1, 1, 1], CTAOrder = [0, 1, 2]}>
+#blocked4 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#blocked5 = #triton_gpu.blocked<{sizePerThread = [2, 2], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+tt.func @test_canonicalize_convert_view_with_dot_operand_encoding(%arg0: tensor<32x4x32xbf16, #blocked3>) -> tensor<32x128xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked5}>> {
+    %v = tt.view %arg0 : (tensor<32x4x32xbf16, #blocked3>) -> tensor<32x128xbf16, #blocked4>
+    %c0 = triton_gpu.convert_layout %v : (tensor<32x128xbf16, #blocked4>) -> tensor<32x128xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked5}>>
+    tt.return %c0 : tensor<32x128xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked5}>>
+}


### PR DESCRIPTION
In `TritonGPU` phase, under `CanonicalizeConvertFromConvert` pattern, `cvt(view) -> cvt` always runs as long as the `view` is consider as inexpensive, regardless of the encodings of the operand/result.

In `TritonGPUToLLVM` phase, `ViewOp` is converted to unpacking and packing operations, which requires the element type to match between unpacking and packing. However, different encodings might use different element types, which makes it unsafe for `view` to change encoding unconditionally.