### PR TITLE
Adding RTZ rounding mode for f32->f16, f32->bf16 and f32->f8e5 conversions

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
+++ b/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
@@ -93,8 +93,6 @@ def TT_RoundingModeAttr : I32EnumAttr<
     [
         I32EnumAttrCase<"RTZ", 0, "rtz">,
         I32EnumAttrCase<"RTNE", 1, "rtne">,
-        I32EnumAttrCase<"RU", 2, "ru">,
-        I32EnumAttrCase<"RD", 3, "rd">,
     ]> {
     let cppNamespace = "::mlir::triton";
 }

--- a/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
+++ b/include/triton/Dialect/Triton/IR/TritonAttrDefs.td
@@ -87,5 +87,17 @@ def TT_ProgramDim : I32EnumAttr<
     let cppNamespace = "::mlir::triton";
 }
 
+// Rounding mode.
+def TT_RoundingModeAttr : I32EnumAttr<
+    "RoundingMode", "",
+    [
+        I32EnumAttrCase<"RTZ", 0, "rtz">,
+        I32EnumAttrCase<"RTNE", 1, "rtne">,
+        I32EnumAttrCase<"RU", 2, "ru">,
+        I32EnumAttrCase<"RD", 3, "rd">,
+    ]> {
+    let cppNamespace = "::mlir::triton";
+}
+
 
 #endif

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -79,7 +79,6 @@ def TT_BitcastOp : TT_Op<"bitcast", [Elementwise,
     // TODO: Add verifier
 }
 
-// FIXME: Not elementwise because scalars are not supported
 def TT_FpToFpOp : TT_Op<"fp_to_fp", [SameOperandsAndResultShape,
                                      SameOperandsAndResultEncoding,
                                      Pure,
@@ -92,9 +91,9 @@ def TT_FpToFpOp : TT_Op<"fp_to_fp", [SameOperandsAndResultShape,
         F8 <-> FP16, BF16, FP32, FP64
     }];
 
-    let arguments = (ins TT_FloatLike:$from, OptionalAttr<TT_RoundingModeAttr>:$rounding);
+    let arguments = (ins TT_FloatTensor:$from, OptionalAttr<TT_RoundingModeAttr>:$rounding);
 
-    let results = (outs TT_FloatLike:$result);
+    let results = (outs TT_FloatTensor:$result);
 
     let assemblyFormat = "$from attr-dict `:` type($from) `->` type($result)";
 

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -87,7 +87,7 @@ def TT_FpToFpOp : TT_Op<"fp_to_fp", [SameOperandsAndResultShape,
     let summary = "Floating point casting for custom types";
 
     let description = [{
-        Floating point casting for custom types (F8).
+        Floating point casting for custom types (F8), and non-default rounding modes.
 
         F8 <-> FP16, BF16, FP32, FP64
     }];
@@ -98,7 +98,7 @@ def TT_FpToFpOp : TT_Op<"fp_to_fp", [SameOperandsAndResultShape,
 
     let assemblyFormat = "$from attr-dict `:` type($from) `->` type($result)";
 
-    // TODO: We need a verifier here.
+    let hasVerifier = 1;
 }
 
 //

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -92,7 +92,7 @@ def TT_FpToFpOp : TT_Op<"fp_to_fp", [SameOperandsAndResultShape,
         F8 <-> FP16, BF16, FP32, FP64
     }];
 
-    let arguments = (ins TT_FloatLike:$from);
+    let arguments = (ins TT_FloatLike:$from, OptionalAttr<TT_RoundingModeAttr>:$rounding);
 
     let results = (outs TT_FloatLike:$result);
 

--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -654,6 +654,8 @@ private:
       addWSNamedAttrs(newCvt, cvtOp->getAttrs());
       auto newRet = builder.create<mlir::triton::FpToFpOp>(
           cvtOp.getLoc(), cvtOp.getType(), newCvt.getResult());
+      newRet.setRounding(
+          triton::RoundingMode::RTNE); // Downcast requires rounding mode
       addWSNamedAttrs(newRet, cvtOp->getAttrs());
       cvtOp.replaceAllUsesWith(newRet.getResult());
       cvtOp.erase();

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -788,6 +788,18 @@ mlir::LogicalResult mlir::triton::ReshapeOp::verify() {
   return mlir::success();
 }
 
+//-- FpToFpOp --
+mlir::LogicalResult mlir::triton::FpToFpOp::verify() {
+  auto dstType = getType().cast<RankedTensorType>().getElementType();
+  auto srcType =
+      getOperand().getType().cast<RankedTensorType>().getElementType();
+  if ((dstType.getIntOrFloatBitWidth() < srcType.getIntOrFloatBitWidth()) &&
+      (!getRounding().has_value())) {
+    return emitError("Rounding mode is required for FP downcast");
+  }
+  return mlir::success();
+}
+
 //-- BroadcastOp --
 LogicalResult BroadcastOp::canonicalize(BroadcastOp op,
                                         PatternRewriter &rewriter) {

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -246,9 +246,7 @@ void init_triton_ir(py::module &&m) {
 
   py::enum_<mlir::triton::RoundingMode>(m, "ROUNDING_MODE", py::module_local())
       .value("RTZ", mlir::triton::RoundingMode::RTZ)
-      .value("RTNE", mlir::triton::RoundingMode::RTNE)
-      .value("RU", mlir::triton::RoundingMode::RU)
-      .value("RD", mlir::triton::RoundingMode::RD);
+      .value("RTNE", mlir::triton::RoundingMode::RTNE);
 
   py::class_<mlir::MLIRContext>(m, "context", py::module_local())
       .def(py::init<>())

--- a/python/src/triton.cc
+++ b/python/src/triton.cc
@@ -970,7 +970,7 @@ void init_triton_ir(py::module &&m) {
            })
 
       // Cast instructions
-      // Conversions for custom FP types (FP8)
+      // Conversions for custom FP types (FP8 and non-standard rounding modes)
       .def("create_fp_to_fp",
            [](TritonOpBuilder &self, mlir::Value &src, mlir::Type &dstType,
               std::optional<::mlir::triton::RoundingMode> roundingMode)

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1540,7 +1540,7 @@ def test_fp8_fpN_roundtrip(in_dtype, out_dtype, device):
     check_type_supported(in_dtype, device)
     check_type_supported(out_dtype, device)
     if is_hip():
-        pytest.skip('test_abs_fp8 not supported on HIP.')
+        pytest.skip('test_fp8_fpN_roundtrip not supported on HIP.')
 
     @triton.jit
     def copy_kernel(input_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -779,6 +779,20 @@ class tensor:
 
     @builtin
     def to(self, dtype, fp_downcast_rounding: str = None, bitcast=False, _builder=None):
+        """
+        Casts the tensor to the given :code:`dtype`.
+        :param dtype: The target data type.
+        :type dtype: DType
+        :param fp_downcast_rounding: The rounding mode for downcasting floating-point values. \
+            This parameter is only used when self is a floating-point tensor and dtype is a floating-point type \
+            with a smaller bitwidth. Supported values are :code:`"rtne"` (round to nearest, ties to even) and \
+            :code:`"rtz"` (round towards zero).
+        :type fp_downcast_rounding: str
+        :param bitcast: If true, the tensor is bitcasted to the given :code:`dtype`, instead of being casted.
+        :type bitcast: bool
+        :param _builder: The IR builder.
+        :type _builder: ir.builder
+        """
         if isinstance(bitcast, constexpr):
             bitcast = bitcast.value
         if bitcast:

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -778,12 +778,12 @@ class tensor:
         assert False, "Transposition must be created by the AST Visitor"
 
     @builtin
-    def to(self, dtype, bitcast=False, _builder=None):
+    def to(self, dtype, fp_downcast_rounding: str = None, bitcast=False, _builder=None):
         if isinstance(bitcast, constexpr):
             bitcast = bitcast.value
         if bitcast:
             return semantic.bitcast(self, dtype, _builder)
-        return semantic.cast(self, dtype, _builder)
+        return semantic.cast(self, dtype, _builder, fp_downcast_rounding)
 
 
 # -----------------------

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -675,7 +675,8 @@ def cast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder, fp_downcast_ro
         if fp_downcast_rounding is None: fp_downcast_rounding = ir.ROUNDING_MODE.RTNE
         elif fp_downcast_rounding != ir.ROUNDING_MODE.RTNE: use_custom_rounding = True
     else:
-        raise ValueError("fp_downcast_rounding should be set only for truncating fp conversions. "
+        if fp_downcast_rounding is not None:
+            raise ValueError("fp_downcast_rounding should be set only for truncating fp conversions. "
                          "Source scalar type is " + str(src_sca_ty) + " and destination type is " + str(dst_sca_ty))
 
     if (src_sca_ty.is_fp8e4nv() or dst_sca_ty.is_fp8e4nv()):

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -623,6 +623,20 @@ def broadcast_impl_value(lhs: tl.tensor, rhs: tl.tensor, builder: ir.builder) ->
 #######
 
 
+def _str_to_rounding_mode(rounding_mode: str):
+    if rounding_mode is None:
+        return None
+    if rounding_mode == 'rtne':
+        return ir.ROUNDING_MODE.RTNE
+    if rounding_mode == 'rtz':
+        return ir.ROUNDING_MODE.RTZ
+    if rounding_mode == 'ru':
+        return ir.ROUNDING_MODE.RU
+    if rounding_mode == 'rd':
+        return ir.ROUNDING_MODE.RD
+    raise ValueError(f"Invalid rounding mode: {rounding_mode}")
+
+
 def bitcast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder) -> tl.tensor:
     src_ty = input.type
     if src_ty.is_block():
@@ -642,10 +656,12 @@ def bitcast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder) -> tl.tenso
     return tl.tensor(builder.create_bitcast(input.handle, dst_ty.to_ir(builder)), dst_ty)
 
 
-def cast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder) -> tl.tensor:
+def cast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder, fp_downcast_rounding: str = None) -> tl.tensor:
     src_ty = input.type
     if isinstance(dst_ty, tl.constexpr):
         dst_ty = dst_ty.value
+    if isinstance(fp_downcast_rounding, tl.constexpr):
+        fp_downcast_rounding = fp_downcast_rounding.value
     if src_ty.is_block():
         dst_ty = tl.block_type(dst_ty.scalar, input.type.get_block_shapes())
     if src_ty == dst_ty:
@@ -654,13 +670,26 @@ def cast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder) -> tl.tensor:
     src_sca_ty = src_ty.scalar
     dst_sca_ty = dst_ty.scalar
 
+    # For fp downcasting default rounding mode should be RTNE, for all other conversions it should
+    # not be set
+    fp_downcast_rounding = _str_to_rounding_mode(fp_downcast_rounding)
+    use_custom_rounding = False
+    if dst_sca_ty.is_floating() and src_sca_ty.is_floating(
+    ) and dst_sca_ty.primitive_bitwidth < src_sca_ty.primitive_bitwidth:
+        if fp_downcast_rounding is None: fp_downcast_rounding = ir.ROUNDING_MODE.RTNE
+        elif fp_downcast_rounding != ir.ROUNDING_MODE.RTNE: use_custom_rounding = True
+    else:
+        assert fp_downcast_rounding is None
+
     if (src_sca_ty.is_fp8e4nv() or dst_sca_ty.is_fp8e4nv()):
         assert builder.options.allow_fp8e4nv, "fp8e4nv data type is not supported on CUDA arch < 89"
 
     # Casting with customized floating types involved: fp8 <=> bf16, fp16, fp32, fp64
+    # and non-default rounding modes for downcasting
     if (src_sca_ty.is_fp8() and dst_sca_ty.is_floating()) or \
-       (src_sca_ty.is_floating() and dst_sca_ty.is_fp8()):
-        return tl.tensor(builder.create_fp_to_fp(input.handle, dst_ty.to_ir(builder)), dst_ty)
+       (src_sca_ty.is_floating() and dst_sca_ty.is_fp8()) or \
+       use_custom_rounding:
+        return tl.tensor(builder.create_fp_to_fp(input.handle, dst_ty.to_ir(builder), fp_downcast_rounding), dst_ty)
 
     # bf16 <=> (not fp32)
     if (src_sca_ty.is_fp16() and not dst_sca_ty.is_fp32()) or \

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -630,11 +630,7 @@ def _str_to_rounding_mode(rounding_mode: str):
         return ir.ROUNDING_MODE.RTNE
     if rounding_mode == 'rtz':
         return ir.ROUNDING_MODE.RTZ
-    if rounding_mode == 'ru':
-        return ir.ROUNDING_MODE.RU
-    if rounding_mode == 'rd':
-        return ir.ROUNDING_MODE.RD
-    raise ValueError(f"Invalid rounding mode: {rounding_mode}")
+    raise ValueError(f"Invalid rounding mode: {rounding_mode}. Supported rounding modes are 'rtne' and 'rtz'.")
 
 
 def bitcast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder) -> tl.tensor:
@@ -679,7 +675,8 @@ def cast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder, fp_downcast_ro
         if fp_downcast_rounding is None: fp_downcast_rounding = ir.ROUNDING_MODE.RTNE
         elif fp_downcast_rounding != ir.ROUNDING_MODE.RTNE: use_custom_rounding = True
     else:
-        assert fp_downcast_rounding is None
+        raise ValueError("fp_downcast_rounding should be set only for truncating fp conversions. "
+                         "Source scalar type is " + str(src_sca_ty) + " and destination type is " + str(dst_sca_ty))
 
     if (src_sca_ty.is_fp8e4nv() or dst_sca_ty.is_fp8e4nv()):
         assert builder.options.allow_fp8e4nv, "fp8e4nv data type is not supported on CUDA arch < 89"

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -677,7 +677,7 @@ def cast(input: tl.tensor, dst_ty: tl.dtype, builder: ir.builder, fp_downcast_ro
     else:
         if fp_downcast_rounding is not None:
             raise ValueError("fp_downcast_rounding should be set only for truncating fp conversions. "
-                         "Source scalar type is " + str(src_sca_ty) + " and destination type is " + str(dst_sca_ty))
+                             "Source scalar type is " + str(src_sca_ty) + " and destination type is " + str(dst_sca_ty))
 
     if (src_sca_ty.is_fp8e4nv() or dst_sca_ty.is_fp8e4nv()):
         assert builder.options.allow_fp8e4nv, "fp8e4nv data type is not supported on CUDA arch < 89"

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -202,14 +202,14 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
     %out2 = tt.fp_to_fp %in0 : tensor<128xf8E5M2, #blocked> -> tensor<128xbf16, #blocked>
 
     // CHECK-COUNT-2: cvt.rn.satfinite.e5m2x2.f16x2 {{.*}} "=h,r" %{{.*}} : (i32) -> vector<2xi8>
-    %out3 = tt.fp_to_fp %in2 : tensor<128xf16, #blocked> -> tensor<128xf8E5M2, #blocked>
+    %out3 = tt.fp_to_fp %in2 {rounding = 1 : i32} : tensor<128xf16, #blocked> -> tensor<128xf8E5M2, #blocked>
     // CHECK-COUNT-2: cvt.rn.satfinite.e4m3x2.f16x2 {{.*}} "=h,r" %{{.*}} : (i32) -> vector<2xi8>
-    %out4 = tt.fp_to_fp %in2 : tensor<128xf16, #blocked> -> tensor<128xf8E4M3FNUZ, #blocked>
+    %out4 = tt.fp_to_fp %in2 {rounding = 1 : i32} : tensor<128xf16, #blocked> -> tensor<128xf8E4M3FNUZ, #blocked>
 
     // CHECK-COUNT-2: cvt.rn.satfinite.e5m2x2.f32 {{.*}} "=h,r,r" %{{.*}}, %{{.*}} : (i32, i32) -> vector<2xi8>
-    %out5 = tt.fp_to_fp %in3 : tensor<128xf32, #blocked> -> tensor<128xf8E5M2, #blocked>
+    %out5 = tt.fp_to_fp %in3 {rounding = 1 : i32} : tensor<128xf32, #blocked> -> tensor<128xf8E5M2, #blocked>
     // CHECK-COUNT-2: cvt.rn.satfinite.e4m3x2.f32 {{.*}} "=h,r,r" %{{.*}}, %{{.*}} : (i32, i32) -> vector<2xi8>
-    %out6 = tt.fp_to_fp %in3 : tensor<128xf32, #blocked> -> tensor<128xf8E4M3FNUZ, #blocked>
+    %out6 = tt.fp_to_fp %in3 {rounding = 1 : i32} : tensor<128xf32, #blocked> -> tensor<128xf8E4M3FNUZ, #blocked>
     tt.return
   }
 }


### PR DESCRIPTION
* Adding an optional `fp_downcast_rounding` argument to `tensor.to()` method. It defaults to `None`, as rounding is not required for anything than downcasting operations. When downcasting without specifying this argument, it defaults to `rtne` which is the existing default behavior.
* All f32->f16 conversions with RTNE rounding go through `arith::TruncFOp` as they were, while RTZ versions go through `triton::FpToFpOp` which is intended to handle all custom fp conversions (not only fp8)