### PR TITLE
Enable mma shortcut for the first operand in dot op for bfloat16 on H100

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -440,8 +440,6 @@ static bool isMmaToMmaShortcut(Attribute srcEncoding, Attribute dstEncoding) {
   auto dst = dstEncoding.dyn_cast<triton::gpu::MmaEncodingAttr>();
   if (!src || !dst)
     return false;
-  auto srcInstrShape = src.getInstrShape();
-  auto dstInstrShape = dst.getInstrShape();
   // when #mma = MmaEncoding<version=3, warpsPerCTA=[..., 1]>
   return src && dst && src.getVersionMajor() == 3 &&
          src.getWarpsPerCTA()[1] == 1 && dst.getVersionMajor() == 3 &&
@@ -452,16 +450,18 @@ bool isMmaToMmaShortcut(RankedTensorType srcTy, RankedTensorType dstTy) {
   return isMmaToMmaShortcut(srcTy.getEncoding(), dstTy.getEncoding());
 }
 
-// For MMAV3 dotOperand layout matches mma operand for f16 case.
+// For MMAV3 dotOperand layout matches mma operand for f16 and bf16 cases.
 bool matchMmaV3AndDotOperandLayout(RankedTensorType srcTy,
                                    RankedTensorType dstTy) {
   auto srcLayout = srcTy.getEncoding();
   auto dstLayout = dstTy.getEncoding();
   auto mmaLayout = srcLayout.cast<triton::gpu::MmaEncodingAttr>();
   auto dotOperandLayout = dstLayout.cast<triton::gpu::DotOperandEncodingAttr>();
-  return mmaLayout.getVersionMajor() == 3 && dotOperandLayout.getOpIdx() == 0 &&
-         isMmaToMmaShortcut(dotOperandLayout.getParent(), srcLayout) &&
-         srcTy.getElementType().isF16();
+  auto ans =
+      mmaLayout.getVersionMajor() == 3 && dotOperandLayout.getOpIdx() == 0 &&
+      isMmaToMmaShortcut(dotOperandLayout.getParent(), srcLayout) &&
+      (srcTy.getElementType().isF16() || srcTy.getElementType().isBF16());
+  return ans;
 }
 
 bool isMmaToDotShortcut(RankedTensorType srcTy, RankedTensorType dstTy) {

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1302,7 +1302,7 @@ unsigned MmaEncodingAttr::getTotalElemsPerThreadForOperands(
   int warpsPerCTAN = getWarpsPerCTA()[1];
   // H100
   if (isHopper()) {
-    if (eltTy.isF16())
+    if (eltTy.isF16() || eltTy.isBF16())
       return getTotalElemsPerThread(shape, eltTy);
   }
   // A100

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -259,11 +259,12 @@ struct MMAV3UseRegOperand : public OpRewritePattern<triton::DotOp> {
     if (!srcEncoding || srcEncoding.getVersionMajor() != 3 || !dstEncoding ||
         dstEncoding.getVersionMajor() != 3)
       return failure();
-    // We currently only support convert from f16 mma to f16 dot operand as the
-    // other types require shuffling data across threads.
+    // We currently only support convert from f16 and bf16 mma to f16 and bf16
+    // dot operand as the other types require shuffling data across threads.
     // TODO: extend it to more types.
     auto srcType = convertLhs.getSrc().getType().cast<RankedTensorType>();
-    if (!srcType.getElementType().isF16())
+    if (!(srcType.getElementType().isF16() ||
+          srcType.getElementType().isBF16()))
       return failure();
     auto dotOperandEncoding =
         DotOperandEncodingAttr::get(dotOp.getContext(), 0, srcEncoding, 0);

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2366,7 +2366,7 @@ def test_permute(dtype_str, shape, perm, num_ctas, device):
                                                                                                     'float32')]] +
     [(64, 64, 64, 4, col_a, col_b, 'none', False, 'float32', 'float32')
      for col_a in [True, False]
-     for col_b in [True, False]])
+     for col_b in [True, False]] + [(64, 64, 64, 4, False, False, 'chain-dot', False, 'bfloat16', 'float32')])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, out_dtype, num_ctas, device):
     check_cuda_only(device)


### PR DESCRIPTION
Enable a shortcut from the output of MMA to the input operand A for another MMA operation for bfloat16
Issue: https://github.com/openai/triton/issues/2745