### PR TITLE
Exclude arith.select from hoisting for dot_operand layout

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -132,12 +132,6 @@ public:
         src->getDialect()->getTypeID() != TypeID::get<arith::ArithDialect>())
       return failure();
 
-    // TODO(jlebar): Why do we exclude arith trunc ops specifically?
-    // arith.select needs to be excluded because dot_operand layout hoisting
-    // will go through the mask, which is i1 type. Mask parents are most likely
-    // of integer types. When lowering shared -> dot_operand layout, integer
-    // types are not supported. 
-
     // Currently, these instructions are not supported during lowering of
     // shared -> dot_operand layout. Not all types and type conversions are
     // supported.

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -132,8 +132,12 @@ public:
         src->getDialect()->getTypeID() != TypeID::get<arith::ArithDialect>())
       return failure();
 
-    // TODO(jlebar): Why do we exclude these two ops specifically?
-    if (isa<arith::TruncIOp, arith::TruncFOp>(src))
+    // TODO(jlebar): Why do we exclude arith trunc ops specifically?
+    // arith.select needs to be excluded because dot_operand layout hoisting
+    // will go through the mask, which is i1 type. Mask parents are most likely
+    // of integer types. When lowering shared -> dot_operand layout, integer
+    // types are not supported. 
+    if (isa<arith::TruncIOp, arith::TruncFOp, arith::SelectOp>(src))
       return failure();
 
     // Check that the conversion is transitively dependent on a load, and all

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -137,6 +137,10 @@ public:
     // will go through the mask, which is i1 type. Mask parents are most likely
     // of integer types. When lowering shared -> dot_operand layout, integer
     // types are not supported. 
+
+    // Currently, these instructions are not supported during lowering of
+    // shared -> dot_operand layout. Not all types and type conversions are
+    // supported.
     if (isa<arith::TruncIOp, arith::TruncFOp, arith::SelectOp>(src))
       return failure();
 

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -159,7 +159,7 @@ tt.func @mma_v3_reg_operand_A(%arg0: tensor<128x64xf16, #mma>, %arg1: tensor<64x
 #mma = #triton_gpu.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], instrShape = [16, 8]}>
 module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
 // CHECK: tt.func @a_impl
-// CHECK-NOT: %[[SELECT:.*]] = arith.select {{.*}} : tensor<128x128xi1, #triton_gpu.dot_op<{{.*}}>, tensor<128x128xf16, #triton_gpu.dot_op<{{.*}}>  
+// CHECK-NOT: %[[SELECT:.*]] = arith.select {{.*}} : tensor<128x128xi1, #triton_gpu.dot_op<{{.*}}>, tensor<128x128xf16, #triton_gpu.dot_op<{{.*}}>
   tt.func @a_impl(%pa: tensor<128x128x!tt.ptr<f16, 1>, #blocked>) -> tensor<128x128xf32, #mma> {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>

--- a/test/TritonGPU/dot-operands.mlir
+++ b/test/TritonGPU/dot-operands.mlir
@@ -158,6 +158,8 @@ tt.func @mma_v3_reg_operand_A(%arg0: tensor<128x64xf16, #mma>, %arg1: tensor<64x
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [0, 1]}>
 #mma = #triton_gpu.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], instrShape = [16, 8]}>
 module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+// CHECK: tt.func @a_impl
+// CHECK-NOT: %[[SELECT:.*]] = arith.select {{.*}} : tensor<128x128xi1, #triton_gpu.dot_op<{{.*}}>, tensor<128x128xf16, #triton_gpu.dot_op<{{.*}}>  
   tt.func @a_impl(%pa: tensor<128x128x!tt.ptr<f16, 1>, #blocked>) -> tensor<128x128xf32, #mma> {
     %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #mma>
     %cst_0 = arith.constant dense<0.000000e+00> : tensor<128x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>


### PR DESCRIPTION
Hoisting dot_operand layout through arith.select crashes the compiler due to propagating the layout to the mask input, which is of i1 type. Also hoisting further up the mask's parents will probably be of integer type. The crash happens during ConvertTritonGPUToLLVM pass.

2 examples where the crash happen:
- arith.cmpi -> broadcast -> layout_conv -> arith.select (dot_op layout) -> dot.
In this example the crash would happen due to SharedToDotOperandMMAv2.cpp assuming that the bit-width is at least 8 when computing elemBytes. It also assumes the types are mma-compatible (for Ampere for example mma16816) which don't include int type when doing floating dot.

- arith.cmpi -> layout_conv -> broadcast -> arith.select (dot_op layout) -> dot.
This example requires allowing HoistLayoutConversion to also propagate through Broadcast. Again, arith.cmpi is on integer 32 which is not supported in the lowering of shared -> dot_operand layout.