### PR TITLE
[interpreter][test] add test_interpreter

### DIFF
--- a/python/test/unit/runtime/conftest.py
+++ b/python/test/unit/runtime/conftest.py
@@ -1,0 +1,12 @@
+# content of conftest.py
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--device", action="store", default='cuda')
+
+
+@pytest.fixture
+def device(request):
+    return request.config.getoption("--device")

--- a/python/test/unit/runtime/test_interpreter.py
+++ b/python/test/unit/runtime/test_interpreter.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import pytest
+
+# activate interpreter mode
+os.environ['TRITON_INTERPRET'] = '1'
+
+# resolve the relative path to test_core.py 
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_CORE = os.path.join(TEST_DIR, '..', 'language')
+sys.path.append(TEST_CORE)
+
+
+from test_core import test_bin_op

--- a/python/test/unit/runtime/test_interpreter.py
+++ b/python/test/unit/runtime/test_interpreter.py
@@ -12,3 +12,6 @@ sys.path.append(TEST_CORE)
 
 
 from test_core import test_bin_op
+
+# turn off
+os.environ['TRITON_INTERPRET'] = '0'


### PR DESCRIPTION
this PR add a test file for the interpreter, it mostly reuse the test from the test_core file but run in interpreter mode

Currently only binary ops are included, more test can be included if necessary (indexing, broadcasting etc...)

cc @Jokeren @ptillet 