### PR TITLE
[BACKEND] Refactor wgmma descriptor creation

### DIFF
--- a/include/triton/Dialect/NVGPU/IR/NVGPUOps.td
+++ b/include/triton/Dialect/NVGPU/IR/NVGPUOps.td
@@ -89,31 +89,6 @@ def NVGPU_NamedBarrierWaitOp : NVGPU_Op<"bar_wait", []> {
   let assemblyFormat = "$bar `,` $numThreads attr-dict `:` type(operands)";
 }
 
-def WGMMADesc_ModeAttr : I32EnumAttr<"WGMMADescMode",
-    "wgmma desc mode, either 'none', 'swizzle128', 'swizzle64', or 'swizzle32'",
-    [
-      I32EnumAttrCase<"none", 0>,
-      I32EnumAttrCase<"swizzle128", 1>,
-      I32EnumAttrCase<"swizzle64", 2>,
-      I32EnumAttrCase<"swizzle32", 3>
-    ]>{
-  let cppNamespace = "::mlir::triton::nvgpu";
-}
-
-def NVGPU_WGMMADescCreateOp : NVGPU_Op<"wgmma_desc_create", []> {
-  let arguments = (ins LLVM_AnyPointer:$buffer, I32:$height, WGMMADesc_ModeAttr:$mode, I64Attr:$swizzling);
-  let builders = [
-    OpBuilder<(ins "Value":$buffer,
-                     "Value":$height,
-                     "WGMMADescMode":$mode), [{
-                      uint32_t mode_ = static_cast<uint32_t>(mode);
-                      uint64_t swizzling = (mode_ == 1 ? 128 : mode_ == 2 ? 64 : 32);
-                      build($_builder, $_state, $_builder.getIntegerType(64), buffer, height, WGMMADescModeAttr::get($_builder.getContext(), mode), $_builder.getI64IntegerAttr(swizzling));
-                     }]>];
-  let results = (outs I64:$res);
-  let assemblyFormat = "$buffer `,` $height attr-dict `:` functional-type(operands, results)";
-}
-
 def NVGPU_TMALoadTiledOp : NVGPU_Op<"tma_load_tiled", [AttrSizedOperandSegments]> {
   let arguments = (ins LLVM_PointerShared:$dst, LLVM_PointerShared:$mbarrier, LLVM_PointerGlobal:$tmaDesc, I64:$l2Desc,
                        I1:$pred, Variadic<I32>:$coords, Optional<I16>:$mcastMask);

--- a/lib/Conversion/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/lib/Conversion/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -35,24 +35,6 @@ const std::string Fence_Mbarrier_Init_Op =
 const std::string Cga_Barrier_Arrive_Op = "barrier.cluster.arrive;";
 const std::string Cga_Barrier_Wait_Op = "barrier.cluster.wait;";
 const std::string Reg_Dealloc_Op = "setmaxnreg.dec.sync.aligned.u32 #regCount;";
-const std::string Wgmma_Desc_Create_op =
-    "{\n"
-    ".reg .u64 a<5>;                              \n"
-    "mov.u64 a0, #swizzling;\n"
-    "shl.b64 a1, a0, 3;\n"             // stride dimension
-    "shr.b64 a1, a1, 4;\n"             // stride dimension
-    "mul.lo.u64 a2, $2, #swizzling;\n" // leadingDimension
-    "shr.b64 a2, a2, 4;\n"             // leadingDimension
-    "shl.b64 a3, $1, 46; \n"           // startAddr
-    "shr.b64 a3, a3, 50; \n"           // startAddr
-    "mov.u64 a4, #mode; \n"            // mode
-    "shl.b64 a4, a4, 62; \n"
-    "shl.b64 a1, a1, 32; \n"
-    "or.b64 a1, a4, a1; \n"
-    "shl.b64 a2, a2, 16; \n"
-    "or.b64 a1, a1, a2; \n"
-    "or.b64 $0, a1, a3; \n"
-    "}";
 
 const std::string Mbarrier_Init_Op =
     "@$1 mbarrier.init.shared.b64 [$0], #count;";
@@ -1125,9 +1107,6 @@ public:
         context, Cluster_Cta_Id_Op, Constraints({"=r"}), Constraints());
     patterns.add<NVGPUOpGenericPattern<ttn::CanonicalWarpIdOp>>(
         context, Canonical_Warp_Id_Op, Constraints({"=r"}), Constraints());
-    patterns.add<NVGPUOpGenericPattern<ttn::WGMMADescCreateOp>>(
-        context, Wgmma_Desc_Create_op, Constraints({"=l"}),
-        Constraints({"l", "l"}));
 
     patterns.add<FenceAsyncSharedOpPattern, StoreMatrixOpPattern,
                  OffsetOfStmatrixV4OpPattern, MBarrierArriveOpPattern,

--- a/test/NVGPU/test_wgmma.mlir
+++ b/test/NVGPU/test_wgmma.mlir
@@ -1,24 +1,4 @@
 // RUN: triton-opt %s -split-input-file --convert-nv-gpu-to-llvm | FileCheck %s
-#SHARED = #triton_gpu.shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
-module attributes {"triton_gpu.num-warps" = 4 : i32,  "triton_gpu.num-ctas" = 2 : i32} {
-  tt.func @test_tma(%opC : !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32)>) {
-    %buffer = llvm.mlir.zero : !llvm.ptr<3>
-    %height = arith.constant 16 : i32
-    // CHECK: llvm.ptrtoint
-    // CHECK: llvm.inline_asm
-    %descA = nvgpu.wgmma_desc_create %buffer, %height {mode = 2 : i32, swizzling = 64 : i64}: (!llvm.ptr<3>, i32) -> (i64)
-    // CHECK: llvm.ptrtoint
-    // CHECK: llvm.inline_asm
-    %descB = nvgpu.wgmma_desc_create %buffer, %height {mode = 2 : i32, swizzling = 64 : i64}: (!llvm.ptr<3>, i32) -> (i64)
-
-    // CHECK-COUNT-32: llvm.extractvalue
-    // CHECK: llvm.inline_asm has_side_effects asm_dialect = att operand_attrs = [] "wgmma.mma_async.sync.aligned.m64n64k16.f32.f16.f16 {$0,$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31}, $64, $65, 1, 1, 1, 0, 1;"
-    %acc0 = nvgpu.wgmma %descA, %descB, %opC {m=64:i32, n=64:i32, k=16:i32, eltTypeC=7:i32, eltTypeA=4:i32, eltTypeB=4:i32, layoutA=0:i32, layoutB=0:i32} : (i64, i64, !llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32)>) -> (!llvm.struct<(f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32, f32)>)
-    tt.return
-  }
-} // end module
-
-// -----
 
 module attributes {"triton_gpu.num-warps" = 4 : i32,  "triton_gpu.num-ctas" = 2 : i32} {
   tt.func @wgmma_no_acc(%descA: i64, %descB: i64) {


### PR DESCRIPTION
Avoid using extra op and long sequence of inline ptx to create descriptor that is mostly constant.
Also add the base address late to expose more oportuinity for LICM since the base address is usually the only changing part in matmul loop.