### PR TITLE
[DEBUG] Enable print-after-all with env variable LLVM_IR_ENABLE_DUMP

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -48,6 +48,14 @@ std::string translateLLVMIRToASM(llvm::Module &module,
     assert(shortPtr);
     shortPtr->setValue(true);
   }
+  if (triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
+    auto optIt = options.find("print-after-all");
+    if (optIt != options.end()) {
+      auto optPtr = static_cast<llvm::cl::opt<bool> *>(optIt->second);
+      *optPtr = true;
+    }
+  }
+
   // inline everything
   for (llvm::Function &f : module.functions())
     if (!f.hasFnAttribute(llvm::Attribute::NoInline))
@@ -169,6 +177,12 @@ void init_triton_llvm(py::module &&m) {
     if (triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
       standardInstr.registerCallbacks(passInstrCb, &mam);
       instrCbPtr = &passInstrCb;
+      auto optMap = llvm::cl::getRegisteredOptions();
+      auto optIt = optMap.find("print-after-all");
+      if (optIt != optMap.end()) {
+        auto optPtr = static_cast<llvm::cl::opt<bool> *>(optIt->second);
+        *optPtr = true;
+      }
     }
 
     PipelineTuningOptions tuningOptions;


### PR DESCRIPTION
Summary: export LLVM_IR_ENABLE_DUMP=1 run
python vector-add.py | grep "IR Dump"
will show all the IRs after each llvm pass, including llvm passes in optimize_module and translate_to_asm.