### PR TITLE
[BUILD] Add missing LLVMAnalysis library for triton-llvm-opt target

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -53,6 +53,7 @@ add_llvm_executable(triton-llvm-opt
 target_link_libraries(triton-llvm-opt PRIVATE
   TritonLLVMIR
 
+  LLVMAnalysis
   LLVMCore
   LLVMSupport
   LLVMOption


### PR DESCRIPTION
Meet building error

```
      ld.lld: error: undefined symbol: llvm::AnalysisManager<llvm::Loop, llvm::LoopStandardAnalysisResults&>::AnalysisManager()
      >>> referenced by triton-llvm-opt.cpp:47 (/home/triton/work/triton/bin/triton-llvm-opt.cpp:47)
      >>>               bin/CMakeFiles/triton-llvm-opt.dir/triton-llvm-opt.cpp.o:(std::_Function_handler<llvm::Error (llvm::Module*), (anonymous namespace)::makeOptimizingPipeline()::$_0>::_M_invoke(std::_Any_data const&, llvm::Module*&&))
      
      ld.lld: error: undefined symbol: llvm::AnalysisManager<llvm::LazyCallGraph::SCC, llvm::LazyCallGraph&>::AnalysisManager()
      >>> referenced by triton-llvm-opt.cpp:49 (/home/triton/work/triton/bin/triton-llvm-opt.cpp:49)

```