### PR TITLE
[IR] Eliminate need for .cast<RankedTensorType>() in most places.

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonTypes.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypes.td
@@ -15,17 +15,17 @@ class TritonTypeDef<string name, string _mnemonic>
 
 // Floating-point Type
 def TT_Float : AnyTypeOf<[F8E4M3FNUZ, F8E4M3FN, F8E4M3B11FNUZ, F8E5M2, F16, BF16, F32, F64], "floating-point">;
-def TT_FloatTensor : TensorOf<[TT_Float]>;
+def TT_FloatTensor : RankedTensorOf<[TT_Float]>;
 def TT_FloatLike : AnyTypeOf<[TT_Float, TT_FloatTensor]>;
 
 // Boolean Type
 // TT_Bool -> I1
-def TT_BoolTensor : TensorOf<[I1]>;
+def TT_BoolTensor : RankedTensorOf<[I1]>;
 def TT_BoolLike : AnyTypeOf<[I1, TT_BoolTensor]>;
 
 // Integer Type
 def TT_Int : AnyTypeOf<[I1, I8, I16, I32, I64], "integer">;
-def TT_IntTensor : TensorOf<[TT_Int]>;
+def TT_IntTensor : RankedTensorOf<[TT_Int]>;
 def TT_IntLike : AnyTypeOf<[TT_Int, TT_IntTensor]>;
 
 // I32 Type
@@ -75,14 +75,14 @@ def TT_PtrType : TritonTypeDef<"Pointer", "ptr"> {
 def TT_Ptr : TT_PtrOf<[AnyType]>;
 
 // Tensor of Pointer Type: `tensor<ptr<>>`
-def TT_PtrTensor : TensorOf<[TT_Ptr]>;
+def TT_PtrTensor : RankedTensorOf<[TT_Ptr]>;
 
 // Tensor of Pointer Type or Pointer type: `tensor<ptr<>>` or `ptr<>`
 def TT_PtrLike : AnyTypeOf<[TT_Ptr, TT_PtrTensor]>;
 
 // Tensor Type
-def TT_FpIntTensor : AnyTypeOf<[TT_FloatTensor, TT_IntTensor]>;
-def TT_Tensor : AnyTypeOf<[TT_FpIntTensor, TT_PtrTensor]>;
+def TT_FpIntTensor : RankedTensorOf<[TT_Float, TT_Int]>;
+def TT_Tensor : RankedTensorOf<[TT_Float, TT_Int, TT_Ptr]>;
 
 // Pointer Type to Tensor Type: `ptr<tensor<>>`
 def TT_TensorPtr : TT_PtrOf<[TT_Tensor]>;

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -208,7 +208,7 @@ def TTG_InsertSliceAsyncOp : TTG_Op<"insert_slice_async",
       ```
   }];
 
-  let arguments = (ins TT_PtrLike:$src, TT_Tensor:$dst, I32:$index,
+  let arguments = (ins TT_PtrTensor:$src, TT_Tensor:$dst, I32:$index,
                        Optional<I1Tensor>:$mask, Optional<TT_Type>:$other,
                        TT_CacheModifierAttr:$cache, TT_EvictionPolicyAttr:$evict,
                        BoolAttr:$isVolatile, I32Attr:$axis);

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -404,7 +404,7 @@ mlir::LogicalResult mlir::triton::TransOp::inferReturnTypes(
 
 LogicalResult triton::TransOp::verify() {
   // Check that the op's `order` attribute is a permutation of the right length.
-  auto srcTy = getSrc().getType().cast<RankedTensorType>();
+  auto srcTy = getSrc().getType();
 
   ArrayRef<int32_t> order = getOrder();
   if (order.size() != srcTy.getRank()) {
@@ -449,8 +449,8 @@ mlir::LogicalResult mlir::triton::DotOp::inferReturnTypes(
 }
 
 LogicalResult mlir::triton::DotOp::verify() {
-  auto aTy = getOperand(0).getType().cast<RankedTensorType>();
-  auto bTy = getOperand(1).getType().cast<RankedTensorType>();
+  auto aTy = getA().getType();
+  auto bTy = getB().getType();
   if (aTy.getElementType().getIntOrFloatBitWidth() !=
       bTy.getElementType().getIntOrFloatBitWidth())
     return emitError(
@@ -857,8 +857,8 @@ OpFoldResult ReshapeOp::fold(FoldAdaptor adaptor) {
 }
 
 mlir::LogicalResult mlir::triton::ReshapeOp::verify() {
-  auto dstTy = getType().cast<RankedTensorType>();
-  auto srcTy = getSrc().getType().cast<RankedTensorType>();
+  auto dstTy = getType();
+  auto srcTy = getSrc().getType();
   if (dstTy.getNumElements() != srcTy.getNumElements()) {
     return emitError(
         "number of src and dst elements of reshape must be the same");

--- a/test/Triton/invalid.mlir
+++ b/test/Triton/invalid.mlir
@@ -69,7 +69,7 @@ tt.func public @fn(%arg0: tensor<f32>, %arg1: tensor<f32>) {
 // -----
 
 tt.func public @fn(%arg0: f32, %arg1: f32) {
-    // expected-error @+1 {{tensor}}
+    // expected-error @+1 {{kind of type}}
     %a = tt.experimental_interleave %arg0, %arg1 : f32 -> f32
     tt.return
 }


### PR DESCRIPTION
If we tweak how we define TT_Tensor, MLIR can see that it's always a
RankedTensorType.  Then suddenly all our generated functions know this,
and we don't have to cast to RankedTensorType everywhere!!!

This isn't a global cleanup, just a demonstration.

Already found a bug, namely that TritonGPUOps.td defined
InsertSliceAsyncOp's src as PtrLike, but (based on the code) it actually
must be PtrTensor.
