### PR TITLE
[IR] Get rid of some now-unnecessary cast<RankedTensorType>.

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -65,10 +65,8 @@ public:
   LogicalResult
   matchAndRewrite(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value src = op.getSrc();
-    Value dst = op.getResult();
-    auto srcTy = src.getType().cast<RankedTensorType>();
-    auto dstTy = dst.getType().cast<RankedTensorType>();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getResult().getType();
     Attribute srcLayout = srcTy.getEncoding();
     Attribute dstLayout = dstTy.getEncoding();
     if (isaDistributedLayout(srcLayout) &&
@@ -461,10 +459,8 @@ private:
                               ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
     auto typeConverter = getTypeConverter();
-    Value src = op.getSrc();
-    Value dst = op.getResult();
-    auto srcTy = src.getType().cast<RankedTensorType>();
-    auto dstTy = dst.getType().cast<RankedTensorType>();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getResult().getType();
     auto srcLayout = srcTy.getEncoding();
     auto dstLayout = dstTy.getEncoding();
     auto srcShapePerCTA = getShapePerCTA(srcTy);
@@ -547,11 +543,9 @@ private:
                                 OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    Value src = op.getSrc();
-    Value dst = op.getResult();
     auto typeConverter = getTypeConverter();
-    auto srcTy = src.getType().cast<RankedTensorType>();
-    auto dstTy = dst.getType().cast<RankedTensorType>();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getResult().getType();
     Attribute srcLayout = srcTy.getEncoding();
     Attribute dstLayout = dstTy.getEncoding();
 
@@ -680,11 +674,8 @@ private:
                            ConversionPatternRewriter &rewriter) const {
     auto typeConverter = getTypeConverter();
     auto loc = op.getLoc();
-    Value src = op.getSrc();
-    Value dst = op.getResult();
-    auto srcTy = src.getType().cast<RankedTensorType>();
-    auto srcShape = srcTy.getShape();
-    auto dstTy = dst.getType().cast<RankedTensorType>();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getResult().getType();
     auto dstShape = dstTy.getShape();
     assert(dstShape.size() == 2 &&
            "Unexpected rank of ConvertLayout(shared->blocked)");
@@ -698,11 +689,12 @@ private:
     auto elemTy = typeConverter->convertType(dstTy.getElementType());
 
     auto srcStrides =
-        getStridesFromShapeAndOrder(srcShape, inOrd, loc, rewriter);
+        getStridesFromShapeAndOrder(srcTy.getShape(), inOrd, loc, rewriter);
     auto dstIndices = emitIndices(loc, rewriter, dstLayout, dstTy, true);
 
-    SmallVector<Value> outVals = loadSharedToDistributed(
-        dst, dstIndices, src, smemObj, elemTy, loc, rewriter);
+    SmallVector<Value> outVals =
+        loadSharedToDistributed(op.getResult(), dstIndices, op.getSrc(),
+                                smemObj, elemTy, loc, rewriter);
 
     Value result = packLLElements(loc, typeConverter, outVals, rewriter, dstTy);
     rewriter.replaceOp(op, result);
@@ -814,18 +806,13 @@ private:
   lowerDistributedToShared(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
                            ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    Value src = op.getSrc();
-    Value dst = op.getResult();
-    auto srcTy = src.getType().cast<RankedTensorType>();
-    auto srcShape = srcTy.getShape();
-    auto dstTy = dst.getType().cast<RankedTensorType>();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getResult().getType();
     auto dstShapePerCTA = triton::gpu::getShapePerCTA(dstTy);
     auto srcLayout = srcTy.getEncoding();
-    auto dstSharedLayout = dstTy.getEncoding().cast<SharedEncodingAttr>();
-    auto inOrd = getOrder(srcLayout);
-    auto outOrd = dstSharedLayout.getOrder();
-    assert(srcShape.size() == 2 ||
-           (srcShape.size() <= 3 && outOrd[2] == 0) &&
+    auto outOrd = dstTy.getEncoding().cast<SharedEncodingAttr>().getOrder();
+    assert(srcTy.getShape().size() == 2 ||
+           (srcTy.getShape().size() <= 3 && outOrd[2] == 0) &&
                "Unexpected rank of ConvertLayout(blocked->shared)");
     Value smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, op.getOperation());
@@ -840,8 +827,8 @@ private:
         getStridesFromShapeAndOrder(dstShapePerCTA, outOrd, loc, rewriter);
     auto srcIndices = emitIndices(loc, rewriter, srcLayout, srcTy, false);
     auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-    storeDistributedToShared(src, inVals, dstStrides, srcIndices, dst, smemBase,
-                             elemTy, loc, rewriter);
+    storeDistributedToShared(op.getSrc(), inVals, dstStrides, srcIndices,
+                             op.getResult(), smemBase, elemTy, loc, rewriter);
     auto smemObj = SharedMemoryObject(smemBase, elemTy, dstShapePerCTA, outOrd,
                                       loc, rewriter);
     auto retVal = getStructFromSharedMemoryObject(loc, smemObj, rewriter);
@@ -854,21 +841,18 @@ private:
   lowerSharedToDotOperand(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
                           ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    Value src = op.getSrc();
-    Value dst = op.getResult();
-    auto dstTensorTy = dst.getType().cast<RankedTensorType>();
-    auto srcTensorTy = src.getType().cast<RankedTensorType>();
+    auto srcTensorTy = op.getSrc().getType();
+    auto dstTensorTy = op.getResult().getType();
     auto dotOperandLayout =
         dstTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
     auto sharedLayout = srcTensorTy.getEncoding().cast<SharedEncodingAttr>();
 
-    bool isOuter{};
-    int K{};
+    int K;
     if (dotOperandLayout.getOpIdx() == 0) // $a
       K = dstTensorTy.getShape()[sharedLayout.getOrder()[0]];
     else // $b
       K = dstTensorTy.getShape()[sharedLayout.getOrder()[1]];
-    isOuter = K == 1;
+    bool isOuter = K == 1;
 
     Value res;
     if (auto mmaLayout = dotOperandLayout.getParent()
@@ -882,8 +866,8 @@ private:
           dstTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
       auto thread = getThreadId(rewriter, loc);
       res = SharedToDotOperandFMA::convertLayout(
-          dotOpLayout.getOpIdx(), src, adaptor.getSrc(), blockedLayout, thread,
-          loc, getTypeConverter(), rewriter);
+          dotOpLayout.getOpIdx(), op.getSrc(), adaptor.getSrc(), blockedLayout,
+          thread, loc, getTypeConverter(), rewriter);
     } else {
       assert(false && "Unsupported dot operand layout found");
     }
@@ -897,8 +881,8 @@ private:
   lowerMmaToDotOperand(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
                        ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
-    auto dstTy = op.getResult().getType().cast<RankedTensorType>();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getResult().getType();
     if (matchMmaV3AndDotOperandLayout(srcTy, dstTy)) {
       rewriter.replaceOp(op, adaptor.getSrc());
       return success();
@@ -969,8 +953,8 @@ private:
                               OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
-    auto dstTy = op.getResult().getType().cast<RankedTensorType>();
+    auto srcTy = op.getSrc().getType();
+    auto dstTy = op.getResult().getType();
     if (triton::gpu::getTotalElemsPerThread(srcTy) ==
         triton::gpu::getTotalElemsPerThread(dstTy)) {
       rewriter.replaceOp(op, adaptor.getSrc());
@@ -1008,12 +992,12 @@ private:
                              const DotOperandEncodingAttr &dotOperandLayout,
                              bool isOuter) const {
     auto loc = op.getLoc();
-    Value src = op.getSrc();
-    Value dst = op.getResult();
+    auto src = op.getSrc();
+    auto dst = op.getResult();
     bool isMMA = supportMMA(dst, mmaLayout.getVersionMajor());
 
-    auto llvmElemTy = getTypeConverter()->convertType(
-        src.getType().cast<RankedTensorType>().getElementType());
+    auto llvmElemTy =
+        getTypeConverter()->convertType(src.getType().getElementType());
 
     auto smemObj = getSharedMemoryObjectFromStruct(loc, adaptor.getSrc(),
                                                    llvmElemTy, rewriter);
@@ -1024,10 +1008,8 @@ private:
           smemObj, getTypeConverter(), getThreadId(rewriter, loc));
     } else if (!isOuter && mmaLayout.isVolta() && isMMA) { // tensor core v1
       bool isMMAv1Row = mmaLayout.getMMAv1IsRow(dotOperandLayout.getOpIdx());
-      auto srcSharedLayout = src.getType()
-                                 .cast<RankedTensorType>()
-                                 .getEncoding()
-                                 .cast<SharedEncodingAttr>();
+      auto srcSharedLayout =
+          src.getType().getEncoding().cast<SharedEncodingAttr>();
 
       // Can only convert [1, 0] to row or [0, 1] to col for now
       if ((srcSharedLayout.getOrder()[0] == 1 && !isMMAv1Row) ||

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -516,26 +516,16 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
 LogicalResult convertWGMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                            const LLVMTypeConverter *typeConverter,
                            ConversionPatternRewriter &rewriter, Value thread) {
-  auto loc = op.getLoc();
-  Value A = op.getA();
-  Value B = op.getB();
-  Value C = op.getC();
-  auto ATensorTy = A.getType().cast<RankedTensorType>();
-  auto BTensorTy = B.getType().cast<RankedTensorType>();
-
-  assert(ATensorTy.getEncoding().isa<SharedEncodingAttr>() ||
-         ATensorTy.getEncoding().isa<DotOperandEncodingAttr>());
-  assert(BTensorTy.getEncoding().isa<SharedEncodingAttr>() &&
+  auto AEnc = op.getA().getType().getEncoding();
+  auto BEnc = op.getB().getType().getEncoding();
+  assert(AEnc.isa<SharedEncodingAttr>() || AEnc.isa<DotOperandEncodingAttr>());
+  assert(BEnc.isa<SharedEncodingAttr>() &&
          "Operand B should use Shared layout.");
-
-  Value llA, llB, llC;
-  llA = adaptor.getA();
-  llB = adaptor.getB();
-  llC = adaptor.getC();
-
-  return convertDot(typeConverter, rewriter, loc, op.getOperation(), A, B, C,
-                    op.getD(), llA, llB, llC, op.getAllowTF32(),
-                    op.getMaxNumImpreciseAcc(), true, thread);
+  return convertDot(typeConverter, rewriter, op.getLoc(), op.getOperation(), //
+                    op.getA(), op.getB(), op.getC(), op.getD(),              //
+                    adaptor.getA(), adaptor.getB(), adaptor.getC(),          //
+                    op.getAllowTF32(), op.getMaxNumImpreciseAcc(), true,
+                    thread);
 }
 
 LogicalResult convertAsyncWGMMA(triton::nvidia_gpu::DotAsyncOp op,
@@ -543,24 +533,14 @@ LogicalResult convertAsyncWGMMA(triton::nvidia_gpu::DotAsyncOp op,
                                 const LLVMTypeConverter *typeConverter,
                                 ConversionPatternRewriter &rewriter,
                                 Value thread) {
-  auto loc = op.getLoc();
-  Value A = op.getA();
-  Value B = op.getB();
-  Value C = op.getC();
-  auto ATensorTy = A.getType().cast<RankedTensorType>();
-  auto BTensorTy = B.getType().cast<RankedTensorType>();
-
-  assert(ATensorTy.getEncoding().isa<SharedEncodingAttr>() ||
-         ATensorTy.getEncoding().isa<DotOperandEncodingAttr>());
-  assert(BTensorTy.getEncoding().isa<SharedEncodingAttr>() &&
+  auto AEnc = op.getA().getType().getEncoding();
+  auto BEnc = op.getB().getType().getEncoding();
+  assert(AEnc.isa<SharedEncodingAttr>() || AEnc.isa<DotOperandEncodingAttr>());
+  assert(BEnc.isa<SharedEncodingAttr>() &&
          "Operand B should use Shared layout.");
-
-  Value llA, llB, llC;
-  llA = adaptor.getA();
-  llB = adaptor.getB();
-  llC = adaptor.getC();
-
-  return convertDot(typeConverter, rewriter, loc, op.getOperation(), A, B, C,
-                    op.getD(), llA, llB, llC, op.getAllowTF32(),
-                    op.getMaxNumImpreciseAcc(), false, thread);
+  return convertDot(typeConverter, rewriter, op.getLoc(), op.getOperation(), //
+                    op.getA(), op.getB(), op.getC(), op.getD(),              //
+                    adaptor.getA(), adaptor.getB(), adaptor.getC(),
+                    op.getAllowTF32(), op.getMaxNumImpreciseAcc(), false,
+                    thread);
 }

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -212,7 +212,7 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
   LogicalResult
   matchAndRewrite(triton::DotOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    RankedTensorType origType = op.getType().cast<RankedTensorType>();
+    RankedTensorType origType = op.getType();
     auto origShape = origType.getShape();
     auto typeConverter = getTypeConverter<TritonGPUTypeConverter>();
     int numWarps = typeConverter->getNumWarps();
@@ -290,8 +290,8 @@ struct TritonCatPattern : public OpConversionPattern<triton::CatOp> {
                        .cast<RankedTensorType>();
     auto retEncoding =
         retType.getEncoding().cast<triton::gpu::BlockedEncodingAttr>();
-    auto lhsType = adaptor.getLhs().getType().cast<RankedTensorType>();
-    auto rhsType = adaptor.getRhs().getType().cast<RankedTensorType>();
+    auto lhsType = adaptor.getLhs().getType();
+    auto rhsType = adaptor.getRhs().getType();
     auto lhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(lhsType);
     auto rhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(rhsType);
     auto retTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(retType);
@@ -415,9 +415,8 @@ struct TritonBroadcastPattern
     auto srcEncoding = srcType.getEncoding();
     if (!srcEncoding)
       return failure();
-    auto opType = op.getType().cast<RankedTensorType>();
-    Type retType = RankedTensorType::get(opType.getShape(),
-                                         opType.getElementType(), srcEncoding);
+    Type retType = RankedTensorType::get(
+        op.getType().getShape(), op.getType().getElementType(), srcEncoding);
     // Type retType = this->getTypeConverter()->convertType(op.getType());
     addNamedAttrs(rewriter.replaceOpWithNewOp<triton::BroadcastOp>(
                       op, retType, adaptor.getOperands()),

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -159,7 +159,7 @@ namespace mlir {
 namespace triton {
 
 //-- LoadOp --
-static Type getLoadOpResultType(::mlir::OpBuilder &builder, Type ptrType) {
+static Type getLoadOpResultType(OpBuilder &builder, Type ptrType) {
   auto ptrTensorType = ptrType.dyn_cast<RankedTensorType>();
   if (!ptrTensorType)
     return ptrType.cast<PointerType>().getPointeeType();
@@ -169,44 +169,39 @@ static Type getLoadOpResultType(::mlir::OpBuilder &builder, Type ptrType) {
   return RankedTensorType::get(shape, elementType);
 }
 
-void LoadOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
-                   ::mlir::Value ptr, ::mlir::triton::CacheModifier cache,
-                   ::mlir::triton::EvictionPolicy evict, bool isVolatile) {
+void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                   CacheModifier cache, EvictionPolicy evict, bool isVolatile) {
   LoadOp::build(builder, state, ptr, /*mask=*/{}, /*other=*/{},
                 /*boundaryCheck=*/{}, /*padding=*/{}, cache, evict, isVolatile);
 }
 
-void LoadOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
-                   ::mlir::Value ptr, ArrayRef<int32_t> boundaryCheck,
-                   std::optional<::mlir::triton::PaddingOption> padding,
-                   ::mlir::triton::CacheModifier cache,
-                   ::mlir::triton::EvictionPolicy evict, bool isVolatile) {
+void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                   ArrayRef<int32_t> boundaryCheck,
+                   std::optional<PaddingOption> padding, CacheModifier cache,
+                   EvictionPolicy evict, bool isVolatile) {
   LoadOp::build(builder, state, ptr, /*mask=*/{}, /*other=*/{}, boundaryCheck,
                 padding, cache, evict, isVolatile);
 }
 
-void LoadOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
-                   ::mlir::Value ptr, ::mlir::Value mask,
-                   ::mlir::triton::CacheModifier cache,
-                   ::mlir::triton::EvictionPolicy evict, bool isVolatile) {
+void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                   Value mask, CacheModifier cache, EvictionPolicy evict,
+                   bool isVolatile) {
   LoadOp::build(builder, state, ptr, mask, /*other=*/{}, /*boundaryCheck=*/{},
                 /*padding=*/{}, cache, evict, isVolatile);
 }
 
-void LoadOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
-                   ::mlir::Value ptr, ::mlir::Value mask, ::mlir::Value other,
-                   ::mlir::triton::CacheModifier cache,
-                   ::mlir::triton::EvictionPolicy evict, bool isVolatile) {
+void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                   Value mask, Value other, CacheModifier cache,
+                   EvictionPolicy evict, bool isVolatile) {
   LoadOp::build(builder, state, ptr, mask, other, /*boundaryCheck=*/{},
                 /*padding=*/{}, cache, evict, isVolatile);
 }
 
-void LoadOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
-                   ::mlir::Value ptr, ::mlir::Value mask, ::mlir::Value other,
+void LoadOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                   Value mask, Value other,
                    std::optional<ArrayRef<int32_t>> boundaryCheck,
-                   std::optional<::mlir::triton::PaddingOption> padding,
-                   ::mlir::triton::CacheModifier cache,
-                   ::mlir::triton::EvictionPolicy evict, bool isVolatile) {
+                   std::optional<PaddingOption> padding, CacheModifier cache,
+                   EvictionPolicy evict, bool isVolatile) {
   // Operands
   state.addOperands(ptr);
   if (mask) {
@@ -225,16 +220,14 @@ void LoadOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
                        builder.getDenseI32ArrayAttr(boundaryCheck.value()));
   }
   if (padding.has_value()) {
-    state.addAttribute(getPaddingAttrName(state.name),
-                       ::mlir::triton::PaddingOptionAttr::get(
-                           builder.getContext(), padding.value()));
+    state.addAttribute(
+        getPaddingAttrName(state.name),
+        PaddingOptionAttr::get(builder.getContext(), padding.value()));
   }
-  state.addAttribute(
-      getCacheAttrName(state.name),
-      ::mlir::triton::CacheModifierAttr::get(builder.getContext(), cache));
-  state.addAttribute(
-      getEvictAttrName(state.name),
-      ::mlir::triton::EvictionPolicyAttr::get(builder.getContext(), evict));
+  state.addAttribute(getCacheAttrName(state.name),
+                     CacheModifierAttr::get(builder.getContext(), cache));
+  state.addAttribute(getEvictAttrName(state.name),
+                     EvictionPolicyAttr::get(builder.getContext(), evict));
   state.addAttribute(getIsVolatileAttrName(state.name),
                      builder.getBoolAttr(isVolatile));
 
@@ -245,30 +238,28 @@ void LoadOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
 
 // load(ptr, splat(1), ...)        -> load(ptr, ...)
 // load(ptr, splat(0), other, ...) -> other
-struct CanonicalizeMaskedLoadPattern
-    : public mlir::OpRewritePattern<triton::LoadOp> {
-  CanonicalizeMaskedLoadPattern(mlir::MLIRContext *context)
-      : OpRewritePattern<triton::LoadOp>(context, 1) {}
+struct CanonicalizeMaskedLoadPattern : public OpRewritePattern<LoadOp> {
+  CanonicalizeMaskedLoadPattern(MLIRContext *context)
+      : OpRewritePattern<LoadOp>(context, 1) {}
 
-  mlir::LogicalResult
-  matchAndRewrite(triton::LoadOp loadOp,
-                  mlir::PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(LoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
     auto mask = loadOp.getMask();
     if (!mask)
-      return mlir::failure();
+      return failure();
 
     auto constantMask =
         llvm::dyn_cast_or_null<arith::ConstantOp>(mask.getDefiningOp());
     if (!constantMask)
-      return mlir::failure();
+      return failure();
 
     auto splatMask = constantMask.getValue().dyn_cast<SplatElementsAttr>();
     if (!splatMask)
-      return mlir::failure();
+      return failure();
 
     if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
       // mask = splat(1)
-      rewriter.replaceOpWithNewOp<triton::LoadOp>(
+      rewriter.replaceOpWithNewOp<LoadOp>(
           loadOp, loadOp.getType(), loadOp.getPtr(), Value(), Value(),
           loadOp.getBoundaryCheckAttr(), loadOp.getPaddingAttr(),
           loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
@@ -279,40 +270,35 @@ struct CanonicalizeMaskedLoadPattern
       // optimize it in the future.x
       auto otherVal = loadOp.getOther();
       if (!otherVal)
-        return mlir::failure();
+        return failure();
       rewriter.replaceOp(loadOp, otherVal);
     }
-    return mlir::success();
+    return success();
   }
 };
 
-void triton::LoadOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                                 MLIRContext *context) {
+void LoadOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                         MLIRContext *context) {
   results.add<CanonicalizeMaskedLoadPattern>(context);
 }
 
 //-- StoreOp --
-void StoreOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
-                    ::mlir::Value ptr, ::mlir::Value value,
-                    ::mlir::triton::CacheModifier cache,
-                    ::mlir::triton::EvictionPolicy evict) {
+void StoreOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                    Value value, CacheModifier cache, EvictionPolicy evict) {
   return StoreOp::build(builder, state, ptr, value, /*mask=*/{},
                         /*boundaryCheck=*/{}, cache, evict);
 }
 
-void StoreOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
-                    ::mlir::Value ptr, ::mlir::Value value, ::mlir::Value mask,
-                    ::mlir::triton::CacheModifier cache,
-                    ::mlir::triton::EvictionPolicy evict) {
+void StoreOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                    Value value, Value mask, CacheModifier cache,
+                    EvictionPolicy evict) {
   return StoreOp::build(builder, state, ptr, value, mask, /*boundaryCheck=*/{},
                         cache, evict);
 }
 
-void StoreOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
-                    ::mlir::Value ptr, ::mlir::Value value,
-                    ArrayRef<int32_t> boundaryCheck,
-                    ::mlir::triton::CacheModifier cache,
-                    ::mlir::triton::EvictionPolicy evict) {
+void StoreOp::build(OpBuilder &builder, OperationState &state, Value ptr,
+                    Value value, ArrayRef<int32_t> boundaryCheck,
+                    CacheModifier cache, EvictionPolicy evict) {
   return StoreOp::build(builder, state, ptr, value, /*mask=*/{},
                         builder.getDenseI32ArrayAttr(boundaryCheck), cache,
                         evict);
@@ -320,54 +306,52 @@ void StoreOp::build(::mlir::OpBuilder &builder, ::mlir::OperationState &state,
 
 // store(ptr, value, splat(1), ...) -> store(ptr, value, ...)
 // store(ptr, value, splat(0), ...) -> [none]
-struct CanonicalizeMaskedStorePattern
-    : public mlir::OpRewritePattern<triton::StoreOp> {
-  CanonicalizeMaskedStorePattern(mlir::MLIRContext *context)
-      : OpRewritePattern<triton::StoreOp>(context, 1) {}
+struct CanonicalizeMaskedStorePattern : public OpRewritePattern<StoreOp> {
+  CanonicalizeMaskedStorePattern(MLIRContext *context)
+      : OpRewritePattern<StoreOp>(context, 1) {}
 
-  mlir::LogicalResult
-  matchAndRewrite(triton::StoreOp storeOp,
-                  mlir::PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(StoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
     auto mask = storeOp.getMask();
     if (!mask)
-      return mlir::failure();
+      return failure();
 
     auto constantMask =
         llvm::dyn_cast_or_null<arith::ConstantOp>(mask.getDefiningOp());
     if (!constantMask)
-      return mlir::failure();
+      return failure();
 
     auto splatMask = constantMask.getValue().dyn_cast<SplatElementsAttr>();
     if (!splatMask)
-      return mlir::failure();
+      return failure();
 
     if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
       // mask = splat(1)
-      rewriter.replaceOpWithNewOp<triton::StoreOp>(
+      rewriter.replaceOpWithNewOp<StoreOp>(
           storeOp, storeOp.getPtr(), storeOp.getValue(), storeOp.getCache(),
           storeOp.getEvict());
     } else {
       // mask = splat(0)
       rewriter.eraseOp(storeOp);
     }
-    return mlir::success();
+    return success();
   }
 };
 
-void triton::StoreOp::getCanonicalizationPatterns(RewritePatternSet &results,
-                                                  MLIRContext *context) {
+void StoreOp::getCanonicalizationPatterns(RewritePatternSet &results,
+                                          MLIRContext *context) {
   results.add<CanonicalizeMaskedStorePattern>(context);
 }
 
 //-- TransOp --
-OpFoldResult mlir::triton::TransOp::fold(FoldAdaptor adaptor) {
+OpFoldResult TransOp::fold(FoldAdaptor adaptor) {
   // transpose(x, order=[0, 1, ...]) -> x
-  if (triton::isIota(getOrder())) {
+  if (isIota(getOrder())) {
     return getSrc();
   }
 
   // transpose(transpose(x)) -> transpose(x)
-  if (auto innerTrans = getSrc().getDefiningOp<triton::TransOp>()) {
+  if (auto innerTrans = getSrc().getDefiningOp<TransOp>()) {
     setOrder(applyPermutation(innerTrans.getOrder(), getOrder()));
     setOperand(innerTrans.getSrc());
     return getResult();
@@ -376,7 +360,7 @@ OpFoldResult mlir::triton::TransOp::fold(FoldAdaptor adaptor) {
   return {};
 }
 
-mlir::LogicalResult mlir::triton::TransOp::inferReturnTypes(
+LogicalResult TransOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
@@ -394,15 +378,15 @@ mlir::LogicalResult mlir::triton::TransOp::inferReturnTypes(
     if (inferLayoutInterface
             ->inferTransOpEncoding(argEncoding, order, retEncoding)
             .failed()) {
-      return mlir::failure();
+      return failure();
     }
   }
   inferredReturnTypes.push_back(
       RankedTensorType::get(retShape, retEltTy, retEncoding));
-  return mlir::success();
+  return success();
 }
 
-LogicalResult triton::TransOp::verify() {
+LogicalResult TransOp::verify() {
   // Check that the op's `order` attribute is a permutation of the right length.
   auto srcTy = getSrc().getType();
 
@@ -424,10 +408,11 @@ LogicalResult triton::TransOp::verify() {
 }
 
 //-- DotOp --
-mlir::LogicalResult mlir::triton::DotOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
-    SmallVectorImpl<Type> &inferredReturnTypes) {
+LogicalResult
+DotOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
+                        ValueRange operands, DictionaryAttr attributes,
+                        OpaqueProperties properties, RegionRange regions,
+                        SmallVectorImpl<Type> &inferredReturnTypes) {
   // type is the same as the accumulator
   auto accTy = operands[2].getType().cast<RankedTensorType>();
   inferredReturnTypes.push_back(accTy);
@@ -441,14 +426,14 @@ mlir::LogicalResult mlir::triton::DotOp::inferReturnTypes(
     Dialect &dialect = aEnc.getDialect();
     auto interface = dyn_cast<DialectInferLayoutInterface>(&dialect);
     if (interface->inferDotOpEncoding(aEnc, 0, retEnc, location).failed())
-      return mlir::failure();
+      return failure();
     if (interface->inferDotOpEncoding(bEnc, 1, retEnc, location).failed())
-      return mlir::failure();
+      return failure();
   }
-  return mlir::success();
+  return success();
 }
 
-LogicalResult mlir::triton::DotOp::verify() {
+LogicalResult DotOp::verify() {
   auto aTy = getA().getType();
   auto bTy = getB().getType();
   if (aTy.getElementType().getIntOrFloatBitWidth() !=
@@ -458,7 +443,7 @@ LogicalResult mlir::triton::DotOp::verify() {
   auto aEncoding = aTy.getEncoding();
   auto bEncoding = bTy.getEncoding();
   if (!aEncoding && !bEncoding)
-    return mlir::success();
+    return success();
   // Verify that the encodings are valid.
   if (!aEncoding || !bEncoding)
     return emitError("mismatching encoding between A and B operands");
@@ -484,10 +469,7 @@ LogicalResult MakeRangeOp::verify() {
   if (start > end) {
     return this->emitOpError() << "start must be less than or equal to end";
   }
-  auto ty = getType().dyn_cast<RankedTensorType>();
-  if (!ty) {
-    return this->emitOpError() << "return type must be a ranked tensor";
-  }
+  auto ty = getType();
   if (ty.getShape().size() != 1) {
     return this->emitOpError() << "return type must be a 1D tensor";
   }
@@ -504,7 +486,7 @@ LogicalResult MakeRangeOp::verify() {
 }
 
 //-- ReduceOp --
-static mlir::LogicalResult
+static LogicalResult
 inferReduceReturnShape(const RankedTensorType &argTy, const Type &retEltTy,
                        int axis, SmallVectorImpl<Type> &inferredReturnTypes) {
   auto retShape = argTy.getShape().vec();
@@ -525,18 +507,18 @@ inferReduceReturnShape(const RankedTensorType &argTy, const Type &retEltTy,
               ->inferReduceOpEncoding(argEncoding, axis, retEncoding)
               .failed()) {
         llvm::report_fatal_error("failed to infer layout for ReduceOp");
-        return mlir::failure();
+        return failure();
       }
     }
     // create type
     inferredReturnTypes.push_back(
         RankedTensorType::get(retShape, retEltTy, retEncoding));
   }
-  return mlir::success();
+  return success();
 }
 
-void ReduceOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
-                     mlir::ValueRange operands, int axis) {
+void ReduceOp::build(OpBuilder &builder, OperationState &state,
+                     ValueRange operands, int axis) {
   SmallVector<Type> inferredReturnTypes;
   for (unsigned i = 0; i < operands.size(); ++i) {
     auto argTy = operands[i].getType().cast<RankedTensorType>();
@@ -547,7 +529,7 @@ void ReduceOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
   ReduceOp::build(builder, state, inferredReturnTypes, operands, axis);
 }
 
-mlir::LogicalResult mlir::triton::ReduceOp::inferReturnTypes(
+LogicalResult ReduceOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> location, ValueRange operands,
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
@@ -564,7 +546,7 @@ mlir::LogicalResult mlir::triton::ReduceOp::inferReturnTypes(
   return success();
 }
 
-mlir::LogicalResult mlir::triton::ReduceOp::verify() {
+LogicalResult ReduceOp::verify() {
   if (this->getOperands().size() < 1) {
     return this->emitOpError() << "must have at least 1 operand";
   }
@@ -578,7 +560,7 @@ mlir::LogicalResult mlir::triton::ReduceOp::verify() {
 
 // Helpers for Reductions and Scans
 template <class ReturnOp, class Op>
-static mlir::LogicalResult verifyRegionsImpl(Op &op) {
+static LogicalResult verifyRegionsImpl(Op &op) {
   auto argElementTypes = op.getElementTypes();
   const auto &operands = op.getOperands();
   const auto numArgs = 2 * operands.size();
@@ -621,11 +603,11 @@ static mlir::LogicalResult verifyRegionsImpl(Op &op) {
              << " to have type " << argElemTy << " but got " << resultTy;
     }
   }
-  return mlir::success();
+  return success();
 }
 
-static llvm::SmallVector<mlir::RankedTensorType>
-getInputTypesImpl(const mlir::Operation::operand_range &operands) {
+static llvm::SmallVector<RankedTensorType>
+getInputTypesImpl(const Operation::operand_range &operands) {
   llvm::SmallVector<RankedTensorType> srcTys;
   srcTys.reserve(operands.size());
   for (const auto &ty : operands.getTypes()) {
@@ -635,7 +617,7 @@ getInputTypesImpl(const mlir::Operation::operand_range &operands) {
 }
 
 static llvm::SmallVector<Type>
-getElementTypesImpl(const mlir::Operation::operand_range &operands) {
+getElementTypesImpl(const Operation::operand_range &operands) {
   llvm::SmallVector<Type> srcElemTys;
   srcElemTys.reserve(operands.size());
   for (const auto &op : operands) {
@@ -645,12 +627,12 @@ getElementTypesImpl(const mlir::Operation::operand_range &operands) {
   return srcElemTys;
 }
 
-mlir::LogicalResult mlir::triton::ReduceOp::verifyRegions() {
-  using ReturnOp = mlir::triton::ReduceReturnOp;
+LogicalResult ReduceOp::verifyRegions() {
+  using ReturnOp = ReduceReturnOp;
   return verifyRegionsImpl<ReturnOp>(*this);
 }
 
-llvm::SmallVector<mlir::RankedTensorType> ReduceOp::getInputTypes() {
+llvm::SmallVector<RankedTensorType> ReduceOp::getInputTypes() {
   return getInputTypesImpl(this->getOperands());
 }
 
@@ -661,41 +643,42 @@ llvm::SmallVector<Type> ReduceOp::getElementTypes() {
 unsigned ReduceOp::getNumOperands() { return this->getOperands().size(); }
 
 //-- ScanOp --
-void ScanOp::build(mlir::OpBuilder &builder, mlir::OperationState &state,
-                   mlir::ValueRange operands, int axis) {
+void ScanOp::build(OpBuilder &builder, OperationState &state,
+                   ValueRange operands, int axis) {
   SmallVector<Type> inferredReturnTypes;
   for (auto arg : operands)
     inferredReturnTypes.push_back(arg.getType());
   ReduceOp::build(builder, state, inferredReturnTypes, operands, axis);
 }
 
-mlir::LogicalResult mlir::triton::ScanOp::inferReturnTypes(
-    MLIRContext *context, std::optional<Location> location, ValueRange operands,
-    DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
-    SmallVectorImpl<Type> &inferredReturnTypes) {
+LogicalResult
+ScanOp::inferReturnTypes(MLIRContext *context, std::optional<Location> location,
+                         ValueRange operands, DictionaryAttr attributes,
+                         OpaqueProperties properties, RegionRange regions,
+                         SmallVectorImpl<Type> &inferredReturnTypes) {
   for (auto arg : operands)
     inferredReturnTypes.push_back(arg.getType());
   return success();
 }
 
-mlir::LogicalResult mlir::triton::ScanOp::verify() {
+LogicalResult ScanOp::verify() {
   if (this->getOperands().size() < 1) {
     return this->emitOpError() << "must have at least 1 operand";
   }
-  for (const auto &operand : this->getOperands()) {
+  /*for (const auto &operand : this->getOperands()) {
     if (!dyn_cast<RankedTensorType>(operand.getType())) {
       return this->emitOpError() << "operands must be RankedTensorType";
     }
-  }
+  }*/
   return success();
 }
 
-mlir::LogicalResult mlir::triton::ScanOp::verifyRegions() {
-  using ReturnOp = mlir::triton::ScanReturnOp;
+LogicalResult ScanOp::verifyRegions() {
+  using ReturnOp = ScanReturnOp;
   return verifyRegionsImpl<ReturnOp>(*this);
 }
 
-llvm::SmallVector<mlir::RankedTensorType> ScanOp::getInputTypes() {
+llvm::SmallVector<RankedTensorType> ScanOp::getInputTypes() {
   return getInputTypesImpl(this->getOperands());
 }
 
@@ -716,7 +699,7 @@ OpFoldResult SplatOp::fold(FoldAdaptor adaptor) {
 }
 
 //-- ExpandDimsOp --
-mlir::LogicalResult mlir::triton::ExpandDimsOp::inferReturnTypes(
+LogicalResult ExpandDimsOp::inferReturnTypes(
     MLIRContext *context, std::optional<Location> loc, ValueRange operands,
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
@@ -742,20 +725,19 @@ mlir::LogicalResult mlir::triton::ExpandDimsOp::inferReturnTypes(
   auto argEltTy = argTy.getElementType();
   inferredReturnTypes.push_back(
       RankedTensorType::get(retShape, argEltTy, retEncoding));
-  return mlir::success();
+  return success();
 }
 
 LogicalResult ExpandDimsOp::canonicalize(ExpandDimsOp op,
                                          PatternRewriter &rewriter) {
   auto definingOp = op.getOperand().getDefiningOp();
   if (!definingOp) {
-    return mlir::failure();
+    return failure();
   }
   // expand_dims(splat) -> splat
-  if (auto splat = dyn_cast<triton::SplatOp>(definingOp)) {
-    rewriter.replaceOpWithNewOp<triton::SplatOp>(op, op.getType(),
-                                                 splat.getOperand());
-    return mlir::success();
+  if (auto splat = dyn_cast<SplatOp>(definingOp)) {
+    rewriter.replaceOpWithNewOp<SplatOp>(op, op.getType(), splat.getOperand());
+    return success();
   }
   // expand_dims(broadcast(x)) -> broadcast(expand_dims(x))
   //
@@ -763,9 +745,9 @@ LogicalResult ExpandDimsOp::canonicalize(ExpandDimsOp op,
   //    broadcast(expand_dims(broadcast))
   // -> broadcast(broadcast(expand_dims))
   // -> broadcast(expand_dims)
-  if (auto broadcast = dyn_cast<triton::BroadcastOp>(definingOp)) {
+  if (auto broadcast = dyn_cast<BroadcastOp>(definingOp)) {
     auto src = broadcast.getSrc();
-    auto srcTy = src.getType().dyn_cast<RankedTensorType>();
+    auto srcTy = src.getType();
     SmallVector<int64_t> newExpandShape(srcTy.getShape());
     newExpandShape.insert(newExpandShape.begin() + op.getAxis(), 1);
 
@@ -783,15 +765,15 @@ LogicalResult ExpandDimsOp::canonicalize(ExpandDimsOp op,
 
     auto newExpandTy = RankedTensorType::get(
         newExpandShape, srcTy.getElementType(), newExpandEnc);
-    auto newExpand = rewriter.create<triton::ExpandDimsOp>(
-        op.getLoc(), newExpandTy, src, op.getAxis());
-    auto newBroadcast = rewriter.create<triton::BroadcastOp>(
+    auto newExpand = rewriter.create<ExpandDimsOp>(op.getLoc(), newExpandTy,
+                                                   src, op.getAxis());
+    auto newBroadcast = rewriter.create<BroadcastOp>(
         broadcast.getLoc(), op.getType(), newExpand.getResult());
     rewriter.replaceOp(op, {newBroadcast.getResult()});
-    return mlir::success();
+    return success();
   }
 
-  return mlir::failure();
+  return failure();
 }
 
 template <typename ViewLikeOp>
@@ -799,7 +781,7 @@ static OpFoldResult foldViewLikeOp(ViewLikeOp op, Attribute value) {
   if (!value)
     return {};
 
-  auto shapedType = op.getType().template cast<mlir::ShapedType>();
+  auto shapedType = op.getType().template cast<ShapedType>();
   if (auto denseElemsAttr = value.dyn_cast<DenseElementsAttr>()) {
     if (denseElemsAttr.isSplat()) {
       return denseElemsAttr.resizeSplat(shapedType);
@@ -820,7 +802,7 @@ LogicalResult canonicalizeViewOrBroadcast(OpType op,
                                           PatternRewriter &rewriter) {
   auto definingOp = op.getOperand().getDefiningOp();
   if (!definingOp) {
-    return mlir::failure();
+    return failure();
   }
 
   // view(view) -> view
@@ -828,17 +810,16 @@ LogicalResult canonicalizeViewOrBroadcast(OpType op,
     rewriter.replaceOpWithNewOp<OpType>(op, TypeRange({op.getType()}),
                                         parentView->getOperands(),
                                         parentView->getAttrs());
-    return mlir::success();
+    return success();
   }
 
   // view(splat) -> splat
-  if (auto splat = dyn_cast<triton::SplatOp>(definingOp)) {
-    rewriter.replaceOpWithNewOp<triton::SplatOp>(op, op.getType(),
-                                                 splat.getOperand());
-    return mlir::success();
+  if (auto splat = dyn_cast<SplatOp>(definingOp)) {
+    rewriter.replaceOpWithNewOp<SplatOp>(op, op.getType(), splat.getOperand());
+    return success();
   }
 
-  return mlir::failure();
+  return failure();
 }
 
 LogicalResult ReshapeOp::canonicalize(ReshapeOp op, PatternRewriter &rewriter) {
@@ -856,7 +837,7 @@ OpFoldResult ReshapeOp::fold(FoldAdaptor adaptor) {
   return foldViewLikeOp(*this, adaptor.getSrc());
 }
 
-mlir::LogicalResult mlir::triton::ReshapeOp::verify() {
+LogicalResult ReshapeOp::verify() {
   auto dstTy = getType();
   auto srcTy = getSrc().getType();
   if (dstTy.getNumElements() != srcTy.getNumElements()) {
@@ -892,15 +873,14 @@ mlir::LogicalResult mlir::triton::ReshapeOp::verify() {
 }
 
 //-- FpToFpOp --
-mlir::LogicalResult mlir::triton::FpToFpOp::verify() {
-  auto dstType = getType().cast<RankedTensorType>().getElementType();
-  auto srcType =
-      getOperand().getType().cast<RankedTensorType>().getElementType();
+LogicalResult FpToFpOp::verify() {
+  auto dstType = getType().getElementType();
+  auto srcType = getFrom().getType().getElementType();
   if ((dstType.getIntOrFloatBitWidth() < srcType.getIntOrFloatBitWidth()) &&
       (!getRounding().has_value())) {
     return emitError("Rounding mode is required for FP downcast");
   }
-  return mlir::success();
+  return success();
 }
 
 //-- BroadcastOp --
@@ -927,12 +907,9 @@ OpFoldResult BroadcastOp::fold(FoldAdaptor adaptor) {
 }
 
 //-- MakeTensorPtrOp --
-void MakeTensorPtrOp::build(::mlir::OpBuilder &builder,
-                            ::mlir::OperationState &state, ::mlir::Value base,
-                            ::mlir::ValueRange shape,
-                            ::mlir::ValueRange strides,
-                            ::mlir::ValueRange offsets,
-                            ArrayRef<int32_t> tensorShape,
+void MakeTensorPtrOp::build(OpBuilder &builder, OperationState &state,
+                            Value base, ValueRange shape, ValueRange strides,
+                            ValueRange offsets, ArrayRef<int32_t> tensorShape,
                             ArrayRef<int32_t> order) {
   // Get pointer type from `base`
   auto pointerType = base.getType().cast<PointerType>();
@@ -953,10 +930,9 @@ void MakeTensorPtrOp::build(::mlir::OpBuilder &builder,
 // https://github.com/llvm/llvm-project/blob/main/mlir/lib/Dialect/Func/IR/FuncOps.cpp
 // We could revert it back once MLIR has a better inliner interface.
 //-- FuncOp --
-void triton::FuncOp::build(OpBuilder &builder, OperationState &state,
-                           StringRef name, FunctionType type,
-                           ArrayRef<NamedAttribute> attrs,
-                           ArrayRef<DictionaryAttr> argAttrs) {
+void FuncOp::build(OpBuilder &builder, OperationState &state, StringRef name,
+                   FunctionType type, ArrayRef<NamedAttribute> attrs,
+                   ArrayRef<DictionaryAttr> argAttrs) {
   state.addAttribute(SymbolTable::getSymbolAttrName(),
                      builder.getStringAttr(name));
   state.addAttribute(getFunctionTypeAttrName(state.name), TypeAttr::get(type));
@@ -971,7 +947,7 @@ void triton::FuncOp::build(OpBuilder &builder, OperationState &state,
       getArgAttrsAttrName(state.name), getResAttrsAttrName(state.name));
 }
 
-ParseResult triton::FuncOp::parse(OpAsmParser &parser, OperationState &result) {
+ParseResult FuncOp::parse(OpAsmParser &parser, OperationState &result) {
   auto buildFuncType =
       [](Builder &builder, ArrayRef<Type> argTypes, ArrayRef<Type> results,
          function_interface_impl::VariadicFlag,
@@ -983,15 +959,14 @@ ParseResult triton::FuncOp::parse(OpAsmParser &parser, OperationState &result) {
       getArgAttrsAttrName(result.name), getResAttrsAttrName(result.name));
 }
 
-void triton::FuncOp::print(OpAsmPrinter &printer) {
+void FuncOp::print(OpAsmPrinter &printer) {
   function_interface_impl::printFunctionOp(
       printer, *this, /*isVariadic=*/false, getFunctionTypeAttrName(),
       getArgAttrsAttrName(), getResAttrsAttrName());
 }
 
 // -- CallOp --
-LogicalResult
-triton::CallOp::verifySymbolUses(mlir::SymbolTableCollection &symbolTable) {
+LogicalResult CallOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   // Check that the callee attribute was specified.
   auto fnAttr = (*this).getProperties().callee;
   if (!fnAttr)
@@ -1027,8 +1002,8 @@ triton::CallOp::verifySymbolUses(mlir::SymbolTableCollection &symbolTable) {
 }
 
 // -- ReturnOp --
-LogicalResult triton::ReturnOp::verify() {
-  auto function = cast<triton::FuncOp>((*this)->getParentOp());
+LogicalResult ReturnOp::verify() {
+  auto function = cast<FuncOp>((*this)->getParentOp());
 
   // The operand number and types must match the function signature.
   const auto &results = function.getFunctionType().getResults();
@@ -1049,14 +1024,13 @@ LogicalResult triton::ReturnOp::verify() {
 }
 
 // -- ExperimentalInterleaveOp --
-LogicalResult triton::ExperimentalInterleaveOp::verify() {
+LogicalResult ExperimentalInterleaveOp::verify() {
   // A built-in verifier already checked that LHS and RHS have the same shape
   // (including same encoding).
-  assert(getLhs().getType().cast<RankedTensorType>().getShape() ==
-         getRhs().getType().cast<RankedTensorType>().getShape());
+  assert(getLhs().getType().getShape() == getRhs().getType().getShape());
 
-  auto srcTy = getLhs().getType().cast<RankedTensorType>();
-  auto dstTy = getResult().getType().cast<RankedTensorType>();
+  auto srcTy = getLhs().getType();
+  auto dstTy = getResult().getType();
   if (srcTy.getRank() != dstTy.getRank()) {
     return emitError("operands and result must have the same rank");
   }

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -61,7 +61,6 @@ warpsPerTileV2(tt::DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps) {
       auto chainedDot = cast<tt::DotOp>(op);
       if (auto mmaEncoding = chainedDot.getResult()
                                  .getType()
-                                 .cast<RankedTensorType>()
                                  .getEncoding()
                                  .dyn_cast<NvidiaMmaEncodingAttr>()) {
         return ttg::getWarpsPerCTA(mmaEncoding);
@@ -159,8 +158,7 @@ class BlockedToMMA : public mlir::RewritePattern {
     getBackwardSlice(x, &slice, opt);
     for (auto op : slice) {
       if (Value arg = op->getOperand(0))
-        if (RankedTensorType argTy =
-                arg.getType().dyn_cast<RankedTensorType>()) {
+        if (auto argTy = arg.getType().dyn_cast<RankedTensorType>()) {
           auto argBitWidth = argTy.getElementType().getIntOrFloatBitWidth();
           if (argBitWidth != origBitWidth) {
             origBitWidth = std::min<int>(origBitWidth, argBitWidth);
@@ -228,13 +226,10 @@ public:
     auto dotOp = cast<tt::DotOp>(op);
     auto ctx = op->getContext();
     // TODO: Check data-types and SM compatibility
-    auto oldRetType = dotOp.getResult().getType().cast<RankedTensorType>();
+    auto oldRetType = dotOp.getResult().getType();
     if (!oldRetType.getEncoding() ||
         oldRetType.getEncoding().isa<ttg::NvidiaMmaEncodingAttr>())
       return failure();
-
-    auto AType = dotOp.getOperand(0).getType().cast<RankedTensorType>();
-    auto BType = dotOp.getOperand(1).getType().cast<RankedTensorType>();
 
     // get MMA encoding for the given number of warps
     auto retShapePerCTA = ttg::getShapePerCTA(oldRetType);
@@ -246,13 +241,13 @@ public:
     if (!versionMajor)
       return failure();
 
-    auto instrShape =
-        mmaVersionToInstrShape(versionMajor, retShapePerCTA, AType);
+    auto instrShape = mmaVersionToInstrShape(versionMajor, retShapePerCTA,
+                                             dotOp.getA().getType());
     // operands
     Value a = dotOp.getA();
     Value b = dotOp.getB();
-    auto oldAType = a.getType().cast<RankedTensorType>();
-    auto oldBType = b.getType().cast<RankedTensorType>();
+    auto oldAType = dotOp.getA().getType();
+    auto oldBType = dotOp.getB().getType();
 
     ttg::NvidiaMmaEncodingAttr mmaEnc;
     if (versionMajor == 1) {
@@ -266,9 +261,8 @@ public:
       // get the source of the first conversion found in slices
       auto getCvtArgOrder = [](Operation *op) {
         return cast<ConvertLayoutOp>(op)
-            .getOperand()
+            .getSrc()
             .getType()
-            .cast<RankedTensorType>()
             .getEncoding()
             .cast<BlockedEncodingAttr>()
             .getOrder();
@@ -353,15 +347,12 @@ static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
 // supported.
 static void decomposeMixedModeDotOp(ModuleOp mod) {
   mod.walk([](tt::DotOp dotOp) -> void {
-    Value D = dotOp.getResult();
+    auto D = dotOp.getD();
     OpBuilder builder(dotOp);
-    Type AElType =
-        dotOp.getA().getType().cast<RankedTensorType>().getElementType();
+    Type AElType = dotOp.getA().getType().getElementType();
     Type promoteType;
-    NvidiaMmaEncodingAttr mmaLayout = D.getType()
-                                          .cast<RankedTensorType>()
-                                          .getEncoding()
-                                          .dyn_cast<NvidiaMmaEncodingAttr>();
+    NvidiaMmaEncodingAttr mmaLayout =
+        D.getType().getEncoding().dyn_cast<NvidiaMmaEncodingAttr>();
     if (mmaLayout) {
       bool isNativeHopperFP8 =
           AElType.isFloat8E5M2() || AElType.isFloat8E4M3FNUZ();
@@ -372,9 +363,8 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
       promoteType = builder.getF16Type();
     } else {
       // FMA case.
-      Type AElType =
-          dotOp.getA().getType().cast<RankedTensorType>().getElementType();
-      Type DElType = D.getType().cast<RankedTensorType>().getElementType();
+      Type AElType = dotOp.getA().getType().getElementType();
+      Type DElType = D.getType().getElementType();
       if (AElType == DElType)
         return;
       promoteType = DElType;

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -47,7 +47,7 @@ class Prefetcher {
   unsigned prefetchWidth = 32;
 
   /// dots to be prefetched
-  SetVector<Value> dots;
+  SetVector<triton::DotOp> dots;
   /// dot => dot operand
   DenseMap<Value, Value> dot2aLoopArg;
   DenseMap<Value, Value> dot2aHeaderDef;
@@ -199,8 +199,8 @@ LogicalResult Prefetcher::initialize() {
   };
 
   for (triton::DotOp dot : dotsInFor) {
-    auto aType = dot.getA().getType().cast<RankedTensorType>();
-    auto bType = dot.getB().getType().cast<RankedTensorType>();
+    auto aType = dot.getA().getType();
+    auto bType = dot.getB().getType();
     auto aEnc = aType.getEncoding().cast<triton::gpu::DotOperandEncodingAttr>();
     auto bEnc = bType.getEncoding().cast<triton::gpu::DotOperandEncodingAttr>();
     int aKWidth = aEnc.getKWidth();
@@ -248,9 +248,8 @@ LogicalResult Prefetcher::initialize() {
 void Prefetcher::emitPrologue() {
   OpBuilder builder(forOp);
 
-  for (Value dot : dots) {
-    Attribute dotEncoding =
-        dot.getType().cast<RankedTensorType>().getEncoding();
+  for (triton::DotOp dot : dots) {
+    Attribute dotEncoding = dot.getType().getEncoding();
     Value aPrefetched =
         generatePrefetch(dot2aHeaderDef[dot], 0, true, dotEncoding, builder);
     cloneElementwiseOps(aPrefetched, dot2aVals[dot], builder);
@@ -258,10 +257,8 @@ void Prefetcher::emitPrologue() {
         generatePrefetch(dot2bHeaderDef[dot], 1, true, dotEncoding, builder);
     cloneElementwiseOps(bPrefetched, dot2bVals[dot], builder);
 
-    operand2headPrefetch[dot.getDefiningOp<triton::DotOp>().getA()] =
-        aPrefetched;
-    operand2headPrefetch[dot.getDefiningOp<triton::DotOp>().getB()] =
-        bPrefetched;
+    operand2headPrefetch[dot.getA()] = aPrefetched;
+    operand2headPrefetch[dot.getB()] = bPrefetched;
   }
 }
 
@@ -271,11 +268,9 @@ scf::ForOp Prefetcher::createNewForOp() {
   SmallVector<Value> loopArgs;
   for (auto v : forOp.getInitArgs())
     loopArgs.push_back(v);
-  for (Value dot : dots) {
-    loopArgs.push_back(
-        operand2headPrefetch[dot.getDefiningOp<triton::DotOp>().getA()]);
-    loopArgs.push_back(
-        operand2headPrefetch[dot.getDefiningOp<triton::DotOp>().getB()]);
+  for (triton::DotOp dot : dots) {
+    loopArgs.push_back(operand2headPrefetch[dot.getA()]);
+    loopArgs.push_back(operand2headPrefetch[dot.getB()]);
   }
 
   auto newForOp = builder.create<scf::ForOp>(
@@ -292,8 +287,7 @@ scf::ForOp Prefetcher::createNewForOp() {
     Operation *newOp = builder.clone(op, mapping);
     auto dot = dyn_cast<triton::DotOp>(&op);
     if (dot && dots.contains(dot)) {
-      Attribute dotEncoding =
-          dot.getType().cast<RankedTensorType>().getEncoding();
+      Attribute dotEncoding = dot.getType().getEncoding();
       // prefetched dot
       Operation *firstDot = builder.clone(*dot, mapping);
       if (Value a = operand2headPrefetch.lookup(dot.getA()))
@@ -305,9 +299,7 @@ scf::ForOp Prefetcher::createNewForOp() {
 
       // remaining part
       int64_t kOff = prefetchWidth;
-      int64_t kRem =
-          dot.getA().getType().cast<RankedTensorType>().getShape()[1] -
-          prefetchWidth;
+      int64_t kRem = dot.getA().getType().getShape()[1] - prefetchWidth;
       Operation *prevDot = firstDot;
       while (kRem != 0) {
         // int64_t kShape = largestPow2(kRem);
@@ -341,9 +333,8 @@ scf::ForOp Prefetcher::createNewForOp() {
   SmallVector<Value> yieldValues;
   for (Value v : forOp.getBody()->getTerminator()->getOperands())
     yieldValues.push_back(mapping.lookupOrDefault(v));
-  for (Value dot : dots) {
-    Attribute dotEncoding =
-        dot.getType().cast<RankedTensorType>().getEncoding();
+  for (triton::DotOp dot : dots) {
+    Attribute dotEncoding = dot.getType().getEncoding();
     Value aToYield = generatePrefetch(mapping.lookup(dot2aYield[dot]), 0, true,
                                       dotEncoding, builder);
     cloneElementwiseOps(aToYield, dot2aVals[dot], builder);


### PR DESCRIPTION
These are unnecessary now that we've taught tablegen which of our ops
accept RankedTensorType, 70dd60538e73784cf75a190b43f2e80011d22855.

Also get rid of some unnecessary namespace qualifications.
