### PR TITLE
Fix for #2752 - Removing undefined symbols

### DIFF
--- a/python/triton/compiler/__init__.py
+++ b/python/triton/compiler/__init__.py
@@ -1,7 +1,4 @@
 from .compiler import (CompiledKernel, ASTSource, compile, AttrsDescriptor)
 from .errors import CompilationError
 
-__all__ = [
-    "compile", "ASTSource", "AttrsDescriptor", "CompiledKernel", "CompilationError", "get_arch_default_num_warps",
-    "get_arch_default_num_stages"
-]
+__all__ = ["compile", "ASTSource", "AttrsDescriptor", "CompiledKernel", "CompilationError"]


### PR DESCRIPTION
Undefined symbols removed:
- `get_arch_default_num_warps`
- `get_arch_default_num_stages`

@ptillet 