### PR TITLE
[AMD] run ci on pull requests

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -75,9 +75,17 @@ jobs:
           ref: ${{ (github.event_name == 'issue_comment') && github.event.issue.pull_request.head.ref || 'main' }}
           submodules: 'true'
 
+      - name: Set ROCM ENV
+        run: |
+          echo "BACKEND=ROCM" >> "${GITHUB_ENV}"
+
       - name: Clear cache
         run: |
           rm -rf ~/.triton
+
+      - name: Update PATH
+        run: |
+          echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
 
       - name: Install Dependencies
         run: |
@@ -100,11 +108,10 @@ jobs:
         run: |
           python3 -m pytest -n 32 --capture=tee-sys -rfs --verbose "python/test/unit/language/test_core.py" -k "not test_flip"
 
-
   Integration-Tests-Intel:
     needs: Runner-Preparation
     timeout-minutes: 20
-    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+    if: false && ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
 
     runs-on: ${{ matrix.runner }}
 

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -24,7 +24,7 @@ jobs:
 
 
   Integration-Tests-Shared-Middle-Layer:
-
+    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -57,9 +57,8 @@ jobs:
           python3 setup.py build
           python3 -m pip install --no-build-isolation -vvv '.[tests]'
 
-
   Integration-Tests-AMD:
-    if: github.event.issue.pull_request && contains(github.event.comment.body, '/run-amd-tests')
+    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event.issue.pull_request && contains(github.event.comment.body, '/run-amd-tests'))
     needs: Runner-Preparation
     timeout-minutes: 20
 
@@ -73,19 +72,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          ref: ${{ (github.event_name == 'issue_comment') && github.event.issue.pull_request.head.ref || 'main' }}
           submodules: 'true'
-
-      - name: Set ROCM ENV
-        run: |
-          echo "BACKEND=ROCM" >> "${GITHUB_ENV}"
 
       - name: Clear cache
         run: |
           rm -rf ~/.triton
-
-      - name: Update PATH
-        run: |
-          echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
 
       - name: Install Dependencies
         run: |
@@ -108,10 +100,11 @@ jobs:
         run: |
           python3 -m pytest -n 32 --capture=tee-sys -rfs --verbose "python/test/unit/language/test_core.py" -k "not test_flip"
 
+
   Integration-Tests-Intel:
     needs: Runner-Preparation
     timeout-minutes: 20
-    if: false
+    if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     runs-on: ${{ matrix.runner }}
 


### PR DESCRIPTION
* this is a follow up to https://github.com/openai/triton/pull/3003. It does the following

  * checks out the pull request when ci jobs starts with a `/run-amd-tests` comment
  * limit the comment trigger to AMD jobs only 
  * other backend ci jobs follow the default behavior as before. They can be started either manually or when push to main