### PR TITLE
[OPTIMIZER] Take numWarps into account for  Hopper mma op

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -23,7 +23,8 @@ class SharedEncodingAttr;
 
 SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
                                                 const ArrayRef<int64_t> &shape,
-                                                TensorOrMemDesc type);
+                                                TensorOrMemDesc type,
+                                                int numWarps);
 
 /// Returns true if the Load uses block pointer.
 bool isLoadFromTensorPtr(triton::LoadOp op);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -244,7 +244,7 @@ public:
       return failure();
 
     auto instrShape = mmaVersionToInstrShape(versionMajor, retShapePerCTA,
-                                             dotOp.getA().getType());
+                                             dotOp.getA().getType(), numWarps);
     // operands
     Value a = dotOp.getA();
     Value b = dotOp.getB();

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -22,7 +22,8 @@ using namespace triton;
 
 SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
                                                 const ArrayRef<int64_t> &shape,
-                                                TensorOrMemDesc type) {
+                                                TensorOrMemDesc type,
+                                                int numWarps) {
   if (version == 1)
     return {16, 16};
   else if (version == 2) {
@@ -53,9 +54,13 @@ SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
                      24, 16, 8});
     }
 
+    unsigned m = 16;
+    unsigned mWarps = std::max<unsigned>(shape[0] / m, 1);
+    unsigned nWarps = std::max<unsigned>(numWarps / mWarps, 1);
+    unsigned maxN = std::max<unsigned>(shape[1] / nWarps, 8);
     for (auto n : validN) {
-      if (shape[1] % n == 0) {
-        return {16, n, k};
+      if (shape[1] % n == 0 && n <= maxN) {
+        return {m, n, k};
       }
     }
 

--- a/python/test/unit/hopper/test_gemm.py
+++ b/python/test/unit/hopper/test_gemm.py
@@ -440,4 +440,5 @@ def test_gemm(BLOCK_M, BLOCK_N, BLOCK_K, NUM_WARPS, NUM_CTAS, M, N, K, TRANS_A, 
     disable_mmav3 = os.environ.get('DISABLE_MMA_V3', 'not found').lower()
     if disable_mmav3 not in ["on", "true", "1"] and BLOCK_M >= 64 and NUM_CTAS == 1 and BLOCK_N <= 256:
         ptx = pgm.asm['ptx']
-        assert re.search(r'wgmma.mma_async.sync.aligned.m\d+n{}k16(?:.row.col)?.f32.f16.f16'.format(BLOCK_N), ptx)
+        wgmma_n = int(max(BLOCK_N / max(NUM_WARPS / max(BLOCK_M / 16, 1), 1), 8))
+        assert re.search(r'wgmma.mma_async.sync.aligned.m\d+n{}k16(?:.row.col)?.f32.f16.f16'.format(wgmma_n), ptx)

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -130,3 +130,22 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
     tt.return
   }
 }
+
+// -----
+
+// CHECK: #mma = #triton_gpu.nvidia_mma<{versionMajor = 3, {{.*}}, instrShape = [16, 32, 16]}>
+#blocked = #triton_gpu.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [32, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 32 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func @check_instrShape_per_warps(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}) {
+    // CHECK-LABEL: check_instrShape_per_warps
+    %mask = arith.constant dense<true> : tensor<128x128xi1, #blocked>
+    %zero_f32 = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %a = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>
+    %b = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>>
+
+    %result = tt.dot %a, %b, %zero_f32 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<128x128xf32, #blocked>
+    %result_ptr = tt.splat %arg0 : !tt.ptr<f32, 1> -> tensor<128x128x!tt.ptr<f32, 1>, #blocked>
+    tt.store %result_ptr, %result, %mask {cache = 1 : i32, evict = 1 : i32} : tensor<128x128xf32, #blocked>
+    tt.return
+  }
+}


### PR DESCRIPTION
This changes the `wgmma`  instruction shape based on the total number of warps.

Instead of always using the largest version of `wgmma`, it honors
the user's `numWarps` hint, and uses a smaller `wgmma` shape to
distribute the work to all warps, rather than having some of them
idle.

Using m's shape, it calculates how many warps will be used in the m
dimension, then see how many are left for the n dimension. Then, it
chooses the largest N such that it is still evenly distributed.
    
This resolves issue https://github.com/openai/triton/issues/2662.