### PR TITLE
Add a matmul test from int8, bf16

### DIFF
--- a/python/triton/ops/__init__.py
+++ b/python/triton/ops/__init__.py
@@ -2,13 +2,6 @@
 from . import blocksparse
 from .cross_entropy import _cross_entropy, cross_entropy
 from .flash_attention import attention
-from .matmul import _matmul, matmul
+from .matmul import _matmul, get_higher_dtype, matmul
 
-__all__ = [
-    "blocksparse",
-    "_cross_entropy",
-    "cross_entropy",
-    "_matmul",
-    "matmul",
-    "attention",
-]
+__all__ = ["blocksparse", "_cross_entropy", "cross_entropy", "_matmul", "matmul", "attention", "get_higher_dtype"]

--- a/python/triton/ops/matmul.py
+++ b/python/triton/ops/matmul.py
@@ -4,10 +4,18 @@ from .. import Config, autotune, cdiv, heuristics, jit
 from .. import language as tl
 from .matmul_perf_model import early_config_prune, estimate_matmul_time
 
-_ordered_datatypes = [torch.float16, torch.bfloat16, torch.float32]
+_ordered_datatypes = [torch.int8, torch.float16, torch.bfloat16, torch.float32]
+
+
+def upcast_if_fp8(a):
+    if "fp8" in str(a):
+        return torch.float16
+    return a
 
 
 def get_higher_dtype(a, b):
+    a = upcast_if_fp8(a)
+    b = upcast_if_fp8(b)
     if a is b:
         return a
 
@@ -81,7 +89,7 @@ def _kernel(A, B, C, M, N, K,  #
             stride_am, stride_ak,  #
             stride_bk, stride_bn,  #
             stride_cm, stride_cn,  #
-            dot_out_dtype: tl.constexpr,  #
+            acc_dtype: tl.constexpr,  #
             allow_tf32: tl.constexpr,  #
             fp8_fast_accum: tl.constexpr,  #
             BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr, BLOCK_K: tl.constexpr,  #
@@ -107,7 +115,7 @@ def _kernel(A, B, C, M, N, K,  #
     # pointers
     A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
     B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=dot_out_dtype)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=acc_dtype)
     for k in range(0, tl.cdiv(K, BLOCK_K * SPLIT_K)):
         if EVEN_K:
             a = tl.load(A)
@@ -117,13 +125,13 @@ def _kernel(A, B, C, M, N, K,  #
             _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
             a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
             b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
-        if AB_DTYPE:
-            a = a.to(C.dtype.element_ty)
-            b = b.to(C.dtype.element_ty)
+        if AB_DTYPE is not None:
+            a = a.to(AB_DTYPE)
+            b = b.to(AB_DTYPE)
         if fp8_fast_accum:
-            acc = tl.dot(a, b, acc, out_dtype=dot_out_dtype, allow_tf32=allow_tf32)
+            acc = tl.dot(a, b, acc, out_dtype=acc_dtype, allow_tf32=allow_tf32)
         else:
-            acc += tl.dot(a, b, out_dtype=dot_out_dtype, allow_tf32=allow_tf32)
+            acc += tl.dot(a, b, out_dtype=acc_dtype, allow_tf32=allow_tf32)
         A += BLOCK_K * SPLIT_K * stride_ak
         B += BLOCK_K * SPLIT_K * stride_bk
     acc = acc.to(C.dtype.element_ty)
@@ -145,7 +153,7 @@ class _matmul(torch.autograd.Function):
     _locks = {}
 
     @staticmethod
-    def _call(a, b, dot_out_dtype, allow_tf32, fp8_fast_accum):
+    def _call(a, b, acc_dtype, allow_tf32, fp8_fast_accum, output_dtype):
         device = a.device
         # handle non-contiguous inputs if necessary
         if a.stride(0) > 1 and a.stride(1) > 1:
@@ -156,33 +164,39 @@ class _matmul(torch.autograd.Function):
         assert a.shape[1] == b.shape[0], "incompatible dimensions"
         M, K = a.shape
         _, N = b.shape
+
+        # common type between a and b
+        ab_dtype = get_higher_dtype(a.dtype, b.dtype)
+
         # allocates output
-        if a.dtype in [tl.float8e4nv, tl.float8e4b15, tl.float8e5] or\
-           b.dtype in [tl.float8e4nv, tl.float8e4b15, tl.float8e5]:
-            c_dtype = torch.float16
-        elif a.dtype in [torch.int8] or b.dtype in [torch.int8]:
-            c_dtype = torch.int32
+        if (output_dtype is None):
+            output_dtype = ab_dtype
+
+        c = torch.empty((M, N), device=device, dtype=output_dtype)
+
+        # Allowed types for acc_type given the types of a and b.
+        supported_acc_dtypes = {
+            torch.float16: (torch.float32, torch.float16), torch.bfloat16: (torch.float32, torch.bfloat16),
+            torch.float32: (torch.float32, ), torch.int8: (torch.int32, )
+        }
+
+        if acc_dtype is None:
+            acc_dtype = supported_acc_dtypes[ab_dtype][0]
         else:
-            c_dtype = get_higher_dtype(a.dtype, b.dtype)
-        c = torch.empty((M, N), device=device, dtype=c_dtype)
-        if dot_out_dtype is None:
-            if c_dtype in [torch.float16, torch.float32, torch.bfloat16]:
-                dot_out_dtype = tl.float32
-            else:
-                dot_out_dtype = tl.int32
-        else:
-            assert isinstance(dot_out_dtype, torch.dtype), "dot_out_dtype must be a torch.dtype"
-            if dot_out_dtype == torch.float16:
-                dot_out_dtype = tl.float16
-            elif dot_out_dtype in [torch.float32, torch.bfloat16]:
-                dot_out_dtype = tl.float32
-            else:
-                dot_out_dtype = tl.int32
-        ab_dtype = True
+            assert isinstance(acc_dtype, torch.dtype), "acc_dtype must be a torch.dtype"
+            assert acc_dtype in supported_acc_dtypes[a.dtype], "acc_dtype not compatible with the type of a"
+            assert acc_dtype in supported_acc_dtypes[b.dtype], "acc_dtype not compatible with the type of b"
+
+        def to_tl_type(ty):
+            return getattr(tl, str(ty).split(".")[-1])
+
+        acc_dtype = to_tl_type(acc_dtype)
+        ab_dtype = to_tl_type(ab_dtype)
+        output_dtype = to_tl_type(output_dtype)
+
+        # Tensor cores support input with mixed float8 types.
         if a.dtype in [tl.float8e4nv, tl.float8e5] and b.dtype in [tl.float8e4nv, tl.float8e5]:
-            ab_dtype = False
-        if a.dtype in [torch.int8] and b.dtype in [torch.int8]:
-            ab_dtype = False
+            ab_dtype = None
         # launch kernel
         grid = lambda META: (cdiv(M, META['BLOCK_M']) * cdiv(N, META['BLOCK_N']), META['SPLIT_K'])
         _kernel[grid](
@@ -190,15 +204,16 @@ class _matmul(torch.autograd.Function):
             a.stride(0), a.stride(1),  #
             b.stride(0), b.stride(1),  #
             c.stride(0), c.stride(1),  #
-            dot_out_dtype=dot_out_dtype,  #
+            acc_dtype=acc_dtype,  #
             allow_tf32=allow_tf32,  #
             fp8_fast_accum=fp8_fast_accum,  #
             GROUP_M=8, AB_DTYPE=ab_dtype)
         return c
 
     @staticmethod
-    def forward(ctx, a, b, dot_out_dtype=None, allow_tf32=True, fp8_fast_accum=True):
-        return _matmul._call(a, b, dot_out_dtype=dot_out_dtype, allow_tf32=allow_tf32, fp8_fast_accum=fp8_fast_accum)
+    def forward(ctx, a, b, acc_dtype=None, allow_tf32=True, fp8_fast_accum=True, output_dtype=None):
+        return _matmul._call(a, b, acc_dtype=acc_dtype, allow_tf32=allow_tf32, fp8_fast_accum=fp8_fast_accum,
+                             output_dtype=output_dtype)
 
 
 matmul = _matmul.apply


### PR DESCRIPTION
In this PR we are adding a matmul test from `int8`, `bf16`. 

- First I included two new params:
  - `acc_dtype`: So users of the test class can specify the type used internally in the dot, and not the one set by default given the two types. There are several restrictions for these types anyway.
  - `output_dtype`: The return type of the matmul. I included a few tests in the case of making a dot with two float16.
- I had to modify test_matmul to use a small range of values to prevent numerical issues. In the case of testing with two `float16` and `acc_dtype` `float16`, since I can't force torch to use `float16` internally (it uses `float32`), I was having precision issues when comparing the results with triton. Anyway, the goal of this test shouldn't be testing precision.
- I also needed to include `torch.int8` in the possible datatypes.
- I clean/refactor files a bit.
- Finally I tried to simplify a bit the logic of matmul because after adding these two parameters it was a bit hard to follow why we needed every part of the code, so I included a `supported_acc_dtypes` for the allowed types in relation of the types of the operands a and b.