### PR TITLE
[ANALYSIS] Improve AxisInfo Analysis for `cmpi` ops

### DIFF
--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -225,26 +225,107 @@ tt.func @splat(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}) {
 
 // -----
 
-// CHECK-LABEL: @cmp
-tt.func @cmp() {
+// CHECK-LABEL: @cmp_all_contiguous
+tt.func @cmp_all_contiguous() {
   // CHECK: contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [4611686018427387904], constancy = [128], constant_value = 0
   %1 = arith.constant dense<0> : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
-  %2 = arith.cmpi eq, %0, %1 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
-  %3 = arith.cmpi slt, %0, %1 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
-  %4 = arith.cmpi sle, %0, %1 : tensor<128xi32>
+  %2 = arith.cmpi eq, %0, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %3 = arith.cmpi ne, %0, %1 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
-  %5 = arith.cmpi sge, %0, %1 : tensor<128xi32>
+  %4 = arith.cmpi slt, %0, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %5 = arith.cmpi sle, %0, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
+  %6 = arith.cmpi sge, %0, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %7 = arith.cmpi sgt, %0, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %8 = arith.cmpi eq, %1, %0 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %9 = arith.cmpi ne, %1, %0 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %10 = arith.cmpi slt, %1, %0 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
+  %11 = arith.cmpi sle, %1, %0 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %12 = arith.cmpi sge, %1, %0 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
+  %13 = arith.cmpi sgt, %1, %0 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [8], constancy = [128], constant_value = 8
-  %6 = arith.constant dense<8> : tensor<128xi32>
+  %14 = arith.constant dense<8> : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
-  %7 = arith.cmpi sgt, %0, %6 : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = 0
-  %8 = arith.cmpi sgt, %1, %6 : tensor<128xi32>
+  %15 = arith.cmpi sgt, %14, %0 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = 1
+  %16 = arith.cmpi sgt, %14, %1 : tensor<128xi32>
+  tt.return
+}
+
+// CHECK-LABEL: @cmp_partial_contiguous
+tt.func @cmp_partial_contiguous() {
+  // CHECK: contiguity = [128], divisibility = [1073741824], constancy = [1], constant_value = <none>
+  %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [8], constancy = [128], constant_value = 8
+  %1 = arith.constant dense<8> : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [32], constancy = [128], constant_value = 32
+  %3 = arith.constant dense<32> : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [32], divisibility = [32], constancy = [1], constant_value = <none>
+  %4 = arith.remsi %0, %3 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %5 = arith.cmpi eq, %4, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %6 = arith.cmpi ne, %4, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  %7 = arith.cmpi slt, %4, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %8 = arith.cmpi sle, %4, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  %9 = arith.cmpi sge, %4, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %10 = arith.cmpi sgt, %4, %1 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %11 = arith.cmpi eq, %1, %4 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %12 = arith.cmpi ne, %1, %4 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %13 = arith.cmpi slt, %1, %4 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  %14 = arith.cmpi sle, %1, %4 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %15 = arith.cmpi sge, %1, %4 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>
+  %16 = arith.cmpi sgt, %1, %4 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [16], constancy = [128], constant_value = 48
+  %17 = arith.constant dense<48> : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [16], divisibility = [16], constancy = [1], constant_value = <none>
+  %18 = arith.remsi %0, %17 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %19 = arith.cmpi eq, %18, %3 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %20 = arith.cmpi ne, %18, %3 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>
+  %21 = arith.cmpi slt, %18, %3 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %22 = arith.cmpi sle, %18, %3 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>
+  %23 = arith.cmpi sge, %18, %3 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %24 = arith.cmpi sgt, %18, %3 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %25 = arith.cmpi eq, %3, %18 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %26 = arith.cmpi ne, %3, %18 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %27 = arith.cmpi slt, %3, %18 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none>
+  %28 = arith.cmpi sle, %3, %18 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
+  %29 = arith.cmpi sge, %3, %18 : tensor<128xi32>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [16], constant_value = <none
+  %30 = arith.cmpi sgt, %3, %18 : tensor<128xi32>
   tt.return
 }
 
@@ -285,7 +366,7 @@ tt.func @select(%arg0 : i1, %arg1 : tensor<4xi1>) {
   %0 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [4611686018427387904], constancy = [128], constant_value = 0
   %1 = arith.constant dense<0> : tensor<128xi32>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %2 = arith.cmpi eq, %0, %1 : tensor<128xi32>
   // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
   %3 = arith.cmpi slt, %0, %1 : tensor<128xi32>
@@ -295,13 +376,13 @@ tt.func @select(%arg0 : i1, %arg1 : tensor<4xi1>) {
   %7 = tt.splat %4 : (i1) -> tensor<128xi1>
   // CHECK-NEXT: contiguity = [1], divisibility = [4611686018427387904], constancy = [128], constant_value = 0
   %5 = arith.select %4, %3, %7 : tensor<128xi1>
-  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [128], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1], divisibility = [1], constancy = [1], constant_value = <none>
   %8 = arith.select %7, %3, %2 : tensor<128xi1>, tensor<128xi1>
-  // CHECK-NEXT: contiguity = [1, 1], divisibility = [1, 1], constancy = [128, 1], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1, 1], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>
   %9 = tt.expand_dims %2 {axis = 1 : i32} : (tensor<128xi1>) -> tensor<128x1xi1>
   // CHECK-NEXT: contiguity = [1, 1], divisibility = [1, 1], constancy = [128, 1], constant_value = <none>
   %10 = tt.expand_dims %3 {axis = 1 : i32} : (tensor<128xi1>) -> tensor<128x1xi1>
-  // CHECK-NEXT: contiguity = [1, 1], divisibility = [1, 1], constancy = [128, 1], constant_value = <none>
+  // CHECK-NEXT: contiguity = [1, 1], divisibility = [1, 1], constancy = [1, 1], constant_value = <none>
   %11 = arith.select %arg0, %9, %10 : tensor<128x1xi1>
   // CHECK-NEXT: contiguity = [1], divisibility = [4], constancy = [4], constant_value = 4
   %cst = arith.constant dense<4> : tensor<4xi32>


### PR DESCRIPTION
1. We didn't handle `eq` and `ne` modifiers properly. If only one of the operand is a constant, we cannot infer the constancy of the result.
2. We can remove the restriction that one of the operand must be all contiguous. 
If operand `a` is constant, operand `b` could be partially contiguous.
Take `gcd` as the greatest common divisor of `a`'s divisibility, `b`'s divisibility, and `b`'s contiguity.
We can divide `b` into segments of length `gcd`.
For each segment, if `a`'s value doesn't fall into it, the constancy would be simply `gcd`.
Otherwise, `a` can only be the start of the segment, and therefore we could check the modifiers to see if we could assign `gcd` as the constancy.