### PR TITLE
[BACKEND] Simplifying minOverHistories as there is no TMA support

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -488,9 +488,9 @@ minWaitNumberForExtract(ttg::ExtractSliceOp extractOp) {
   // we calculate the number of async_commit. Then we select the minimum number
   // of async_commit ops among all the paths.
   // If the wait is not needed return std::nullopt.
-  std::function<std::optional<int>(Value, Operation *, int)> minOverHistories =
+  std::function<int(Value, Operation *, int)> minOverHistories =
       [&](Value val, Operation *sinkOp,
-          int thisHistorySum) -> std::optional<int> {
+          int thisHistorySum) -> int {
     if (Operation *defOp = val.getDefiningOp()) {
       if (isa<ttg::InsertSliceAsyncOp>(defOp)) {
         thisHistorySum += countCommitsBetween(defOp->getNextNode(), sinkOp);
@@ -517,32 +517,26 @@ minWaitNumberForExtract(ttg::ExtractSliceOp extractOp) {
       // get the value value assigned to the argument coming from outside the
       // loop
       Value incomingVal = forOp.getInitArgs()[arg.getArgNumber() - 1];
-      std::optional<int> min1 =
+      int min1 =
           minOverHistories(incomingVal, forOp, thisHistorySum);
-      if (!min1.has_value())
-        return std::nullopt;
 
       // get the value value assigned to the argument coming from the previous
       // iteration
       Operation *yieldOp = block->getTerminator();
       Value prevVal = yieldOp->getOperand(arg.getArgNumber() - 1);
-      std::optional<int> min2 =
+      int min2 =
           minOverHistories(prevVal, yieldOp, thisHistorySum);
-      if (!min1.has_value())
-        return std::nullopt;
-      return std::min(std::min(min1, min2).value(), minCommitNumber);
+      return std::min(std::min(min1, min2), minCommitNumber);
     }
     // Failed to track, return 1 conservatively.
     return 1;
   };
 
-  std::optional<int> minCommits =
+  int minCommits =
       minOverHistories(extractOp.getOperand(0), extractOp, 0);
-  if (minCommits == std::nullopt)
-    return std::nullopt;
   if (minCommits == 0)
     llvm::report_fatal_error("No commits between insert and extract!");
-  return minCommits.value() - 1;
+  return minCommits - 1;
 }
 
 /// Insert wait ops after the extract_slice ops.


### PR DESCRIPTION
In the Pipeliner, TMA support required detection if the `InsertSlice` was TMA or non-TMA kind, as for TMA we weren't supposed to insert `AsyncWait`s. Without TMA, we can simplify `minOverHistories` function that does not have to handle special case anymore.