### PR TITLE
[BACKEND] Correctly invoke NaN propagation workaround on V100

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1871,16 +1871,6 @@ void mlir::triton::populateElementwiseOpToLLVMPatterns(
   POPULATE_BINARY_OP(arith::ShLIOp, LLVM::ShlOp)   // <<
   POPULATE_BINARY_OP(arith::ShRSIOp, LLVM::AShrOp) // >>
   POPULATE_BINARY_OP(arith::ShRUIOp, LLVM::LShrOp) // >>
-  POPULATE_BINARY_OP(arith::MinimumFOp,
-                     LLVM::MinimumOp) // min (return NaN if either op is Nan)
-  POPULATE_BINARY_OP(arith::MaximumFOp,
-                     LLVM::MaximumOp) // max  (return NaN if either op is Nan)
-  POPULATE_BINARY_OP(
-      arith::MinNumFOp,
-      LLVM::MinNumOp) // fmin (return non-NaN if either op is non-NaN)
-  POPULATE_BINARY_OP(
-      arith::MaxNumFOp,
-      LLVM::MaxNumOp) // fmax (return non-NaN if either op is non-NaN)
   POPULATE_BINARY_OP(arith::MinSIOp, LLVM::SMinOp) // smin
   POPULATE_BINARY_OP(arith::MaxSIOp, LLVM::SMaxOp) // smax
   POPULATE_BINARY_OP(arith::MinUIOp, LLVM::UMinOp) // umin
@@ -1934,9 +1924,9 @@ void mlir::triton::populateElementwiseOpToLLVMPatterns(
   // __nv_expf for higher-precision calculation
   patterns.add<ExpOpConversionApprox>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<ClampFOpConversion>(typeConverter, axisInfoAnalysis,
-                                   computeCapability);
+                                   computeCapability, benefit);
   patterns.add<MinMaxFOpConversion<arith::MinimumFOp>>(
-      typeConverter, axisInfoAnalysis, computeCapability);
+      typeConverter, axisInfoAnalysis, computeCapability, benefit);
   patterns.add<MinMaxFOpConversion<arith::MaximumFOp>>(
-      typeConverter, axisInfoAnalysis, computeCapability);
+      typeConverter, axisInfoAnalysis, computeCapability, benefit);
 }


### PR DESCRIPTION
Fixing two bugs that were preventing new Minimum/Maximum patterns from being picked up, and blocked NaN propagation from working on V100:
* Removing `POPULATE_BINARY_OP` for `MinimumFOp/MaximumFOp` and `MinNumFOp/MaxNumFOp`, so new `MinMaxFOpConversion` can be called.
* Passing `benefit` to `MinMaxFOpConversion`, so it is being picked up instead of the default conversions from `mlir::arith::populateArithToLLVMConversionPatterns`