### PR TITLE
Get rid of extra comma in stringified #shared encoding.

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1278,7 +1278,7 @@ Attribute SharedEncodingAttr::parse(AsmParser &parser, Type type) {
 
 void SharedEncodingAttr::print(AsmPrinter &printer) const {
   printer << "<{"
-          << "vec = " << getVec() << ", "
+          << "vec = " << getVec() //
           << ", perPhase = " << getPerPhase()
           << ", maxPhase = " << getMaxPhase() //
           << ", order = [" << getOrder() << "]";


### PR DESCRIPTION
Another bug from 8e61b7212e7d32c85f448490260c6293d2f1885a.  Sorry :(
