### PR TITLE
[UTILS] add triton language server for IDE highlight

### DIFF
--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -45,6 +45,29 @@ target_link_libraries(triton-reduce PRIVATE
 
 mlir_check_all_link_libraries(triton-reduce)
 
+add_llvm_executable(triton-lsp triton-lsp.cpp PARTIAL_SOURCES_INTENDED)
+mlir_check_all_link_libraries(triton-lsp)
+
+llvm_update_compile_flags(triton-lsp)
+target_link_libraries(triton-lsp PRIVATE
+  TritonAnalysis
+  TritonTransforms
+  TritonGPUTransforms
+  TritonNvidiaGPUTransforms
+  ${dialect_libs}
+  ${conversion_libs}
+  ${triton_libs}
+  # tests
+  TritonTestAnalysis
+  # MLIR core
+  MLIRLspServerLib
+  MLIRPass
+  MLIRTransforms
+)
+
+mlir_check_all_link_libraries(triton-lsp)
+
+
 add_llvm_executable(triton-llvm-opt
   triton-llvm-opt.cpp
 

--- a/bin/triton-lsp.cpp
+++ b/bin/triton-lsp.cpp
@@ -1,0 +1,11 @@
+#include "./RegisterTritonDialects.h"
+
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
+
+int main(int argc, char **argv) {
+  mlir::DialectRegistry registry;
+  registerTritonDialects(registry);
+
+  mlir::MLIRContext context(registry);
+  return mlir::failed(mlir::MlirLspServerMain(argc, argv, registry));
+}


### PR DESCRIPTION
Solves https://github.com/openai/triton/issues/2898 .

With the [MLIR VS Code](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-mlir) plugin, here is how the result looks like:

<img width="1195" alt="image" src="https://github.com/openai/triton/assets/23236638/529c02a0-6448-4221-90fc-78d5d416356e">

Further efforts require managing the file extension to be `.mlir` rather than `.ttlr`.