### PR TITLE
[BACKEND] Move dot op decomposition early to allow better clean

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.cpp
@@ -421,7 +421,6 @@ struct ConvertTritonGPUToLLVM
     decomposeMmaToDotOperand(mod, numWarps, threadsPerWarp, numCTAs);
     decomposeBlockedToDotOperand(mod);
     decomposeInsertSliceAsyncOp(mod);
-    decomposeMixedModeDotOp(mod);
 
     // Allocate shared memory and set barrier
     ModuleAllocation allocation(mod);
@@ -865,44 +864,6 @@ private:
         operand.getType().cast<RankedTensorType>().cloneWith(std::nullopt,
                                                              promotedType);
     return builder.create<triton::FpToFpOp>(loc, tensorPromotedType, operand);
-  }
-
-  // promote operands of dot op if the existing combination is not natively
-  // supported.
-  void decomposeMixedModeDotOp(ModuleOp mod) const {
-    mod.walk([](triton::DotOp dotOp) -> void {
-      Value D = dotOp.getResult();
-      OpBuilder builder(dotOp);
-      Type AElType =
-          dotOp.getA().getType().cast<RankedTensorType>().getElementType();
-      Type promoteType;
-      NvidiaMmaEncodingAttr mmaLayout = D.getType()
-                                            .cast<RankedTensorType>()
-                                            .getEncoding()
-                                            .dyn_cast<NvidiaMmaEncodingAttr>();
-      if (mmaLayout) {
-        bool isNativeHopperFP8 =
-            AElType.isFloat8E5M2() || AElType.isFloat8E4M3FNUZ();
-        bool isFP8 = isNativeHopperFP8 || AElType.isFloat8E5M2FNUZ() ||
-                     AElType.isFloat8E4M3FN() || AElType.isFloat8E4M3B11FNUZ();
-        if (!isFP8 || (isNativeHopperFP8 && mmaLayout.isHopper()))
-          return;
-        promoteType = builder.getF16Type();
-      } else {
-        // FMA case.
-        Type AElType =
-            dotOp.getA().getType().cast<RankedTensorType>().getElementType();
-        Type DElType = D.getType().cast<RankedTensorType>().getElementType();
-        if (AElType == DElType)
-          return;
-        promoteType = DElType;
-      }
-      Location loc = dotOp.getLoc();
-      Value promotedA = promoteOperand(builder, loc, dotOp.getA(), promoteType);
-      Value promotedB = promoteOperand(builder, loc, dotOp.getB(), promoteType);
-      dotOp.setOperand(0, promotedA);
-      dotOp.setOperand(1, promotedB);
-    });
   }
 };
 

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -334,6 +334,52 @@ public:
 };
 } // namespace
 
+static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
+                            Type promotedType) {
+  Type tensorPromotedType =
+      operand.getType().cast<RankedTensorType>().cloneWith(std::nullopt,
+                                                           promotedType);
+  return builder.create<tt::FpToFpOp>(loc, tensorPromotedType, operand);
+}
+
+// promote operands of dot op if the existing combination is not natively
+// supported.
+static void decomposeMixedModeDotOp(ModuleOp mod) {
+  mod.walk([](tt::DotOp dotOp) -> void {
+    Value D = dotOp.getResult();
+    OpBuilder builder(dotOp);
+    Type AElType =
+        dotOp.getA().getType().cast<RankedTensorType>().getElementType();
+    Type promoteType;
+    NvidiaMmaEncodingAttr mmaLayout = D.getType()
+                                          .cast<RankedTensorType>()
+                                          .getEncoding()
+                                          .dyn_cast<NvidiaMmaEncodingAttr>();
+    if (mmaLayout) {
+      bool isNativeHopperFP8 =
+          AElType.isFloat8E5M2() || AElType.isFloat8E4M3FNUZ();
+      bool isFP8 = isNativeHopperFP8 || AElType.isFloat8E5M2FNUZ() ||
+                   AElType.isFloat8E4M3FN() || AElType.isFloat8E4M3B11FNUZ();
+      if (!isFP8 || (isNativeHopperFP8 && mmaLayout.isHopper()))
+        return;
+      promoteType = builder.getF16Type();
+    } else {
+      // FMA case.
+      Type AElType =
+          dotOp.getA().getType().cast<RankedTensorType>().getElementType();
+      Type DElType = D.getType().cast<RankedTensorType>().getElementType();
+      if (AElType == DElType)
+        return;
+      promoteType = DElType;
+    }
+    Location loc = dotOp.getLoc();
+    Value promotedA = promoteOperand(builder, loc, dotOp.getA(), promoteType);
+    Value promotedB = promoteOperand(builder, loc, dotOp.getB(), promoteType);
+    dotOp.setOperand(0, promotedA);
+    dotOp.setOperand(1, promotedB);
+  });
+}
+
 #define GEN_PASS_CLASSES
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
@@ -353,6 +399,9 @@ public:
     if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();
     }
+    // now that we pick the mma type decompose dot that are not natively
+    // supported.
+    decomposeMixedModeDotOp(m);
   }
 };
 

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -71,3 +71,25 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
     tt.return %r : tensor<64x128xf32, #blocked1>
   }
 }
+
+// -----
+
+// CHECK-80: #[[MMA:.+]] = #triton_gpu.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 2], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], instrShape = [16, 8]}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
+module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  // CHECK-80-LABEL: mixed_mode_dot
+  tt.func public @mixed_mode_dot(
+    %arg0: tensor<64x128xf8E4M3B11FNUZ, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %arg1: tensor<128x64xf8E5M2, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %arg2: tensor<64x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked1}>>) -> tensor<64x64xf32, #blocked> {
+    %cst_0 = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #blocked>
+  // CHECK-80: tt.fp_to_fp {{.*}} : tensor<64x128xf8E4M3B11FNUZ, #triton_gpu.dot_op<{opIdx = 0, parent = #[[MMA]], kWidth = 4}>> -> tensor<64x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #[[MMA]], kWidth = 4}>>
+  // CHECK-80: tt.fp_to_fp {{.*}} : tensor<128x64xf8E5M2, #triton_gpu.dot_op<{opIdx = 1, parent = #[[MMA]], kWidth = 4}>> -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #[[MMA]], kWidth = 4}>>
+  // CHECK-80: tt.dot {{.*}} -> tensor<64x64xf32, #[[MMA]]>
+    %d = tt.dot %arg0, %arg1, %cst_0 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} :
+      tensor<64x128xf8E4M3B11FNUZ, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x64xf8E5M2, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<64x64xf32, #blocked>
+    tt.return %d : tensor<64x64xf32, #blocked>
+  }
+}


### PR DESCRIPTION
Do decomposition of non native dot op right after mma layout assignment. This will allow following pass to potentially clean up some conversions and avoid generating bad convert layout ops.