### PR TITLE
[BACKEND] Re-introduce TRITON_LIBDEVICE_PATH envvar to Nvidia backend

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -358,7 +358,7 @@ class CUDAOptions:
         default_libdir = Path(__file__).parent / 'lib'
         extern_libs = dict() if self.extern_libs is None else dict(self.extern_libs)
         if not extern_libs.get('libdevice', None):
-            extern_libs['libdevice'] = str(default_libdir / 'libdevice.10.bc')
+            extern_libs['libdevice'] = os.getenv("TRITON_LIBDEVICE_PATH", str(default_libdir / 'libdevice.10.bc'))
         object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
         assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
                "num_warps must be a power of 2"


### PR DESCRIPTION
Sometime back in https://github.com/openai/triton/pull/1166 the environment variable to set the location of libdevice.10.bc was added.

Recently in the backend cleanup to move more Nvidia specifics to third_party it was lost to the code churn
(https://github.com/openai/triton/pull/2844).

This PR brings it back so that dependent projects that use Triton but place their libdevice file in a different location than the default can continue to work.