### PR TITLE
[BACKEND] Prevent vectorization in convert_layout transposes

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -144,6 +144,11 @@ getScratchConfigForCvtLayout(triton::gpu::ConvertLayoutOp op, unsigned &inVec,
     // Don't vectorize for transpose. Only the read or the write can be
     // vectorized and this causes extra bank conflicts on the non-vectorized
     // accesses.
+    // Ex: if we transpose a 32x32 tensor, to avoid bank conflicts with scalar
+    // loads/stores we need a padding of 1 element. If we vectorize the load
+    // into a load4 then the padding has to be either 0 or 4. In both those
+    // cases we would get extra bank conflicts that would make performance
+    // worse.
     inVec = 1;
     outVec = 1;
   }

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -139,10 +139,11 @@ getScratchConfigForCvtLayout(triton::gpu::ConvertLayoutOp op, unsigned &inVec,
   outVec = dstContigPerThread[outOrd[0]];
 
   if (srcLayout.isa<BlockedEncodingAttr>() &&
-      dstLayout.isa<BlockedEncodingAttr>() && outOrd[0] == 0 && inOrd[0] != 0) {
-    // don't vectorize for transpose as only the read or the write can be
-    // vectorized and this cause extra bank conflicts on the non-vectorized
-    // access.
+      dstLayout.isa<BlockedEncodingAttr>() && outOrd[0] != (rank - 1) &&
+      inOrd[0] != outOrd[0]) {
+    // Don't vectorize for transpose. Only the read or the write can be
+    // vectorized and this causes extra bank conflicts on the non-vectorized
+    // accesses.
     inVec = 1;
     outVec = 1;
   }

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -138,6 +138,10 @@ getScratchConfigForCvtLayout(triton::gpu::ConvertLayoutOp op, unsigned &inVec,
   inVec = std::min(srcContigPerThread[inOrd[0]], dstContigPerThread[inOrd[0]]);
   outVec = dstContigPerThread[outOrd[0]];
 
+  // TODO: We could make this condition broader to catch more cases of N-D
+  // transposes that would benefit from this optimization. For example if the
+  // inner dimension is not transposed but is small there could still be
+  // benefits.
   if (srcLayout.isa<BlockedEncodingAttr>() &&
       dstLayout.isa<BlockedEncodingAttr>() && outOrd[0] != (rank - 1) &&
       inOrd[0] != outOrd[0]) {

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -729,9 +729,21 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 :
     // CHECK-SAME: !llvm.ptr<3>
     // CHECK: nvvm.barrier0
     // CHECK: llvm.load
-    // CHECK-SAME: !llvm.ptr<3> -> vector<4xf32>
+    // CHECK-SAME: !llvm.ptr<3>
     // CHECK: llvm.load
-    // CHECK-SAME: !llvm.ptr<3> -> vector<4xf32>
+    // CHECK-SAME: !llvm.ptr<3>
+    // CHECK: llvm.load
+    // CHECK-SAME: !llvm.ptr<3>
+    // CHECK: llvm.load
+    // CHECK-SAME: !llvm.ptr<3>
+    // CHECK: llvm.load
+    // CHECK-SAME: !llvm.ptr<3>
+    // CHECK: llvm.load
+    // CHECK-SAME: !llvm.ptr<3>
+    // CHECK: llvm.load
+    // CHECK-SAME: !llvm.ptr<3>
+    // CHECK: llvm.load
+    // CHECK-SAME: !llvm.ptr<3>
     %0 = triton_gpu.convert_layout %arg0 : (tensor<16x16xf32, #blocked0>) -> tensor<16x16xf32, #blocked1>
     tt.return
   }


### PR DESCRIPTION
When convert layout transpose elements we cannot vectorize both loads and stores. Deciding to only vectorize one would cause extra bank conflicts on the non-vectorized one that cause performance slowdown.