### PR TITLE
Add rm -rf python/build to CI.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -77,6 +77,12 @@ jobs:
           python3 -m pip install cmake==3.24 ninja pytest-xdist
           sudo apt-get update -y
           sudo apt-get install -y ccache clang lld
+
+          # Do a clean build.  We are hoping that this will fix the non-hermetic
+          # failures we're seeing when we try to bump the version number (i.e.
+          # CI fails if it sees builds with different version numbers).
+          rm -rf build
+
           TRITON_BUILD_WITH_CLANG_LLD=true TRITON_BUILD_WITH_CCACHE=true python3 -m pip install --no-build-isolation -vvv '.[tests]'
 
       - name: Run lit tests


### PR DESCRIPTION
We are seeing non-hermetic build failures due to (we think)
https://github.com/openai/triton/pull/2948, which bumps the Triton
version number.  That PR is not submitted, but still it seems it's
causing failures in other, unrelated, PRs.

We are hoping that nuking python/build will fix this.  If not, we will
need more in-depth investigation.
