### PR TITLE
[SETUP] Fix a missing backend issue when running bdist_wheel

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass
 from distutils.command.install import install
 from setuptools.command.develop import develop
 from setuptools.command.egg_info import egg_info
+from wheel.bdist_wheel import bdist_wheel
 
 
 @dataclass
@@ -406,6 +407,13 @@ class plugin_develop(develop):
         develop.run(self)
 
 
+class plugin_bdist_wheel(bdist_wheel):
+
+    def run(self):
+        add_link_to_backends()
+        bdist_wheel.run(self)
+
+
 class plugin_egginfo(egg_info):
 
     def run(self):
@@ -446,6 +454,7 @@ setup(
         "clean": CMakeClean,
         "install": plugin_install,
         "develop": plugin_develop,
+        "bdist_wheel": plugin_bdist_wheel,
         "egg_info": plugin_egginfo,
     },
     zip_safe=False,


### PR DESCRIPTION
Summary: Follow the examples in https://github.com/openai/triton/pull/2982 and make sure backends symlinks are created properly when installing with bdist_wheel