### PR TITLE
[BACKEND] Hotfix for perf regression

### DIFF
--- a/python/triton/compiler/backends/cuda.py
+++ b/python/triton/compiler/backends/cuda.py
@@ -184,7 +184,7 @@ class CUDABackend(BaseBackend):
             ptx_version = ptx_get_version(cuda_version)
         ptx_version = f'{ptx_version//10}.{ptx_version%10}'
         ret = re.sub(r'\.version \d+\.\d+', f'.version {ptx_version}', ret, flags=re.MULTILINE)
-        ret = re.sub(r", debug", "", ret)  # Remove the debug flag that prevents ptxas from optimizing the code
+        ret = re.sub(r",\s*debug|debug,\s*", "", ret)  # Remove the debug flag that prevents ptxas from optimizing the code
         return ret
 
     @staticmethod

--- a/python/triton/compiler/backends/cuda.py
+++ b/python/triton/compiler/backends/cuda.py
@@ -184,7 +184,8 @@ class CUDABackend(BaseBackend):
             ptx_version = ptx_get_version(cuda_version)
         ptx_version = f'{ptx_version//10}.{ptx_version%10}'
         ret = re.sub(r'\.version \d+\.\d+', f'.version {ptx_version}', ret, flags=re.MULTILINE)
-        ret = re.sub(r",\s*debug|debug,\s*", "", ret)  # Remove the debug flag that prevents ptxas from optimizing the code
+        # Remove the debug flag that prevents ptxas from optimizing the code
+        ret = re.sub(r",\s*debug|debug,\s*", "", ret)
         return ret
 
     @staticmethod

--- a/python/triton/compiler/backends/cuda.py
+++ b/python/triton/compiler/backends/cuda.py
@@ -184,6 +184,7 @@ class CUDABackend(BaseBackend):
             ptx_version = ptx_get_version(cuda_version)
         ptx_version = f'{ptx_version//10}.{ptx_version%10}'
         ret = re.sub(r'\.version \d+\.\d+', f'.version {ptx_version}', ret, flags=re.MULTILINE)
+        ret = re.sub(r", debug", "", ret)  # Remove the debug flag that prevents ptxas from optimizing the code
         return ret
 
     @staticmethod


### PR DESCRIPTION
When annotated with ".target sm_80, debug" in a ptx file, `ptxas` is not able to apply compiler optimizations.
To validate, adding "-O3" to the compilation command would report conflicts between the "debug" constraints and the optimization flag.
To fix the problem, this PR converts `.target sm_<arch>, debug`  to `.target sm_<arch>` before applying ptxas.