### PR TITLE
[BACKEND] Adding optional environment variable for dumping reproducer mlir files

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -6,6 +6,7 @@ add_llvm_executable(triton-opt triton-opt.cpp PARTIAL_SOURCES_INTENDED)
 # TODO: what's this?
 llvm_update_compile_flags(triton-opt)
 target_link_libraries(triton-opt PRIVATE
+  TritonLLVMIR
   TritonAnalysis
   TritonTransforms
   TritonGPUTransforms
@@ -28,6 +29,7 @@ mlir_check_all_link_libraries(triton-reduce)
 
 llvm_update_compile_flags(triton-reduce)
 target_link_libraries(triton-reduce PRIVATE
+  TritonLLVMIR
   TritonAnalysis
   TritonTransforms
   TritonGPUTransforms

--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -11,9 +11,11 @@
 #include "triton/Conversion/NVGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonGPUToLLVM/Passes.h"
 #include "triton/Conversion/TritonToTritonGPU/Passes.h"
+#include "triton/Target/LLVMIR/Passes.h"
 
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/InitAllPasses.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 
 namespace mlir {
 namespace test {
@@ -36,6 +38,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::triton::registerConvertTritonToTritonGPUPass();
   mlir::triton::registerConvertTritonGPUToLLVMPass();
   mlir::triton::registerConvertNVGPUToLLVMPass();
+  mlir::registerLLVMDIScope();
 
   // TODO: register Triton & TritonGPU passes
   registry.insert<mlir::triton::TritonDialect, mlir::cf::ControlFlowDialect,

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1,4 +1,4 @@
-﻿#include "mlir/Bytecode/BytecodeWriter.h"
+#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
@@ -1574,6 +1574,14 @@ void init_triton_ir(py::module &&m) {
       .def("run", [](mlir::PassManager &self, mlir::ModuleOp &mod) {
         // TODO: maybe dump module to file and print error for better
         // diagnostics
+        auto reproducerPath = ::triton::tools::getenv("TRITON_REPRODUCER_PATH");
+        if (!reproducerPath.empty()) {
+          auto anchorName = self.getOpAnchorName();
+          auto passes = self.getPasses();
+          mlir::Operation *op = mod.getOperation();
+          mlir::makeReproducer(anchorName, passes, op, reproducerPath);
+        }
+
         if (mlir::failed(self.run(mod.getOperation())))
           throw std::runtime_error("PassManager::run failed");
       });

--- a/python/test/unit/language/test_reproducer.py
+++ b/python/test/unit/language/test_reproducer.py
@@ -1,0 +1,39 @@
+import os
+import shutil
+
+import pytest
+
+import torch
+import triton
+
+
+@triton.jit
+def triton_():
+    return
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+def test_reproducer():
+    tmpdir = ".tmp"
+    reproducer = 'triton-reproducer.mlir'
+    if os.path.exists(tmpdir):
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    if os.path.exists(reproducer):
+        os.remove(reproducer)
+    os.environ["TRITON_CACHE_DIR"] = tmpdir
+    os.environ["TRITON_REPRODUCER_PATH"] = reproducer
+    triton_[(1, )]()
+    foundPipeline = ""
+    with open(reproducer, 'r') as f:
+        line = f.read()
+        if 'pipeline:' in line:
+            foundPipeline = line
+    if 0 == len(foundPipeline):
+        raise Exception("Failed to find pipeline info in reproducer file.")
+    if "convert-triton-gpu-to-llvm" not in foundPipeline:
+        raise Exception("Failed to find triton passes in pipeline")
+    # cleanup
+    if os.path.exists(tmpdir):
+        shutil.rmtree(tmpdir, ignore_errors=True)
+    if os.path.exists(reproducer):
+        os.remove(reproducer)

--- a/test/Triton/reproducer.mlir
+++ b/test/Triton/reproducer.mlir
@@ -1,0 +1,20 @@
+// RUN: triton-opt --verify-diagnostics --dump-pass-pipeline --run-reproducer %s 2>&1 | FileCheck %s
+
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @triton__() attributes {noinline = false} {
+    tt.return
+  }
+}
+
+{-#
+  external_resources: {
+    mlir_reproducer: {
+      pipeline: "builtin.module(any(convert-scf-to-cf,convert-index-to-llvm{index-bitwidth=0},convert-triton-gpu-to-llvm{compute-capability=90 target=nvvm},convert-nv-gpu-to-llvm,convert-arith-to-llvm{index-bitwidth=0},canonicalize{  max-iterations=10 max-num-rewrites=-1 region-simplify=true test-convergence=false top-down=true},cse,symbol-dce,enable-line-info))",
+      disable_threading: false,
+      verify_each: false
+    }
+  }
+#-}
+
+// CHECK: Pass Manager with
+// CHECK-NEXT: convert-triton-gpu-to-llvm


### PR DESCRIPTION
This PR is a work in progress and depends on https://github.com/llvm/llvm-project/pull/75421 so only can be landed after Triton bumps it's llvm hash.

This PR makes it possible to dump an MLIR reproducer when setting the env var TRITON_REPRODUCER_PATH to some mlir file path (`export TRITON_REPRODUCER_PATH=$(PWD)/triton-reproducer.mlir`). The reproducer can then be run using triton-opt like so: `triton-opt  --run-reproducer ./triton-reproducer.mlir`

TritonLLVMIR has been added as a link dependency for the bin triton tools because that is needed for properly registering the enable-line-info pass (which gets inserted into the pass pipeline if `export TRITON_DISABLE_LINE_INFO=1` is not set). The enable-line-info pass is also added for registration in RegisterTritonDialects.h as well. 

@ThomasRaoux 