### PR TITLE
[Hopper] Fix hang issue for warp specialized kernel when numstage=1

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/WSPipeline.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/WSPipeline.cpp
@@ -790,7 +790,7 @@ void buildAsyncComm(const DenseMap<Operation *, SmallVector<Channel *>> &map,
               resTy.getEncoding().dyn_cast<ttg::NvidiaMmaEncodingAttr>())
         if (resEnc.isHopper() && dot.hasOneUse() &&
             isa<scf::YieldOp>(*dot.getUsers().begin()) && cArg &&
-            cArg.hasOneUse())
+            cArg.hasOneUse() && numStages > 1)
           return dotOp.getOperation();
     }
     return nullptr;


### PR DESCRIPTION
Disable async launch dots when numstage == 1