### PR TITLE
[AMD] fix test_bin_op_constexpr failures & checkout pr issue

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -69,10 +69,17 @@ jobs:
         runner: ["gfx908"]
 
     steps:
+      - name: Checkout PR
+        uses: actions/checkout@v3
+        if: ${{ github.event_name == 'issue_comment' }}
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+          submodules: 'true'
+
       - name: Checkout
         uses: actions/checkout@v3
+        if: ${{ github.event_name != 'issue_comment' }}
         with:
-          ref: ${{ (github.event_name == 'issue_comment') && github.event.issue.pull_request.head.ref || 'main' }}
           submodules: 'true'
 
       - name: Set ROCM ENV


### PR DESCRIPTION
this pr is a follow up to 

- https://github.com/openai/triton/pull/2996
- https://github.com/openai/triton/pull/3005

it does the following
- applies a fix to `test_bin_op_constexpr` with `<<` and `>>` that was applied to `test_shift_op`. It limits the random shifting value to a range between 0 and the bitwidth
- fixes an issue where the logic to checkout the pr code when triggered from a comment was failing. Thank you to @OctoSabercat for suggesting a solution
   - to ensure the logic works I have made a toy repo with this logic
       - [triggered from main](https://github.com/micmelesse/test_ci/actions/runs/7672726431/job/20913857574)
         - uses the `Checkout` step and prints `README.md` in [main](https://github.com/micmelesse/test_ci/blob/main/README.md)
       - [triggered from pr](https://github.com/micmelesse/test_ci/actions/runs/7672743796/job/20913912082)
         - uses the `Checkout PR` step and prints `README.md` in this [test_pr](https://github.com/micmelesse/test_ci/pull/1)
