### PR TITLE
Increase documentation workflow timeout.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Build-Documentation:
     runs-on: [self-hosted, A100]
-    timeout-minutes: 5
+    timeout-minutes: 20
 
     steps:
       - name: Checkout branch


### PR DESCRIPTION
5m does not seem sufficient; jobs sometimes are timing out, e.g.
https://github.com/openai/triton/actions/runs/6998821726/job/19037291030.

Increase to 20m.
