### PR TITLE
Update CudaDriver is_active condition

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -390,7 +390,7 @@ class CudaDriver(GPUDriver):
     @staticmethod
     def is_active():
         import torch
-        return torch.version.hip is None
+        return torch.cuda.is_available() and (torch.version.hip is None)
 
     def assemble_tensormap_to_arg(self, tensormaps_info, args):
         args_with_tma = list(args)


### PR DESCRIPTION
When there's more than 2 backends, checking hip isn't present isn't enough to decide whether the nvidia backend should be active.