### PR TITLE
[Compiler] Update compiler.py to use cuda backend rather than nvidia backend

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -376,7 +376,7 @@ download_and_copy(
     url_func=lambda arch, version:
     f"https://anaconda.org/nvidia/cuda-nvdisasm/12.3.52/download/linux-{arch}/cuda-nvdisasm-{version}-0.tar.bz2",
 )
-backends = _copy_backends(["nvidia", "amd"])
+backends = _copy_backends(["cuda", "amd"])
 
 package_data = dict()
 package_data["triton/tools"] = ["compile.h", "compile.c"]

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -7,8 +7,7 @@ from .. import __version__
 from ..runtime.autotuner import OutOfResources
 from ..runtime.cache import get_cache_manager
 from ..runtime.driver import driver
-# TODO: this shouldn't be here
-from ..backends.nvidia.compiler import InfoFromBackendForTensorMap
+from ..backends.cuda.compiler import InfoFromBackendForTensorMap
 from dataclasses import dataclass
 from .code_generator import ast_to_ttir
 from pathlib import Path


### PR DESCRIPTION
Fixes https://github.com/openai/triton/issues/2903 .