### PR TITLE
[Utility] Improve some utility functions.

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -177,20 +177,11 @@ inline SmallVector<T_OUT> convertType(ArrayRef<T_IN> in) {
 template <typename Int> Int product(llvm::ArrayRef<Int> arr) {
   return std::accumulate(arr.begin(), arr.end(), 1, std::multiplies{});
 }
+template <typename VecT> auto product(const VecT &vec) {
+  return product(llvm::ArrayRef(vec));
+}
 
 template <typename Int> Int ceil(Int m, Int n) { return (m + n - 1) / n; }
-
-/// output[i] = input[order[i]]
-template <typename T, typename RES_T = T>
-SmallVector<RES_T> reorder(ArrayRef<T> input, ArrayRef<unsigned> order) {
-  size_t rank = order.size();
-  assert(input.size() == rank);
-  SmallVector<RES_T> result(rank);
-  for (auto it : llvm::enumerate(order)) {
-    result[it.index()] = input[it.value()];
-  }
-  return result;
-}
 
 /// Get the highest power of 2 divisor of an integer.
 template <typename T> T highestPowOf2Divisor(T n) {
@@ -374,58 +365,135 @@ triton::MakeTensorPtrOp getMakeTensorPtrOp(Value v);
 
 namespace triton {
 
-template <typename T>
-SmallVector<T> applyPermutation(ArrayRef<T> vec,
-                                ArrayRef<int32_t> permutation) {
+// Many functions here have two overloads, fn(ArrayRef<T>) and fn(const VecT&).
+// This is helpful because C++ won't both convert a vector to ArrayRef *and*
+// infer the proper type T in one step.  So without the second overload, we
+// would have to explicitly convert most arguments to ArrayRef at the callsite.
+
+// Better version of llvm::join.  This one works when T is an integer or any
+// other type which defines operator<<(raw_ostream).
+template <typename T> std::string join(ArrayRef<T> elems, StringRef sep) {
+  std::string ret;
+  llvm::raw_string_ostream s(ret);
+  if (elems.empty()) {
+    return ret;
+  }
+
+  s << elems[0];
+  for (int i = 1; i < elems.size(); i++) {
+    s << sep << elems[i];
+  }
+  return ret;
+}
+
+template <typename VecT> std::string join(const VecT &elems, StringRef sep) {
+  return join(ArrayRef(elems), sep);
+}
+
+template <typename T, typename U>
+SmallVector<T> applyPermutation(ArrayRef<T> vec, ArrayRef<U> permutation) {
+  static_assert(std::is_integral_v<U>);
   assert(vec.size() == permutation.size());
 
   // Check that `permutation` is actually a permutation.
 #ifndef NDEBUG
-  SmallVector<int32_t> sortedPerm(permutation);
+  SmallVector<U> sortedPerm(permutation);
+  llvm::sort(sortedPerm);
+  for (U i = 0; i < static_cast<U>(sortedPerm.size()); i++) {
+    assert(sortedPerm[i] == i);
+  }
+#endif
+
+  SmallVector<T> ret;
+  ret.reserve(vec.size());
+  for (const U &i : permutation) {
+    ret.push_back(vec[i]);
+  }
+  return ret;
+}
+
+template <typename VecT, typename PermT>
+auto applyPermutation(const VecT &vec, const PermT &permutation) {
+  return applyPermutation(ArrayRef(vec), ArrayRef(permutation));
+}
+
+template <typename T>
+[[nodiscard]] SmallVector<T> inversePermutation(ArrayRef<T> permutation) {
+  // Check that `permutation` is actually a permutation.
+#ifndef NDEBUG
+  SmallVector<T> sortedPerm(permutation);
   llvm::sort(sortedPerm);
   for (int i = 0; i < sortedPerm.size(); ++i) {
     assert(sortedPerm[i] == i);
   }
 #endif
 
-  SmallVector<T> result;
-  result.reserve(vec.size());
-  for (auto i : permutation) {
-    result.push_back(vec[i]);
+  SmallVector<T> ret(permutation.size());
+  for (int i = 0; i < permutation.size(); ++i) {
+    ret[permutation[i]] = i;
   }
-  return result;
+  return ret;
 }
 
-// These overloads are necessary to get applyPermutation() to work without an
-// explicit cast of the operands to ArrayRef.
-inline SmallVector<int32_t> applyPermutation(ArrayRef<int32_t> vec,
-                                             ArrayRef<int32_t> permutation) {
-  return applyPermutation<int32_t>(vec, permutation);
-}
-inline SmallVector<unsigned> applyPermutation(ArrayRef<unsigned> vec,
-                                              ArrayRef<int32_t> permutation) {
-  return applyPermutation<unsigned>(vec, permutation);
-}
-inline SmallVector<int64_t> applyPermutation(ArrayRef<int64_t> vec,
-                                             ArrayRef<int32_t> permutation) {
-  return applyPermutation<int64_t>(vec, permutation);
-}
-inline SmallVector<Value> applyPermutation(ArrayRef<Value> vec,
-                                           ArrayRef<int32_t> permutation) {
-  return applyPermutation<Value>(vec, permutation);
+template <typename VecT>
+[[nodiscard]] auto inversePermutation(const VecT &permutation) {
+  return inversePermutation(ArrayRef(permutation));
 }
 
-[[nodiscard]] SmallVector<int32_t>
-inversePermutation(ArrayRef<int32_t> permutation);
+template <typename T, typename U>
+[[nodiscard]] SmallVector<T> gather(ArrayRef<T> elems, ArrayRef<U> indices) {
+  SmallVector<T> ret;
+  ret.reserve(indices.size());
+  for (const U &i : indices) {
+    ret.push_back(elems[i]);
+  }
+  return ret;
+}
+
+template <typename VecT, typename IdxT>
+[[nodiscard]] auto gather(const VecT &elems, const IdxT &indices) {
+  return gather(ArrayRef(elems), ArrayRef(indices));
+}
 
 // Is `vec` [0, 1, ..., n]?  Returns true on empty list.
 template <typename T> bool isIota(ArrayRef<T> vec) {
+  static_assert(std::is_integral_v<T>);
   for (T i = 0; i < vec.size(); ++i) {
     if (vec[i] != i) {
       return false;
     }
   }
   return true;
+}
+
+template <typename VecT> bool isIota(const VecT &vec) {
+  return isIota(ArrayRef(vec));
+}
+
+// Is `vals` some permutation of the numbers 0..(vals.size()-1)?
+template <typename T> bool isPermutationOfIota(ArrayRef<T> vals) {
+  SmallVector<T> sorted(vals);
+  llvm::sort(sorted);
+  return isIota(sorted);
+}
+
+template <typename VecT> bool IsPermutationOfIota(const VecT &vec) {
+  return isPermutationOfIota(ArrayRef(vec));
+}
+
+// Is `vec` [i, i+1, ..., i+n]?  Returns true on empty list.
+template <typename T> bool isConsecutive(ArrayRef<T> vec) {
+  static_assert(std::is_integral_v<T>);
+  for (int i = 1; i < vec.size(); i++) {
+    if (vec[i] != vec[i - 1] + 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename VecT> bool isConsecutive(const VecT &vec) {
+  return isConsecutive(ArrayRef(vec));
 }
 
 } // namespace triton

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -846,12 +846,4 @@ triton::MakeTensorPtrOp getMakeTensorPtrOp(Value v) {
   llvm_unreachable("Unable to getMakeTensorPtr()");
 }
 
-SmallVector<int32_t> triton::inversePermutation(ArrayRef<int32_t> permutation) {
-  SmallVector<int32_t> ret(permutation.size());
-  for (int i = 0; i < permutation.size(); ++i) {
-    ret[permutation[i]] = i;
-  }
-  return ret;
-}
-
 } // namespace mlir

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -640,9 +640,8 @@ public:
       SmallVector<unsigned> order = triton::gpu::getOrder(encoding);
       if (rank != order.size())
         return resultVals;
-      ArrayRef<unsigned> orderRef(order);
-      elemsPerThread = reorder(ArrayRef<unsigned>(elemsPerThread), orderRef);
-      constancy = reorder(ArrayRef<int64_t>(constancy), orderRef);
+      elemsPerThread = applyPermutation(elemsPerThread, order);
+      constancy = applyPermutation(constancy, order);
     }
 
     SmallVector<unsigned> strides(rank, 1);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -178,7 +178,7 @@ SmallVector<Value> delinearize(ConversionPatternRewriter &rewriter,
                                ArrayRef<unsigned> order) {
   unsigned rank = shape.size();
   assert(rank == order.size());
-  auto reordered = reorder(shape, order);
+  auto reordered = applyPermutation(shape, order);
   SmallVector<Value> reorderedMultiDim(rank);
   if (auto constantOp = linear.getDefiningOp<arith::ConstantOp>()) {
     unsigned intVal =
@@ -227,8 +227,8 @@ SmallVector<Value> delinearize(ConversionPatternRewriter &rewriter,
 Value linearize(ConversionPatternRewriter &rewriter, Location loc,
                 ArrayRef<Value> multiDim, ArrayRef<unsigned> shape,
                 ArrayRef<unsigned> order) {
-  return linearize(rewriter, loc, reorder<Value>(multiDim, order),
-                   reorder<unsigned>(shape, order));
+  return linearize(rewriter, loc, applyPermutation(multiDim, order),
+                   applyPermutation(shape, order));
 }
 
 Value linearize(ConversionPatternRewriter &rewriter, Location loc,

--- a/lib/Conversion/TritonGPUToLLVM/Utility.h
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.h
@@ -150,7 +150,7 @@ llvm::SmallVector<T> getMultiDimIndex(T linearIndex, llvm::ArrayRef<T> shape,
                                       llvm::ArrayRef<unsigned> order) {
   size_t rank = shape.size();
   assert(rank == order.size());
-  auto reordered = reorder(shape, order);
+  auto reordered = applyPermutation(shape, order);
   auto reorderedMultiDim = getMultiDimIndexImpl<T>(linearIndex, reordered);
   llvm::SmallVector<T> multiDim(rank);
   for (unsigned i = 0; i < rank; ++i) {
@@ -180,8 +180,8 @@ template <typename T>
 T getLinearIndex(llvm::ArrayRef<T> multiDimIndex, llvm::ArrayRef<T> shape,
                  llvm::ArrayRef<unsigned> order) {
   assert(shape.size() == order.size());
-  return getLinearIndexImpl<T>(reorder(multiDimIndex, order),
-                               reorder(shape, order));
+  return getLinearIndexImpl<T>(applyPermutation(multiDimIndex, order),
+                               applyPermutation(shape, order));
 }
 
 } // namespace triton

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -382,7 +382,7 @@ mlir::LogicalResult mlir::triton::TransOp::inferReturnTypes(
     SmallVectorImpl<Type> &inferredReturnTypes) {
   // type is the same as the input
   auto argTy = operands[0].getType().cast<RankedTensorType>();
-  auto order = properties.as<Properties *>()->order;
+  auto order = properties.as<Properties *>()->order.asArrayRef();
   SmallVector<int64_t> retShape = applyPermutation(argTy.getShape(), order);
 
   auto retEltTy = argTy.getElementType();

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -407,18 +407,6 @@ bool isExpensiveCat(CatOp cat, Attribute targetEncoding) {
   return newTotalElemsPerThread < totalElemsPerThread;
 }
 
-// Is `vals` some permutation of the numbers 0..(vals.size()-1)?
-static bool isPermutationOfIota(ArrayRef<unsigned> vals) {
-  SmallVector<unsigned, 4> sorted(vals.begin(), vals.end());
-  llvm::sort(sorted);
-  for (int i = 0; i < sorted.size(); i++) {
-    if (sorted[i] != i) {
-      return false;
-    }
-  }
-  return true;
-}
-
 LogicalResult CTALayoutAttr::verify(
     function_ref<InFlightDiagnostic()> emitError, ArrayRef<unsigned> CTAsPerCGA,
     ArrayRef<unsigned> CTASplitNum, ArrayRef<unsigned> CTAOrder) {
@@ -1879,8 +1867,7 @@ struct TritonGPUInferLayoutInterface
           getDialect()->getContext(),
           applyPermutation(layout.getCTAsPerCGA(), order),
           applyPermutation(layout.getCTASplitNum(), order),
-          applyPermutation(invOrderUnsigned,
-                           SmallVector<int32_t>(layout.getCTAOrder())));
+          applyPermutation(invOrderUnsigned, layout.getCTAOrder()));
     };
 
     if (auto enc = operandEncoding.dyn_cast<SharedEncodingAttr>()) {
@@ -1893,9 +1880,7 @@ struct TritonGPUInferLayoutInterface
       }
       resultEncoding = SharedEncodingAttr::get(
           getDialect()->getContext(), enc.getVec(), enc.getPerPhase(),
-          enc.getMaxPhase(),
-          applyPermutation(invOrderUnsigned,
-                           SmallVector<int32_t>(enc.getOrder())),
+          enc.getMaxPhase(), applyPermutation(invOrderUnsigned, enc.getOrder()),
           *ctaLayout, enc.getHasLeadingOffset());
       return success();
     }
@@ -1916,9 +1901,7 @@ struct TritonGPUInferLayoutInterface
           applyPermutation(enc.getSizePerThread(), order),
           applyPermutation(enc.getThreadsPerWarp(), order),
           applyPermutation(enc.getWarpsPerCTA(), order),
-          applyPermutation(invOrderUnsigned,
-                           SmallVector<int32_t>(enc.getOrder())),
-          *ctaLayout);
+          applyPermutation(invOrderUnsigned, enc.getOrder()), *ctaLayout);
       return success();
     }
 

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -599,7 +599,7 @@ SmallVector<Value> delinearize(OpBuilder &b, Location loc, Value linear,
                                ArrayRef<unsigned> order) {
   unsigned rank = shape.size();
   assert(rank == order.size());
-  auto reordered = reorder(shape, order);
+  auto reordered = triton::applyPermutation(shape, order);
   auto reorderedMultiDim = delinearize(b, loc, linear, reordered);
   SmallVector<Value> multiDim(rank);
   for (unsigned i = 0; i < rank; ++i) {
@@ -629,8 +629,8 @@ SmallVector<Value> delinearize(OpBuilder &b, Location loc, Value linear,
 
 Value linearize(OpBuilder &b, Location loc, ArrayRef<Value> multiDim,
                 ArrayRef<unsigned> shape, ArrayRef<unsigned> order) {
-  return linearize(b, loc, reorder<Value>(multiDim, order),
-                   reorder<unsigned>(shape, order));
+  return linearize(b, loc, triton::applyPermutation(multiDim, order),
+                   triton::applyPermutation(shape, order));
 }
 
 Value linearize(OpBuilder &b, Location loc, ArrayRef<Value> multiDim,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1354,9 +1354,8 @@ public:
       SmallVector<unsigned> order = triton::gpu::getOrder(encoding);
       if (rank != order.size())
         return resultVals;
-      ArrayRef<unsigned> orderRef(order);
-      elemsPerThread = reorder(ArrayRef<unsigned>(elemsPerThread), orderRef);
-      constancy = reorder(ArrayRef<int64_t>(constancy), orderRef);
+      elemsPerThread = applyPermutation(elemsPerThread, order);
+      constancy = applyPermutation(constancy, order);
     }
 
     SmallVector<unsigned> strides(rank, 1);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -155,7 +155,7 @@ llvm::SmallVector<T> getMultiDimIndex(T linearIndex, llvm::ArrayRef<T> shape,
                                       llvm::ArrayRef<unsigned> order) {
   size_t rank = shape.size();
   assert(rank == order.size());
-  auto reordered = reorder(shape, order);
+  auto reordered = applyPermutation(shape, order);
   auto reorderedMultiDim = getMultiDimIndexImpl<T>(linearIndex, reordered);
   llvm::SmallVector<T> multiDim(rank);
   for (unsigned i = 0; i < rank; ++i) {
@@ -185,8 +185,8 @@ template <typename T>
 T getLinearIndex(llvm::ArrayRef<T> multiDimIndex, llvm::ArrayRef<T> shape,
                  llvm::ArrayRef<unsigned> order) {
   assert(shape.size() == order.size());
-  return getLinearIndexImpl<T>(reorder(multiDimIndex, order),
-                               reorder(shape, order));
+  return getLinearIndexImpl<T>(applyPermutation(multiDimIndex, order),
+                               applyPermutation(shape, order));
 }
 
 } // namespace triton

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -12,14 +12,14 @@ TEST(Analysis, reorder) {
   SmallVector<int> shape({10, 20, 30});
   {
     SmallVector<unsigned> order({2, 1, 0});
-    auto reordered = reorder<int>(shape, order);
+    auto reordered = triton::applyPermutation(shape, order);
     EXPECT_EQ(reordered[0], 30);
     EXPECT_EQ(reordered[1], 20);
     EXPECT_EQ(reordered[2], 10);
   }
   {
     SmallVector<unsigned> order({1, 0, 2});
-    auto reordered = reorder<int>(shape, order);
+    auto reordered = triton::applyPermutation(shape, order);
     EXPECT_EQ(reordered[0], 20);
     EXPECT_EQ(reordered[1], 10);
     EXPECT_EQ(reordered[2], 30);


### PR DESCRIPTION
<git-pr-chain>


[Utility] Improve some utility functions.

- Given `template <typename T> foo(ArrayRef<T>)`, I don't want you to
  have to type out `foo(ArrayRef(val))`.  You should be able to call it
  as simply `foo(val)`.

  Previously I accomplished this by writing overloads like

      foo(ArrayRef<unsigned>)
      foo(ArrayRef<int>)

  but this is verbose, especially when foo takes *two* ArrayRef
  arguments.  I figured out a better way to do it, making use of
  ArrayRef's CTAD.  It's sort of like concepts, actually...

- Add some additional utilities:

    isPermutationOfIota
    isConsecutive
    join

- Remove reorder() function, in favor of applyPermutation().  It's a bit
  more verbose, but I think it gets the point across more clearly, and
  it plays well with e.g. inversePermutation().


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3049 👈 **YOU ARE HERE**
1. #3050


</git-pr-chain>
