### PR TITLE
[TESTING] Added precision option to benchmark CSV data saving

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -261,7 +261,8 @@ class Mark:
         self.fn = fn
         self.benchmarks = benchmarks
 
-    def _run(self, bench: Benchmark, save_path: str, show_plots: bool, print_data: bool, diff_col=False, **kwrags):
+    def _run(self, bench: Benchmark, save_path: str, show_plots: bool, print_data: bool, diff_col=False,
+             save_precision=6, **kwrags):
         import os
 
         import matplotlib.pyplot as plt
@@ -325,7 +326,8 @@ class Mark:
             print(bench.plot_name + ':')
             print(df)
         if save_path:
-            df.to_csv(os.path.join(save_path, f"{bench.plot_name}.csv"), float_format='%.1f', index=False)
+            df.to_csv(os.path.join(save_path, f"{bench.plot_name}.csv"), float_format=f"%.{save_precision}f",
+                      index=False)
         return df
 
     def run(self, show_plots=False, print_data=False, save_path='', return_df=False, **kwargs):


### PR DESCRIPTION
This PR adds the `save_precision` argument to `benchmark.run()`, and makes its default value 6 (which is somewhat arbitrary, but seems reasonable).  Right now it is not user configurable, and has an unusually low default of `.1f`.

**Context:**

I was using the benchmarking capability, and found that the CSV which was being generated had unacceptably low precision (`.1f`).  This was after I had run a long-ish benchmarking session, and I was surprised that many of my benchmarks had an inference time of 0.

For the benchmarks I am performing, I need a higher degree of precision.  I do not think the downsides of higher precision, namely larger file sizes for the CSVs is relevant compared to the downsides of losing data.  By making the value configurable, this gives us the best of both worlds.

