### PR TITLE
Disabling LLVM optimization under a switch

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -30,9 +30,9 @@
 namespace triton {
 
 const std::set<std::string> ENV_VARS = {
-    "DISABLE_MMA_V3",    "TRITON_DISABLE_LINE_INFO", "DISABLE_FAST_REDUCTION",
-    "ENABLE_TMA",        "MLIR_ENABLE_DUMP",         "LLVM_IR_ENABLE_DUMP",
-    "AMDGCN_ENABLE_DUMP"};
+    "DISABLE_MMA_V3",     "TRITON_DISABLE_LINE_INFO", "DISABLE_FAST_REDUCTION",
+    "ENABLE_TMA",         "MLIR_ENABLE_DUMP",         "LLVM_IR_ENABLE_DUMP",
+    "AMDGCN_ENABLE_DUMP", "DISABLE_LLVM_OPT"};
 
 namespace tools {
 

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -1,6 +1,7 @@
 ﻿#include "mlir/IR/BuiltinOps.h" // mlir::ModuleOp
 #include "mlir/Target/LLVMIR/LLVMTranslationInterface.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
@@ -152,6 +153,8 @@ void init_triton_llvm(py::module &&m) {
 
   m.def("optimize_module", [](llvm::Module *mod,
                               const llvm::OptimizationLevel &opt) {
+    if (triton::tools::getBoolEnv("DISABLE_LLVM_OPT"))
+      return;
     using namespace llvm;
     LoopAnalysisManager lam;
     FunctionAnalysisManager fam;

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -483,8 +483,7 @@ class CUDABackend(BaseBackend):
         if options.extern_libs:
             for name, path in options.extern_libs:
                 llvm.link_extern_lib(llvm_mod, path)
-        if os.environ.get('DISABLE_LLVM_OPT', '0') == "0":
-            llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
+        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
         # Get some metadata
         if len(tma_infos) > 0:
             metadata["tensormaps_info"] = parse_tma_info(tma_infos, metadata["ids_of_folded_args"])

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -483,7 +483,8 @@ class CUDABackend(BaseBackend):
         if options.extern_libs:
             for name, path in options.extern_libs:
                 llvm.link_extern_lib(llvm_mod, path)
-        llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
+        if os.environ.get('DISABLE_LLVM_OPT', '0') == "0":
+            llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
         # Get some metadata
         if len(tma_infos) > 0:
             metadata["tensormaps_info"] = parse_tma_info(tma_infos, metadata["ids_of_folded_args"])


### PR DESCRIPTION
Adding an environment variable named `DISABLE_LLVM_OPT` to disable llvm optimizations. The pre-optimized LLVM IR dump is useful for investigating LLVM issues. 