### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -27,11 +27,11 @@ jobs:
         id: set-matrix
         run: |
           if [ x"${{ github.repository }}" == x"openai/triton" ]; then
-            echo '::set-output name=matrix-required::[["self-hosted", "A100"], ["self-hosted", "H100"]]'
-            echo '::set-output name=matrix-optional::[["self-hosted", "gfx908"], ["self-hosted", "arc770"]]'
+            echo "matrix-required=[["self-hosted", "A100"], ["self-hosted", "H100"]]" >> $GITHUB_OUTPUT
+            echo "matrix-optional=[["self-hosted", "gfx908"], ["self-hosted", "arc770"]]" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=matrix-required::["ubuntu-latest"]'
-            echo '::set-output name=matrix-optional::["ubuntu-latest"]'
+            echo "matrix-required=["ubuntu-latest"]" >> $GITHUB_OUTPUT
+            echo "matrix-optional=["ubuntu-latest"]" >> $GITHUB_OUTPUT
           fi
 
   Integration-Tests:

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -15,9 +15,9 @@ jobs:
         id: set-matrix
         run: |
           if [ x"${{ github.repository }}" == x"openai/triton" ]; then
-            echo '::set-output name=matrix-optional::[["self-hosted", "gfx908"], ["self-hosted", "arc770"]]'
+            echo "matrix-optional=[["self-hosted", "gfx908"], ["self-hosted", "arc770"]]" >> $GITHUB_OUTPUT
           else
-            echo '::set-output name=matrix-optional::["ubuntu-latest"]'
+            echo "matrix-optional=["ubuntu-latest"]" >> $GITHUB_OUTPUT
           fi
 
 

--- a/.github/workflows/torch-inductor-tests.yml
+++ b/.github/workflows/torch-inductor-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Prepare runner matrix
         id: set-matrix
         run: |
-          echo '::set-output name=matrix::[["self-hosted", "A100"]]'
+          echo "matrix=[["self-hosted", "A100"]]" >> $GITHUB_OUTPUT
 
   Integration-Tests:
     needs: Runner-Preparation


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


