### PR TITLE
[IR] Fix two bugs in ExpandDimsOp::canonicalize.

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -347,7 +347,22 @@ def TT_ReshapeOp : TT_Op<"reshape", [Pure,
 def TT_BroadcastOp : TT_Op<"broadcast", [Pure,
                                          SameOperandsAndResultElementType,
                                          SameOperandsAndResultEncoding]> {
-    let summary = "broadcast. No left-padding as of now.";
+    let summary = "broadcast a tensor or a scalar";
+
+    let description = [{
+      If given a tensor, broadcast changes one or more dimensions with size 1 to
+      a new size, e.g. tensor<1x32x1xf32> -> tensor<2x32x4xf32>.
+
+      If given a scalar, broadcast converts it to a tensor with arbitrary size,
+      e.g. f32 -> tensor<2x4xf32> (identical to tt.splat).
+
+      Note that many other Triton ops only accept tensors, so it's common to do
+      op.getType().cast<RankedTensorType>.  Don't make that mistake if op is a
+      broadcast!
+
+      TODO(jlebar): Change broadcast so it only works on tensors -- splat is
+      sufficient for scalars.
+    }];
 
     let arguments = (ins TT_Type:$src);
 

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -688,29 +688,44 @@ LogicalResult ExpandDimsOp::canonicalize(ExpandDimsOp op,
                                                  splat.getOperand());
     return mlir::success();
   }
-  // expand_dims(broadcast) -> broadcast(expand_dims)
+  // expand_dims(broadcast(x)) -> broadcast(expand_dims(x))
   //
-  // On it's own this doesn't do much, but consider
+  // On its own this doesn't do much, but consider
   //    broadcast(expand_dims(broadcast))
   // -> broadcast(broadcast(expand_dims))
   // -> broadcast(expand_dims)
+  //
+  // Note we can't do this if x is a scalar, because expandDims requires a
+  // tensor input.  (We could change it to broadcast(expand_dims(splat(x))), but
+  // it's unclear that's better.)  broadcast currently accepts scalar inputs,
+  // but it probably shouldn't (just use splat instead).
   if (auto broadcast = dyn_cast<triton::BroadcastOp>(definingOp)) {
     auto src = broadcast.getSrc();
-    auto srcTy = src.getType().dyn_cast<RankedTensorType>();
-    auto elemTy = srcTy.getElementType();
-    auto srcShape = srcTy.getShape();
+    if (auto srcTy = src.getType().dyn_cast<RankedTensorType>()) {
+      SmallVector<int64_t> newExpandShape(srcTy.getShape());
+      newExpandShape.insert(newExpandShape.begin() + op.getAxis(), 1);
 
-    llvm::SmallVector<int64_t, 4> newExpandShape(srcShape.begin(),
-                                                 srcShape.end());
-    newExpandShape.insert(newExpandShape.begin() + op.getAxis(), 1);
-    auto newExpandTy = RankedTensorType::get(newExpandShape, elemTy);
+      // Infer the encoding of the new expand op, if encodings are present.
+      Attribute newExpandEnc;
+      if (auto srcEnc = srcTy.getEncoding()) {
+        if (dyn_cast<DialectInferLayoutInterface>(&srcEnc.getDialect())
+                ->inferExpandDimsOpEncoding(srcEnc, op.getAxis(), newExpandEnc,
+                                            op.getLoc())
+                .failed()) {
+          return emitOptionalError(op.getLoc(),
+                                   "failed to infer layout for ExpandDimsOp");
+        }
+      }
 
-    auto newExpand = rewriter.create<triton::ExpandDimsOp>(
-        op.getLoc(), newExpandTy, src, op.getAxis());
-    auto newBroadcast = rewriter.create<triton::BroadcastOp>(
-        broadcast.getLoc(), op.getType(), newExpand.getResult());
-    rewriter.replaceOp(op, {newBroadcast.getResult()});
-    return mlir::success();
+      auto newExpandTy = RankedTensorType::get(
+          newExpandShape, srcTy.getElementType(), newExpandEnc);
+      auto newExpand = rewriter.create<triton::ExpandDimsOp>(
+          op.getLoc(), newExpandTy, src, op.getAxis());
+      auto newBroadcast = rewriter.create<triton::BroadcastOp>(
+          broadcast.getLoc(), op.getType(), newExpand.getResult());
+      rewriter.replaceOp(op, {newBroadcast.getResult()});
+      return mlir::success();
+    }
   }
 
   return mlir::failure();


### PR DESCRIPTION
<git-pr-chain>


[IR] Fix two bugs in ExpandDimsOp::canonicalize.

* Don't assume that the input to broadcast is a tensor.  Scalars are
  also allowed (although IMO they should not be, because that's
  what splat is for).

* Don't drop the encoding.  Previously, if we matched this pattern after
  adding encodings, we'd drop the encoding on the new canonicalized
  operation, resulting in invalid IR.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #2975 👈 **YOU ARE HERE**


</git-pr-chain>
