### PR TITLE
[LINEINFO] Specify explicit locations when ops are combined

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.td
+++ b/lib/Dialect/Triton/Transforms/Combine.td
@@ -13,21 +13,21 @@ include "mlir/IR/PatternBase.td"
 // AddFOp(d, DotOp(a, b, c)) and c==0 => DotOp(a, b, d)
 def CombineDotAddIPattern : Pat<
         (Arith_AddIOp $d, (TT_DotOp:$res $a, $b, $c, $allowTF32, $maxNumImpreciseAcc)),
-        (TT_DotOp $a, $b, $d, $allowTF32, $maxNumImpreciseAcc),
+        (TT_DotOp $a, $b, $d, $allowTF32, $maxNumImpreciseAcc, (location $res)),
         [(Constraint<CPred<"isZero($0)">> $c)]>;
 def CombineDotAddFPattern : Pat<
         (Arith_AddFOp $d, (TT_DotOp:$res $a, $b, $c, $allowTF32, $maxNumImpreciseAcc), $fastmath),
-        (TT_DotOp $a, $b, $d, $allowTF32, $maxNumImpreciseAcc),
+        (TT_DotOp $a, $b, $d, $allowTF32, $maxNumImpreciseAcc, (location $res)),
         [(Constraint<CPred<"isZero($0)">> $c),
          (Constraint<CPred<"::llvm::cast<::mlir::IntegerAttr>($0).getInt() == 0">> $maxNumImpreciseAcc)]>;
 
 def CombineDotAddIRevPattern : Pat<
         (Arith_AddIOp (TT_DotOp:$res $a, $b, $c, $allowTF32, $maxNumImpreciseAcc), $d),
-        (TT_DotOp $a, $b, $d, $allowTF32, $maxNumImpreciseAcc),
+        (TT_DotOp $a, $b, $d, $allowTF32, $maxNumImpreciseAcc, (location $res)),
         [(Constraint<CPred<"isZero($0)">> $c)]>;
 def CombineDotAddFRevPattern : Pat<
         (Arith_AddFOp (TT_DotOp:$res $a, $b, $c, $allowTF32, $maxNumImpreciseAcc), $d, $fastmath),
-        (TT_DotOp $a, $b, $d, $allowTF32, $maxNumImpreciseAcc),
+        (TT_DotOp $a, $b, $d, $allowTF32, $maxNumImpreciseAcc, (location $res)),
         [(Constraint<CPred<"isZero($0)">> $c),
          (Constraint<CPred<"::llvm::cast<::mlir::IntegerAttr>($0).getInt() == 0">> $maxNumImpreciseAcc)]>;
 
@@ -44,7 +44,7 @@ def CombineDotAddFRevPattern : Pat<
 def getConstantValue : NativeCodeCall<"getConstantValue($_builder, $0, $1)">;
 def CombineBroadcastConstantPattern : Pat<
     (TT_BroadcastOp:$bcast_res (Arith_ConstantOp $value)),
-    (Arith_ConstantOp (getConstantValue $value, $bcast_res)),
+    (Arith_ConstantOp (getConstantValue $value, $bcast_res), (location $bcast_res)),
     [(Constraint<CPred<"isBroadcastConstantCombinable($0)">> $value)]>;
 
 #endif

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -63,6 +63,9 @@ def kernel_autotune(X, Y, SIZE: tl.constexpr, BLOCK: tl.constexpr):
         tl.store(Y + i + tl.arange(0, BLOCK), x)
 
 
+# AddIOp(DotOp(a, b, c), d) and c==0 => DotOp(a, b, d)
+# Since the + symbol will take effect in the dot op after combination,
+# it seems making sense to annotate with the same line as dot.
 @triton.jit
 def kernel_dot_combine(x):
     c = tl.full((32, 32), 4, dtype=tl.int8)
@@ -156,5 +159,5 @@ def test_line_info(func: str):
         assert (check_file_lines(file_lines, "test_line_info.py", 62))
         assert (check_file_lines(file_lines, "test_line_info.py", 63))
     elif func == "dot_combine":
-        assert (check_file_lines(file_lines, "test_line_info.py", 70))
-        assert (check_file_lines(file_lines, "test_line_info.py", 71, should_contain=False))
+        assert (check_file_lines(file_lines, "test_line_info.py", 73))
+        assert (check_file_lines(file_lines, "test_line_info.py", 74, should_contain=False))

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -63,6 +63,15 @@ def kernel_autotune(X, Y, SIZE: tl.constexpr, BLOCK: tl.constexpr):
         tl.store(Y + i + tl.arange(0, BLOCK), x)
 
 
+@triton.jit
+def kernel_dot_combine(x):
+    c = tl.full((32, 32), 4, dtype=tl.int8)
+    a = (tl.arange(0, 32)[:, None] + tl.arange(0, 32)[None, :]).to(tl.int8)
+    d = tl.dot(a, a)
+    d = d + c
+    tl.device_print("", d)
+
+
 def extract_file_lines(asm):
     nvdisasm, _ = path_to_nvdisasm()
     fd, path = tempfile.mkstemp()
@@ -78,18 +87,26 @@ def extract_file_lines(asm):
     return file_lines
 
 
-def check_file_lines(file_lines, file_name, lineno):
+def check_file_lines(file_lines, file_name, lineno, should_contain=True):
+    """
+    Check if the file name and line number is in the file_lines
+
+    Args:
+        file_lines: list of (file_name, line_number)
+        file_name: file name
+        lineno: line number, -1 means do not check line number
+        should_contain: whether the file name and line number should be in the file_lines
+    """
     for file, line in file_lines:
-        # -1 means do not check line number
         if lineno == -1:
             if file_name in file:
                 return True
         if file_name in file and str(lineno) in line:
-            return True
-    return False
+            return should_contain
+    return not should_contain
 
 
-func_types = ["single", "call", "call_noinline", "multi_files", "autotune"]
+func_types = ["single", "call", "call_noinline", "multi_files", "autotune", "dot_combine"]
 
 
 @pytest.mark.parametrize("func", func_types)
@@ -111,6 +128,8 @@ def test_line_info(func: str):
         kernel_info = kernel_multi_files.warmup(torch.float32, torch.float32, BLOCK=shape[0], grid=(1,))
     elif func == "autotune":
         kernel_info = kernel_autotune.warmup(torch.float32, torch.float32, SIZE=shape[0], grid=(1,))[0]
+    elif func == "dot_combine":
+        kernel_info = kernel_dot_combine.warmup(20, grid=(1,))
 
     file_lines = extract_file_lines(kernel_info.asm["cubin"])
     if func == "single":
@@ -136,3 +155,6 @@ def test_line_info(func: str):
         assert (check_file_lines(file_lines, "test_line_info.py", 61))
         assert (check_file_lines(file_lines, "test_line_info.py", 62))
         assert (check_file_lines(file_lines, "test_line_info.py", 63))
+    elif func == "dot_combine":
+        assert (check_file_lines(file_lines, "test_line_info.py", 70))
+        assert (check_file_lines(file_lines, "test_line_info.py", 71, should_contain=False))


### PR DESCRIPTION
If not specified, MLIR will by default generate a fused location combining the locations of the inputs, which may confuse ptxas to yield weird line mapping that maps `mma` to two different lines.

e.g.,  before this commit

```
  //## File "/home/keren/code/triton/python/test/unit/language/test_line_info.py", line 69
        /*06c0*/                   PRMT R29, R18, 0x654, R37 ;
        /*06d0*/                   IMMA.16832.S8.S8.SAT R4, R8.ROW, R6.COL, R12 ;
  //## File "/home/keren/code/triton/python/test/unit/language/test_line_info.py", line 72
        /*06e0*/                   STL.64 [R1], R26 ;
  //## File "/home/keren/code/triton/python/test/unit/language/test_line_info.py", line 67
        /*06f0*/                   IADD3 R37, P0, R1, c[0x0][0x20], RZ ;
        /*0700*/                   IMAD.X R36, RZ, RZ, c[0x0][0x24], P0 ;
        /*0710*/                   IMMA.16832.S8.S8.SAT R12, R8.ROW, R28.COL, R12 ;
```