### PR TITLE
[FRONTEND] Allow implicit cast in tl.store with block pointer

### DIFF
--- a/python/test/unit/language/test_block_pointer.py
+++ b/python/test/unit/language/test_block_pointer.py
@@ -17,29 +17,32 @@ def block_copy_kernel(a_ptr, b_ptr, N, BLOCK_SIZE: tl.constexpr, padding_option:
     tl.store(b_block_ptr, a, boundary_check=(0, ))
 
 
-@pytest.mark.parametrize("dtype_str, n, padding_option", [  #
-    (dtype_str, n, padding)
-    for dtype_str in ("bool", "int16", "float16")
+@pytest.mark.parametrize("dtypes_str, n, padding_option", [  #
+    (dtypes_str, n, padding)
+    for dtypes_str in (("bool", "bool"), ("int16", "int16"), ("float16", "float16"), ("int16", "float16"))
     for n in (64, 128, 256, 512, 1024)
     for padding in ("zero", "nan")  #
 ])
-def test_block_copy(dtype_str, n, padding_option):
+def test_block_copy(dtypes_str, n, padding_option):
     capability = torch.cuda.get_device_capability()
     if capability[0] >= 9:
         pytest.skip("Hopper support is working in progress")
 
-    dtype = getattr(torch, dtype_str)
-    if dtype_str in ("bool", "int16"):
+    src_dtype_str = dtypes_str[0]
+    dst_dtype_str = dtypes_str[0]
+    src_dtype = getattr(torch, src_dtype_str)
+    dst_dtype = getattr(torch, dst_dtype_str)
+    if src_dtype_str in ("bool", "int16"):
         if padding_option == "nan":
             pytest.skip("Padding with NaN is not supported for integer types")
-        a = torch.randint(0, 2, (n, ), device="cuda", dtype=dtype)
+        a = torch.randint(0, 2, (n, ), device="cuda", dtype=src_dtype)
     else:
-        a = torch.randn((n, ), device="cuda", dtype=dtype)
-    b = torch.zeros((n, ), device="cuda", dtype=dtype)
+        a = torch.randn((n, ), device="cuda", dtype=src_dtype)
+    b = torch.zeros((n, ), device="cuda", dtype=dst_dtype)
 
     grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]), )
     block_copy_kernel[grid](a_ptr=a, b_ptr=b, N=n, BLOCK_SIZE=64, padding_option=padding_option)
-
+    a.to(dst_dtype)
     assert torch.all(a[0:n // 2] == b[0:n // 2])
     if padding_option == "zero":
         assert torch.all(b[n // 2:n] == 0)

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -977,6 +977,9 @@ def _store_block_pointer(ptr, val, mask, boundary_check, cache, eviction, builde
     # Check `boundary_check` argument
     boundary_check = _canonicalize_boundary_check(boundary_check, block_shape)
 
+    # Cast to target data type
+    val = cast(val, elt_ty, builder)
+
     # Build IR
     return tl.tensor(builder.create_tensor_pointer_store(ptr.handle, val.handle, boundary_check, cache, eviction),
                      tl.void)


### PR DESCRIPTION
This makes tl.store with block pointer match the behavior of the ptr case and implicitly cast the value to the type pointer.