### PR TITLE
[FRONTEND] Handle LD_LIBRARY_PATH

### DIFF
--- a/python/triton/common/build.py
+++ b/python/triton/common/build.py
@@ -27,6 +27,9 @@ def libcuda_dirs():
     # libcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1
     locs = [line.split()[-1] for line in libs.splitlines() if "libcuda.so" in line]
     dirs = [os.path.dirname(loc) for loc in locs]
+    env_ld_library_path = os.getenv("LD_LIBRARY_PATH")
+    if env_ld_library_path and not dirs:
+        dirs = [dir for dir in env_ld_library_path.split(":") if os.path.exists(os.path.join(dir, "libcuda.so"))]
     msg = 'libcuda.so cannot found!\n'
     if locs:
         msg += 'Possible files are located at %s.' % str(locs)


### PR DESCRIPTION
cherry-pick into release/2.2.x branch.

If `libcuda.so` can not be found using `ldconfig -P`, check if `LD_LIBRARY_PATH` environment variable is defined and search for it there

Test plan:
https://colab.research.google.com/drive/16Kd88j-nFS4iMI-UfJS5rukH42L6UuyP?usp=sharing

Fixes https://github.com/openai/triton/issues/2507