### PR TITLE
Enable loc info when printing .ttir .ttgir

### DIFF
--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -461,7 +461,9 @@ void init_triton_ir(py::module &&m) {
            [](mlir::OpState &self) -> std::string {
              std::string str;
              llvm::raw_string_ostream os(str);
-             self->print(os);
+             auto printingFlags = mlir::OpPrintingFlags();
+             printingFlags.enableDebugInfo();
+             self->print(os, printingFlags);
              return str;
            })
       .def("append_operand",
@@ -498,7 +500,9 @@ void init_triton_ir(py::module &&m) {
            [](mlir::ModuleOp &self) -> std::string {
              std::string str;
              llvm::raw_string_ostream os(str);
-             self.print(os);
+             auto printingFlags = mlir::OpPrintingFlags();
+             printingFlags.enableDebugInfo();
+             self.print(os, printingFlags);
              return str;
            })
       .def("bytecode",


### PR DESCRIPTION
Summary: in triton.cc, enable_debug on PM will make sure debugging info is dumped when MLIR_ENABLE_DUMP is on. But for printing .ttir .ttgir, we are using the default OpPrintingFlags for Operation::print: const OpPrintingFlags &flags = std::nullopt

With this patch, we pass in OpPrintingFlags with debug info enabled.

Since the generation of debug info is controlled via env var: TRITON_DISABLE_LINE_INFO, it should be okay to print loc info as long as it exists.
