### PR TITLE
Correct OpIdx in MMAv1

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv1.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/MMAv1.cpp
@@ -71,7 +71,7 @@ LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   assert(isBRow == isBRow_);
 
   unsigned numM = mmaLayout.getMMAv1NumOuter(AShape, ALayout.getOpIdx());
-  unsigned numN = mmaLayout.getMMAv1NumOuter(BShape, ALayout.getOpIdx());
+  unsigned numN = mmaLayout.getMMAv1NumOuter(BShape, BLayout.getOpIdx());
   unsigned NK = AShape[1];
 
   auto has = extractLoadedOperand(adaptor.getA(), NK, rewriter, typeConverter,

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1500,3 +1500,18 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
     tt.return
   }
 }
+
+// -----
+
+//  CHECK-LABEL: volta_dot
+#mma = #triton_gpu.mma<{versionMajor = 1, versionMinor = 2, warpsPerCTA = [1, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], instrShape = [16, 16]}>
+module attributes {"triton_gpu.compute-capability" = 70 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {
+  tt.func @volta_dot() {
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #mma>
+    %a = arith.constant dense<0.000000e+00> : tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+    %b = arith.constant dense<0.000000e+00> : tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma}>>
+
+    %87 = tt.dot %a, %b, %cst {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<32x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>> * tensor<64x32xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma}>> -> tensor<32x32xf32, #mma>
+    tt.return
+  }
+}


### PR DESCRIPTION
I believe this is just a copy-paste accident that came from https://github.com/openai/triton/pull/2652. I added a very simple lit test that just checks that compiling a dot on volta with reasonable shapes doesn't crash (as it does before this change).