### PR TITLE
[OPTIMIZER] Fix MoveOpAfterLayoutConversion to bail out when there is a Select Op

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -110,9 +110,13 @@ public:
       if (isa<triton::LoadOp>(currOp))
         checkOp = true;
       else if (checkOp) {
+        // Bail out if there exists an op after Load that is not FpToFp, Bitcast, or Arith.
         if (!isa<triton::FpToFpOp, triton::BitcastOp>(currOp) &&
             currOp->getDialect()->getTypeID() !=
                 mlir::TypeID::get<arith::ArithDialect>())
+          return mlir::failure();
+        // Also bail out if there exists an op after Load that is Select.
+        if (isa<arith::SelectOp>(currOp))
           return mlir::failure();
       }
     }

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -110,7 +110,8 @@ public:
       if (isa<triton::LoadOp>(currOp))
         checkOp = true;
       else if (checkOp) {
-        // Bail out if there exists an op after Load that is not FpToFp, Bitcast, or Arith.
+        // Bail out if there exists an op after Load that is not FpToFp,
+        // Bitcast, or Arith.
         if (!isa<triton::FpToFpOp, triton::BitcastOp>(currOp) &&
             currOp->getDialect()->getTypeID() !=
                 mlir::TypeID::get<arith::ArithDialect>())

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -153,3 +153,24 @@ tt.func @mma_v3_reg_operand_A(%arg0: tensor<128x64xf16, #mma>, %arg1: tensor<64x
   tt.return %r : tensor<128x64xf32, #mma>
 }
 }
+
+// -----
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+#mma = #triton_gpu.mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], instrShape = [16, 8]}>
+module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @a_impl(%pa: tensor<128x128x!tt.ptr<f16, 1>, #blocked>) -> tensor<128x128xf32, #mma> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+    %cst_3 = arith.constant dense<5> : tensor<128x1xi32, #blocked>
+    %cst_4 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #blocked>
+    %tl = tt.load %pa {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x128xf16, #blocked>
+    %tr = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %te = tt.expand_dims %tr {axis = 1 : i32} : (tensor<128xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>) -> tensor<128x1xi32, #blocked>
+    %tc = arith.cmpi slt, %te, %cst_3 : tensor<128x1xi32, #blocked>
+    %tb = tt.broadcast %tc : (tensor<128x1xi1, #blocked>) -> tensor<128x128xi1, #blocked>
+    %ts = arith.select %tb, %tl, %cst_4 : tensor<128x128xi1, #blocked>, tensor<128x128xf16, #blocked>
+    %conv = triton_gpu.convert_layout %ts : (tensor<128x128xf16, #blocked>) -> tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    %td = tt.dot %cst_0, %conv, %cst {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x128xf32, #mma>
+    tt.return %td : tensor<128x128xf32, #mma>
+  }
+}


### PR DESCRIPTION
Summary: Fix https://github.com/openai/triton/issues/2655 When there is a Select Op after a Load Op, the type of the operands for the Select Op will be different, we can't use the same newCvtTy for all the operands when creating ConvertLayoutOp.
