### PR TITLE
Add threads_per_warp to meta information of the CompiledKernel 

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -642,6 +642,8 @@ class CompiledKernel:
         # initialize metadata
         self.shared = metadata["shared"]
         self.num_warps = metadata["num_warps"]
+        if "threads_per_warp" in metadata:
+            self.threads_per_warp = metadata["threads_per_warp"]
         self.num_ctas = metadata["num_ctas"]
         self.num_stages = metadata["num_stages"]
         self.clusterDims = metadata["clusterDims"]


### PR DESCRIPTION
Add threads_per_warp to meta information of the CompiledKernel when JIT the Triton kernel. It is required for the backend which support variant threads per warp size.