### PR TITLE
[BACKEND][NFC] Minor refactor of inferDstEncoding/inferSrcEncoding

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -234,7 +234,14 @@ void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
       continue;
     bool hasChanged = false;
     for (auto encoding : info.encodings) {
-      auto dstEncoding = inferDstEncoding(op, encoding);
+      std::optional<Attribute> dstEncoding;
+      if (isa<triton::gpu::ConvertLayoutOp>(op)) {
+        // Try to remove the convert by making the dst encoding match the source
+        // encoding.
+        dstEncoding = encoding;
+      } else {
+        dstEncoding = inferDstEncoding(op, encoding);
+      }
       if (dstEncoding)
         hasChanged |= layouts[value].encodings.insert(*dstEncoding);
     }

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -369,13 +369,6 @@ std::optional<Attribute> inferSrcEncoding(Operation *op, Attribute encoding) {
   if (auto trans = dyn_cast<triton::TransOp>(op))
     return inferSrcEncoding(trans, encoding);
 
-  // We have to return `encoding` for ConvertLayoutOp or we get spurrious
-  // conversion ops in the final compiled result.  I think this is due to a
-  // quirk in the impl of RemoveLayoutConversions.  I suppose ConvertLayoutOp
-  // *can* accept the same src and dst encodings, though why would you want to?
-  if (isa<triton::gpu::ConvertLayoutOp>(op))
-    return encoding;
-
   return std::nullopt;
 }
 
@@ -393,11 +386,6 @@ std::optional<Attribute> inferDstEncoding(Operation *op, Attribute encoding) {
     return inferDstEncoding(interleave, encoding);
   if (auto trans = dyn_cast<triton::TransOp>(op))
     return inferDstEncoding(trans, encoding);
-
-  // As in inferSrcEncoding, we have to return `encoding` for ConvertLayoutOp.
-  if (isa<triton::gpu::ConvertLayoutOp>(op))
-    return encoding;
-
   return std::nullopt;
 }
 


### PR DESCRIPTION
Minor refactor of helpers to make them more consistent by only propagating when the dst/src encoding can be inferred from the src/dst encoding and handle convert layout explicitly in the forward propagation