### PR TITLE
[CI] remove shared middle-layer lit tests as the plugin does not exist now

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -55,16 +55,6 @@ jobs:
           python3 setup.py build
           python3 -m pip install --no-build-isolation -vvv '.[tests]'
 
-      - name: Run shared middle-layer lit tests
-        run: |
-          python3 -m pip install lit
-          cd python
-          LIT_TEST_DIR="build/$(ls build | grep -i cmake)/third_party/triton_shared/test"
-          if [ ! -d "${LIT_TEST_DIR}" ]; then
-            echo "Coult not find '${LIT_TEST_DIR}'" ; exit -1
-          fi
-          lit -v "${LIT_TEST_DIR}"
-
 
   Integration-Tests-AMD:
     needs: Runner-Preparation


### PR DESCRIPTION
This PR https://github.com/openai/triton/pull/2887 removes `third_party/triton_shared`, and the corresponding test should be removed. Otherwise it will fail (and now it indeed fail) all the CI tests.