### PR TITLE
Adds builtin `tl.tanh` support.

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -122,9 +122,10 @@ void populateMathPatternsAndLegality(TritonGPUTypeConverter &typeConverter,
   MLIRContext *context = patterns.getContext();
   // Rewrite rule
   patterns.add<GenericOpPattern<math::ExpOp>, GenericOpPattern<math::CosOp>,
-               GenericOpPattern<math::SinOp>, GenericOpPattern<math::LogOp>,
-               GenericOpPattern<math::AbsFOp>, GenericOpPattern<math::AbsIOp>,
-               GenericOpPattern<math::SqrtOp>>(typeConverter, context);
+               GenericOpPattern<math::SinOp>, GenericOpPattern<math::TanhOp>,
+               GenericOpPattern<math::LogOp>, GenericOpPattern<math::AbsFOp>,
+               GenericOpPattern<math::AbsIOp>, GenericOpPattern<math::SqrtOp>>(
+      typeConverter, context);
 }
 
 //

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -638,13 +638,13 @@ bool CTAPlanner::isElementwiseOp(Operation *op) const {
                 arith::SubIOp, arith::TruncFOp, arith::TruncIOp,
                 arith::UIToFPOp, arith::XOrIOp>(op))
     return true;
-  if (llvm::isa<math::AbsFOp, math::AbsIOp, math::AtanOp, math::Atan2Op,
-                math::CeilOp, math::CopySignOp, math::CosOp, math::SinOp,
-                math::CountLeadingZerosOp, math::CountTrailingZerosOp,
-                math::CtPopOp, math::ErfOp, math::ExpOp, math::Exp2Op,
-                math::ExpM1Op, math::FloorOp, math::FmaOp, math::LogOp,
-                math::Log10Op, math::Log1pOp, math::Log2Op, math::PowFOp,
-                math::RsqrtOp, math::SqrtOp, math::TanhOp>(op))
+  if (llvm::isa<
+          math::AbsFOp, math::AbsIOp, math::AtanOp, math::Atan2Op, math::CeilOp,
+          math::CopySignOp, math::CosOp, math::SinOp, math::TanhOp,
+          math::CountLeadingZerosOp, math::CountTrailingZerosOp, math::CtPopOp,
+          math::ErfOp, math::ExpOp, math::Exp2Op, math::ExpM1Op, math::FloorOp,
+          math::FmaOp, math::LogOp, math::Log10Op, math::Log1pOp, math::Log2Op,
+          math::PowFOp, math::RsqrtOp, math::SqrtOp, math::TanhOp>(op))
     return true;
   if (llvm::isa<triton::IntToPtrOp, triton::PtrToIntOp, triton::BitcastOp,
                 triton::FpToFpOp, triton::AddPtrOp>(op))

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -1508,6 +1508,10 @@ void init_triton_ir(py::module &&m) {
            [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
              return self.create<mlir::math::SinOp>(val);
            })
+      .def("create_tanh",
+           [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
+             return self.create<mlir::math::TanhOp>(val);
+           })
       .def("create_log",
            [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
              return self.create<mlir::math::LogOp>(val);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -797,7 +797,7 @@ def test_unary_op(dtype_x, expr, num_ctas, device):
 
 @pytest.mark.parametrize("dtype_x, expr, x", [(dtype_x, expr, x)
                                               for dtype_x in ["float32", "float64"]
-                                              for expr in ['exp', 'log', 'cos', 'sin']
+                                              for expr in ['exp', 'log', 'cos', 'sin', 'tanh']
                                               for x in ['x', '3.0']])
 def test_math_op(dtype_x, expr, device, x):
     _test_unary(dtype_x, f'tl.{expr}({x})', f'np.{expr}({x}) ', device=device)

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -84,6 +84,7 @@ from .core import (
     static_print,
     store,
     static_range,
+    tanh,
     tensor,
     trans,
     # triton,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1362,6 +1362,13 @@ def sin(x, _builder=None):
 
 
 @builtin
+@_add_math_1arg_docstr('hyperbolic tangent')
+def tanh(x, _builder=None):
+  x = _to_tensor(x, _builder)
+  return semantic.tanh(x, _builder)
+
+
+@builtin
 @_add_math_1arg_docstr("square root")
 def sqrt(x, _builder=None):
     x = _to_tensor(x, _builder)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1431,6 +1431,11 @@ def sin(x: tl.tensor, builder: ir.builder) -> tl.tensor:
 
 
 @_check_dtype(dtypes=["fp32", "fp64"])
+def tanh(x: tl.tensor, builder: ir.builder) -> tl.tensor:
+  return tl.tensor(builder.create_tanh(x.handle), x.type)
+
+
+@_check_dtype(dtypes=["fp32", "fp64"])
 def sqrt(x: tl.tensor, builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_sqrt(x.handle), x.type)
 


### PR DESCRIPTION
`gelu` is commonly used in transformers as activations. And `tanh` is commonly used to approximate gelu implementation. So it is important to run `tanh` fast.

Calling `__nv_tanh` is very expensive compared to using `tanh.approx.fp32` instrinsic. The main problems are:
- The device function cannot be efficiently inlined when we have high register allocation pressure.
- The math function call might get rematerialized over and over again, which makes the situation even worse.

In our use case, switching from `__nv_tanh` to `tanh.approx.fp32` provides a 47% performance boost on the fused kernel.