### PR TITLE
Add a verifier for ElementwiseInlineAsmOp.

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -604,9 +604,11 @@ def TT_MakeRangeOp : TT_Op<"make_range", [Pure]> {
 //
 // ElementwiseInlineAsm Op
 //
-def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [Elementwise,
-                                                                 SameOperandsAndResultEncoding,
-                                                                 DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [
+  Elementwise,
+  SameOperandsAndResultEncoding,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
+]> {
   let summary = "inline assembly applying an elementwise operation to a group of packed elements.";
   let description = [{
     Runs an inline asm block to generate one or more tensors.
@@ -621,6 +623,8 @@ def TT_ElementwiseInlineAsmOp : TT_Op<"elementwise_inline_asm", [Elementwise,
   let assemblyFormat = [{
     $asm_string attr-dict ($args^ `:` type($args))? `->` type($result)
   }];
+
+  let hasVerifier = 1;
 }
 
 //

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1250,18 +1250,13 @@ struct ElementwiseInlineAsmOpConversion
     // equals the number of output elements per return value, except when the
     // asm has no inputs, in which case there's 1 output element.
     size_t numInputElems = unpackedOperands[0].size();
-    for (unsigned i = 0; i < unpackedOperands.size(); ++i) {
-      if (unpackedOperands[i].size() != numInputElems) {
-        llvm::report_fatal_error("Inline asm op has operands with different "
-                                 "numbers of elements.");
-      }
-    }
 
-    // TODO(jlebar): This should be checked by the verifier.
-    if (numInputElems % op.getPackedElement() != 0) {
-      llvm::report_fatal_error("Inline asm op has packed_element=k, but k does "
-                               "not divide the number of elements per thread.");
-    }
+    // These are checked by the verifier, so we don't need to raise a nice
+    // error.
+    assert(all_of(unpackedOperands, [&](auto &operands) {
+      return operands.size() == numInputElems;
+    }));
+    assert(numInputElems % op.getPackedElement() == 0);
 
     // Run the inline asm op on each block of elements.
     //

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -1098,6 +1098,20 @@ void ElementwiseInlineAsmOp::getEffects(
                        SideEffects::DefaultResource::get());
 }
 
+LogicalResult ElementwiseInlineAsmOp::verify() {
+  if (getNumOperands() >= 1) {
+    size_t numInputElems =
+        getOperand(0).getType().cast<RankedTensorType>().getNumElements();
+    if (numInputElems % this->getPackedElement() != 0) {
+      return emitError("number of input elements ")
+             << numInputElems
+             << " must be a multiple of the op's packed_element attribute, "
+             << getPackedElement();
+    }
+  }
+  return success();
+}
+
 // -- ExternElementwiseOp --
 void ExternElementwiseOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -1,5 +1,23 @@
 // RUN: triton-opt --split-input-file %s --verify-diagnostics
 
+tt.func public @fn(%arg0: tensor<128xf32>) {
+    // expected-error @+1 {{packed_element}}
+    %a = tt.elementwise_inline_asm ""
+      {constraints = "=r,r", packed_element=3:i32, pure=true} %arg0 : tensor<128xf32> -> tensor<128xf32>
+    tt.return
+}
+
+// -----
+
+tt.func public @fn(%arg0: tensor<128xf32>, %arg1: tensor<64xf32>) {
+    // expected-error @+1 {{same shape}}
+    %a = tt.elementwise_inline_asm ""
+      {constraints = "=r,r,r", packed_element=1:i32, pure=true}
+      %arg0, %arg1: tensor<128xf32>, tensor<64xf32> -> tensor<128xf32>
+    tt.return
+}
+// -----
+
 tt.func public @reshape_different_num_elements(%arg0: tensor<32x128xf16>) {
     // expected-error @+1 {{number of src and dst elements of reshape must be the same}}
     %a = tt.reshape %arg0 {allow_reorder = false} : tensor<32x128xf16> -> tensor<64x32xf16>


### PR DESCRIPTION
Fixes a TODO, and lets us improve the error messages we get when you
type an invalid asm op -- now it's a nice compile error instead of a
crash.
