### PR TITLE
[BACKEND] Use stmatrix when converting mma layout to distributed

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -638,7 +638,7 @@ private:
                                  multiDimRepId, inVec, paddedRepShape, outOrd,
                                  vals, smemBase, shape);
         else if (isStMatrixCompatible(srcTy) && accumNumReplicates == 1 &&
-                 outOrd[0] == 1) {
+                 outOrd[0] == 1 && paddedRepShape[1] % 8 == 0) {
           Value llvmSrc = adaptor.getSrc();
           storeDistributedToSharedWithStMatrix(srcTy, llvmSrc, smemBase,
                                                paddedRepShape, origRepShape,

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -305,7 +305,6 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
   }
 }
 
-
 // -----
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
@@ -317,6 +316,20 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
 
     // CHECK: %{{[a-zA-Z0-9]+}} = llvm.inline_asm asm_dialect = att operand_attrs = [] "min.xorsign.abs.f32 $0, $1, $2;", "=f,f,f" %{{[a-zA-Z0-9]+}}, %{{[a-zA-Z0-9]+}} : (f32, f32) -> f32
     %12 = tt.clampf %x, %neg_limit, %limit {propagateNan = 0 : i32} : tensor<1024xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], instrShape = [16, 256, 16]}>
+// CHECK-LABEL: convert_mma_to_blocked
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @convert_mma_to_blocked(%a: tensor<128x256xf16, #mma>) {
+    // CHECK-COUNT-16: nvgpu.stmatrix
+    //          CHECK: nvvm.barrier0
+    %c = triton_gpu.convert_layout %a : (tensor<128x256xf16, #mma>) -> tensor<128x256xf16, #blocked>
     tt.return
   }
 }


### PR DESCRIPTION
On Hopper when storing mma tensor to shared memory we can use stmatrix to reduce the number of store intrusctions. This give a very small improvements to the epilogue for fp16 output. It will later be combined with cp.async.bulked to improve performance further.