### PR TITLE
[AOT] Torch extension

### DIFF
--- a/python/test/unit/tools/kernels.py
+++ b/python/test/unit/tools/kernels.py
@@ -1,0 +1,897 @@
+import torch
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def add_kernel(
+    x_ptr,  # *Pointer* to first input vector.
+    y_ptr,  # *Pointer* to second input vector.
+    output_ptr,  # *Pointer* to output vector.
+    n_elements,  # Size of the vector.
+    BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
+    # NOTE: `constexpr` so it can be used as a shape value.
+):
+    # There are multiple 'programs' processing different data. We identify which program
+    # we are here:
+    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+    # This program will process inputs that are offset from the initial data.
+    # For instance, if you had a vector of length 256 and block_size of 64, the programs
+    # would each access the elements [0:64, 64:128, 128:192, 192:256].
+    # Note that offsets is a list of pointers:
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    # Create a mask to guard memory operations against out-of-bounds accesses.
+    mask = offsets < n_elements
+    # Load x and y from DRAM, masking out any extra elements in case the input is not a
+    # multiple of the block size.
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    output = x + y
+    # Write x + y back to DRAM.
+    tl.store(output_ptr + offsets, output, mask=mask)
+
+
+@triton.jit
+def softmax_kernel(
+    output_ptr,
+    input_ptr,
+    input_row_stride,
+    output_row_stride,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # The rows of the softmax are independent, so we parallelize across those
+    row_idx = tl.program_id(0)
+    # The stride represents how much we need to increase the pointer to advance 1 row
+    row_start_ptr = input_ptr + row_idx * input_row_stride
+    # The block size is the next power of two greater than n_cols, so we can fit each
+    # row in a single block
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    input_ptrs = row_start_ptr + col_offsets
+    # Load the row into SRAM, using a mask since BLOCK_SIZE may be > than n_cols
+    row = tl.load(input_ptrs, mask=col_offsets < n_cols, other=-float("inf"))
+    # Subtract maximum for numerical stability
+    row_minus_max = row - tl.max(row, axis=0)
+    # Note that exponentiation in Triton is fast but approximate (i.e., think __expf in CUDA)
+    numerator = tl.exp(row_minus_max)
+    denominator = tl.sum(numerator, axis=0)
+    softmax_output = numerator / denominator
+    # Write back output to DRAM
+    output_row_start_ptr = output_ptr + row_idx * output_row_stride
+    output_ptrs = output_row_start_ptr + col_offsets
+    tl.store(output_ptrs, softmax_output, mask=col_offsets < n_cols)
+
+
+@triton.jit
+def leaky_relu(x):
+    x = x + 1
+    return tl.where(x >= 0, x, 0.01 * x)
+
+
+@triton.jit
+def matmul_kernel(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    # Matrix dimensions
+    M,
+    N,
+    K,
+    # The stride variables represent how much to increase the ptr by when moving by 1
+    # element in a particular dimension. E.g. `stride_am` is how much to increase `a_ptr`
+    # by to get the element one row down (A has M rows).
+    stride_am,
+    stride_ak,  #
+    stride_bk,
+    stride_bn,  #
+    stride_cm,
+    stride_cn,
+    # Meta-parameters
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,  #
+    GROUP_SIZE_M: tl.constexpr,  #
+    ACTIVATION: tl.constexpr,  #
+):
+    """Kernel for computing the matmul C = A x B.
+    A has shape (M, K), B has shape (K, N) and C has shape (M, N)
+    """
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse.
+    # See above `L2 Cache Optimizations` section for details.
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + (pid % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    # We will advance this pointer as we move in the K direction
+    # and accumulate
+    # `a_ptrs` is a block of [BLOCK_SIZE_M, BLOCK_SIZE_K] pointers
+    # `b_ptrs` is a block of [BLOCK_SIZE_K, BLOCK_SIZE_N] pointers
+    # See above `Pointer Arithmetics` section for details
+    offs_am = (pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)) % M
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)) % N
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    # We accumulate into a `[BLOCK_SIZE_M, BLOCK_SIZE_N]` block
+    # of fp32 values for higher accuracy.
+    # `accumulator` will be converted back to fp16 after the loop.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        # Load the next block of A and B, generate a mask by checking the K dimension.
+        # If it is out of bounds, set it to 0.
+        a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
+        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
+        # We accumulate along the K dimension.
+        accumulator += tl.dot(a, b)
+        # Advance the ptrs to the next K block.
+        a_ptrs += BLOCK_SIZE_K * stride_ak
+        b_ptrs += BLOCK_SIZE_K * stride_bk
+    # You can fuse arbitrary activation functions here
+    # while the accumulator is still in FP32!
+    if ACTIVATION == "leaky_relu":
+        accumulator = leaky_relu(accumulator)
+    c = accumulator.to(tl.float16)
+
+    # -----------------------------------------------------------
+    # Write back the block of the output matrix C with masks.
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
+    tl.store(c_ptrs, c, mask=c_mask)
+
+
+MATMUL_CONFIGS = [
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 256,
+            "BLOCK_SIZE_K": 64,
+            "GROUP_SIZE_M": 8,
+        },
+        num_stages=3,
+        num_warps=8,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 256,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 8,
+        },
+        num_stages=4,
+        num_warps=4,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 8,
+        },
+        num_stages=4,
+        num_warps=4,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 8,
+        },
+        num_stages=4,
+        num_warps=4,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 128,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 8,
+        },
+        num_stages=4,
+        num_warps=4,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 128,
+            "BLOCK_SIZE_N": 32,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 8,
+        },
+        num_stages=4,
+        num_warps=4,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_N": 32,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 8,
+        },
+        num_stages=5,
+        num_warps=2,
+    ),
+    triton.Config(
+        {
+            "BLOCK_SIZE_M": 32,
+            "BLOCK_SIZE_N": 64,
+            "BLOCK_SIZE_K": 32,
+            "GROUP_SIZE_M": 8,
+        },
+        num_stages=5,
+        num_warps=2,
+    ),
+]
+
+matmul_tuner = triton.autotune(
+    configs=MATMUL_CONFIGS,
+    key=["M", "N", "K"],
+)
+
+
+@triton.jit
+def _attn_fwd_inner(
+    acc,
+    l_i,
+    m_i,
+    q,  #
+    K_block_ptr,
+    V_block_ptr,  #
+    start_m,
+    qk_scale,  #
+    BLOCK_M: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,
+    offs_m: tl.constexpr,
+    offs_n: tl.constexpr,  #
+    N_CTX: tl.constexpr,
+):
+    # range of values handled by this stage
+    if STAGE == 1:
+        lo, hi = 0, start_m * BLOCK_M
+    elif STAGE == 2:
+        lo, hi = start_m * BLOCK_M, (start_m + 1) * BLOCK_M
+        lo = tl.multiple_of(lo, BLOCK_M)
+    # causal = False
+    else:
+        lo, hi = 0, N_CTX
+    K_block_ptr = tl.advance(K_block_ptr, (0, lo))
+    V_block_ptr = tl.advance(V_block_ptr, (lo, 0))
+    # loop over k, v and update accumulator
+    for start_n in range(lo, hi, BLOCK_N):
+        start_n = tl.multiple_of(start_n, BLOCK_N)
+        # -- compute qk ----
+        k = tl.load(K_block_ptr)
+        qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        qk += tl.dot(q, k)
+        if STAGE == 2:
+            mask = offs_m[:, None] >= (start_n + offs_n[None, :])
+            qk = qk * qk_scale + tl.where(mask, 0, -1.0e6)
+            m_ij = tl.maximum(m_i, tl.max(qk, 1))
+            qk -= m_ij[:, None]
+        else:
+            m_ij = tl.maximum(m_i, tl.max(qk, 1) * qk_scale)
+            qk = qk * qk_scale - m_ij[:, None]
+        p = tl.math.exp2(qk)
+        l_ij = tl.sum(p, 1)
+        # -- update m_i and l_i
+        alpha = tl.math.exp2(m_i - m_ij)
+        l_i = l_i * alpha + l_ij
+        # -- update output accumulator --
+        acc = acc * alpha[:, None]
+        # update acc
+        v = tl.load(V_block_ptr)
+        acc += tl.dot(p.to(tl.float16), v)
+        # update m_i and l_i
+        m_i = m_ij
+        V_block_ptr = tl.advance(V_block_ptr, (BLOCK_N, 0))
+        K_block_ptr = tl.advance(K_block_ptr, (0, BLOCK_N))
+    return acc, l_i, m_i
+
+
+@triton.jit
+def _attn_fwd(
+    Q,
+    K,
+    V,
+    sm_scale,
+    M,
+    Out,  #
+    stride_qz,
+    stride_qh,
+    stride_qm,
+    stride_qk,  #
+    stride_kz,
+    stride_kh,
+    stride_kn,
+    stride_kk,  #
+    stride_vz,
+    stride_vh,
+    stride_vk,
+    stride_vn,  #
+    stride_oz,
+    stride_oh,
+    stride_om,
+    stride_on,  #
+    Z,
+    H,  #
+    N_CTX: tl.constexpr,  #
+    BLOCK_M: tl.constexpr,  #
+    BLOCK_DMODEL: tl.constexpr,  #
+    BLOCK_N: tl.constexpr,  #
+    STAGE: tl.constexpr,  #
+):
+    start_m = tl.program_id(0)
+    off_hz = tl.program_id(1)
+    off_z = off_hz // H
+    off_h = off_hz % H
+    qvk_offset = off_z.to(tl.int64) * stride_qz + off_h.to(tl.int64) * stride_qh
+
+    # block pointers
+    Q_block_ptr = tl.make_block_ptr(
+        base=Q + qvk_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_qm, stride_qk),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0),
+    )
+    V_block_ptr = tl.make_block_ptr(
+        base=V + qvk_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_vk, stride_vn),
+        offsets=(0, 0),
+        block_shape=(BLOCK_N, BLOCK_DMODEL),
+        order=(1, 0),
+    )
+    K_block_ptr = tl.make_block_ptr(
+        base=K + qvk_offset,
+        shape=(BLOCK_DMODEL, N_CTX),
+        strides=(stride_kk, stride_kn),
+        offsets=(0, 0),
+        block_shape=(BLOCK_DMODEL, BLOCK_N),
+        order=(0, 1),
+    )
+    O_block_ptr = tl.make_block_ptr(
+        base=Out + qvk_offset,
+        shape=(N_CTX, BLOCK_DMODEL),
+        strides=(stride_om, stride_on),
+        offsets=(start_m * BLOCK_M, 0),
+        block_shape=(BLOCK_M, BLOCK_DMODEL),
+        order=(1, 0),
+    )
+    # initialize offsets
+    offs_m = start_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    # initialize pointer to m and l
+    m_i = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
+    l_i = tl.zeros([BLOCK_M], dtype=tl.float32) + 1.0
+    acc = tl.zeros([BLOCK_M, BLOCK_DMODEL], dtype=tl.float32)
+    # load scales
+    qk_scale = sm_scale
+    qk_scale *= 1.44269504  # 1/log(2)
+    # load q: it will stay in SRAM throughout
+    q = tl.load(Q_block_ptr)
+    # stage 1: off-band
+    # For causal = True, STAGE = 3 and _attn_fwd_inner gets 1 as its STAGE
+    # For causal = False, STAGE = 1, and _attn_fwd_inner gets 3 as its STAGE
+    if STAGE & 1:
+        acc, l_i, m_i = _attn_fwd_inner(
+            acc,
+            l_i,
+            m_i,
+            q,
+            K_block_ptr,
+            V_block_ptr,  #
+            start_m,
+            qk_scale,  #
+            BLOCK_M,
+            BLOCK_DMODEL,
+            BLOCK_N,  #
+            4 - STAGE,
+            offs_m,
+            offs_n,
+            N_CTX,  #
+        )
+    # stage 2: on-band
+    if STAGE & 2:
+        # barrier makes it easier for compielr to schedule the
+        # two loops independently
+        tl.debug_barrier()
+        acc, l_i, m_i = _attn_fwd_inner(
+            acc,
+            l_i,
+            m_i,
+            q,
+            K_block_ptr,
+            V_block_ptr,  #
+            start_m,
+            qk_scale,  #
+            BLOCK_M,
+            BLOCK_DMODEL,
+            BLOCK_N,  #
+            2,
+            offs_m,
+            offs_n,
+            N_CTX,  #
+        )
+    # epilogue
+    m_i += tl.math.log2(l_i)
+    acc = acc / l_i[:, None]
+    m_ptrs = M + off_hz * N_CTX + offs_m
+    tl.store(m_ptrs, m_i)
+    tl.store(O_block_ptr, acc.to(Out.type.element_ty))
+
+
+@triton.jit
+def _attn_bwd_preprocess(
+    O, DO, Delta, Z, H, N_CTX, BLOCK_M: tl.constexpr, D_HEAD: tl.constexpr  #  #  #  #
+):
+    off_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    off_hz = tl.program_id(1)
+    off_n = tl.arange(0, D_HEAD)
+    # load
+    o = tl.load(O + off_hz * D_HEAD * N_CTX + off_m[:, None] * D_HEAD + off_n[None, :])
+    do = tl.load(
+        DO + off_hz * D_HEAD * N_CTX + off_m[:, None] * D_HEAD + off_n[None, :]
+    ).to(tl.float32)
+    delta = tl.sum(o * do, axis=1)
+    # write-back
+    tl.store(Delta + off_hz * N_CTX + off_m, delta)
+
+
+# The main inner-loop logic for computing dK and dV.
+@triton.jit
+def _attn_bwd_dkdv(
+    dk,
+    dv,  #
+    Q,
+    k,
+    v,
+    sm_scale,  #
+    DO,  #
+    M,
+    D,  #
+    # shared by Q/K/V/DO.
+    stride_tok,
+    stride_d,  #
+    H,
+    N_CTX,
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_DMODEL: tl.constexpr,  #
+    # Filled in by the wrapper.
+    start_n,
+    start_m,
+    num_steps,  #
+    MASK: tl.constexpr,
+):
+    offs_m = start_m + tl.arange(0, BLOCK_M1)
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+    qT_ptrs = Q + offs_m[None, :] * stride_tok + offs_k[:, None] * stride_d
+    do_ptrs = DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+    # BLOCK_N1 must be a multiple of BLOCK_M1, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_N1 % BLOCK_M1 == 0)
+    curr_m = start_m
+    step_m = BLOCK_M1
+    for blk_idx in range(num_steps):
+        qT = tl.load(qT_ptrs)
+        # Load m before computing qk to reduce pipeline stall.
+        offs_m = curr_m + tl.arange(0, BLOCK_M1)
+        m = tl.load(M + offs_m)
+        qkT = tl.dot(k, qT)
+        pT = tl.math.exp2(qkT - m[None, :])
+        # Autoregressive masking.
+        if MASK:
+            mask = offs_m[None, :] >= offs_n[:, None]
+            pT = tl.where(mask, pT, 0.0)
+        do = tl.load(do_ptrs)
+        # Compute dV.
+        ppT = pT
+        ppT = ppT.to(tl.float16)
+        dv += tl.dot(ppT, do)
+        # D (= delta) is pre-divided by ds_scale.
+        Di = tl.load(D + offs_m)
+        # Compute dP and dS.
+        dpT = tl.dot(v, tl.trans(do)).to(tl.float32)
+        dsT = pT * (dpT - Di[None, :])
+        dsT = dsT.to(tl.float16)
+        dk += tl.dot(dsT, tl.trans(qT))
+        # Increment pointers.
+        curr_m += step_m
+        qT_ptrs += step_m * stride_tok
+        do_ptrs += step_m * stride_tok
+    return dk, dv
+
+
+# the main inner-loop logic for computing dQ
+@triton.jit
+def _attn_bwd_dq(
+    dq,
+    q,
+    K,
+    V,  #
+    do,
+    m,
+    D,
+    # shared by Q/K/V/DO.
+    stride_tok,
+    stride_d,  #
+    H,
+    N_CTX,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLOCK_DMODEL: tl.constexpr,
+    # Filled in by the wrapper.
+    start_m,
+    start_n,
+    num_steps,  #
+    MASK: tl.constexpr,
+):
+    offs_m = start_m + tl.arange(0, BLOCK_M2)
+    offs_n = start_n + tl.arange(0, BLOCK_N2)
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+    kT_ptrs = K + offs_n[None, :] * stride_tok + offs_k[:, None] * stride_d
+    vT_ptrs = V + offs_n[None, :] * stride_tok + offs_k[:, None] * stride_d
+    # D (= delta) is pre-divided by ds_scale.
+    Di = tl.load(D + offs_m)
+    # BLOCK_M2 must be a multiple of BLOCK_N2, otherwise the code wouldn't work.
+    tl.static_assert(BLOCK_M2 % BLOCK_N2 == 0)
+    curr_n = start_n
+    step_n = BLOCK_N2
+    for blk_idx in range(num_steps):
+        kT = tl.load(kT_ptrs)
+        vT = tl.load(vT_ptrs)
+        qk = tl.dot(q, kT)
+        p = tl.math.exp2(qk - m)
+        # Autoregressive masking.
+        if MASK:
+            offs_n = curr_n + tl.arange(0, BLOCK_N2)
+            mask = offs_m[:, None] >= offs_n[None, :]
+            p = tl.where(mask, p, 0.0)
+        # Compute dP and dS.
+        dp = tl.dot(do, vT).to(tl.float32)
+        ds = p * (dp - Di[:, None])
+        ds = ds.to(tl.float16)
+        # Compute dQ.
+        # NOTE: We need to de-scale dq in the end, because kT was pre-scaled.
+        dq += tl.dot(ds, tl.trans(kT))
+        # Increment pointers.
+        curr_n += step_n
+        kT_ptrs += step_n * stride_tok
+        vT_ptrs += step_n * stride_tok
+    return dq
+
+
+@triton.jit
+def _attn_bwd(
+    Q,
+    K,
+    V,
+    sm_scale,  #
+    DO,  #
+    DQ,
+    DK,
+    DV,  #
+    M,
+    D,
+    # shared by Q/K/V/DO.
+    stride_z,
+    stride_h,
+    stride_tok,
+    stride_d,  #
+    H,
+    N_CTX,  #
+    BLOCK_M1: tl.constexpr,  #
+    BLOCK_N1: tl.constexpr,  #
+    BLOCK_M2: tl.constexpr,  #
+    BLOCK_N2: tl.constexpr,  #
+    BLK_SLICE_FACTOR: tl.constexpr,  #
+    BLOCK_DMODEL: tl.constexpr,
+):
+    LN2: tl.constexpr = 0.6931471824645996  # = ln(2)
+
+    bhid = tl.program_id(2)
+    off_chz = (bhid * N_CTX).to(tl.int64)
+    adj = (stride_h * (bhid % H) + stride_z * (bhid // H)).to(tl.int64)
+    pid = tl.program_id(0)
+
+    # offset pointers for batch/head
+    Q += adj
+    K += adj
+    V += adj
+    DO += adj
+    DQ += adj
+    DK += adj
+    DV += adj
+    M += off_chz
+    D += off_chz
+
+    # load scales
+    offs_k = tl.arange(0, BLOCK_DMODEL)
+
+    start_n = pid * BLOCK_N1
+    start_m = start_n
+
+    MASK_BLOCK_M1: tl.constexpr = BLOCK_M1 // BLK_SLICE_FACTOR
+    offs_n = start_n + tl.arange(0, BLOCK_N1)
+
+    dv = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
+    dk = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
+
+    # load K and V: they stay in SRAM throughout the inner loop.
+    k = tl.load(K + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d)
+    v = tl.load(V + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d)
+
+    num_steps = BLOCK_N1 // MASK_BLOCK_M1
+
+    dk, dv = _attn_bwd_dkdv(
+        dk,
+        dv,  #
+        Q,
+        k,
+        v,
+        sm_scale,  #
+        DO,  #
+        M,
+        D,  #
+        stride_tok,
+        stride_d,  #
+        H,
+        N_CTX,  #
+        MASK_BLOCK_M1,
+        BLOCK_N1,
+        BLOCK_DMODEL,  #
+        start_n,
+        start_m,
+        num_steps,  #
+        MASK=True,  #
+    )
+
+    start_m += num_steps * MASK_BLOCK_M1
+    num_steps = (N_CTX - start_m) // BLOCK_M1
+
+    # Compute dK and dV for non-masked blocks.
+    dk, dv = _attn_bwd_dkdv(  #
+        dk,
+        dv,  #
+        Q,
+        k,
+        v,
+        sm_scale,  #
+        DO,  #
+        M,
+        D,  #
+        stride_tok,
+        stride_d,  #
+        H,
+        N_CTX,  #
+        BLOCK_M1,
+        BLOCK_N1,
+        BLOCK_DMODEL,  #
+        start_n,
+        start_m,
+        num_steps,  #
+        MASK=False,  #
+    )
+
+    dv_ptrs = DV + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+    tl.store(dv_ptrs, dv)
+
+    # Write back dK.
+    dk *= sm_scale
+    dk_ptrs = DK + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+    tl.store(dk_ptrs, dk)
+
+    # THIS BLOCK DOES DQ:
+    start_m = pid * BLOCK_M2
+    end_n = start_m + BLOCK_M2
+
+    MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
+    offs_m = start_m + tl.arange(0, BLOCK_M2)
+
+    q = tl.load(Q + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d)
+    dq = tl.zeros([BLOCK_M2, BLOCK_DMODEL], dtype=tl.float32)
+    do = tl.load(DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d)
+
+    m = tl.load(M + offs_m)
+    m = m[:, None]
+
+    # Compute dQ for masked (diagonal) blocks.
+    # NOTE: This code scans each row of QK^T backward (from right to left,
+    # but inside each call to _attn_bwd_dq, from left to right), but that's
+    # not due to anything important.  I just wanted to reuse the loop
+    # structure for dK & dV above as much as possible.
+    num_steps = BLOCK_M2 // MASK_BLOCK_N2
+    dq = _attn_bwd_dq(
+        dq,
+        q,
+        K,
+        V,  #
+        do,
+        m,
+        D,  #
+        stride_tok,
+        stride_d,  #
+        H,
+        N_CTX,  #
+        BLOCK_M2,
+        MASK_BLOCK_N2,
+        BLOCK_DMODEL,  #
+        start_m,
+        end_n - num_steps * MASK_BLOCK_N2,
+        num_steps,  #
+        MASK=True,  #
+    )
+    end_n -= num_steps * MASK_BLOCK_N2
+    # stage 2
+    num_steps = end_n // BLOCK_N2
+    dq = _attn_bwd_dq(
+        dq,
+        q,
+        K,
+        V,  #
+        do,
+        m,
+        D,  #
+        stride_tok,
+        stride_d,  #
+        H,
+        N_CTX,  #
+        BLOCK_M2,
+        BLOCK_N2,
+        BLOCK_DMODEL,  #
+        start_m,
+        end_n - num_steps * BLOCK_N2,
+        num_steps,  #
+        MASK=False,  #
+    )
+    # Write back dQ.
+    dq_ptrs = DQ + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+    dq *= LN2
+    tl.store(dq_ptrs, dq)
+
+
+class _attention(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, q, k, v, causal, sm_scale):
+        # shape constraints
+        Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
+        assert Lq == Lk and Lk == Lv
+        assert Lk in {16, 32, 64, 128}
+        o = torch.empty_like(q)
+        BLOCK_M = 128
+        BLOCK_N = 64 if Lk <= 64 else 32
+        num_stages = 4 if Lk <= 64 else 3
+        num_warps = 4
+        stage = 3 if causal else 1
+        # Tuning for H100
+        if torch.cuda.get_device_capability()[0] == 9:
+            num_warps = 8
+            num_stages = 7 if Lk >= 64 else 3
+        grid = (triton.cdiv(q.shape[2], BLOCK_M), q.shape[0] * q.shape[1], 1)
+        M = torch.empty(
+            (q.shape[0], q.shape[1], q.shape[2]), device=q.device, dtype=torch.float32
+        )
+        _attn_fwd[grid](
+            q,
+            k,
+            v,
+            sm_scale,
+            M,
+            o,  #
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),  #
+            k.stride(0),
+            k.stride(1),
+            k.stride(2),
+            k.stride(3),  #
+            v.stride(0),
+            v.stride(1),
+            v.stride(2),
+            v.stride(3),  #
+            o.stride(0),
+            o.stride(1),
+            o.stride(2),
+            o.stride(3),  #
+            q.shape[0],
+            q.shape[1],  #
+            N_CTX=q.shape[2],  #
+            BLOCK_M=BLOCK_M,  #
+            BLOCK_N=BLOCK_N,  #
+            BLOCK_DMODEL=Lk,  #
+            STAGE=stage,  #
+            num_warps=num_warps,  #
+            num_stages=num_stages,  #
+        )
+
+        ctx.save_for_backward(q, k, v, o, M)
+        ctx.grid = grid
+        ctx.sm_scale = sm_scale
+        ctx.BLOCK_DMODEL = Lk
+        ctx.causal = causal
+        return o
+
+    @staticmethod
+    def backward(ctx, do):
+        q, k, v, o, M = ctx.saved_tensors
+        assert do.is_contiguous()
+        assert q.stride() == k.stride() == v.stride() == o.stride() == do.stride()
+        dq = torch.empty_like(q)
+        dk = torch.empty_like(k)
+        dv = torch.empty_like(v)
+        BATCH, N_HEAD, N_CTX = q.shape[:3]
+        PRE_BLOCK = 128
+        NUM_WARPS, NUM_STAGES = 4, 5
+        BLOCK_M1, BLOCK_N1, BLOCK_M2, BLOCK_N2 = 32, 128, 128, 32
+        BLK_SLICE_FACTOR = 2
+        RCP_LN2 = 1.4426950408889634  # = 1.0 / ln(2)
+        arg_k = k
+        arg_k = arg_k * (ctx.sm_scale * RCP_LN2)
+        PRE_BLOCK = 128
+        assert N_CTX % PRE_BLOCK == 0
+        pre_grid = (N_CTX // PRE_BLOCK, BATCH * N_HEAD)
+        delta = torch.empty_like(M)
+        _attn_bwd_preprocess[pre_grid](
+            o,
+            do,  #
+            delta,  #
+            BATCH,
+            N_HEAD,
+            N_CTX,  #
+            BLOCK_M=PRE_BLOCK,
+            D_HEAD=ctx.BLOCK_DMODEL,  #
+        )
+        grid = (N_CTX // BLOCK_N1, 1, BATCH * N_HEAD)
+        _attn_bwd[grid](
+            q,
+            arg_k,
+            v,
+            ctx.sm_scale,
+            do,
+            dq,
+            dk,
+            dv,  #
+            M,
+            delta,  #
+            q.stride(0),
+            q.stride(1),
+            q.stride(2),
+            q.stride(3),  #
+            N_HEAD,
+            N_CTX,  #
+            BLOCK_M1=BLOCK_M1,
+            BLOCK_N1=BLOCK_N1,  #
+            BLOCK_M2=BLOCK_M2,
+            BLOCK_N2=BLOCK_N2,  #
+            BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
+            BLOCK_DMODEL=ctx.BLOCK_DMODEL,  #
+            num_warps=NUM_WARPS,  #
+            num_stages=NUM_STAGES,  #
+        )
+
+        return dq, dk, dv, None, None
+
+
+attention = _attention.apply

--- a/python/test/unit/tools/test_torch_extension.py
+++ b/python/test/unit/tools/test_torch_extension.py
@@ -1,0 +1,138 @@
+import json
+import os
+import shutil
+from dataclasses import dataclass
+
+import pytest
+import torch
+from torch.utils.cpp_extension import load
+
+import triton
+import triton.language as tl
+from triton.compiler.compiler import CompiledKernel
+from triton.runtime.driver import driver
+from triton.tools.extension import TorchExtCodeGen
+
+torch.manual_seed(0)
+
+
+@pytest.fixture
+def cache_dir(tmp_path):
+    os.environ["TRITON_CACHE_DIR"] = str(tmp_path.absolute())
+    yield tmp_path.absolute()
+
+
+def clear_torch_extension_dir():
+    torch_extension_dir = os.path.expanduser("~/.cache/torch_extensions")
+    if os.path.exists(torch_extension_dir):
+        shutil.rmtree(torch_extension_dir)
+
+
+def load_extension(cache_dir, kernel_name):
+    clear_torch_extension_dir()
+    fn_cache_dir = list(cache_dir.glob(f"**/{kernel_name}.json"))[0].parent
+
+    metadata_path = f"{fn_cache_dir}/{kernel_name}.json"
+    metadata_group = f"{fn_cache_dir}/__grp__{kernel_name}.json"
+
+    metadata = json.load(open(metadata_path))
+    metadata_group = json.load(open(metadata_group))["child_paths"]
+    cubin_path = metadata_group[f"{kernel_name}.cubin"]
+    # extension_path = cache_dir / f"{kernel_name}.cu"
+    extension_path = f"{kernel_name}.cu"
+
+    codegen = TorchExtCodeGen(
+        kernel_name=kernel_name, metadata=metadata, metadata_group=metadata_group
+    )
+    codegen.generate(extension_path)
+    module = load(
+        name=f"{kernel_name}",
+        sources=[extension_path],
+        extra_cflags=["-O2"],
+        extra_ldflags=["-lcuda"],
+        verbose=True,
+    )
+    return module, cubin_path
+
+
+def run_jit(kernel, grid, *args, **kwargs):
+    kernel.run(*args, grid=grid, warmup=True, save_extra_meta=True, **kwargs)
+
+
+def test_add_kernel(cache_dir):
+    from kernels import add_kernel
+
+    size = 98432
+    dtype = torch.half
+    x = torch.rand(size, device="cuda", dtype=dtype)
+    y = torch.rand(size, device="cuda", dtype=dtype)
+    output = torch.empty_like(x)
+    n_elements = output.numel()
+    BLOCK_SIZE = 1024
+
+    # Run JIT kernel to generate metadata and cubin
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    run_jit(add_kernel, grid, x, y, output, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+    kernel_module, cubin_path = load_extension(cache_dir, "add_kernel")
+
+    kernel_interface = [
+        getattr(kernel_module, attr) for attr in dir(kernel_module) if "Kernel" in attr
+    ]
+    assert len(kernel_interface) == 1
+    kernel_interface = kernel_interface[0]
+    assert getattr(kernel_interface, "BLOCK_SIZE") == BLOCK_SIZE
+
+    # Compile AOT kernel
+    kernel = kernel_interface(cubin_path)
+    output = torch.empty_like(x)
+    args = (x, y, output, n_elements)
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE), 1, 1)
+    kernel[grid](*args)
+
+    output_torch = x + y
+    assert torch.allclose(output, output_torch)
+
+
+@pytest.mark.parametrize("shape", [(1823, 781), (2000, 2048), (2000, 4096)])
+def test_fused_softmax(cache_dir, shape):
+    from kernels import softmax_kernel
+
+    x = torch.randn(*shape, device="cuda")
+    y_torch = torch.softmax(x, axis=1)
+    n_rows, n_cols = x.shape
+    BLOCK_SIZE = triton.next_power_of_2(n_cols)
+    num_warps = 4
+    if BLOCK_SIZE >= 2048:
+        num_warps = 8
+    if BLOCK_SIZE >= 4096:
+        num_warps = 16
+    y_triton = torch.empty_like(x)
+    grid = (n_rows, 1, 1)
+    run_jit(
+        softmax_kernel,
+        grid,
+        y_triton,
+        x,
+        x.stride(0),
+        y_triton.stride(0),
+        n_cols,
+        num_warps=num_warps,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    kernel_module, cubin_path = load_extension(cache_dir, f"softmax_kernel")
+    kernel_interface = [
+        getattr(kernel_module, attr) for attr in dir(kernel_module) if "Kernel" in attr
+    ]
+    assert len(kernel_interface) == 1
+    kernel_interface = kernel_interface[0]
+
+    assert getattr(kernel_interface, "BLOCK_SIZE") == BLOCK_SIZE
+    assert getattr(kernel_interface, "NUM_WARPS") == num_warps
+
+    torch_kernel = kernel_interface(cubin_path)
+    output = torch.empty_like(x)
+    args = (output, x, x.stride(0), output.stride(0), n_cols)
+    torch_kernel[grid](*args)
+    assert torch.allclose(output, y_torch)

--- a/python/test/unit/tools/test_torch_extension.py
+++ b/python/test/unit/tools/test_torch_extension.py
@@ -81,24 +81,21 @@ def load_extension(cache_dir, kernel_name):
     metadata = json.load(open(metadata_path))
     metadata_group = json.load(open(metadata_group))["child_paths"]
     cubin_path = metadata_group[f"{kernel_name}.cubin"]
-    # extension_path = cache_dir / f"{kernel_name}.cu"
 
-    # with tempfile.TemporaryDirectory() as tmp_dir:
-    from pathlib import Path
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        extension_path = os.path.join(tmp_dir, f"{kernel_name}.cu")
 
-    extension_path = os.path.join(f"{kernel_name}.cu")
-
-    codegen = TorchExtCodeGen(
-        kernel_name=kernel_name, metadata=metadata, metadata_group=metadata_group
-    )
-    codegen.generate(extension_path)
-    module = load(
-        name=f"{kernel_name}",
-        sources=[extension_path],
-        extra_cflags=["-O2"],
-        extra_ldflags=["-lcuda"],
-        verbose=True,
-    )
+        codegen = TorchExtCodeGen(
+            kernel_name=kernel_name, metadata=metadata, metadata_group=metadata_group
+        )
+        codegen.generate(extension_path)
+        module = load(
+            name=f"{kernel_name}",
+            sources=[extension_path],
+            extra_cflags=["-O2"],
+            extra_ldflags=["-lcuda"],
+            verbose=True,
+        )
     return module, cubin_path
 
 
@@ -394,15 +391,15 @@ def test_flash_attention(Z, H, N_CTX, D_HEAD, causal, dtype, cache_dir, cuda_con
         v,
         sm_scale,
         M,
-        o,  #
+        o,
         q.stride(0),
         q.stride(1),
         q.stride(2),
-        q.stride(3),  #
+        q.stride(3),
         k.stride(0),
         k.stride(1),
         k.stride(2),
-        k.stride(3),  #
+        k.stride(3),
         v.stride(0),
         v.stride(1),
         v.stride(2),
@@ -422,15 +419,15 @@ def test_flash_attention(Z, H, N_CTX, D_HEAD, causal, dtype, cache_dir, cuda_con
         v,
         sm_scale,
         M,
-        o,  #
+        o,
         q.stride(0),
         q.stride(1),
         q.stride(2),
-        q.stride(3),  #
+        q.stride(3),
         k.stride(0),
         k.stride(1),
         k.stride(2),
-        k.stride(3),  #
+        k.stride(3),
         v.stride(0),
         v.stride(1),
         v.stride(2),

--- a/python/test/unit/tools/test_torch_extension.py
+++ b/python/test/unit/tools/test_torch_extension.py
@@ -154,6 +154,10 @@ def test_add_kernel(cache_dir, cuda_context):
     assert torch.allclose(triton_output, extension_output)
 
 
+@pytest.mark.skipif(
+    skip_torch_extension_tests(),
+    reason="Torch extension tests skipped, set RUN_TORCH_EXTENSION_TESTS=1 to run",
+)
 @pytest.mark.parametrize("shape", [(1823, 781), (2000, 2048), (2000, 4096)])
 def test_fused_softmax(cache_dir, shape, cuda_context):
     from kernels import softmax_kernel
@@ -207,6 +211,10 @@ def test_fused_softmax(cache_dir, shape, cuda_context):
     assert torch.allclose(output, y_torch)
 
 
+@pytest.mark.skipif(
+    skip_torch_extension_tests(),
+    reason="Torch extension tests skipped, set RUN_TORCH_EXTENSION_TESTS=1 to run",
+)
 @pytest.mark.parametrize(
     "activation",
     ["", "leaky_relu"],
@@ -327,6 +335,10 @@ def test_matmul(cache_dir, config, activation, cuda_context):
     assert torch.allclose(extension_output, triton_output, atol=1e-2, rtol=0)
 
 
+@pytest.mark.skipif(
+    skip_torch_extension_tests(),
+    reason="Torch extension tests skipped, set RUN_TORCH_EXTENSION_TESTS=1 to run",
+)
 @pytest.mark.parametrize("Z, H, N_CTX, D_HEAD", [(1, 2, 1024, 64)])
 @pytest.mark.parametrize("causal", [True])
 @pytest.mark.parametrize("dtype", [torch.float16])

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -155,7 +155,7 @@ class IRSource:
         return dict()
 
 
-def compile(src, target=None, options=None):
+def compile(src, target=None, options=None, save_extra_meta=False, arg_names=None):
     if target is None:
         target = driver.get_current_target()
     backend = make_backend(target)
@@ -184,6 +184,17 @@ def compile(src, target=None, options=None):
         **get_env_vars(),
         **src.metadata(),
     }
+    if save_extra_meta:
+    metadata = {
+        "signature": src.signature,
+        "constants": src.constants,
+        "arg_names": arg_names
+        if arg_names
+        else [f"arg_{i}" for i in range(len(src.signature))],
+        "attrs": src.attrs.serialize() if src.attrs else None,
+        **metadata,
+    }
+
     # run compilation pipeline  and populate metadata
     stages = dict()
     backend.add_stages(stages, options)

--- a/python/triton/tools/extension.py
+++ b/python/triton/tools/extension.py
@@ -218,7 +218,7 @@ void test_cubin() {{
         IMPORTANT NOTES: 
             - The grid should be sized according to the same heuristics as the original kernel, as constexprs are baked into the kernel.
             E.g., if the original grid was lambda meta: (triton.cdiv(n_elements, meta[\'BLOCK_SIZE\']), 1, 1), then the grid should be (triton.cdiv(n_elements, BLOCK_SIZE), 1, 1).
-            - The kernel is launched on device 0.
+            - The kernel is launched on current device and stream using torch cuda API.
         Constants are also exposed as attributes.  
         E.g., if the kernel has a constant named BLOCK_SIZE, then the constant can be accessed as kernel.BLOCK_SIZE.)";
     """

--- a/python/triton/tools/extension.py
+++ b/python/triton/tools/extension.py
@@ -1,0 +1,486 @@
+import json
+
+
+def ty_to_torch_cpp(ty):
+    if ty[0] == "*":
+        return "at::Tensor"
+    return {
+        "i1": "int32_t",
+        "i8": "int8_t",
+        "i16": "int16_t",
+        "i32": "int32_t",
+        "i64": "int64_t",
+        "u32": "uint32_t",
+        "u64": "uint64_t",
+        "fp16": "float",
+        "bf16": "float",
+        "fp32": "float",
+        "f32": "float",
+        "fp64": "double",
+    }[ty]
+
+
+class TorchExtTemplates:
+    PREFIX = """
+#include <torch/extension.h>
+#include<iostream>
+#include <filesystem>
+#include<pybind11/functional.h>
+#include<pybind11/stl.h>
+
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+
+#define CUDA_DRIVER_CHECK(EXPR)                    do {                                                   CUresult code = EXPR;                              const char *msg;                                   cuGetErrorString(code, &msg);                      if (code != CUDA_SUCCESS) {                            throw std::runtime_error(                              std::string("CUDA driver error: ") +               std::string(msg));                         }                                              } while (0);
+
+static inline CUfunction loadKernel(
+        std::string filePath,
+        const std::string &funcName,
+        uint32_t sharedMemBytes,
+        const std::optional<std::string> &cubinDir = std::nullopt) {
+    if (cubinDir) {
+        std::filesystem::path p1{*cubinDir};
+        std::filesystem::path p2{filePath};
+        filePath = (p1 / p2.filename()).string();
+    }
+
+    CUmodule mod;
+    CUfunction func;
+    CUDA_DRIVER_CHECK(cuModuleLoad(&mod, filePath.c_str()));
+    CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
+    
+    auto device = c10::cuda::current_device();
+    int shared_optin;
+    CUDA_DRIVER_CHECK(cuDeviceGetAttribute(
+        &shared_optin, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+        device));
+
+    if (sharedMemBytes > 49152 && shared_optin > 49152) {
+        CUDA_DRIVER_CHECK(cuFuncSetCacheConfig(func, CU_FUNC_CACHE_PREFER_SHARED));
+        int shared_total, shared_static;
+        CUDA_DRIVER_CHECK(cuDeviceGetAttribute(
+            &shared_total, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR,
+            device));
+        CUDA_DRIVER_CHECK(cuFuncGetAttribute(
+            &shared_static, CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, func));
+        CUDA_DRIVER_CHECK(cuFuncSetAttribute(
+            func, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+            shared_optin - shared_static));
+    }
+    
+    return func;
+}
+
+static inline void launchKernel(
+        CUfunction func,
+        uint32_t gridX,
+        uint32_t gridY,
+        uint32_t gridZ,
+        uint32_t numWarps,
+        uint32_t sharedMemBytes,
+        void* args[],
+        cudaStream_t stream) {
+    CUDA_DRIVER_CHECK(cuLaunchKernel(
+        func, gridX, gridY, gridZ, 32*numWarps, 1, 1, sharedMemBytes, stream, args, nullptr
+    ));
+}
+"""
+    KERNEL_INTERFACE = """
+    class {KERNEL_INTERFACE_NAME} {{
+    private: 
+        const std::string cubinPath;
+    public:
+        {KERNEL_INTERFACE_NAME}(const std::string &cubinPath) : cubinPath(cubinPath) {{}}
+    """
+
+    KERNEL_LAMBDA = """
+    std::function<void(at::Tensor, at::Tensor, at::Tensor, int)> operator[](const std::vector<int> &grid) {{
+        return [this, grid](at::Tensor x, at::Tensor y, at::Tensor out, int n_elements) {{ this->run(grid, x, y, out, n_elements); }};
+    }}
+
+}};
+"""
+    KERNEL_HANDLE = """
+    static CUfunction {KERNEL_NAME}_0 = nullptr;
+    """
+
+    __CUBIN_LOADER = """
+    static inline CUfunction loadCubin(
+        const std::string &funcName,
+        uint32_t sharedMemBytes) {
+
+    CUmodule mod;
+    CUfunction func;
+    void *bin = (void *)&CUBIN_NAME;
+    CUDA_DRIVER_CHECK(cuModuleLoadData(&mod, &bin));
+    CUDA_DRIVER_CHECK(cuModuleGetFunction(&func, mod, funcName.c_str()));
+    if (sharedMemBytes > 0) {
+        CUDA_DRIVER_CHECK(cuFuncSetAttribute(
+            func,
+            CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+            sharedMemBytes
+        ))
+    }
+    return func;
+}
+    """
+    CUBIN_LOADER = """
+    // globals
+#define CUBIN_NAME {KERNEL_NAME}_cubin
+CUmodule {KERNEL_NAME}_mod = NULL;
+CUfunction {KERNEL_NAME}_func = NULL;
+unsigned char CUBIN_NAME[{BIN_SIZE}] = {{ {BIN_DATA} }};
+
+void unload_{KERNEL_NAME}(void) {{
+    CUDA_DRIVER_CHECK(cuModuleUnload({KERNEL_NAME}_mod));
+}}
+
+// TODO: some code duplication with `runtime/backend/cuda.c`
+void load_{KERNEL_NAME}() {{
+    int dev = 0;
+    void *bin = (void *)&CUBIN_NAME;
+    int shared = {SHARED};
+    CUDA_DRIVER_CHECK(cuModuleLoadData(&{KERNEL_NAME}_mod, bin));
+    CUDA_DRIVER_CHECK(cuModuleGetFunction(&{KERNEL_NAME}_func, {KERNEL_NAME}_mod, "{MANGLED_NAME}"));
+    // set dynamic shared memory if necessary
+    int shared_optin;
+    CUDA_DRIVER_CHECK(cuDeviceGetAttribute(&shared_optin, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, dev));
+    if (shared > 49152 && shared_optin > 49152) {{
+      CUDA_DRIVER_CHECK(cuFuncSetCacheConfig({KERNEL_NAME}_func, CU_FUNC_CACHE_PREFER_SHARED));
+      CUDA_DRIVER_CHECK(cuFuncSetAttribute({KERNEL_NAME}_func, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, shared_optin));
+    }}
+}}
+void test_cubin() {{
+    CUdevice dev;
+    CUcontext ctx;
+    CUstream stream;
+    CUdeviceptr A, B, C;
+    cuInit(0);
+    cuDeviceGet(&dev, 0);
+    cuCtxCreate(&ctx, 0, dev);
+    cuStreamCreate(&stream, 0);
+    load_{KERNEL_NAME}();
+    cuCtxDestroy(ctx);
+
+}}
+"""
+    __CUBIN_IMAGE = """
+    #define CUBIN_NAME {KERNEL_NAME}_cubin
+    const char CUBIN_NAME[] = {{ {BIN_DATA} }};
+    """
+
+    CUDA_CONTEXT = """
+        at::cuda::CUDAGuard device_guard(0);
+        cudaStream_t stream0 = at::cuda::getCurrentCUDAStream(0);
+    """
+
+    POINTER_TEMPLATE = (
+        "CUdeviceptr {PREFIX}_{i} = reinterpret_cast<CUdeviceptr>({ARG}.data_ptr())"
+    )
+
+    ARG_DECL = """
+        void* kernel_args[] = {{{}}};
+    """
+
+    KERNEL_LOADER_TEMPLATE = """
+        if ({KERNEL_NAME}_0 == nullptr) {{
+            {KERNEL_NAME}_0 = loadKernel(cubinPath, "{KERNEL_MANGLED_NAME}", {SHARED_MEM_BYTES});
+        }}
+    """
+
+    GRID_DECL = """
+        dim3 grid({GRID});
+    """
+
+    LAUNCH_KERNEL_TEMPLATE = """
+        launchKernel(add_kernel_0, grid.x, grid.y, grid.z, {NUM_WARPS}, {SHARED_MEM_BYTES}, kernel_args, stream0);
+    """
+
+    CONST_DECL = """
+        m.attr("{NAME}") = py::int_({VALUE});
+    """
+
+    STATIC_PROP_TEMPLATE = """
+    .def_property_readonly_static("{NAME}", [](py::object) {{ return {VALUE}; }})
+    """
+
+    KERNEL_INTERFACE_BINDING_DOC = """
+    PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {{
+        m.doc() = R"(Interface to the {KERNEL_NAME} kernel.  Use {KERNEL_INTERFACE_NAME} to get a handle to the kernel.
+        Construct the kernel by passing the path to the cubin file to the constructor.  The kernel can be launched by either calling the launch method or by indexing the object with a grid.
+        If using launch, the first argument is the grid and the remaining arguments are the kernel arguments {KERNEL_ARGS_WITH_TYPES}.
+        If using indexing, the grid should be a tuple or list of len 3 and the remaining arguments are the kernel arguments {KERNEL_ARGS_WITH_TYPES}.
+        Example:
+            kernel = {KERNEL_INTERFACE_NAME}(\'{KERNEL_NAME}.cubin\')
+            kernel.launch((1, 1, 1), {KERNEL_ARGS})
+        Equivalently
+            kernel[(1, 1, 1)]({KERNEL_ARGS})
+        IMPORTANT NOTES: 
+            - The grid should be sized according to the same heuristics as the original kernel, as constexprs are baked into the kernel.
+            E.g., if the original grid was lambda meta: (triton.cdiv(n_elements, meta[\'BLOCK_SIZE\']), 1, 1), then the grid should be (triton.cdiv(n_elements, BLOCK_SIZE), 1, 1).
+            - The kernel is launched on device 0.
+        Constants are also exposed as attributes.  
+        E.g., if the kernel has a constant named BLOCK_SIZE, then the constant can be accessed as kernel.BLOCK_SIZE.)";
+    """
+
+    KERNEL_INTERFACE_BINDING_PROPER = """
+        py::class_<{KERNEL_INTERFACE_NAME}>(m, "{KERNEL_INTERFACE_NAME}")        
+        .def(py::init<const std::string&>(), "Loads the cubin file from the given path", py::arg("cubin_path"))
+        .def("__getitem__", &{KERNEL_INTERFACE_NAME}::operator[])
+        .def("launch", &{KERNEL_INTERFACE_NAME}::run, "Launches the kernel with the given grid size, grid should be a tuple or list of len 3", py::arg("grid"), {PY_ARG_NAMES})\t{STATIC_PROPS};
+    """
+
+    EXTENSION_DECL = """
+    PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {{
+        m.def("{KERNEL_NAME}", torch::wrap_pybind_function({KERNEL_NAME}), "{KERNEL_NAME}");
+    """
+    BINDING_DECL = """
+    PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+        m.def("test_launch", &test_launch, "test_launch");
+                
+}"""
+
+
+class TorchExtCodeGen:
+    """Generates Torch extension for Triton Kernel
+
+    Maintains same API as original kernel with auto-generated grid
+    """
+
+    TEMPLATES = TorchExtTemplates
+
+    def __init__(
+        self,
+        *,
+        kernel_name,
+        metadata,
+        metadata_group=None,
+        var_prefix="var",
+    ):
+        """Generates Torch extension for Triton Kernel
+
+        Args:
+            kernel_name (str): name of original jitted kernel
+            metadata (dict): metadata of jitted kernel
+            var_prefix (str, optional): prefix to use for each arg passed to actual CUDA kernel. Defaults to "var".
+        """
+        self.kernel_name = kernel_name
+        self.mangled_name = metadata.pop("name")  # metadata["name"]
+        self.num_warps = metadata["num_warps"]
+        self.num_ctas = metadata["num_ctas"]
+        self.shared_mem = metadata["shared"]
+        self.signature = metadata.pop("signature")  # metadata["signature"]
+        self.arg_names = metadata.pop("arg_names")  # metadata.get("arg_names")
+        self.constants = {int(k): v for k, v in metadata.pop("constants").items()}
+        self.specializations = metadata.get("attrs")
+        self.args = [
+            self.arg_names[i]
+            for i in range(len(self.arg_names))
+            if not (
+                (i in self.constants.keys())
+                and not (i in self.specializations["equal_to_1"])
+            )
+        ]
+        self.constexprs = {
+            k: v
+            for k, v in self.constants.items()
+            if k not in self.specializations["equal_to_1"]
+        }
+
+        self.constant_names = [self.arg_names[i] for i in self.constexprs.keys()]
+        self.constant_values = list(self.constexprs.values())
+        self.metadata_group = metadata_group
+        assert len(self.args) == len(self.signature)
+        assert len(self.arg_names) == len(self.args) + len(self.constexprs)
+        assert len(self.constant_names) == len(self.constant_values)
+
+        self._metadata = metadata
+        self.id = (
+            hash(metadata.values())
+            + hash(metadata_group.values() if metadata_group else 0)
+            + hash(self.constexprs.values())
+        )
+        self.prefix = var_prefix
+        self.kernel_interface_name = "".join(
+            [s.title() for s in self.kernel_name.split("_") if s.lower() != "kernel"]
+            + [f"Kernel_{self.id}"]
+        )
+
+    def make_kernel_decl_args(self):
+        arg_names = self.args
+        arg_types = list(self.signature.values())
+        arg_types = [ty_to_torch_cpp(ty) for ty in arg_types]
+
+        return ", ".join([f"{ty} {name}" for ty, name in zip(arg_types, arg_names)])
+
+    def make_kernel_decl(
+        self,
+    ):
+        return f"void {self.kernel_name}({self.make_kernel_decl_args()})" + "{\n"
+
+    def make_kernel_interface_impl(self):
+        return f"""
+    void run(const std::vector<int> &grid, {self.make_kernel_decl_args()}) {{
+        auto device = c10::cuda::current_device();
+        at::cuda::CUDAGuard device_guard(device);
+        cudaStream_t stream = at::cuda::getCurrentCUDAStream(device);
+        {self.make_kernel_loader()}
+        {self.make_normalized_arg_assigns()}
+        {self.make_kernel_args_array()};
+        
+        TORCH_CHECK(grid.size() == 3, "Grid must be 3-dimensional");
+        
+        launchKernel({self.kernel_name}_0, grid[0], grid[1], grid[2], {self.num_warps}, {self.shared_mem}, kernel_args,
+               stream);
+    }}
+    """
+
+    def make_kernel_lambda(self):
+        return f"""
+        std::function<void({self.make_kernel_decl_args()})> operator[](const std::vector<int> &grid) {{
+            return [this, grid]({self.make_kernel_decl_args()}) {{ this->run(grid, {", ".join(self.args)}); }};
+        }}
+        """
+
+    def make_normalized_arg_assigns(self):
+        normalized_args = []
+
+        for i, (arg, arg_ty) in enumerate(zip(self.args, self.signature.values())):
+            if arg_ty[0] == "*":
+                normalized_args.append(
+                    self.TEMPLATES.POINTER_TEMPLATE.format(
+                        i=i, ARG=arg, PREFIX=self.prefix
+                    )
+                )
+            else:
+                normalized_args.append(
+                    f"{ty_to_torch_cpp(arg_ty)} {self.prefix}_{i} = {arg}"
+                )
+        return ";\n\t".join(normalized_args) + ";"
+
+    def make_kernel_args_array(self):
+        args = ", ".join(
+            [
+                f"&{self.prefix}_{i}"
+                for i in range(len(self.signature))
+                if i not in self.specializations["equal_to_1"]
+            ]
+        )
+        return self.TEMPLATES.ARG_DECL.format(args)
+
+    def make_kernel_loader(self):
+        return self.TEMPLATES.KERNEL_LOADER_TEMPLATE.format(
+            KERNEL_NAME=self.kernel_name,
+            KERNEL_MANGLED_NAME=self.mangled_name,
+            SHARED_MEM_BYTES=self.shared_mem,
+        )
+
+    def make_kernel_launcher(self):
+        return self.TEMPLATES.LAUNCH_KERNEL_TEMPLATE.format(
+            NUM_WARPS=self.num_warps, SHARED_MEM_BYTES=self.shared_mem
+        )
+
+    def make_constants(self):
+        for name, value in zip(self.constant_names, self.constant_values):
+            yield self.TEMPLATES.CONST_DECL.format(NAME=name, VALUE=value)
+
+    def make_props(self):
+        constants = [
+            self.TEMPLATES.STATIC_PROP_TEMPLATE.format(
+                KERNEL_INTERFACE_NAME=self.kernel_interface_name, NAME=name, VALUE=value
+            )
+            if isinstance(value, int)
+            else self.TEMPLATES.STATIC_PROP_TEMPLATE.format(
+                KERNEL_INTERFACE_NAME=self.kernel_interface_name,
+                NAME=name,
+                VALUE=f'"{value}"',
+            )
+            for name, value in zip(self.constant_names, self.constant_values)
+        ]
+        metadata = []
+
+        def make_initializer_list(vs):
+            return "{ " + ", ".join(str(v) for v in vs) + " }"
+
+        for k, v in self._metadata.items():
+            if k == "target":
+                v = ":".join(str(i) for i in v)
+                v = '"' + v + '"'
+            elif isinstance(v, list):
+                v = f"std::vector<int>({make_initializer_list(v)})"
+            elif isinstance(v, dict):
+                vs = ", ".join(
+                    f'{{"{k}", {make_initializer_list(v)}}}' for k, v in v.items()
+                )
+                v = f"std::map<std::string, std::vector<int>>({{{vs}}})"
+            elif not v:
+                v = "nullptr"
+            elif isinstance(v, str):
+                v = f'"{v}"'
+            else:
+                v = json.dumps(v)
+            metadata.append(
+                self.TEMPLATES.STATIC_PROP_TEMPLATE.format(
+                    KERNEL_INTERFACE_NAME=self.kernel_interface_name,
+                    NAME=k.upper(),
+                    VALUE=v,
+                )
+            )
+        if self.metadata_group:
+            for k, v in self.metadata_group.items():
+                metadata.append(
+                    self.TEMPLATES.STATIC_PROP_TEMPLATE.format(
+                        KERNEL_INTERFACE_NAME=self.kernel_interface_name,
+                        NAME=k.upper(),
+                        VALUE=f'"{v}"',
+                    )
+                )
+        return constants + metadata
+
+    def make_binding(self):
+        # binding = self.TEMPLATES.EXTENSION_DECL.format(KERNEL_NAME=self.kernel_name)
+        py_arg_names = [f'py::arg("{name}")' for name in self.args]
+
+        kernel_args = ", ".join(self.args)
+        kernel_args_with_types = ", ".join(
+            [f"{name}:{ty}" for name, ty in zip(self.args, self.signature.values())]
+        )
+
+        props = "\n".join(self.make_props())
+        binding_doc = self.TEMPLATES.KERNEL_INTERFACE_BINDING_DOC.format(
+            KERNEL_INTERFACE_NAME=self.kernel_interface_name,
+            KERNEL_NAME=self.kernel_name,
+            KERNEL_ARGS=kernel_args,
+            KERNEL_ARGS_WITH_TYPES=kernel_args_with_types,
+            PY_ARG_NAMES=", ".join(py_arg_names),
+            STATIC_PROPS=props,
+        )
+        binding_cls = self.TEMPLATES.KERNEL_INTERFACE_BINDING_PROPER.format(
+            KERNEL_INTERFACE_NAME=self.kernel_interface_name,
+            KERNEL_NAME=self.kernel_name,
+            KERNEL_ARGS=kernel_args,
+            PY_ARG_NAMES=", ".join(py_arg_names),
+            STATIC_PROPS=props,
+        )
+        return "\n".join([binding_doc, binding_cls]) + "\n}"
+
+    def generate(self, save_dir=None):
+        src = ""
+        src += self.TEMPLATES.PREFIX
+        # src += self.make_cubin_image()
+        src += self.TEMPLATES.KERNEL_HANDLE.format(KERNEL_NAME=self.kernel_name)
+        src += self.TEMPLATES.KERNEL_INTERFACE.format(
+            KERNEL_INTERFACE_NAME=self.kernel_interface_name,
+            KERNEL_NAME=self.kernel_name,
+            KERNEL_MANGLED_NAME=self.mangled_name,
+            NUM_WARPS=self.num_warps,
+            SHARED_MEM_BYTES=self.shared_mem,
+        )
+        src += self.make_kernel_interface_impl()
+        src += self.make_kernel_lambda()
+        src += "};\n"
+        src += self.make_binding()
+        if save_dir:
+            with open(save_dir, "w") as f:
+                f.write(src)
+        return src


### PR DESCRIPTION
### [AOT] Torch Extension Codegen

Add tool that automatically generates torch extension from `triton`  `jit` kernels.  The extension can be used as an AOT module that exposes a similar interface as the original triton kernel.

### Usage
```python
@triton.jit
def add_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
    ...

## Run jit kernel with additional `save_extra_meta` kwarg
add_kernel.run(x, y, output, n_elements, grid=grid, warmup=True, save_extra_meta=True, BLOCK_SIZE=BLOCK_SIZE)

## Compile extension module

#Kernel metadata and metadata groups are necessary for generating the extension module 
metadata_path = "path_to_triton_kernel_cache/add_kernel.json"
metadata_group = "path_to_triton_kernel_cache/__grp__add_kernel.json"
metadata = json.load(open(metadata_path))
metadata_group = json.load(open(metadata_group))["child_paths"]

# Generate extension source and save to extension_path
extension_path = "add_kernel.cu"
codegen = TorchExtCodeGen(
    kernel_name=kernel_name, metadata=metadata, metadata_group=metadata_group
)
codegen.generate(extension_path)

# Load module from generated source
from torch.utils.cpp_extension import load
module = load(
    name=kernel_name,
    sources=[extension_path],
    extra_cflags=["-O2"],
    extra_ldflags=["-lcuda"],
    verbose=True,
)

#Cubin is loaded upon instantiation of the module's kernel interface
cubin_path = metadata_group[f"{kernel_name}.cubin"]

#Kernel interface is exposed as title cased kernel, e.g., AddKernel_{suffix} where suffix is a hash based on signature, constexprs and other launch params to ensure unique kernel for each config
kernel_iface_name = [attr for attr in dir(module) if "Kernel" in attr][0]

kernel_interface = getattr(module, kernel_iface_name)
kernel = kernel_interface(cubin_path)
```

After kernel has been loaded, it can be called as such:
```
grid = (triton.cdiv(n_elements / kernel.BLOCK_SIZE), 1, 1)
kernel[grid](x, y, output, n_elements)
```

`Constexprs`, `launch` config, and other static metadata are encoded as (static) attributes of the kernel.

Running the following:
```python
for attr in dir(kernel):
    if not attr.startswith("__"):
        print(f"{attr}: {getattr(kernel, attr)}")
```
Will print:
```
ADD_KERNEL.CUBIN: path_to_triton_cache/add_kernel.cubin
...
ALLOW_FP8E4NV: None
AMDGCN_ENABLE_DUMP: None
ATTRS: {'divisible_by_16': [0, 1, 2, 3, 4], 'divisible_by_8': [3, 4], 'equal_to_1': [], 'ids_of_folded_args': []}
BLOCK_SIZE: 1024
CLUSTER_DIMS: [1, 1, 1]
DEBUG: None
...
NUM_CTAS: 1
NUM_STAGES: 3
NUM_WARPS: 4
OPTIMIZE_EPILOGUE: None
PTX_VERSION: None
SHARED: None
TARGET: cuda:86
TRITON_DISABLE_LINE_INFO: None
```
Also, documentation is autogenerated for the module:
```python
print(module.__doc__)
```
prints out:
```
Interface to the add_kernel kernel.  Use AddKernel_26346395149236 to get a handle to the kernel.
        Construct the kernel by passing the path to the cubin file to the constructor.  The kernel can be launched by either calling the launch method or by indexing the object with a grid.
        If using launch, the first argument is the grid and the remaining arguments are the kernel arguments x_ptr:*fp16, y_ptr:*fp16, output_ptr:*fp16, n_elements:i32.
        If using indexing, the grid should be a tuple or list of len 3 and the remaining arguments are the kernel arguments x_ptr:*fp16, y_ptr:*fp16, output_ptr:*fp16, n_elements:i32.
        Example:
            kernel = AddKernel_26346395149236('add_kernel.cubin')
            kernel.launch((1, 1, 1), x_ptr, y_ptr, output_ptr, n_elements)
        Equivalently
            kernel[(1, 1, 1)](x_ptr, y_ptr, output_ptr, n_elements)
        IMPORTANT NOTES: 
            - The grid should be sized according to the same heuristics as the original kernel, as constexprs are baked into the kernel.
            E.g., if the original grid was lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']), 1, 1), then the grid should be (triton.cdiv(n_elements, BLOCK_SIZE), 1, 1).
            - The kernel is launched on current device and stream per torch's cuda API.
        Constants are also exposed as attributes.  
        E.g., if the kernel has a constant named BLOCK_SIZE, then the constant can be accessed as kernel.BLOCK_SIZE.
```

### Tests
The extension module has been tested on kernels in the `triton` tutorials, including `add_kernel`, `fused_softmax`, `matmul` (with activation), and `flash_attention`. See `python/test/unit/tools/test_torch_extension.py` for more details on usage.  

**Note**: Since compiling extension modules can be slow, the tests are turned off by default. To run, set environment variable `RUN_TORCH_EXTENSION_TESTS=1`.  

#### Additional Notes
The codegen is located in `python/tools/extension.py`.  

**Note**: It does not generate [runtime launch configs](https://github.com/openai/triton/blob/03ceaa64cbd484038d8bdb40d69c6958e4662f08/python/triton/compiler/make_launcher.py#L159C3-L183C7) for Hopper architecture (i.e., when `num_ctas > 1`) but this can be added easily.