### PR TITLE
[WIP] Allow the user to control pipelining via LoadOp attributes

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -153,29 +153,35 @@ def TT_LoadOp : TT_Op<"load",
     let arguments = (ins AnyTypeOf<[TT_PtrLike, TT_TensorPtr]>:$ptr, Optional<TT_BoolLike>:$mask,
                          Optional<TT_Type>:$other, OptionalAttr<DenseI32ArrayAttr>:$boundaryCheck,
                          OptionalAttr<TT_PaddingOptionAttr>:$padding, TT_CacheModifierAttr:$cache,
-                         TT_EvictionPolicyAttr:$evict, BoolAttr:$isVolatile);
+                         TT_EvictionPolicyAttr:$evict, BoolAttr:$isVolatile,
+                         OptionalAttr<BoolAttr>:$pipeline);
 
     let results = (outs TT_Type:$result);
 
     let builders = [
         // A tensor of pointers or a pointer to a scalar
         OpBuilder<(ins "Value":$ptr, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<bool>":$pipeline)>,
         // A tensor pointer with boundary check and padding
         OpBuilder<(ins "Value":$ptr, "ArrayRef<int32_t>":$boundaryCheck,
                        "std::optional<triton::PaddingOption>":$padding, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<bool>":$pipeline)>,
         // A tensor of pointers or a pointer to a scalar with mask
         OpBuilder<(ins "Value":$ptr, "Value":$mask, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<bool>":$pipeline)>,
         // A tensor of pointers or a pointer to a scalar with mask and other
         OpBuilder<(ins "Value":$ptr, "Value":$mask, "Value":$other, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>,
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<bool>":$pipeline)>,
         // A utility function to build the operation with all attributes
         OpBuilder<(ins "Value":$ptr, "Value":$mask, "Value":$other,
                        "std::optional<ArrayRef<int32_t>>":$boundaryCheck,
                        "std::optional<triton::PaddingOption>":$padding, "triton::CacheModifier":$cache,
-                       "triton::EvictionPolicy":$evict, "bool":$isVolatile)>
+                       "triton::EvictionPolicy":$evict, "bool":$isVolatile,
+                       "std::optional<bool>":$pipeline)>
     ];
 
     // Format: `tt.load operands attrs : optional(type(ptr)) -> type(result)`

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -814,7 +814,7 @@ private:
           // TODO(Chenggang): confirm `boundaryCheck` and `padding`
           /*boundaryCheck=*/nullptr, /*padding=*/nullptr,
           insertSliceAsyncOp.getCache(), insertSliceAsyncOp.getEvict(),
-          insertSliceAsyncOp.getIsVolatile());
+          insertSliceAsyncOp.getIsVolatile(), builder.getBoolAttr(false));
       addWSNamedAttrs(loadOp, insertSliceAsyncOp->getAttrs());
 
       // insert_slice

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -95,7 +95,7 @@ public:
     rewriter.replaceOpWithNewOp<triton::LoadOp>(
         op, loadOp.getPtr(), loadOp.getMask(), falseValue,
         loadOp.getBoundaryCheck(), loadOp.getPadding(), loadOp.getCache(),
-        loadOp.getEvict(), loadOp.getIsVolatile());
+        loadOp.getEvict(), loadOp.getIsVolatile(), loadOp.getPipeline());
     return mlir::success();
   }
 };

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -309,7 +309,7 @@ public:
     if (auto loadOp = dyn_cast<triton::LoadOp>(op)) {
       auto newResult = builder.create<triton::LoadOp>(
           loadOp.getLoc(), newPtr, newMask, newOther, loadOp.getCache(),
-          loadOp.getEvict(), loadOp.getIsVolatile());
+          loadOp.getEvict(), loadOp.getIsVolatile(), loadOp.getPipeline());
       op->getResult(0).replaceAllUsesWith(newResult);
     } else if (auto storeOp = dyn_cast<triton::StoreOp>(op)) {
       builder.create<triton::StoreOp>(storeOp.getLoc(), newPtr,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/RewriteTensorPointer.cpp
@@ -544,7 +544,8 @@ public:
       auto newResult = builder.create<tt::LoadOp>(
           loadOp.getLoc(), loadOp.getResult().getType(), newPtr, newMask,
           newOther, loadOp.getBoundaryCheckAttr(), loadOp.getPaddingAttr(),
-          loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+          loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile(),
+          loadOp.getPipelineAttr());
       op->getResult(0).replaceAllUsesWith(newResult);
     } else if (auto storeOp = dyn_cast<tt::StoreOp>(op)) {
       builder.create<tt::StoreOp>(storeOp.getLoc(), newPtr, storeOp.getValue(),

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -1312,9 +1312,9 @@ void init_triton_ir(py::module &&m) {
            [](TritonOpBuilder &self, mlir::Value &ptrs,
               mlir::triton::CacheModifier cacheModifier,
               mlir::triton::EvictionPolicy evictionPolicy,
-              bool isVolatile) -> mlir::Value {
+              bool isVolatile, std::optional<bool> pipeline) -> mlir::Value {
              return self.create<mlir::triton::LoadOp>(
-                 ptrs, cacheModifier, evictionPolicy, isVolatile);
+                 ptrs, cacheModifier, evictionPolicy, isVolatile, pipeline);
            })
       .def("create_store",
            [](TritonOpBuilder &self, mlir::Value &ptrs, mlir::Value &value,
@@ -1329,10 +1329,10 @@ void init_triton_ir(py::module &&m) {
               std::optional<mlir::triton::PaddingOption> paddingOption,
               mlir::triton::CacheModifier cacheModifier,
               mlir::triton::EvictionPolicy evictionPolicy,
-              bool isVolatile) -> mlir::Value {
+              bool isVolatile, std::optional<bool> pipeline) -> mlir::Value {
              return self.create<mlir::triton::LoadOp>(
                  ptr, boundaryCheck, paddingOption, cacheModifier,
-                 evictionPolicy, isVolatile);
+                 evictionPolicy, isVolatile, pipeline);
            })
       .def("create_tensor_pointer_store",
            [](TritonOpBuilder &self, mlir::Value &ptr, mlir::Value &val,
@@ -1347,10 +1347,10 @@ void init_triton_ir(py::module &&m) {
               std::optional<mlir::Value> &other,
               mlir::triton::CacheModifier cacheModifier,
               mlir::triton::EvictionPolicy evictionPolicy,
-              bool isVolatile) -> mlir::Value {
+              bool isVolatile, std::optional<bool> pipeline) -> mlir::Value {
              return self.create<mlir::triton::LoadOp>(
                  ptrs, mask, other.value_or(mlir::Value()), cacheModifier,
-                 evictionPolicy, isVolatile);
+                 evictionPolicy, isVolatile, pipeline);
            })
       .def("create_masked_store",
            [](TritonOpBuilder &self, mlir::Value &ptrs, mlir::Value &val,

--- a/python/test/unit/language/test_compiler.py
+++ b/python/test/unit/language/test_compiler.py
@@ -1,0 +1,129 @@
+"""Test the compilation steps but do not require a GPU to run.
+"""
+
+import os
+from pathlib import Path
+import functools
+import torch
+import triton.language as tl
+import triton
+import triton.common.backend as tcb
+from triton.runtime.driver import DriverBase
+import sys
+import unittest
+from unittest import mock
+from triton.compiler.compiler import parse_mlir_module, optimize_ttgir, ttir_to_ttgir, CudaTargetDescriptor, ClusterInfo, ttgir_to_llir, TMAInfos, ir
+
+
+class MockCudaDesc(CudaTargetDescriptor, dict):
+    def __init__(self, *, num_stages, **kw):
+        super().__init__(**kw)
+        self['num_warps'] = kw['num_warps']
+        self['num_stages'] = num_stages
+
+class MockGpuBackend(tcb.BaseBackend):
+    def __init__(self, device_type: str) -> None:
+        super(MockGpuBackend, self).__init__(device_type)
+        self.driver = DriverBase()
+        self.version_key = None
+
+    def add_stages(self, arch, extern_libs, stages):
+        enable_persistent = False
+        enable_warp_specialization = False
+        optimize_epilogue = False
+        target = self.get_architecture_descriptor()
+        num_warps = target.num_warps
+        num_stages = 3
+        num_ctas = 1
+        stages["ttgir"] = (lambda path: parse_mlir_module(path, ir.context()),
+                           lambda src: optimize_ttgir(
+                               ttir_to_ttgir(src, num_warps, num_ctas, target),
+                               num_stages, num_warps, num_ctas, target, ClusterInfo(),
+                               enable_warp_specialization, enable_persistent, optimize_epilogue))
+        stages["llir"] = (lambda path: Path(path).read_text(),
+                          lambda src: ttgir_to_llir(src, extern_libs, target, TMAInfos()))
+
+    def add_meta_info(self, ir, cur_module, next_module, metadata, asm):
+        metadata["name"] = "extension_backend_name"
+
+    def get_driver(self):
+        return self.driver
+
+    def get_stream(self):
+        return ""
+
+    @functools.lru_cache(None)
+    def get_device_properties(self, device):
+        return self.driver.utils.get_device_properties()
+
+    def get_current_device(self):
+        return torch.device("cpu")
+
+    def set_current_device(self, device):
+        pass
+
+    def get_load_binary_fn(self):
+        return self.driver.utils.load_binary
+
+    def get_kernel_bin(self):
+        return "ttgir"
+
+    def get_architecture_descriptor(self, **kwargs):
+        return MockCudaDesc(capability=80, num_stages=3, num_warps=4, enable_fp_fusion=False)
+
+    def get_version_key(self):
+        return "vesion_key"
+
+    def make_launcher_stub(self, name, signature, constants, ids):
+        return '/tmp/test.py'
+
+def get_kernel_asm(kernel, *args, **kw):
+    """Compile the kernel but don't run it, return the cached IRs.
+
+    Useful for testing without a local GPU.
+    """
+
+    tcb.register_backend('mock_gpu', MockGpuBackend)
+    kw['device_type'] = 'mock_gpu'
+    kw['num_stages'] = 3
+    kw['warmup'] = True
+    with mock.patch.dict('sys.modules', {'importlib': mock.MagicMock()}):
+        pgm = kernel[(1,)](*args, **kw)
+
+    return pgm.asm
+
+
+def test_pipelined_load():
+    """Test the pipeline argument.
+
+    A lonely load in a for{} will certainly not be matched for
+    pipelining, but if we explicitly request pipelining it should be
+    pipelined.
+
+    """
+
+    inp = torch.rand((100,), dtype=torch.float32)
+
+    @triton.jit
+    def _kernel(in_ptr, pipeline: tl.constexpr):
+        off = tl.arange(0, 10)
+        for i in range(10):
+            piped = tl.load(in_ptr + off + i, pipeline=pipeline)
+
+    # TODO(cperivol): test that a load() that would otherwse be
+    # pipelined is actually not if we tell it pipeline=False.
+
+    # Return true if the kernel was pipelined
+    check_papielined = lambda kern_asm: "triton_gpu.async_wait" in kern_asm['ttgir']
+
+    asm_true = get_kernel_asm(_kernel, inp, True)
+    asm_false = get_kernel_asm(_kernel, inp, False)
+    asm_none = get_kernel_asm(_kernel, inp, None)
+
+    assert asm_none['ttir'] == asm_false['ttir']
+
+    # With true there is pipelinin
+    assert check_pipelined(asm_true)
+    # With false or none there is not pipelining
+    assert not check_pipelined(asm_false)
+    assert not check_pipelined(asm_none)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2666,7 +2666,6 @@ def test_arange(start, num_ctas, device):
 # test load
 # ---------------
 
-
 @pytest.mark.parametrize("dtype_str, size, size_diff", [(dtype_str, size, size_diff)
                                                         for dtype_str in torch_dtypes
                                                         for size in [128, 512]

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1026,7 +1026,7 @@ def dot(input, other, acc=None, allow_tf32=True, max_num_imprecise_acc=None, out
 
 @builtin
 def load(pointer, mask=None, other=None, boundary_check=tuple(), padding_option="", cache_modifier="",
-         eviction_policy="", volatile=False, _builder=None):
+         eviction_policy="", volatile=False, pipeline=None, _builder=None):
     """
     Return a tensor of data whose values are loaded from memory at location defined by `pointer`:
         (1) `pointer` could be a single element pointer, then a scalar will be loaded
@@ -1062,6 +1062,8 @@ def load(pointer, mask=None, other=None, boundary_check=tuple(), padding_option=
     :type eviction_policy: str, optional
     :param volatile: changes volatile option in NVIDIA PTX
     :type volatile: bool, optional
+    :param pipeline: If true the compiler will try to pipeline, False will avoid pipelining and None will use the pattern matching machinery.
+    :type pipeline: bool, optional
     """
     # `mask` and `other` can be constexpr
     if _constexpr_to_value(mask) is not None:
@@ -1072,8 +1074,9 @@ def load(pointer, mask=None, other=None, boundary_check=tuple(), padding_option=
     cache_modifier = _constexpr_to_value(cache_modifier)
     eviction_policy = _constexpr_to_value(eviction_policy)
     volatile = _constexpr_to_value(volatile)
+    pipeline = _constexpr_to_value(pipeline)
     return semantic.load(pointer, mask, other, boundary_check, padding_option, cache_modifier, eviction_policy,
-                         volatile, _builder)
+                         volatile, pipeline, _builder)
 
 
 @builtin


### PR DESCRIPTION
The current heuristics easily extend to cases like `where(load(mask),dot(...),..)` that might also be beneficial, they can get complicated and shmem/reg pressure is hard to reason about.

`tl.load(.., pipeline={True,False,None})` could move some of the responsibility to decide what to pipeline to the user. `True` forces pipelining if possible, `False` avoids it and `None` (the default) lets the compiler decide (current sistuation). This has the added benefit that earlier passes can potentially request pipelining when they know they are breaking patterns that would otherwise be matched by the pipeliner.

The tests currentlyf fail, I am submitting this as an initial approach to make sure it is desirable and in line with design principles?