### PR TITLE
[BACKEND] Handle correctly the rank of ptr of tensor in axis info

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -68,6 +68,9 @@ AxisInfo AxisInfo::getPessimisticValueState(Value value) {
   auto rank = 1;
   if (TensorType ty = value.getType().dyn_cast<TensorType>())
     rank = ty.getRank();
+  if (triton::PointerType ty = value.getType().dyn_cast<triton::PointerType>())
+    if (TensorType elemTy = ty.getPointeeType().dyn_cast<TensorType>())
+      rank = elemTy.getRank();
 
   DimVectorT knownContiguity(rank, 1);
   DimVectorT knownDivisibility(rank, 1);

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -643,3 +643,13 @@ tt.func @call_graph(%arg0: i32) {
 }
 
 }
+
+// -----
+
+// CHECK-LABEL: @tensor_ptr
+tt.func @tensor_ptr(%arg0: !tt.ptr<tensor<64x16xi32>, 1>) {
+  // CHECK: contiguity = [1, 1], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>
+  %0 = tt.load %arg0 {boundaryCheck = array<i32: 0>, cache = 1 : i32, evict = 1 : i32, isVolatile = false} :
+    !tt.ptr<tensor<64x16xi32>, 1> -> tensor<64x16xi32>
+  tt.return
+}


### PR DESCRIPTION
We should use the rank of the underlying tensor to get the correct propagation.