### PR TITLE
[FRONTEND] Decouple the Triton compiler.py and jit.py for 3rd party backend.

### DIFF
--- a/python/triton/compiler/backends/__init__.py
+++ b/python/triton/compiler/backends/__init__.py
@@ -1,0 +1,1 @@
+from . import cuda

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -8,13 +8,14 @@ from .._C.libtriton.triton import (get_env_vars, ir)
 # TODO: runtime.errors
 from ..runtime.autotuner import OutOfResources
 from ..runtime.cache import get_cache_manager
-from ..runtime.driver import driver
+from ..runtime.driver import driver as builtin_driver
 from .utils import InfoFromBackendForTensorMap
-from .backends.cuda import CUDABackend
+from ..common.backend import get_backend
 from dataclasses import dataclass
 from .code_generator import ast_to_ttir
 from pathlib import Path
 import re
+from . import backends
 
 
 @dataclass
@@ -157,15 +158,18 @@ class IRSource:
 
 def compile(src, target=None, options=None):
     if target is None:
-        target = driver.get_current_target()
-    backend = CUDABackend(target)
+        # if no target specified, use the builtin driver as the default backend.
+        target = builtin_driver.get_current_target()
+    assert isinstance(target, tuple)
+    backend_type = target[0]
+    backend = get_backend(backend_type)
     # create backend
     if not isinstance(src, ASTSource):
         assert isinstance(src, str), "source must be either AST or a filepath"
         src = IRSource(src)
     name = str(src.fn) if isinstance(src, ASTSource) else src.path
     extra_options = src.parse_options()
-    options = backend.parse_options(dict(options or dict(), **extra_options))
+    options = backend.parse_options(dict(options or dict(), **extra_options), target)
     # create cache manager
     key = f"{src.hash()}-{backend.hash()}-{options.hash()}-{frozenset(sorted(get_env_vars().items()))}"
     hash = hashlib.md5(key.encode("utf-8")).hexdigest()
@@ -229,11 +233,14 @@ class CompiledKernel:
             setattr(self, key, val)
         # stores the text of each level of IR that was generated during compilation
         asm_files = [Path(p) for c, p in metadata_group.items() if not c.endswith(".json")]
+        backend_type = self.target[0]
+        backend = get_backend(backend_type)
+        self.driver = backend.get_driver()
         self.asm = {
-            file.suffix[1:]: file.read_bytes() if file.suffix[1:] == driver.binary_ext else file.read_text()
+            file.suffix[1:]: file.read_bytes() if file.suffix[1:] == self.driver.binary_ext else file.read_text()
             for file in asm_files
         }
-        self.kernel = self.asm[driver.binary_ext]
+        self.kernel = self.asm[self.driver.binary_ext]
         # binaries are lazily initialized
         # because it involves doing runtime things
         # (e.g., checking amount of shared memory on current device)
@@ -243,13 +250,13 @@ class CompiledKernel:
     def _init_handles(self):
         if self.module is not None:
             return
-        device = driver.get_current_device()
+        device = self.driver.get_current_device()
         # not enough shared memory to run the kernel
-        max_shared = driver.utils.get_device_properties(device)["max_shared_mem"]
+        max_shared = self.driver.get_device_properties(device)["max_shared_mem"]
         if self.shared > max_shared:
             raise OutOfResources(self.shared, max_shared, "shared memory")
         # TODO: n_regs, n_spills should be metadata generated when calling `ptxas`
-        self.module, self.function, self.n_regs, self.n_spills = driver.utils.load_binary(
+        self.module, self.function, self.n_regs, self.n_spills = self.driver.load_binary(
             self.name, self.kernel, self.shared, device)
 
     def __getattribute__(self, name):
@@ -261,10 +268,10 @@ class CompiledKernel:
         self._init_handles()
 
         def runner(*args, stream=None):
-            args_expand = driver.assemble_tensormap_to_arg(self.tensormaps_info, args)
+            args_expand = self.driver.assemble_tensormap_to_arg(self.tensormaps_info, args)
             if stream is None:
-                device = driver.get_current_device()
-                stream = driver.get_current_stream(device)
+                device = self.driver.get_current_device()
+                stream = self.driver.get_current_stream(device)
             self.run(grid[0], grid[1], grid[2], self.num_warps, self.num_ctas, self.cluster_dims[0],
                      self.cluster_dims[1], self.cluster_dims[2], self.shared, stream, self.function,
                      CompiledKernel.launch_enter_hook, CompiledKernel.launch_exit_hook, self, *args_expand)

--- a/python/triton/runtime/driver.py
+++ b/python/triton/runtime/driver.py
@@ -112,6 +112,8 @@ class CudaDriver(DriverBase):
             self.get_current_stream = lambda idx: torch.cuda.current_stream(idx).cuda_stream
         self.get_current_device = torch.cuda.current_device
         self.set_current_device = torch.cuda.set_device
+        self.get_device_properties = self.utils.get_device_properties
+        self.load_binary = self.utils.load_binary
 
     @functools.lru_cache()
     def get_current_target(self):


### PR DESCRIPTION
The front end scripts has some coupled code with CUDA backend. 
To enable the 3rd party backend extension by changing the compiler.py and jit.py:

* Deduce the device type from the attribute `device.type` of the input tensor in Triton JIT compiling.
* Make the CUDABackend to be a stateless class and Register the CUDABackend to the common 3p backends module.
* CUDABackend is used as the default backend type if no target is specified in compiler.py.
* Decouples the code with the `get_backend` and the APIs of the backends interface.