### PR TITLE
Allow setting active driver through env var

### DIFF
--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -1,10 +1,19 @@
 from abc import ABCMeta, abstractmethod, abstractclassmethod
+import os
 
 
 class DriverBase(metaclass=ABCMeta):
 
-    @abstractclassmethod
-    def is_active(self):
+    @classmethod
+    def is_active(cls):
+        active_driver = os.environ.get("TRITON_ACTIVE_DRIVER")
+        if active_driver is not None:
+            return active_driver == cls.target_name()
+        return cls.should_activate()
+
+    @staticmethod
+    @abstractmethod
+    def target_name():
         pass
 
     @abstractmethod

--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -1,4 +1,4 @@
-from abc import ABCMeta, abstractmethod, abstractclassmethod
+from abc import ABCMeta, abstractmethod
 import os
 
 

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -242,7 +242,7 @@ PyMODINIT_FUNC PyInit___triton_launcher(void) {{
 
 
 class HIPLauncher(object):
-    
+
     def __init__(self, src, metadata):
         ids = {
             "ids_of_folded_args": metadata.ids_of_folded_args,
@@ -252,7 +252,7 @@ class HIPLauncher(object):
         src = make_launcher(constants, src.signature, ids)
         mod = compile_module_from_src(src, "__triton_launcher")
         self.launch = mod.launch
-    
+
     def __call__(self, *args, **kwargs):
         self.launch(*args, **kwargs)
 
@@ -266,11 +266,15 @@ class HIPDriver(GPUDriver):
         self.launcher_cls = HIPLauncher
 
     @staticmethod
-    def is_active():
+    def target_name():
+        return "hip"
+
+    @staticmethod
+    def should_activate():
         import torch
         return torch.version.hip is not None
 
     def get_current_target(self):
         device = self.get_current_device()
         arch = self.utils.get_device_properties(device)['arch']
-        return ("hip", arch.split(':')[0])
+        return (HIPDriver.target_name(), arch.split(':')[0])

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -330,7 +330,7 @@ class CudaLauncher(object):
 
     def __init__(self, src, metadata):
         ids = {
-            "ids_of_tensormaps": metadata.ids_of_tensormaps, 
+            "ids_of_tensormaps": metadata.ids_of_tensormaps,
             "ids_of_folded_args": metadata.ids_of_folded_args,
             "ids_of_const_exprs": src.fn.constexprs if hasattr(src, "fn") else tuple()
         }
@@ -385,10 +385,14 @@ class CudaDriver(GPUDriver):
         device = self.get_current_device()
         capability = self.get_device_capability(device)
         capability = capability[0] * 10 + capability[1]
-        return ("cuda", capability)
+        return (CudaDriver.target_name(), capability)
 
     @staticmethod
-    def is_active():
+    def target_name():
+        return "cuda"
+
+    @staticmethod
+    def should_activate():
         import torch
         return torch.version.hip is None
 


### PR DESCRIPTION
The current driver logic currently enforces:
1. only one active driver at a time
2. only either amd or nvidia driver

Allow force-setting active driver through the environment variable `TRITON_ACTIVE_DRIVER=target_name`. If this variable is set, we only choose the driver that matches the provided target.

## Alternative approach

I considered setting active driver using `triton.runtime.driver = DriverWrapper()` but turns out setting a global variable exposed through a module has very strange and surprising behaviours that I don't think is worth it.

When running `pytest` on a folder, if a test within a folder sets an active driver, all other tests will have that same driver set.

(Implementation notes for this obsolete approach)

Setting active driver:

```python
import triton
triton.runtime.driver = SomeDriver()
```

Unfortunately, this doesn't quite work out because currently we import the `driver` using `from runtime.driver import driver`, which means all modules have their `driver` variables pointed to `LazyProxy(_create_driver)` when we first import triton.

This means even if we set `runtime.driver` to something else after, other importing modules won't see the changes.

My proposed solution is to instead wrap the driver inside a class instance and export that:

```python
@dataclass
class Driver:
    active = LazyProxy(_create_driver)

driver = Driver()
```

Then for other importing modules, instead of doing `driver.whatever()`, we will do `driver.active.whatever()`.

Now we can do this to force setting an active driver if necessary:

```python
import triton
from triton.backends.triton_shared.driver import CPUDriver

triton.runtime.driver.active = CPUDriver()
```