### PR TITLE
[RUNTIME] Fix libcuda.so linker errors

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -1,5 +1,7 @@
+import functools
 import os
 import hashlib
+import subprocess
 import tempfile
 from pathlib import Path
 from triton.runtime.build import _build
@@ -8,8 +10,38 @@ from triton.backends.driver import GPUDriver
 
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dir = [os.path.join(dirname, "include")]
-library_dir = [os.path.join(dirname, "lib")]
+libdevice_dir = os.path.join(dirname, "lib")
 libraries = ['cuda']
+
+
+@functools.lru_cache()
+def libcuda_dirs():
+    env_libcuda_path = os.getenv("TRITON_LIBCUDA_PATH")
+    if env_libcuda_path:
+        return [env_libcuda_path]
+
+    libs = subprocess.check_output(["/sbin/ldconfig", "-p"]).decode()
+    # each line looks like the following:
+    # libcuda.so.1 (libc6,x86-64) => /lib/x86_64-linux-gnu/libcuda.so.1
+    locs = [line.split()[-1] for line in libs.splitlines() if "libcuda.so" in line]
+    dirs = [os.path.dirname(loc) for loc in locs]
+    env_ld_library_path = os.getenv("LD_LIBRARY_PATH")
+    if env_ld_library_path and not dirs:
+        dirs = [dir for dir in env_ld_library_path.split(":") if os.path.exists(os.path.join(dir, "libcuda.so"))]
+    msg = 'libcuda.so cannot found!\n'
+    if locs:
+        msg += 'Possible files are located at %s.' % str(locs)
+        msg += 'Please create a symlink of libcuda.so to any of the file.'
+    else:
+        msg += 'Please make sure GPU is setup and then run "/sbin/ldconfig"'
+        msg += ' (requires sudo) to refresh the linker cache.'
+    assert any(os.path.exists(os.path.join(path, 'libcuda.so')) for path in dirs), msg
+    return dirs
+
+
+@functools.lru_cache()
+def library_dirs():
+    return [libdevice_dir, *libcuda_dirs()]
 
 
 def compile_module_from_src(src, name):
@@ -21,7 +53,7 @@ def compile_module_from_src(src, name):
             src_path = os.path.join(tmpdir, "main.c")
             with open(src_path, "w") as f:
                 f.write(src)
-            so = _build(name, src_path, tmpdir, library_dir, include_dir, libraries)
+            so = _build(name, src_path, tmpdir, library_dirs(), include_dir, libraries)
             with open(so, "rb") as f:
                 cache_path = cache.put(f.read(), f"{name}.so", binary=True)
     import importlib.util


### PR DESCRIPTION
Recent builds of triton are failing at runtime with a linker error:
```
../x86_64-conda-linux-gnu/bin/ld: cannot find -lcuda: No such file or directory
```

This failure was introduced in #2887 which removed the function `libcuda_dirs`, which searched for `libcuda.so`. This PR restores the function as it was before the nvidia backend refactor.