### PR TITLE
[FRONTEND][BUILD] Fix for the build issue coming from mixing two methods of defining target link libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ if(TRITON_BUILD_PYTHON_MODULE AND NOT WIN32)
     set(PYTHON_LDFLAGS "-undefined dynamic_lookup -flto")
   endif()
 
-  target_link_libraries(triton ${PYTHON_LDFLAGS})
+  target_link_libraries(triton PRIVATE ${PYTHON_LDFLAGS})
 endif()
 
 add_subdirectory(bin)


### PR DESCRIPTION
Cmake requires that you either specify PUBLIC/PRIVATE keyword in target_link_libraries, or you don't. Mixing two methods is not supported.