### PR TITLE
Fix MLIR python binding after MLIR commit da784a2

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -272,7 +272,8 @@ void init_triton_ir(py::module &&m) {
            })
       .def("get_num_arguments", &mlir::Block::getNumArguments)
       .def("dump", &mlir::Block::dump)
-      .def("move_before", &mlir::Block::moveBefore)
+      .def("move_before",
+           [](mlir::Block &self, mlir::Block *tgt) { self.moveBefore(tgt); })
       .def("insert_before", &mlir::Block::insertBefore)
       .def("get_parent", &mlir::Block::getParent, ret::reference)
       .def("merge_block_before",


### PR DESCRIPTION
Commit da784a2 in the MLIR repo adds an overload to mlir::Block::moveBefore and so we need to specify which overload we're using 

Ref: https://github.com/llvm/llvm-project/commit/da784a25557e29996bd33638d51d569ddf989faf