### PR TITLE
[FRONTEND] Support inline asm with no returns.

### DIFF
--- a/include/triton/Dialect/Triton/IR/Traits.h
+++ b/include/triton/Dialect/Triton/IR/Traits.h
@@ -33,6 +33,11 @@ LogicalResult
 verifySameOperandsAndResultEncoding(Operation *op,
                                     bool allowTensorPointerType = false);
 
+LogicalResult verifySameOperandsAndResultIfPresentEncoding(
+    Operation *op, bool allowTensorPointerType = false);
+
+LogicalResult verifySameOperandsAndResultIfPresentShape(Operation *op);
+
 LogicalResult verifySameLoadStoreOperandsShape(Operation *op);
 
 LogicalResult verifySameLoadStoreOperandsAndResultShape(Operation *op);
@@ -66,6 +71,27 @@ class SameOperandsAndResultEncoding
 public:
   static LogicalResult verifyTrait(Operation *op) {
     return impl::verifySameOperandsAndResultEncoding(op);
+  }
+};
+
+// Like SameOperandsAndResultEncoding, except it allows the op to have 0
+// results.
+template <typename ConcreteType>
+class SameOperandsAndResultIfPresentEncoding
+    : public TraitBase<ConcreteType, SameOperandsAndResultIfPresentEncoding> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return impl::verifySameOperandsAndResultIfPresentEncoding(op);
+  }
+};
+
+// Like SameOperandsAndResultShape, except it allows the op to have 0 results.
+template <typename ConcreteType>
+class SameOperandsAndResultIfPresentShape
+    : public TraitBase<ConcreteType, SameOperandsAndResultIfPresentShape> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return impl::verifySameOperandsAndResultIfPresentShape(op);
   }
 };
 

--- a/include/triton/Dialect/Triton/IR/TritonInterfaces.td
+++ b/include/triton/Dialect/Triton/IR/TritonInterfaces.td
@@ -12,4 +12,9 @@ def SameLoadStoreOperandsAndResultShape : NativeOpTrait<"SameLoadStoreOperandsAn
 def SameLoadStoreOperandsEncoding : NativeOpTrait<"SameLoadStoreOperandsEncoding">;
 def SameLoadStoreOperandsAndResultEncoding : NativeOpTrait<"SameLoadStoreOperandsAndResultEncoding">;
 
+// Like SameOperandsAndResult{Shape,Encoding}, except those require at least one
+// result, whereas these allow 0 results.
+def SameOperandsAndResultIfPresentShape : NativeOpTrait<"SameOperandsAndResultIfPresentShape">;
+def SameOperandsAndResultIfPresentEncoding : NativeOpTrait<"SameOperandsAndResultIfPresentEncoding">;
+
 #endif // TRITON_INTERFACES

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -511,12 +511,14 @@ def TT_MakeRangeOp : TT_Op<"make_range", [Pure]> {
 //
 // ElementwiseInlineAsm Op
 //
-def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [Elementwise,
-                                                                 SameOperandsAndResultEncoding,
-                                                                 DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
+  SameOperandsAndResultIfPresentShape,
+  SameOperandsAndResultIfPresentEncoding,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
   let summary = "inline assembly applying an elementwise operation to a group of packed elements.";
   let description = [{
-    Runs an inline asm block to generate one or more tensors.
+    Runs an inline asm block to generate zero or more tensors.
 
     The asm block is given `packed_element` elements at a time.  Exactly which
     elems it receives is unspecified.
@@ -526,7 +528,7 @@ def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [Elementwise,
   let results = (outs Variadic<TT_Type>:$result);
 
   let assemblyFormat = [{
-    $asm_string attr-dict ($args^ `:` type($args))? `->` type($result)
+    $asm_string attr-dict ($args^ `:` type($args))? (`->` type($result)^)?
   }];
 }
 

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -5,3 +5,80 @@ tt.func public @reshape_different_num_elements(%arg0: tensor<32x128xf16>) {
     %a = tt.reshape %arg0 {allow_reorder = false} : tensor<32x128xf16> -> tensor<64x32xf16>
     tt.return
 }
+
+// -----
+
+// Valid inline asm; no errors.
+tt.func public @fn(%arg0: tensor<128xi32>, %arg1: tensor<128xf32>) {
+    // No return type
+    tt.elementwise_inline_asm "" {constraints = "", packed_element = 0 : i32, pure = false} %arg0 : tensor<128xi32>
+    // Different element types (but same shape).
+    %a = tt.elementwise_inline_asm "" {constraints = "", packed_element = 0 : i32, pure = false} %arg0 : tensor<128xi32> -> tensor<128xf32>
+    tt.elementwise_inline_asm "" {constraints = "", packed_element = 0 : i32, pure = false} %arg0, %arg1 : tensor<128xi32>, tensor<128xf32>
+    tt.return
+}
+
+// -----
+
+tt.func public @fn(%arg0: tensor<128xi32>) {
+    // No error
+    tt.elementwise_inline_asm "" {constraints = "", packed_element = 0 : i32, pure = false} %arg0 : tensor<128xi32>
+
+    // expected-error @+1 {{same shape}}
+    %0 = tt.elementwise_inline_asm ""
+         {constraints = "", packed_element = 0 : i32, pure = false}
+         %arg0 : tensor<128xi32> -> tensor<256xi32>
+    tt.return
+}
+
+// -----
+
+tt.func public @fn(%arg0: tensor<128xi32>, %arg1: tensor<256xi32>) {
+    // expected-error @+1 {{same shape}}
+    tt.elementwise_inline_asm ""
+         {constraints = "", packed_element = 0 : i32, pure = false}
+         %arg0, %arg1 : tensor<128xi32>, tensor<256xi32>
+    tt.return
+}
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
+tt.func public @fn(%arg0: tensor<128xi32, #blocked>, %arg1: tensor<128xi32, #blocked1>) {
+    // expected-error @+1 {{same encoding}}
+    tt.elementwise_inline_asm ""
+         {constraints = "", packed_element = 0 : i32, pure = false}
+         %arg0, %arg1 : tensor<128xi32, #blocked>, tensor<128xi32, #blocked1>
+    tt.return
+}
+}  // end module
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
+tt.func public @fn(%arg0: tensor<128xi32, #blocked>) {
+    // expected-error @+1 {{same encoding}}
+    tt.elementwise_inline_asm ""
+         {constraints = "", packed_element = 0 : i32, pure = false}
+         %arg0 : tensor<128xi32, #blocked> -> tensor<128xi32, #blocked1>
+    tt.return
+}
+}  // end module
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
+tt.func public @fn() {
+    // expected-error @+1 {{same encoding}}
+    tt.elementwise_inline_asm ""
+         {constraints = "", packed_element = 0 : i32, pure = false}
+         -> tensor<128xi32, #blocked>, tensor<128xi32, #blocked1>
+    tt.return
+}
+}  // end module


### PR DESCRIPTION
[FRONTEND] Allow inline asm to return 0 results.

For example, the inline asm might end in a store.