### PR TITLE
[BACKEND] Support bf16 global atomic add on Hopper and Ampere

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1069,7 +1069,6 @@ struct AtomicRMWOpConversion
             converter, allocation, benefit),
         LoadStoreConversionBase(axisAnalysisPass) {}
 
-#ifdef USE_ROCM
   /// Try to match the mlir::triton::RMWOp to LLVM::AtomicBinOp.
   static std::optional<LLVM::AtomicBinOp> matchAtomicOp(RMWOp atomicOp) {
     switch (atomicOp) {
@@ -1100,8 +1099,8 @@ struct AtomicRMWOpConversion
   }
 
   LogicalResult
-  matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
+  matchAndRewriteROCm(triton::AtomicRMWOp op, OpAdaptor adaptor,
+                      ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
     MLIRContext *ctx = rewriter.getContext();
 
@@ -1211,11 +1210,13 @@ struct AtomicRMWOpConversion
     return success();
   }
 
-#else  // USE_ROCM
-
   LogicalResult
   matchAndRewrite(triton::AtomicRMWOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    #ifdef USE_ROCM
+    return matchAndRewriteROCm(op, adaptor, rewriter);
+    #endif
+
     auto loc = op.getLoc();
     MLIRContext *ctx = rewriter.getContext();
 
@@ -1368,7 +1369,6 @@ struct AtomicRMWOpConversion
     }
     return success();
   }
-#endif // USE_ROCM
 };
 
 struct InsertSliceOpConversion

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -38,7 +38,15 @@ TritonGPUToLLVMTypeConverter::TritonGPUToLLVMTypeConverter(
   });
   // Internally store bfloat16 as int16
   addConversion([&](BFloat16Type type) -> std::optional<Type> {
+    // TODO: Experimental ifdef to try storing bf16 as bf16 since LLVM does
+    // support this type now. Needed because some irgen fails if an instruction
+    // operand expects a bf16 and gets an i16 instead.
+    #define STORE_BF16_AS_BF16 1
+    #if STORE_BF16_AS_BF16
+    return FloatType::getBF16(type.getContext());
+    #else
     return IntegerType::get(type.getContext(), 16);
+    #endif
   });
 }
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1032,7 +1032,7 @@ def atom_red_typechecking_impl(ptr: tl.tensor, val: tl.tensor, mask: tl.tensor, 
     element_ty = ptr.type.scalar.element_ty
     if element_ty is tl.float16 and op != 'add':
         raise ValueError("atomic_" + op + " does not support fp16")
-    if element_ty in [tl.int1, tl.int8, tl.int16, tl.bfloat16]:
+    if element_ty in [tl.int1, tl.int8, tl.int16]:
         raise ValueError("atomic_" + op + " does not support " + str(element_ty))
     if ptr.type.is_block():
         if mask:


### PR DESCRIPTION
This patch adds support for bf16 global atomic adds on Hopper. If the check for Hopper (sm_90) fails, then a atomic compare and swap pattern is produced (as is the case with the cuda C library's atomicAdd().

For the <sm_90 case, lowering code obtained from the ROCm fork of Triton is used to produce the necessary pattern (which is actually handled by the NVPTX LLVM backend for LLVM IR `atomicrmw fadd ptr addrspace(1) %ptr, bfloat %val`). The ROCm matchAndRewrite method works in this case because it is generating a generic LLVM IR instruction.

The patterns produced for each Target are as follows:

Hopper:

`@%p1 atom.global.gpu.acq_rel.add.noftz.bf16 %rs1, [ %rd1 + 0 ], %rs2;`

Ampere:

      $BB:
      shr.u32               %r1, %r2, %r3;
      cvt.u16.u32           %rs1, %r1;
      add.bf16              %rs2, %rs1, %rs1;
      cvt.u32.u16           %r4, %rs2;
      shl.b32               %r5, %r4, %r3;
      and.b32               %r6, %r2, %r9;
      or.b32                %r7, %r6, %r5;
      atom.global.cas.b32   %r8, [%rd1], %r2, %r7;
      setp.ne.s32           %p1, %r8, %r2;
      mov.u32               %r2, %r8;
      @%p1 bra              $BB;
