### PR TITLE
[BACKEND] Fix bug in ForOpDeadArgElimination.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -615,6 +615,22 @@ struct ForOpDeadArgElimination : public OpRewritePattern<scf::ForOp> {
         continue;
       if (yieldOperand.value() == block.getArgument(yieldOperand.index() + 1))
         continue;
+
+      // The yield operand might live outside the loop, e.g.
+      //   %init = ...
+      //   %x = ...
+      //   %y = for iter_args(%unused = %init) {
+      //     yield %x
+      //   }
+      //
+      // In this case, the loop returns %x if it runs 1 or more times, and
+      // otherwise it returns %init.  We cowardly refuse to remove this operand
+      // from the yield.  (We could, but we'd need to prove that the loop runs 0
+      // or >=1 times.)
+      if (!forOp->isAncestor(
+              yieldOperand.value().getParentRegion()->getParentOp()))
+        continue;
+
       deadArg.push_back(yieldOperand.index());
     }
     if (deadArg.empty())


### PR DESCRIPTION
Suppose we have a loop which yields an operand which lives outside the
loop, i.e. is loop-invariant.  Moreover, suppose the same operand in
iter_args is never used.

    %init = ...
    %x = ...
    %y = for iter_args(%unused = %init) {
      yield %x
    }
    return %y

Previously, we would declare that operand 0 of the yield is "dead" and
replace it with `yield %init`.  This is obviously not correct.

The way this happened was:

 - ForOpDeadArgElimination iterates over the forOp's results, in this
   case just [%y].
 - We notice that %y is used, so it's not dead.  We call markLive(%x),
   where %x is the yielded value that corresponds to %y.
 - %x is not defined in the loop body, so markLive skips it.
 - Therefore at the end of the function, operand 0 of the yield is
   considered dead.  We change it to `yield %init`, so it can be removed
   from the loop entirely in a later pass.

In this patch, we add a special case that says that a `yield` which
returns a value from outside the loop isn't dead.

Fixes https://github.com/openai/triton/issues/2672
