### PR TITLE
[AMD] Fix and Enable Scan 2D op test

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1803,8 +1803,6 @@ def linear_recurrence(a1, b1, a2, b2):
 
 @pytest.mark.parametrize("op, dtype_str, shape, axis, num_warps", scan_configs + negative_config)
 def test_scan2d(op, dtype_str, shape, axis, num_warps, device):
-    if is_hip():
-        pytest.skip("test_scan2d is not supported in HIP")
     check_type_supported(dtype_str, device)
 
     # triton kernel

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -507,8 +507,7 @@ private:
 
     // Store to local shared memory
     {
-      auto inVals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(),
-                                                         rewriter, srcTy);
+      auto inVals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(), rewriter);
       auto inIndices =
           emitIndices(loc, rewriter, srcLayout, srcTy, /*withCTAOffset*/ false);
 
@@ -630,8 +629,7 @@ private:
     }
     // Potentially we need to store for multiple CTAs in this replication
     auto accumNumReplicates = product<unsigned>(numReplicates);
-    auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(),
-                                                     rewriter, srcTy);
+    auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(), rewriter);
     unsigned inVec = 0;
     unsigned outVec = 0;
     auto origRepShape = getRepShapeForCvtLayout(op);
@@ -798,8 +796,7 @@ private:
     unsigned numElems = triton::gpu::getTotalElemsPerThread(srcTy);
     if (mmaLayout && mmaLayout.isHopper() && elemSize == 16 &&
         inOrd == outOrd && numElems >= 16) {
-      auto inVals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(),
-                                                         rewriter, srcTy);
+      auto inVals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(), rewriter);
 
       auto srcShapePerCTA = getShapePerCTA(mmaLayout, srcShape);
       auto instrShape = mmaLayout.getInstrShape();
@@ -952,8 +949,7 @@ private:
     auto dstTy = op.getResult().getType().cast<RankedTensorType>();
     if (isMfmaToDotShortcut(srcTy, dstTy)) {
       // get source values
-      auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(),
-                                                       rewriter, srcTy);
+      auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(), rewriter);
       unsigned elems = getTotalElemsPerThread(srcTy);
       Type elemTy =
           this->getTypeConverter()->convertType(srcTy.getElementType());
@@ -1003,8 +999,7 @@ private:
 
     if (isMmaToDotShortcut(srcTy, dstTy)) {
       // get source values
-      auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(),
-                                                       rewriter, srcTy);
+      auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(), rewriter);
       unsigned elems = getTotalElemsPerThread(srcTy);
       Type elemTy =
           this->getTypeConverter()->convertType(srcTy.getElementType());
@@ -1111,8 +1106,7 @@ private:
       return success();
     }
     // get source values
-    auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(),
-                                                     rewriter, srcTy);
+    auto vals = getTypeConverter()->unpackLLElements(loc, adaptor.getSrc(), rewriter);
     SmallVector<Value> retVals;
     SmallVector<unsigned> dstElementPerThread =
         triton::gpu::getElemsPerThread(dstTy);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -79,7 +79,7 @@ static ValueTable getValueTableFromStruct(Value val, int K, int n0, int shapePer
                                    TritonGPUToLLVMTypeConverter *typeConverter,
                                    Type type) {
   ValueTable res;
-  auto elems = typeConverter->unpackLLElements(loc, val, rewriter, type);
+  auto elems = typeConverter->unpackLLElements(loc, val, rewriter);
   int index = 0;
   for (unsigned k = 0; k < K; ++k) {
     for (unsigned m = 0; m < n0; m += shapePerCTA)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -16,7 +16,7 @@ static ValueTableFMA getValueTableFromStructFMA(
     ConversionPatternRewriter &rewriter, Location loc,
     TritonGPUToLLVMTypeConverter *typeConverter, Type type) {
   ValueTableFMA res;
-  auto elems = typeConverter->unpackLLElements(loc, val, rewriter, type);
+  auto elems = typeConverter->unpackLLElements(loc, val, rewriter);
   int index = 0;
   for (unsigned k = 0; k < K; ++k) {
     for (unsigned m = 0; m < n0; m += shapePerCTATile)
@@ -49,8 +49,7 @@ LogicalResult convertFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   BlockedEncodingAttr dLayout =
       dTensorTy.getEncoding().cast<BlockedEncodingAttr>();
   auto order = dLayout.getOrder();
-  auto cc =
-      typeConverter->unpackLLElements(loc, adaptor.getC(), rewriter, dTensorTy);
+  auto cc = typeConverter->unpackLLElements(loc, adaptor.getC(), rewriter);
 
   Value llA = adaptor.getA();
   Value llB = adaptor.getB();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -401,8 +401,7 @@ struct DotOpMFMAConversionHelper {
     ValueTable hb = getValuesFromDotOperandLayoutStruct(
         loadedB, numRepN, numRepK, aTensorTy.getElementType());
     auto dstElemTy = dTensorTy.getElementType();
-    auto fc =
-        typeConverter->unpackLLElements(loc, loadedC, rewriter, dstElemTy);
+    auto fc = typeConverter->unpackLLElements(loc, loadedC, rewriter);
 
     unsigned warpSize = triton::gpu::getWarpSize(mfmaLayout);
     // compute number of output elements that each thread holds for one MFMA
@@ -446,7 +445,7 @@ struct DotOpMFMAConversionHelper {
 
   ValueTable getValuesFromDotOperandLayoutStruct(Value value, int n0, int n1,
                                                  Type type) const {
-    auto elems = typeConverter->unpackLLElements(loc, value, rewriter, type);
+    auto elems = typeConverter->unpackLLElements(loc, value, rewriter);
     ValueTable vals;
     for (int i = 0; i < n0; i++) {
       for (int j = 0; j < n1; j++) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1393,8 +1393,8 @@ public:
     SmallVector<SmallVector<Value>> allOperands;
     for (auto operand : adaptor.getOperands()) {
       auto argTy = op->getOperand(0).getType();
-      auto subOperands = this->getTypeConverter()->unpackLLElements(
-          loc, operand, rewriter, argTy);
+      auto subOperands =
+          this->getTypeConverter()->unpackLLElements(loc, operand, rewriter);
       subOperands = unpackI32(subOperands, argTy, rewriter, loc,
                               this->getTypeConverter());
       allOperands.resize(subOperands.size());
@@ -1970,7 +1970,7 @@ struct ElementwiseInlineAsmOpConversion
     for (auto operand : adaptor.getOperands()) {
       auto argTy = op->getOperand(0).getType();
       auto subOperands =
-          getTypeConverter()->unpackLLElements(loc, operand, rewriter, argTy);
+          getTypeConverter()->unpackLLElements(loc, operand, rewriter);
       unpackedOperands.push_back(
           unpackI32(subOperands, argTy, rewriter, loc, getTypeConverter()));
     }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -111,15 +111,13 @@ struct LoadOpConversion
       vec = std::min<size_t>(vec, getMaskAlignment(mask));
 
     // Get the LLVM values for pointers
-    auto ptrElems = getTypeConverter()->unpackLLElements(loc, llPtr, rewriter,
-                                                         ptr.getType());
+    auto ptrElems = getTypeConverter()->unpackLLElements(loc, llPtr, rewriter);
     assert(ptrElems.size() == numElems);
 
     // Get the LLVM values for mask
     SmallVector<Value> maskElems;
     if (llMask) {
-      maskElems = getTypeConverter()->unpackLLElements(loc, llMask, rewriter,
-                                                       mask.getType());
+      maskElems = getTypeConverter()->unpackLLElements(loc, llMask, rewriter);
       assert(maskElems.size() == numElems);
     }
 
@@ -137,8 +135,7 @@ struct LoadOpConversion
     }
     SmallVector<Value> otherElems;
     if (other) {
-      otherElems = getTypeConverter()->unpackLLElements(loc, llOther, rewriter,
-                                                        other.getType());
+      otherElems = getTypeConverter()->unpackLLElements(loc, llOther, rewriter);
     }
 
     // vectorized iteration through all the pointer/mask/other elements
@@ -356,18 +353,16 @@ struct StoreOpConversion
     unsigned vec = getVectorSize(ptr);
     unsigned elemsPerThread = getTotalElemsPerThread(ptr.getType());
 
-    auto ptrElems = getTypeConverter()->unpackLLElements(loc, llPtr, rewriter,
-                                                         ptr.getType());
-    auto valueElems = getTypeConverter()->unpackLLElements(
-        loc, llValue, rewriter, value.getType());
+    auto ptrElems = getTypeConverter()->unpackLLElements(loc, llPtr, rewriter);
+    auto valueElems =
+        getTypeConverter()->unpackLLElements(loc, llValue, rewriter);
     assert(ptrElems.size() == valueElems.size());
 
     // Determine the vectorization size
     SmallVector<Value> maskElems;
     if (llMask) {
       Value mask = op.getMask();
-      maskElems = getTypeConverter()->unpackLLElements(loc, llMask, rewriter,
-                                                       mask.getType());
+      maskElems = getTypeConverter()->unpackLLElements(loc, llMask, rewriter);
       assert(valueElems.size() == maskElems.size());
 
       unsigned maskAlign = getMaskAlignment(mask);
@@ -501,12 +496,12 @@ struct AtomicCASOpConversion
     Value llCmp = adaptor.getCmp();
     Value llVal = adaptor.getVal();
 
-    auto ptrElements = getTypeConverter()->unpackLLElements(
-        loc, llPtr, rewriter, op.getPtr().getType());
-    auto cmpElements = getTypeConverter()->unpackLLElements(
-        loc, llCmp, rewriter, op.getCmp().getType());
-    auto valElements = getTypeConverter()->unpackLLElements(
-        loc, llVal, rewriter, op.getVal().getType());
+    auto ptrElements =
+        getTypeConverter()->unpackLLElements(loc, llPtr, rewriter);
+    auto cmpElements =
+        getTypeConverter()->unpackLLElements(loc, llCmp, rewriter);
+    auto valElements =
+        getTypeConverter()->unpackLLElements(loc, llVal, rewriter);
 
     auto TensorTy = op.getResult().getType().dyn_cast<RankedTensorType>();
     Type valueElemTy =
@@ -575,12 +570,12 @@ struct AtomicCASOpConversion
     Value llCmp = adaptor.getCmp();
     Value llVal = adaptor.getVal();
 
-    auto ptrElements = getTypeConverter()->unpackLLElements(
-        loc, llPtr, rewriter, op.getPtr().getType());
-    auto cmpElements = getTypeConverter()->unpackLLElements(
-        loc, llCmp, rewriter, op.getCmp().getType());
-    auto valElements = getTypeConverter()->unpackLLElements(
-        loc, llVal, rewriter, op.getVal().getType());
+    auto ptrElements =
+        getTypeConverter()->unpackLLElements(loc, llPtr, rewriter);
+    auto cmpElements =
+        getTypeConverter()->unpackLLElements(loc, llCmp, rewriter);
+    auto valElements =
+        getTypeConverter()->unpackLLElements(loc, llVal, rewriter);
 
     auto valueTy = op.getResult().getType();
     auto TensorTy = valueTy.dyn_cast<RankedTensorType>();
@@ -727,14 +722,14 @@ struct AtomicRMWOpConversion
     Value llVal = adaptor.getVal();
     Value llMask = adaptor.getMask();
 
-    auto valElements = getTypeConverter()->unpackLLElements(
-        loc, llVal, rewriter, val.getType());
-    auto ptrElements = getTypeConverter()->unpackLLElements(
-        loc, llPtr, rewriter, ptr.getType());
+    auto valElements =
+        getTypeConverter()->unpackLLElements(loc, llVal, rewriter);
+    auto ptrElements =
+        getTypeConverter()->unpackLLElements(loc, llPtr, rewriter);
     SmallVector<Value> maskElements;
     if (llMask)
-      maskElements = getTypeConverter()->unpackLLElements(
-          loc, llMask, rewriter, op.getMask().getType());
+      maskElements =
+          getTypeConverter()->unpackLLElements(loc, llMask, rewriter);
 
     Value opResult = op.getResult();
     auto tensorTy = opResult.getType().dyn_cast<RankedTensorType>();
@@ -845,14 +840,14 @@ struct AtomicRMWOpConversion
     Value llVal = adaptor.getVal();
     Value llMask = adaptor.getMask();
 
-    auto valElements = getTypeConverter()->unpackLLElements(
-        loc, llVal, rewriter, val.getType());
-    auto ptrElements = getTypeConverter()->unpackLLElements(
-        loc, llPtr, rewriter, ptr.getType());
+    auto valElements =
+        getTypeConverter()->unpackLLElements(loc, llVal, rewriter);
+    auto ptrElements =
+        getTypeConverter()->unpackLLElements(loc, llPtr, rewriter);
     SmallVector<Value> maskElements;
     if (llMask)
-      maskElements = getTypeConverter()->unpackLLElements(
-          loc, llMask, rewriter, op.getMask().getType());
+      maskElements =
+          getTypeConverter()->unpackLLElements(loc, llMask, rewriter);
 
     auto valueTy = op.getResult().getType();
     auto tensorTy = valueTy.dyn_cast<RankedTensorType>();
@@ -1100,8 +1095,7 @@ struct InsertSliceAsyncOpConversion
     Value llIndex = adaptor.getIndex();
 
     // %src
-    auto srcElems = getTypeConverter()->unpackLLElements(loc, llSrc, rewriter,
-                                                         src.getType());
+    auto srcElems = getTypeConverter()->unpackLLElements(loc, llSrc, rewriter);
 
     // %dst
     auto dstTy = dst.getType().cast<RankedTensorType>();
@@ -1128,8 +1122,7 @@ struct InsertSliceAsyncOpConversion
     // %mask
     SmallVector<Value> maskElems;
     if (llMask) {
-      maskElems = getTypeConverter()->unpackLLElements(loc, llMask, rewriter,
-                                                       mask.getType());
+      maskElems = getTypeConverter()->unpackLLElements(loc, llMask, rewriter);
       assert(srcElems.size() == maskElems.size());
     }
 
@@ -1140,8 +1133,7 @@ struct InsertSliceAsyncOpConversion
       // It's not necessary for now because the pipeline pass will skip
       // generating insert_slice_async if the load op has any "other" tensor.
       // assert(false && "insert_slice_async: Other value not supported yet");
-      otherElems = getTypeConverter()->unpackLLElements(loc, llOther, rewriter,
-                                                        other.getType());
+      otherElems = getTypeConverter()->unpackLLElements(loc, llOther, rewriter);
       assert(srcElems.size() == otherElems.size());
     }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ReduceOpToLLVM.cpp
@@ -126,8 +126,7 @@ private:
     unsigned srcElems = getTotalElemsPerThread(types[0]);
     SmallVector<SmallVector<Value>> srcValues(srcElems);
     for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-      auto values = getTypeConverter()->unpackLLElements(loc, operands[i],
-                                                         rewriter, types[i]);
+      auto values = getTypeConverter()->unpackLLElements(loc, operands[i], rewriter);
 
       assert(values.size() == srcValues.size());
       for (unsigned j = 0; j < srcValues.size(); ++j) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ReduceOpToLLVM.cpp
@@ -18,15 +18,16 @@ using ::AMD::TritonGPUToLLVMTypeConverter;
 using ::AMD::ConvertTritonGPUOpToLLVMPatternBase;
 using ::AMD::ConvertTritonGPUOpToLLVMPattern;
 
+namespace AMD{
 namespace {
 struct ReduceOpConversion
-    : public ConvertTritonGPUOpToLLVMPattern<triton::ReduceOp> {
+    : public ConvertTritonGPUReduceScanToLLVMPattern<triton::ReduceOp> {
 public:
   ReduceOpConversion(
       TritonGPUToLLVMTypeConverter &typeConverter, ModuleAllocation &allocation,
       ConvertTritonGPUOpToLLVMPatternBase::IndexCacheInfo &indexCacheInfo,
       int computeCapability, PatternBenefit benefit)
-      : ConvertTritonGPUOpToLLVMPattern<triton::ReduceOp>(
+      : ConvertTritonGPUReduceScanToLLVMPattern<triton::ReduceOp>(
             typeConverter, allocation, indexCacheInfo, benefit),
         computeCapability(computeCapability) {}
 
@@ -58,7 +59,7 @@ public:
     auto smemShape = helper.getScratchConfig();
 
     SmallVector<Value> smemBases =
-        getSmemBases(helper, op, smemShape, rewriter);
+        getSmemBases(op, product<unsigned>(smemShape), rewriter);
 
     storeWarpReduceToSharedMemory(helper, accs, indices, smemBases, rewriter);
 
@@ -134,36 +135,6 @@ private:
       }
     }
     return srcValues;
-  }
-
-  SmallVector<Value> getSmemBases(ReduceOpHelper &helper, triton::ReduceOp op,
-                                  SmallVector<unsigned> smemShape,
-                                  ConversionPatternRewriter &rewriter) const {
-    auto loc = op.getLoc();
-    unsigned elems = product<unsigned>(smemShape);
-    // indices will store the index of the op operands in descending order
-    // of their bitwidths
-    std::vector<unsigned> indices(op.getNumOperands());
-    std::iota(indices.begin(), indices.end(), 0);
-    std::sort(indices.begin(), indices.end(), [&](unsigned i, unsigned j) {
-      return op.getElementTypes()[i].getIntOrFloatBitWidth() >
-             op.getElementTypes()[j].getIntOrFloatBitWidth();
-    });
-    // Assign base index to each operand in their order in indices
-    std::map<unsigned, Value> indexToBase;
-    indexToBase[indices[0]] =
-        getSharedMemoryBase(loc, rewriter, op.getOperation());
-    for (unsigned i = 1; i < op.getNumOperands(); ++i) {
-      indexToBase[indices[i]] = gep(
-          ptr_ty(rewriter.getContext(), 3), getElementType(op, indices[i - 1]),
-          indexToBase[indices[i - 1]], i32_val(elems));
-    }
-    // smemBases[k] is the base pointer for the k-th operand
-    SmallVector<Value> smemBases(op.getNumOperands());
-    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-      smemBases[i] = indexToBase[i];
-    }
-    return smemBases;
   }
 
   void sync(ConversionPatternRewriter &rewriter, Location loc,
@@ -356,12 +327,6 @@ private:
     rewriter.replaceOp(op, results);
   }
 
-  // Return the pointee type of the shared memory pointer for operand i.
-  Type getElementType(triton::ReduceOp op, int i) const {
-    auto ty = op.getInputTypes()[i].getElementType();
-    return getTypeConverter()->convertType(ty);
-  }
-
   SmallVector<Value>
   getMultiDimWarpId(ReduceOpHelper &helper, Value &warpId, Location &loc,
                     ConversionPatternRewriter &rewriter) const {
@@ -547,7 +512,6 @@ private:
 };
 }
 
-namespace AMD{
 void populateReduceOpToLLVMPatterns(
     TritonGPUToLLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     int numWarps, ModuleAxisInfoAnalysis &axisInfoAnalysis,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ScanOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ScanOpToLLVM.cpp
@@ -405,7 +405,7 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
   auto axisNumWarps = helper.getAxisNumWarpsWithUniqueData();
   warpIdAxis = urem(warpIdAxis, i32_val(axisNumWarps));
   SmallVector<Value> srcValues =
-      getTypeConverter()->unpackLLElements(loc, input, rewriter, type);
+      getTypeConverter()->unpackLLElements(loc, input, rewriter);
 
   // Scan contigous elements in a thread and update `srcValues`.
   scanThreadContiguousElements(srcValues, rewriter, helper);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ScanOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ScanOpToLLVM.cpp
@@ -10,48 +10,57 @@ using ::mlir::LLVM::linearize;
 using ::mlir::LLVM::AMD::shflIdxSync;
 using ::mlir::LLVM::AMD::shflUpSync;
 using ::mlir::LLVM::AMD::storeShared;
+using ::mlir::triton::gpu::getTotalElemsPerThread;
 using ::AMD::TritonGPUToLLVMTypeConverter;
 using ::AMD::ConvertTritonGPUOpToLLVMPatternBase;
 using ::AMD::ConvertTritonGPUOpToLLVMPattern;
 
-// apply combine region to a and b and return the result. If a or b is null,
-// return the other operand.
-static Value accumulate(ConversionPatternRewriter &rewriter, Region &combineOp,
-                        Value a, Value b) {
-  if (!a) {
-    return b;
+// apply combine region to acc and cur and accumulate it into acc
+// TODO(Lezcano) This is now duplicated with ReduceOpConversion::reduce.
+// Deduplicate
+static SmallVector<Value> accumulate(ConversionPatternRewriter &rewriter,
+                                     Region &combineOp, ValueRange acc,
+                                     ValueRange cur) {
+  // Allows for passing an unitialized acc and use cur as the neutral element
+  if (acc.size() == 0) {
+    return cur;
+
   }
-  if (!b) {
-    return a;
-  }
+  assert(cur.size() == acc.size());
   // Create a new copy of the reduce block, and inline it
   Block *currentBlock = rewriter.getBlock();
   Region &parent = *currentBlock->getParent();
   rewriter.cloneRegionBefore(combineOp, &parent.front());
   auto &newScan = parent.front();
   auto returnOp = dyn_cast<triton::ScanReturnOp>(newScan.getTerminator());
-  llvm::SmallVector<Value> combineArgs = {a, b};
+
+  SmallVector<Value> combineArgs(2 * acc.size());
+  for (unsigned i = 0; i < acc.size(); ++i) {
+    combineArgs[i] = acc[i];
+    combineArgs[acc.size() + i] = cur[i];
+  }
   rewriter.inlineBlockBefore(&newScan, &*rewriter.getInsertionPoint(),
                              combineArgs);
   auto results = returnOp.getResult();
-  Value acc = results[0];
   // Delete the terminator, which is no longer used
   rewriter.eraseOp(returnOp);
-  return acc;
+  return results;
 }
 
 // Scan a contiguous elements within a thread and update `srcValues` in place.
-static void scanThreadContiguousElements(SmallVector<Value> &srcValues,
-                                         ConversionPatternRewriter &rewriter,
-                                         ScanLoweringHelper &helper) {
+static void
+scanThreadContiguousElements(SmallVector<SmallVector<Value>> &srcValues,
+                             ConversionPatternRewriter &rewriter,
+                             ScanLoweringHelper &helper) {
   // Depending on layout contiguous elements along axis dim may not be
   // contiguous in srcValues. Keep track of what elements belong to the same
   // chunk of contiguous elements.
   unsigned scanElementsPerThreads = helper.getAxisNumElementsPerThread();
   unsigned numChunks = srcValues.size() / scanElementsPerThreads;
   unsigned stride = helper.getAxisElementStride();
-  SmallVector<Value> accs(numChunks);
+  SmallVector<SmallVector<Value>> accs(numChunks);
   for (unsigned srcIndex = 0; srcIndex < srcValues.size(); srcIndex++) {
+    // Change this into emitOffsetForLayout?
     unsigned accIndex = (srcIndex % stride) +
                         ((srcIndex / stride) / scanElementsPerThreads) * stride;
 
@@ -63,7 +72,7 @@ static void scanThreadContiguousElements(SmallVector<Value> &srcValues,
 
 // Apply a scan across threads of the warp for the last element of each
 // contiguous group of elements.
-static void warpScan(SmallVector<Value> &srcValues,
+static void warpScan(SmallVector<SmallVector<Value>> &srcValues,
                      ConversionPatternRewriter &rewriter,
                      ScanLoweringHelper &helper, Value laneIdAxis) {
   Location loc = helper.getLoc();
@@ -77,12 +86,18 @@ static void warpScan(SmallVector<Value> &srcValues,
     if (elementIdx != scanElementsPerThreads - 1)
       continue;
     // Reduce within warps.
-    Value acc = srcValues[srcIndex];
-    for (unsigned i = 1; i <= (scanDim) / 2; i = i << 1) {
-      Value shfl = shflUpSync(loc, rewriter, acc, i * threadStride);
-      Value tempAcc = accumulate(rewriter, helper.getCombineOp(), shfl, acc);
+    SmallVector<Value> acc = srcValues[srcIndex];
+    for (unsigned i = 1; i <= scanDim / 2; i <<= 1) {
+      SmallVector<Value> shfl(acc.size());
+      for (unsigned j = 0; j < acc.size(); ++j) {
+        shfl[j] = shflUpSync(loc, rewriter, acc[j], i * threadStride);
+      }
+      SmallVector<Value> tempAcc =
+          accumulate(rewriter, helper.getCombineOp(), shfl, acc);
       Value mask = icmp_slt(laneIdAxis, i32_val(i));
-      acc = select(mask, acc, tempAcc);
+      for (unsigned j = 0; j < acc.size(); ++j) {
+        acc[j] = select(mask, acc[j], tempAcc[j]);
+      }
     }
     srcValues[srcIndex] = acc;
   }
@@ -94,10 +109,11 @@ static void warpScan(SmallVector<Value> &srcValues,
 //          -----------------------------------------------------------------
 // chunk 0: | acc[0] warp 0 | acc[1] warp 0 | acc[0] warp 1 | acc[1] warp 1 |
 // chunk 1: | acc[0] warp 0 | acc[1] warp 0 | acc[0] warp 1 | acc[1] warp 1 |
-static void storeWarpAccumulator(SmallVector<Value> &srcValues,
+static void storeWarpAccumulator(SmallVector<SmallVector<Value>> &srcValues,
                                  ConversionPatternRewriter &rewriter,
                                  ScanLoweringHelper &helper, Value laneId,
-                                 Value warpId, Value baseSharedMemPtr,
+                                 Value warpId, SmallVector<Value> smemBases,
+                                 SmallVector<Type> smemTypes,
                                  Value parallelLaneId) {
   Location loc = helper.getLoc();
   unsigned scanElementsPerThreads = helper.getAxisNumElementsPerThread();
@@ -111,13 +127,16 @@ static void storeWarpAccumulator(SmallVector<Value> &srcValues,
     // Only consider the last element of each contiguous chunk of elements.
     if (elementIdx != scanElementsPerThreads - 1)
       continue;
-    Value lastElement = srcValues[srcIndex];
+    auto lastElement = srcValues[srcIndex];
     Value mask = icmp_eq(laneId, i32_val(scanDim - 1));
     Value index = add(parallelLaneId, mul(warpId, i32_val(numParallelLane)));
     index = add(index, i32_val(chunkId * numParallelLane * axisNumWarps));
-    Value writePtr = gep(baseSharedMemPtr.getType(), lastElement.getType(),
-                         baseSharedMemPtr, index);
-    storeShared(rewriter, loc, writePtr, lastElement, mask);
+
+    for (unsigned i = 0; i < lastElement.size(); ++i) {
+      Value writePtr = gep(ptr_ty(rewriter.getContext(), 3), smemTypes[i],
+                           smemBases[i], index);
+      storeShared(rewriter, loc, writePtr, lastElement[i], mask);
+    }
     chunkId++;
   }
 }
@@ -127,11 +146,12 @@ static void storeWarpAccumulator(SmallVector<Value> &srcValues,
 // with the right elements. Within a given contiguous element chunk we update
 // all the elements by accumulating the value from the last element of the
 // reduced value from the previous lane.
-static void AddPartialReduce(SmallVector<Value> &srcValues,
+static void AddPartialReduce(SmallVector<SmallVector<Value>> &srcValues,
                              ConversionPatternRewriter &rewriter,
-                             ScanLoweringHelper &helper, Value sharedMemoryPtr,
-                             Value warpId, Value laneIdAxis,
-                             Value parallelLaneId) {
+                             ScanLoweringHelper &helper,
+                             SmallVector<Value> smemBases,
+                             SmallVector<Type> smemTypes, Value warpId,
+                             Value laneIdAxis, Value parallelLaneId) {
   Location loc = helper.getLoc();
   unsigned numParallelLane = helper.getNonAxisNumThreadsPerCTA();
   unsigned scanElementsPerThreads = helper.getAxisNumElementsPerThread();
@@ -143,8 +163,8 @@ static void AddPartialReduce(SmallVector<Value> &srcValues,
   Value maskFirstLane = icmp_eq(laneIdAxis, i32_val(0));
   Value maskFirstThread = and_(maskFirstWarp, maskFirstLane);
   struct Accumulator {
-    Value acc;
-    Value maskedAcc;
+    SmallVector<Value> acc;
+    SmallVector<Value> maskedAcc;
   };
   unsigned numScanBlocks = helper.getAxisNumBlocks();
   unsigned numParallelBlocks = helper.getNonAxisNumBlocks();
@@ -174,10 +194,15 @@ static void AddPartialReduce(SmallVector<Value> &srcValues,
     for (unsigned i = 0; i < axisNumWarps; ++i) {
       Value index = add(parallelLaneId, i32_val(numParallelLane *
                                                 (i + chunkId * axisNumWarps)));
-      Value ptr = gep(sharedMemoryPtr.getType(), srcValues[srcIndex].getType(),
-                      sharedMemoryPtr, index);
-      Value partialReduce = load(srcValues[srcIndex].getType(), ptr);
-      if (!accumulator.acc) {
+      SmallVector<Value> partialReduce(helper.getNumOperands());
+      for (unsigned j = 0; j < helper.getNumOperands(); ++j) {
+        auto elemTy = smemTypes[j];
+        Value ptr =
+            gep(ptr_ty(rewriter.getContext(), 3), elemTy, smemBases[j], index);
+        partialReduce[j] = load(elemTy, ptr);
+      }
+
+      if (accumulator.acc.size() == 0) {
         accumulator.acc = partialReduce;
         accumulator.maskedAcc = partialReduce;
         continue;
@@ -185,30 +210,40 @@ static void AddPartialReduce(SmallVector<Value> &srcValues,
       accumulator.acc = accumulate(rewriter, helper.getCombineOp(),
                                    accumulator.acc, partialReduce);
       Value mask = icmp_slt(warpId, i32_val(i + 1));
-      accumulator.maskedAcc =
-          select(mask, accumulator.maskedAcc, accumulator.acc);
+      for (unsigned j = 0; j < helper.getNumOperands(); ++j) {
+        accumulator.maskedAcc[j] =
+            select(mask, accumulator.maskedAcc[j], accumulator.acc[j]);
+      }
     }
-    Value temp = accumulate(rewriter, helper.getCombineOp(),
-                            accumulator.maskedAcc, srcValues[srcIndex]);
+    auto temp = accumulate(rewriter, helper.getCombineOp(),
+                           accumulator.maskedAcc, srcValues[srcIndex]);
     if (axisBlockId == 0) {
       // For the first warp and first chunk we don't have anything to
       // accumulate.
-      temp = select(maskFirstWarp, srcValues[srcIndex], temp);
+      auto val = srcValues[srcIndex];
+      for (unsigned i = 0; i < helper.getNumOperands(); ++i) {
+        temp[i] = select(maskFirstWarp, val[i], temp[i]);
+      }
     }
     srcValues[srcIndex] = temp;
     // Update the rest of the contiguous elements.
-    Value lastElement =
-        shflUpSync(loc, rewriter, srcValues[srcIndex], threadStride);
-    lastElement = select(maskFirstLane, accumulator.maskedAcc, lastElement);
+    SmallVector<Value> lastElement(helper.getNumOperands());
+    for (unsigned i = 0; i < helper.getNumOperands(); ++i) {
+      auto elem = shflUpSync(loc, rewriter, temp[i], threadStride);
+      lastElement[i] = select(maskFirstLane, accumulator.maskedAcc[i], elem);
+    }
     for (unsigned i = 1; i < scanElementsPerThreads; ++i) {
-      Value laneValue = srcValues[srcIndex - i * elementStride];
+      auto laneValue = srcValues[srcIndex - i * elementStride];
       laneValue =
           accumulate(rewriter, helper.getCombineOp(), lastElement, laneValue);
       if (axisBlockId == 0) {
         // For the first warp and first chunk we don't have anything to
         // accumulate.
-        laneValue = select(maskFirstThread,
-                           srcValues[srcIndex - i * elementStride], laneValue);
+        for (unsigned j = 0; j < helper.getNumOperands(); ++j) {
+          laneValue[j] =
+              select(maskFirstThread,
+                     srcValues[srcIndex - i * elementStride][j], laneValue[j]);
+        }
       }
       srcValues[srcIndex - i * elementStride] = laneValue;
     }
@@ -219,7 +254,7 @@ static void AddPartialReduce(SmallVector<Value> &srcValues,
   }
 }
 
-static void AddPartialReduceOneWarp(SmallVector<Value> &srcValues,
+static void AddPartialReduceOneWarp(SmallVector<SmallVector<Value>> &srcValues,
                                     ConversionPatternRewriter &rewriter,
                                     ScanLoweringHelper &helper, Value warpId,
                                     Value laneIdAxis, Value laneIdLast) {
@@ -239,8 +274,8 @@ static void AddPartialReduceOneWarp(SmallVector<Value> &srcValues,
   assert(numScanBlocks * numParallelBlocks * parallelElementsPerThread *
              scanElementsPerThreads ==
          srcValues.size());
-  SmallVector<Value> accumulators(numParallelBlocks *
-                                  parallelElementsPerThread);
+  SmallVector<SmallVector<Value>> accumulators(numParallelBlocks *
+                                               parallelElementsPerThread);
   unsigned chunkId = 0;
   unsigned blockStride = helper.getAxisBlockStride();
   for (unsigned srcIndex = 0; srcIndex < srcValues.size(); srcIndex++) {
@@ -254,7 +289,7 @@ static void AddPartialReduceOneWarp(SmallVector<Value> &srcValues,
         ((blockId / blockStride) / numScanBlocks) * blockStride;
     unsigned accumulatorIndex = chunkId % parallelElementsPerThread +
                                 parallelBlockId * parallelElementsPerThread;
-    Value &accumulator = accumulators[accumulatorIndex];
+    auto &accumulator = accumulators[accumulatorIndex];
     unsigned axisBlockId = (blockId / blockStride) % numScanBlocks;
     if (axisBlockId == 0) // First chunk and first block
       accumulator = srcValues[srcIndex];
@@ -262,25 +297,31 @@ static void AddPartialReduceOneWarp(SmallVector<Value> &srcValues,
       srcValues[srcIndex] = accumulate(rewriter, helper.getCombineOp(),
                                        accumulator, srcValues[srcIndex]);
     // Update the rest of the contiguous elements.
-    Value lastElement = srcValues[srcIndex];
+    auto lastElement = srcValues[srcIndex];
     if (scanDim > 1) {
-      lastElement =
-          shflUpSync(loc, rewriter, srcValues[srcIndex], threadStride);
-      lastElement = select(maskFirstLane, accumulator, lastElement);
-      if (numScanBlocks > 1)
-        // Update accumulator with the value from the last lane.
-        accumulator =
-            shflIdxSync(loc, rewriter, srcValues[srcIndex], laneIdLast);
+      for (unsigned i = 0; i < helper.getNumOperands(); ++i) {
+        lastElement[i] =
+            shflUpSync(loc, rewriter, srcValues[srcIndex][i], threadStride);
+        lastElement[i] = select(maskFirstLane, accumulator[i], lastElement[i]);
+        if (numScanBlocks > 1)
+          // Update accumulator with the value from the last lane.
+          accumulator[i] =
+              shflIdxSync(loc, rewriter, srcValues[srcIndex][i], laneIdLast);
+      }
     }
     for (unsigned i = 1; i < scanElementsPerThreads; ++i) {
-      Value laneValue = srcValues[srcIndex - i * elementStride];
+      auto laneValue = srcValues[srcIndex - i * elementStride];
       laneValue =
           accumulate(rewriter, helper.getCombineOp(), lastElement, laneValue);
-      if (axisBlockId == 0)
-        // For the first warp and first chunk we don't have anything to
-        // accumulate.
-        laneValue = select(maskFirstThread,
-                           srcValues[srcIndex - i * elementStride], laneValue);
+      if (axisBlockId == 0) {
+        for (unsigned j = 0; j < helper.getNumOperands(); ++j) {
+          // For the first warp and first chunk we don't have anything to
+          // accumulate.
+          laneValue[j] =
+              select(maskFirstThread,
+                     srcValues[srcIndex - i * elementStride][j], laneValue[j]);
+        }
+      }
       srcValues[srcIndex - i * elementStride] = laneValue;
     }
     // For the next chunk start back from the value containing the
@@ -289,12 +330,13 @@ static void AddPartialReduceOneWarp(SmallVector<Value> &srcValues,
   }
 }
 
+namespace AMD{
 namespace {
 struct ScanOpConversion
-    : public ConvertTritonGPUOpToLLVMPattern<triton::ScanOp> {
+    : public ConvertTritonGPUReduceScanToLLVMPattern<triton::ScanOp> {
 public:
-  using ConvertTritonGPUOpToLLVMPattern<
-      triton::ScanOp>::ConvertTritonGPUOpToLLVMPattern;
+  using ConvertTritonGPUReduceScanToLLVMPattern<
+      triton::ScanOp>::ConvertTritonGPUReduceScanToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(triton::ScanOp op, OpAdaptor adaptor,
@@ -382,6 +424,25 @@ ScanOpConversion::getDelinearizedIds(ConversionPatternRewriter &rewriter,
   return std::make_tuple(laneIdAxis, warpIdAxis, flatIdParallel);
 }
 
+SmallVector<SmallVector<Value>>
+unpackInputs(Location loc, triton::ScanOp op, triton::ScanOpAdaptor adaptor,
+             ConversionPatternRewriter &rewriter,
+             TritonGPUToLLVMTypeConverter &converter) {
+  auto types = op.getInputTypes();
+  auto operands = adaptor.getOperands();
+  unsigned srcElems = getTotalElemsPerThread(types[0]);
+  SmallVector<SmallVector<Value>> srcValues(srcElems);
+  for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+    auto values = converter.unpackLLElements(loc, operands[i], rewriter);
+
+    assert(values.size() == srcValues.size());
+    for (unsigned j = 0; j < srcValues.size(); ++j) {
+      srcValues[j].push_back(values[j]);
+    }
+  }
+  return srcValues;
+}
+
 // Lowering using warp shuffle operations to do warp level scan.
 LogicalResult
 ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
@@ -400,12 +461,10 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
 
   auto [laneIdAxis, warpIdAxis, flatIdParallel] =
       getDelinearizedIds(rewriter, helper, laneId, warpId);
-  auto input = adaptor.getOperands()[0];
-  auto type = op.getOperand(0).getType().cast<RankedTensorType>();
   auto axisNumWarps = helper.getAxisNumWarpsWithUniqueData();
   warpIdAxis = urem(warpIdAxis, i32_val(axisNumWarps));
-  SmallVector<Value> srcValues =
-      getTypeConverter()->unpackLLElements(loc, input, rewriter);
+  auto srcValues =
+      unpackInputs(loc, op, adaptor, rewriter, *getTypeConverter());
 
   // Scan contigous elements in a thread and update `srcValues`.
   scanThreadContiguousElements(srcValues, rewriter, helper);
@@ -416,18 +475,22 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
   if (axisNumWarps > 1) {
     // Slow path for the case where there are multiple warps with unique data on
     // the axis.
-    Type elemPtrTys = LLVM::LLVMPointerType::get(rewriter.getContext(), 3);
-    Value baseSharedMemPtr = bitcast(
-        getSharedMemoryBase(loc, rewriter, op.getOperation()), elemPtrTys);
+    auto elems = helper.getScratchSizeInElems();
+    SmallVector<Value> smemBases = getSmemBases(op, elems, rewriter);
+    SmallVector<Type> smemTypes(op.getNumOperands());
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      smemTypes[i] = getElementType(op, i);
+    }   
+
     // Store the partial reducing for each warp into shared memory.
     storeWarpAccumulator(srcValues, rewriter, helper, laneIdAxis, warpIdAxis,
-                         baseSharedMemPtr, flatIdParallel);
+                         smemBases, smemTypes, flatIdParallel);
     barrier();
     // Read back the partial reduction of each warp and accumulate them based on
     // warpId. Then update each chunk of contiguous elements by adding the
     // accumulated value from the previous lane.
-    AddPartialReduce(srcValues, rewriter, helper, baseSharedMemPtr, warpIdAxis,
-                     laneIdAxis, flatIdParallel);
+    AddPartialReduce(srcValues, rewriter, helper, smemBases, smemTypes,
+                     warpIdAxis, laneIdAxis, flatIdParallel);
   } else if (srcValues.size() > 1) {
     // Fast path for the case where there is only one warp with unique data on
     // the axis.
@@ -441,14 +504,30 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
                             laneIdLast);
   } // else axisNumWarps == 1 and srcValues.size() == 1, nothing to do.
 
-  Value results = getTypeConverter()->packLLElements(loc, srcValues, rewriter,
-                                                     input.getType());
+  auto transpose = [](const SmallVector<SmallVector<Value>> &v) {
+    assert(v.size() > 0 && v[0].size() > 0);
+    auto ret = SmallVector<SmallVector<Value>>(v[0].size(),
+                                               SmallVector<Value>(v.size()));
+    for (int i = 0; i < v.size(); ++i) {
+      for (int j = 0; j < v[0].size(); ++j) {
+        ret[j][i] = v[i][j];
+      }
+    }
+    return ret;
+  };
+
+  SmallVector<Value> results(op.getNumOperands());
+  auto valuesTransposed = transpose(srcValues);
+  for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+    auto resultTy = op.getResult()[i].getType().dyn_cast<RankedTensorType>();
+    results[i] = getTypeConverter()->packLLElements(loc, valuesTransposed[i],
+                                                    rewriter, resultTy);
+  }
   rewriter.replaceOp(op, results);
   return success();
 }
 } // namespace
 
-namespace AMD{
 void populateScanOpToLLVMPatterns(
     TritonGPUToLLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     int numWarps, ModuleAxisInfoAnalysis &axisInfoAnalysis,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -97,7 +97,7 @@ struct BroadcastOpConversion
     auto srcOffsets = emitOffsetForLayout(srcLayout, srcTy);
     auto resultOffsets = emitOffsetForLayout(resultLayout, resultTy);
     SmallVector<Value> srcVals =
-        getTypeConverter()->unpackLLElements(loc, src, rewriter, srcTy);
+        getTypeConverter()->unpackLLElements(loc, src, rewriter);
 
     DenseMap<SmallVector<unsigned>, Value, SmallVectorKeyInfo> srcValues;
     for (size_t i = 0; i < srcOffsets.size(); i++) {
@@ -154,8 +154,7 @@ struct PrintOpConversion
       for (size_t i = 0; i < op.getNumOperands(); i++) {
         // Elements of the tensor that are resident in this GPU thread.
         auto elems = getTypeConverter()->unpackLLElements(
-            loc, adaptor.getOperands()[i], rewriter,
-            op.getOperand(i).getType());
+            loc, adaptor.getOperands()[i], rewriter);
 
         // Get the indices of `elems` within the tensor.  Note that if `elems`
         // has an "interesting" layout, then these will not be in any
@@ -422,7 +421,7 @@ struct AssertOpConversion
     auto loc = op.getLoc();
     auto ctx = rewriter.getContext();
     auto elems = getTypeConverter()->unpackLLElements(
-        loc, adaptor.getCondition(), rewriter, op.getCondition().getType());
+        loc, adaptor.getCondition(), rewriter);
     auto elemTy = elems[0].getType();
     Value condition = int_val(elemTy.getIntOrFloatBitWidth(), 0);
     for (auto elem : elems) {
@@ -680,10 +679,9 @@ struct AddPtrOpConversion
                                               .getPointeeType());
       Type ptrTy =
           getTypeConverter()->convertType(resultTensorTy.getElementType());
-      auto ptrs = getTypeConverter()->unpackLLElements(loc, adaptor.getPtr(),
-                                                       rewriter, ptrTy);
+      auto ptrs = getTypeConverter()->unpackLLElements(loc, adaptor.getPtr(), rewriter);
       auto offsets = getTypeConverter()->unpackLLElements(
-          loc, adaptor.getOffset(), rewriter, offsetTy);
+          loc, adaptor.getOffset(), rewriter);
       SmallVector<Value> resultVals(elems);
       for (unsigned i = 0; i < elems; ++i) {
         resultVals[i] = gep(ptrTy, elemTy, ptrs[i], offsets[i]);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVMBase.h
@@ -15,6 +15,7 @@
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Target/PTX/TmaMetadata.h"
 #include <set>
+#include <type_traits>
 
 #define DEBUG_TYPE "ttgpu_to_llvm"
 
@@ -172,6 +173,11 @@ struct CacheKeyDenseMapInfo {
            LHS.withCTAOffset == RHS.withCTAOffset;
   }
 };
+
+namespace mlir::triton {
+class ReduceOp;
+class ScanOp;
+} // namespace mlir::triton
 
 namespace AMD{
 class ConvertTritonGPUOpToLLVMPatternBase {
@@ -1336,6 +1342,55 @@ protected:
     return (TritonGPUToLLVMTypeConverter *)ret;
   }
 };
-}
 
+template <typename SourceOp>
+class ConvertTritonGPUReduceScanToLLVMPattern
+    : public ConvertTritonGPUOpToLLVMPattern<SourceOp> {
+public:
+  // Make sure the class is only instantiated with Reduce and Scan
+  static_assert(std::is_same_v<SourceOp, ReduceOp> ||
+                std::is_same_v<SourceOp, ScanOp>);
+
+  using ConvertTritonGPUOpToLLVMPatternBase::getSharedMemoryBase;
+  using ConvertTritonGPUOpToLLVMPatternBase::getTypeConverter;
+  using ConvertTritonGPUOpToLLVMPattern<
+      SourceOp>::ConvertTritonGPUOpToLLVMPattern;
+
+  // Return the pointee type of the shared memory pointer for operand i.
+  Type getElementType(SourceOp op, int i) const {
+    auto ty = op.getInputTypes()[i].getElementType();
+    return getTypeConverter()->convertType(ty);
+  }
+
+  // Helper to compute the smem bases in both reductions and scans
+  SmallVector<Value> getSmemBases(SourceOp op, unsigned elems,
+                                  ConversionPatternRewriter &rewriter) const {
+    auto loc = op.getLoc();
+    // indices will store the index of the op operands in descending order
+    // of their bitwidths
+    std::vector<unsigned> indices(op.getNumOperands());
+    std::iota(indices.begin(), indices.end(), 0);
+
+    std::sort(indices.begin(), indices.end(), [&](unsigned i, unsigned j) {
+      return op.getElementTypes()[i].getIntOrFloatBitWidth() >
+             op.getElementTypes()[j].getIntOrFloatBitWidth();
+    });
+    // Assign base index to each operand in their order in indices
+    std::map<unsigned, Value> indexToBase;
+    indexToBase[indices[0]] =
+        getSharedMemoryBase(loc, rewriter, op.getOperation());
+    for (unsigned i = 1; i < op.getNumOperands(); ++i) {
+      indexToBase[indices[i]] = gep(
+          ptr_ty(rewriter.getContext(), 3), getElementType(op, indices[i - 1]),
+          indexToBase[indices[i - 1]], i32_val(elems));
+    }
+    // smemBases[k] is the base pointer for the k-th operand
+    SmallVector<Value> smemBases(op.getNumOperands());
+    for (unsigned i = 0; i < op.getNumOperands(); ++i) {
+      smemBases[i] = indexToBase[i];
+    }
+    return smemBases;
+  }
+};
+}
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVMBase.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVMBase.h
@@ -531,8 +531,7 @@ public:
     unsigned minVec = std::min(outVec, inVec);
     unsigned numElems = triton::gpu::getTotalElemsPerThread(srcTy);
     assert(numElems == srcIndices.size());
-    auto inVals =
-        getTypeConverter()->unpackLLElements(loc, llSrc, rewriter, srcTy);
+    auto inVals = getTypeConverter()->unpackLLElements(loc, llSrc, rewriter);
     auto wordTy = vec_ty(elemTy, minVec);
     Value word;
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TypeConverter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TypeConverter.cpp
@@ -102,8 +102,7 @@ Value TritonGPUToLLVMTypeConverter::packLLElements(
 }
 
 SmallVector<Value> TritonGPUToLLVMTypeConverter::unpackLLElements(
-    Location loc, Value llvmStruct, ConversionPatternRewriter &rewriter,
-    Type type) {
+    Location loc, Value llvmStruct, ConversionPatternRewriter &rewriter) {
   assert(bool(llvmStruct) && "can not unpack null values");
   if (llvmStruct.getType().isIntOrIndexOrFloat() ||
       llvmStruct.getType().isa<triton::PointerType>() ||

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TypeConverter.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TypeConverter.h
@@ -23,8 +23,7 @@ public:
                        ConversionPatternRewriter &rewriter, Type type);
 
   SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
-                                      ConversionPatternRewriter &rewriter,
-                                      Type type);
+                                      ConversionPatternRewriter &rewriter);
 
   Type convertTritonTensorType(RankedTensorType type);
 };

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -93,7 +93,7 @@ static Value commonShflSync(Location loc, ConversionPatternRewriter &rewriter,
   }
 
 #ifdef USE_ROCM
-  auto mod = val.getParentBlock()->getParentOp()->getParentOfType<mlir::ModuleOp>();
+  auto mod = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   Value threadId = rewriter.create<::mlir::gpu::ThreadIdOp>(loc, ::mlir::gpu::Dimension::x);
   threadId = rewriter.create<arith::IndexCastOp>(loc, i32_ty, threadId);
   unsigned iWarpSize = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ViewOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ViewOpToLLVM.cpp
@@ -122,10 +122,10 @@ struct CatOpConversion : public ConvertTritonGPUOpToLLVMPattern<CatOp> {
         this->getTypeConverter()->convertType(resultTy.getElementType());
     SmallVector<Type> types(elems, elemTy);
     // unpack input values
-    auto lhsVals = getTypeConverter()->unpackLLElements(
-        loc, adaptor.getLhs(), rewriter, op.getOperand(0).getType());
-    auto rhsVals = getTypeConverter()->unpackLLElements(
-        loc, adaptor.getRhs(), rewriter, op.getOperand(1).getType());
+    auto lhsVals =
+        getTypeConverter()->unpackLLElements(loc, adaptor.getLhs(), rewriter);
+    auto rhsVals =
+        getTypeConverter()->unpackLLElements(loc, adaptor.getRhs(), rewriter);
     // concatenate (and potentially reorder) values
     SmallVector<Value> retVals;
     for (Value v : lhsVals)
@@ -166,10 +166,10 @@ struct InterleaveOpConversion
     Location loc = op->getLoc();
     auto resultTy = op.getType().cast<RankedTensorType>();
 
-    SmallVector<Value> lhsVals = getTypeConverter()->unpackLLElements(
-        loc, adaptor.getLhs(), rewriter, op.getLhs().getType());
-    SmallVector<Value> rhsVals = getTypeConverter()->unpackLLElements(
-        loc, adaptor.getRhs(), rewriter, op.getRhs().getType());
+    SmallVector<Value> lhsVals =
+        getTypeConverter()->unpackLLElements(loc, adaptor.getLhs(), rewriter);
+    SmallVector<Value> rhsVals =
+        getTypeConverter()->unpackLLElements(loc, adaptor.getRhs(), rewriter);
     assert(lhsVals.size() == rhsVals.size());
 
     SmallVector<Value> interleavedVals;
@@ -218,7 +218,7 @@ struct ReshapeOpConversion : public ConvertTritonGPUOpToLLVMPattern<ReshapeOp> {
     }
 
     auto vals = this->getTypeConverter()->unpackLLElements(
-        loc, adaptor.getSrc(), rewriter, op.getOperand().getType());
+        loc, adaptor.getSrc(), rewriter);
     Value ret =
         this->getTypeConverter()->packLLElements(loc, vals, rewriter, resultTy);
     rewriter.replaceOp(op, ret);
@@ -239,7 +239,7 @@ struct ExpandDimsOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
     auto srcVals = this->getTypeConverter()->unpackLLElements(
-        loc, adaptor.getSrc(), rewriter, op.getOperand().getType());
+        loc, adaptor.getSrc(), rewriter);
 
     auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
     auto resultTy = op.getType().template cast<RankedTensorType>();


### PR DESCRIPTION
A few commits were added recently that are needed in the AMD backend
- https://github.com/openai/triton/commit/5baa3c1a221a6397769d40acca126d3f1832064e
- https://github.com/openai/triton/commit/7afddce963e9290368b80cf5710d9ae69229a3ed

This PR adds propagates this code to the AMD backend. 
This also includes a small fix to how the moduleOp is retrieved in `commonShflSync`