### PR TITLE
[NFC][BACKEND] Rename nvidia_gpu StoreAsyncOp to StoreAsyncTMAOp

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -293,7 +293,7 @@ def TTNG_DotWaitOp : TTNG_Op<"dot_wait", [DeclareOpInterfaceMethods<InferTypeOpI
   let assemblyFormat = "$inputs attr-dict `:` type($inputs)";
 }
 
-def TTNG_StoreAsyncOp : TTNG_Op<"store_async",
+def TTNG_StoreAsyncTMAOp : TTNG_Op<"store_async_tma",
                               [MemoryEffects<[MemWrite]>]> {
   let summary = "store asynchronous by a tensor pointer";
   let arguments = (ins TT_TensorPtr:$dst, TT_Tensor:$src,

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -40,7 +40,7 @@ void SharedMemoryAliasAnalysis::visitOperation(
       // insert_slice %src into %dst[%offsets]
       aliasInfo = AliasInfo(operands[1]->getValue());
       pessimistic = false;
-    } else if (isa<triton::nvidia_gpu::StoreAsyncOp>(op)) {
+    } else if (isa<triton::nvidia_gpu::StoreAsyncTMAOp>(op)) {
       aliasInfo = AliasInfo(operands[0]->getValue());
       pessimistic = false;
     } else if (triton::gpu::hasSharedEncoding(result)) {

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -136,7 +136,7 @@ getScratchConfigForCvtLayout(triton::gpu::ConvertLayoutOp op, unsigned &inVec,
 }
 
 SmallVector<unsigned>
-getScratchConfigForStoreAsync(triton::nvidia_gpu::StoreAsyncOp op) {
+getScratchConfigForStoreAsync(triton::nvidia_gpu::StoreAsyncTMAOp op) {
   auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
   return convertType<unsigned, int64_t>(getShapePerCTA(srcTy));
 }
@@ -285,7 +285,7 @@ private:
       maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, bytes,
                                                           scratchAlignment);
     } else if (auto storeAsyncOp =
-                   dyn_cast<triton::nvidia_gpu::StoreAsyncOp>(op)) {
+                   dyn_cast<triton::nvidia_gpu::StoreAsyncTMAOp>(op)) {
       auto srcTy = storeAsyncOp.getSrc().getType().cast<RankedTensorType>();
       auto srcEncoding = srcTy.getEncoding();
       if (!srcEncoding.isa<NvidiaMmaEncodingAttr>()) {

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -381,7 +381,7 @@ bool maybeAliasOp(Operation *op) {
   return isa<triton::gpu::ExtractSliceOp, triton::TransOp,
              triton::gpu::InsertSliceAsyncOp,
              triton::nvidia_gpu::InsertSliceTMAOp,
-             triton::nvidia_gpu::StoreAsyncOp, tensor::InsertSliceOp>(op);
+             triton::nvidia_gpu::StoreAsyncTMAOp, tensor::InsertSliceOp>(op);
 }
 
 static bool supportMFMAGranularity(int m, int n, int k) {

--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -402,22 +402,22 @@ struct StoreOpConversion
   }
 };
 // TODO: refactor to save common logic with insertsliceasyncv2
-struct StoreAsyncOpConversion
-    : public ConvertTritonGPUOpToLLVMPattern<triton::nvidia_gpu::StoreAsyncOp> {
+struct StoreAsyncTMAOpConversion : public ConvertTritonGPUOpToLLVMPattern<
+                                       triton::nvidia_gpu::StoreAsyncTMAOp> {
   using ConvertTritonGPUOpToLLVMPattern<
-      triton::nvidia_gpu::StoreAsyncOp>::ConvertTritonGPUOpToLLVMPattern;
+      triton::nvidia_gpu::StoreAsyncTMAOp>::ConvertTritonGPUOpToLLVMPattern;
 
-  StoreAsyncOpConversion(TritonGPUToLLVMTypeConverter &converter,
-                         ModuleAllocation &allocation,
-                         mlir::triton::gpu::TMAMetadataTy *tmaMetadata,
-                         const TensorPtrMapT *tensorPtrMap,
-                         PatternBenefit benefit)
-      : ConvertTritonGPUOpToLLVMPattern<triton::nvidia_gpu::StoreAsyncOp>(
+  StoreAsyncTMAOpConversion(TritonGPUToLLVMTypeConverter &converter,
+                            ModuleAllocation &allocation,
+                            mlir::triton::gpu::TMAMetadataTy *tmaMetadata,
+                            const TensorPtrMapT *tensorPtrMap,
+                            PatternBenefit benefit)
+      : ConvertTritonGPUOpToLLVMPattern<triton::nvidia_gpu::StoreAsyncTMAOp>(
             converter, allocation, tmaMetadata, benefit),
         tensorPtrMap(tensorPtrMap) {}
 
   LogicalResult
-  matchAndRewrite(triton::nvidia_gpu::StoreAsyncOp op, OpAdaptor adaptor,
+  matchAndRewrite(triton::nvidia_gpu::StoreAsyncTMAOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
     auto srcEncoding = srcTy.getEncoding();
@@ -428,7 +428,7 @@ struct StoreAsyncOpConversion
     }
   }
 
-  LogicalResult lowerStoreAsync(triton::nvidia_gpu::StoreAsyncOp op,
+  LogicalResult lowerStoreAsync(triton::nvidia_gpu::StoreAsyncTMAOp op,
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
@@ -446,10 +446,10 @@ struct StoreAsyncOpConversion
     assert(rank > 0 && rank <= 5);
 
     auto moduleOp = op->getParentOfType<ModuleOp>();
-    assert(moduleOp && "Parent ModuleOp not found for StoreAsyncOp");
+    assert(moduleOp && "Parent ModuleOp not found for StoreAsyncTMAOp");
 
     auto llFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    assert(llFuncOp && "LLVMFuncOp not found for StoreAsyncOp");
+    assert(llFuncOp && "LLVMFuncOp not found for StoreAsyncTMAOp");
 
     int numTMADescs = getNumTMADescs(llFuncOp);
     assert(numTMADescs > 0);
@@ -526,7 +526,7 @@ struct StoreAsyncOpConversion
         ((elemTy.getIntOrFloatBitWidth() == 16 && sharedLayout.getVec() == 8) or
          (elemTy.getIntOrFloatBitWidth() == 32 &&
           sharedLayout.getVec() == 4)) &&
-        "Unexpected shared layout for StoreAsyncOp");
+        "Unexpected shared layout for StoreAsyncTMAOp");
     if (sharedLayout.getPerPhase() == 4 && sharedLayout.getMaxPhase() == 2)
       swizzle = CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_32B;
     else if (sharedLayout.getPerPhase() == 2 && sharedLayout.getMaxPhase() == 4)
@@ -534,7 +534,7 @@ struct StoreAsyncOpConversion
     else if (sharedLayout.getPerPhase() == 1 && sharedLayout.getMaxPhase() == 8)
       swizzle = CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_128B;
     else
-      llvm::report_fatal_error("Unsupported shared layout for StoreAsyncOp");
+      llvm::report_fatal_error("Unsupported shared layout for StoreAsyncTMAOp");
     tmaInfo.swizzle = swizzle;
     tmaInfo.interleave = CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE;
     tmaInfo.l2Promotion =
@@ -605,7 +605,7 @@ struct StoreAsyncOpConversion
   }
 
   LogicalResult
-  lowerStoreAsyncWithSlice(triton::nvidia_gpu::StoreAsyncOp op,
+  lowerStoreAsyncWithSlice(triton::nvidia_gpu::StoreAsyncTMAOp op,
                            OpAdaptor adaptor,
                            ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
@@ -631,10 +631,10 @@ struct StoreAsyncOpConversion
     assert(rank > 0 && rank <= 5);
 
     auto moduleOp = op->getParentOfType<ModuleOp>();
-    assert(moduleOp && "Parent ModuleOp not found for StoreAsyncOp");
+    assert(moduleOp && "Parent ModuleOp not found for StoreAsyncTMAOp");
 
     auto llFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    assert(llFuncOp && "LLVMFuncOp not found for StoreAsyncOp");
+    assert(llFuncOp && "LLVMFuncOp not found for StoreAsyncTMAOp");
 
     int numTMADescs = getNumTMADescs(llFuncOp);
     assert(numTMADescs > 0);
@@ -723,7 +723,7 @@ struct StoreAsyncOpConversion
              sharedLayout.getVec() == 8) or
             (dstElemTy.getIntOrFloatBitWidth() == 32 &&
              sharedLayout.getVec() == 4)) &&
-           "Unexpected shared layout for StoreAsyncOp");
+           "Unexpected shared layout for StoreAsyncTMAOp");
     if (sharedLayout.getPerPhase() == 4 && sharedLayout.getMaxPhase() == 2)
       swizzle = CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_32B;
     else if (sharedLayout.getPerPhase() == 2 && sharedLayout.getMaxPhase() == 4)
@@ -731,7 +731,7 @@ struct StoreAsyncOpConversion
     else if (sharedLayout.getPerPhase() == 1 && sharedLayout.getMaxPhase() == 8)
       swizzle = CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_128B;
     else
-      llvm::report_fatal_error("Unsupported shared layout for StoreAsyncOp");
+      llvm::report_fatal_error("Unsupported shared layout for StoreAsyncTMAOp");
     tmaInfo.swizzle = swizzle;
     tmaInfo.interleave = CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE;
     tmaInfo.l2Promotion =
@@ -1835,6 +1835,6 @@ void populateLoadStoreOpToLLVMPatterns(
       typeConverter, allocation, indexCacheInfo, axisInfoAnalysis, benefit);
   patterns.add<InsertSliceTMAOpConversion>(typeConverter, allocation,
                                            tmaMetadata, tensorPtrMap, benefit);
-  patterns.add<StoreAsyncOpConversion>(typeConverter, allocation, tmaMetadata,
-                                       tensorPtrMap, benefit);
+  patterns.add<StoreAsyncTMAOpConversion>(typeConverter, allocation,
+                                          tmaMetadata, tensorPtrMap, benefit);
 }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/MaterializeLoadStore.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/MaterializeLoadStore.cpp
@@ -183,7 +183,7 @@ void MaterializeLoadStorePass::materializeStoreTilePtr(
     if (srcMmaLayout && srcMmaLayout.isHopper() && dstBlockedLayout &&
         truncFOP && elemTy.getIntOrFloatBitWidth() == 16 && numElems >= 16 &&
         inOrd == outOrd) {
-      builder.create<ttng::StoreAsyncOp>(loc, dst, cvtOp.getOperand());
+      builder.create<ttng::StoreAsyncTMAOp>(loc, dst, cvtOp.getOperand());
       builder.create<ttg::AsyncBulkCommitGroupOp>(loc);
       builder.create<ttg::AsyncBulkWaitOp>(loc, 0);
       store->erase();
@@ -210,7 +210,7 @@ void MaterializeLoadStorePass::materializeStoreTilePtr(
   auto bufferTy =
       RankedTensorType::get(bufferShape, storeElemTy, sharedEncoding);
   Value cvt = builder.create<ttg::ConvertLayoutOp>(loc, bufferTy, value);
-  builder.create<ttng::StoreAsyncOp>(loc, dst, cvt);
+  builder.create<ttng::StoreAsyncTMAOp>(loc, dst, cvt);
   builder.create<mlir::triton::gpu::AsyncBulkCommitGroupOp>(loc);
   builder.create<mlir::triton::gpu::AsyncBulkWaitOp>(loc, 0);
   store->erase();

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -74,7 +74,7 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
     %c0 = arith.constant 0 : i32
     %dst = tt.make_tensor_ptr %basePtr, [%dim0, %dim1], [%stride0, %stride1], [%coord0, %coord1] {order = array<i32: 1, 0>} : !tt.ptr<tensor<64x64xf32, #blocked>, 1>
     // CHECK: nvgpu.tma_store_tiled %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}} : !llvm.ptr<1>, !llvm.ptr<3>, i1, i32, i32
-    triton_nvidia_gpu.store_async %dst, %src {cache = 1 : i32} : !tt.ptr<tensor<64x64xf32, #blocked>, 1>, tensor<64x64xf32, #shared>
+    triton_nvidia_gpu.store_async_tma %dst, %src {cache = 1 : i32} : !tt.ptr<tensor<64x64xf32, #blocked>, 1>, tensor<64x64xf32, #shared>
     tt.return
   }
 }

--- a/test/TritonGPU/fence-inserstion.mlir
+++ b/test/TritonGPU/fence-inserstion.mlir
@@ -90,7 +90,7 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
     %w = triton_nvidia_gpu.dot_wait %30#0 {pendings = 0 : i32} : tensor<128x128xf32, #mma>
     %31 = arith.truncf %w : tensor<128x128xf32, #mma> to tensor<128x128xf16, #mma>
     %32 = triton_gpu.convert_layout %31 : (tensor<128x128xf16, #mma>) -> tensor<128x128xf16, #shared1>
-    triton_nvidia_gpu.store_async %8, %32 : !tt.ptr<tensor<128x128xf16, #blocked>, 1>, tensor<128x128xf16, #shared1>
+    triton_nvidia_gpu.store_async_tma %8, %32 : !tt.ptr<tensor<128x128xf16, #blocked>, 1>, tensor<128x128xf16, #shared1>
     triton_gpu.async_bulk_commit_group
     triton_gpu.async_bulk_wait {num = 0 : i32}
     tt.return
@@ -191,7 +191,7 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
     %w = triton_nvidia_gpu.dot_wait %30#0 {pendings = 0 : i32} : tensor<128x128xf32, #mma>
     %31 = arith.truncf %w : tensor<128x128xf32, #mma> to tensor<128x128xf16, #mma>
     %32 = triton_gpu.convert_layout %31 : (tensor<128x128xf16, #mma>) -> tensor<128x128xf16, #shared1>
-    triton_nvidia_gpu.store_async %8, %32 : !tt.ptr<tensor<128x128xf16, #blocked>, 1>, tensor<128x128xf16, #shared1>
+    triton_nvidia_gpu.store_async_tma %8, %32 : !tt.ptr<tensor<128x128xf16, #blocked>, 1>, tensor<128x128xf16, #shared1>
     triton_gpu.async_bulk_commit_group
     triton_gpu.async_bulk_wait {num = 0 : i32}
     tt.return


### PR DESCRIPTION
Also update AMD submodule to remove dependency between AMD and this op.
Changing the name will allow us to add support for StoreAsync with consistent naming