### PR TITLE
[TRANSFORM] Fix a special case in ForOpDeadArgElimination

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -643,8 +643,10 @@ struct ForOpDeadArgElimination : public OpRewritePattern<scf::ForOp> {
       // from the yield.  (We could, but we'd need to prove that the loop runs 0
       // or >=1 times.)
       //
-      // A special case occurs when %init is the same as %x; in this case, we
-      // still mark the operand as dead.
+      // As a special case, if it doesn't matter whether the loop runs 0 or >=1
+      // times (because the loop returns the same value in both cases) then we
+      // can still mark the operand as dead. This occurs in the above example
+      // when %init is the same as %x.
       if (!forOp->isAncestor(
               yieldOperand.value().getParentRegion()->getParentOp()) &&
           yieldOperand.value() != forOp.getInitArgs()[yieldOperand.index()])

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -642,8 +642,12 @@ struct ForOpDeadArgElimination : public OpRewritePattern<scf::ForOp> {
       // otherwise it returns %init.  We cowardly refuse to remove this operand
       // from the yield.  (We could, but we'd need to prove that the loop runs 0
       // or >=1 times.)
+      //
+      // A special case occurs when %init is the same as %x; in this case, we
+      // still mark the operand as dead.
       if (!forOp->isAncestor(
-              yieldOperand.value().getParentRegion()->getParentOp()))
+              yieldOperand.value().getParentRegion()->getParentOp()) &&
+          yieldOperand.value() != forOp.getInitArgs()[yieldOperand.index()])
         continue;
 
       deadArg.push_back(yieldOperand.index());


### PR DESCRIPTION
The yield operand might live outside the loop, e.g.

```
    %init = ...
    %x = ...
    %y = for iter_args(%unused = %init) {
    yield %x
}
```

When %init is the same as %x; in this case, we can still mark the operand as dead.