### PR TITLE
NFC cleanups to C++ code.

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -278,7 +278,7 @@ private:
       maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, bytes,
                                                           scratchAlignment);
     } else if (auto histogram = dyn_cast<triton::HistogramOp>(op)) {
-      auto dstTy = histogram.getResult().getType().cast<RankedTensorType>();
+      auto dstTy = histogram.getType();
       int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(
           op->getParentOfType<ModuleOp>());
       auto bytes = std::max<int>(dstTy.getNumElements(), threadsPerWarp) *
@@ -287,7 +287,7 @@ private:
                                                           scratchAlignment);
     } else if (auto cvtLayout = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
       auto srcTy = cvtLayout.getSrc().getType();
-      auto dstTy = cvtLayout.getResult().getType();
+      auto dstTy = cvtLayout.getType();
       auto srcEncoding = srcTy.getEncoding();
       auto dstEncoding = dstTy.getEncoding();
       if (srcEncoding.isa<SharedEncodingAttr>() ||

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -345,7 +345,7 @@ private:
 
   int64_t getConstancy(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                        int dim) override {
-    auto resTy = op.getResult().getType().template dyn_cast<RankedTensorType>();
+    auto resTy = op.getType().template dyn_cast<RankedTensorType>();
     if (!resTy)
       return BinaryOpVisitorImpl<OpTy>::getConstancy(op, lhs, rhs, dim);
     auto shape = resTy.getShape();
@@ -400,7 +400,7 @@ public:
 private:
   int64_t getContiguity(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                         int dim) override {
-    auto resTy = op.getResult().getType().template dyn_cast<RankedTensorType>();
+    auto resTy = op.getType().template dyn_cast<RankedTensorType>();
     if (!resTy)
       return BinaryOpVisitorImpl<OpTy>::getContiguity(op, lhs, rhs, dim);
     auto shape = resTy.getShape();
@@ -434,7 +434,7 @@ private:
 
   int64_t getConstancy(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                        int dim) override {
-    auto resTy = op.getResult().getType().template dyn_cast<RankedTensorType>();
+    auto resTy = op.getType().template dyn_cast<RankedTensorType>();
     if (!resTy)
       return BinaryOpVisitorImpl<OpTy>::getConstancy(op, lhs, rhs, dim);
     auto shape = resTy.getShape();
@@ -583,7 +583,7 @@ public:
   AxisInfo
   getAxisInfo(OpTy op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    auto resTy = op.getResult().getType().template dyn_cast<RankedTensorType>();
+    auto resTy = op.getType().template dyn_cast<RankedTensorType>();
     if (!resTy)
       return AxisInfo();
     auto shape = resTy.getShape();

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -65,8 +65,8 @@ public:
   LogicalResult
   matchAndRewrite(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto srcTy = op.getSrc().getType();
-    auto dstTy = op.getResult().getType();
+    RankedTensorType srcTy = op.getSrc().getType();
+    RankedTensorType dstTy = op.getType();
     Attribute srcLayout = srcTy.getEncoding();
     Attribute dstLayout = dstTy.getEncoding();
     if (isaDistributedLayout(srcLayout) &&
@@ -460,7 +460,7 @@ private:
     auto loc = op.getLoc();
     auto typeConverter = getTypeConverter();
     auto srcTy = op.getSrc().getType();
-    auto dstTy = op.getResult().getType();
+    auto dstTy = op.getType();
     auto srcLayout = srcTy.getEncoding();
     auto dstLayout = dstTy.getEncoding();
     auto srcShapePerCTA = getShapePerCTA(srcTy);
@@ -544,8 +544,8 @@ private:
                                 ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
     auto typeConverter = getTypeConverter();
-    auto srcTy = op.getSrc().getType();
-    auto dstTy = op.getResult().getType();
+    RankedTensorType srcTy = op.getSrc().getType();
+    RankedTensorType dstTy = op.getType();
     Attribute srcLayout = srcTy.getEncoding();
     Attribute dstLayout = dstTy.getEncoding();
 
@@ -947,8 +947,8 @@ private:
                               OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
-    auto dstTy = op.getResult().getType().cast<RankedTensorType>();
+    RankedTensorType srcTy = op.getSrc().getType();
+    RankedTensorType dstTy = op.getType();
     if (triton::gpu::getTotalElemsPerThread(srcTy) ==
         triton::gpu::getTotalElemsPerThread(dstTy)) {
       rewriter.replaceOp(op, adaptor.getSrc());

--- a/lib/Conversion/TritonGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/HistogramOpToLLVM.cpp
@@ -147,8 +147,7 @@ public:
     Value input = adaptor.getSrc();
     auto typeConverter = getTypeConverter();
     SmallVector<Value> srcValues = unpackLLElements(loc, input, rewriter);
-    int numBins =
-        op.getResult().getType().cast<RankedTensorType>().getDimSize(0);
+    int numBins = op.getType().getDimSize(0);
     int numThreadsPerWarp = 32;
     // Pad out the bins so that we have at least one bin per thread within a
     // warp.
@@ -166,7 +165,7 @@ public:
     // data in the default blocked layout.
     Value baseSharedMemPtr =
         LLVM::getSharedMemoryBase(loc, rewriter, op.getOperation());
-    auto dstType = op.getResult().getType().cast<RankedTensorType>();
+    auto dstType = op.getType();
     auto mod = op->getParentOfType<ModuleOp>();
     int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
     Attribute dstEncoding = dstType.getEncoding();
@@ -180,7 +179,7 @@ public:
         numThreadsPerWarp, innerDimIndices, threadId, numWarps);
 
     Value results = packLLElements(loc, typeConverter, histogramValue, rewriter,
-                                   op.getResult().getType());
+                                   op.getType());
     rewriter.replaceOp(op, results);
     return success();
   }

--- a/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -152,9 +152,8 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     Value llOther = adaptor.getOther();
 
     // Determine the vectorization size
-    Type valueTy = op.getResult().getType();
     Type valueElemTy =
-        typeConverter->convertType(getElementTypeOrSelf(valueTy));
+        typeConverter->convertType(getElementTypeOrSelf(op.getType()));
     unsigned vec = getVectorSize(ptr);
     unsigned numElems = getTotalElemsPerThread(ptr.getType());
     if (llMask)
@@ -320,7 +319,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       }
     } // end vec
 
-    Type llvmResultStructTy = typeConverter->convertType(valueTy);
+    Type llvmResultStructTy = typeConverter->convertType(op.getType());
     Value resultStruct = packLLElements(loc, typeConverter, loadedVals,
                                         rewriter, llvmResultStructTy);
     rewriter.replaceOp(op, {resultStruct});
@@ -493,7 +492,7 @@ struct AtomicCASOpConversion
     auto cmpElements = unpackLLElements(loc, llCmp, rewriter);
     auto valElements = unpackLLElements(loc, llVal, rewriter);
 
-    auto valueTy = op.getResult().getType();
+    auto valueTy = op.getType();
     auto tensorTy = valueTy.dyn_cast<RankedTensorType>();
     Type valueElemTy =
         tensorTy ? getTypeConverter()->convertType(tensorTy.getElementType())
@@ -615,7 +614,7 @@ struct AtomicRMWOpConversion
     if (llMask)
       maskElements = unpackLLElements(loc, llMask, rewriter);
 
-    auto valueTy = op.getResult().getType();
+    auto valueTy = op.getType();
     auto tensorTy = valueTy.dyn_cast<RankedTensorType>();
     Type valueElemTy =
         tensorTy ? getTypeConverter()->convertType(tensorTy.getElementType())

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -11,19 +11,19 @@
 
 #include <memory>
 
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+
+namespace mlir::triton {
 namespace {
 
-using namespace mlir;
-using namespace mlir::triton;
-
-bool isZero(mlir::Value val) {
-  if (mlir::matchPattern(val, mlir::m_Zero()) ||
-      mlir::matchPattern(val, mlir::m_AnyZeroFloat()))
+bool isZero(Value val) {
+  if (matchPattern(val, m_Zero()) || matchPattern(val, m_AnyZeroFloat()))
     return true;
   // broadcast(constant_0)
-  if (auto bc = val.getDefiningOp<mlir::triton::BroadcastOp>()) {
-    if (mlir::matchPattern(bc.getSrc(), mlir::m_Zero()) ||
-        mlir::matchPattern(bc.getSrc(), mlir::m_AnyZeroFloat()))
+  if (auto bc = val.getDefiningOp<BroadcastOp>()) {
+    if (matchPattern(bc.getSrc(), m_Zero()) ||
+        matchPattern(bc.getSrc(), m_AnyZeroFloat()))
       return true;
   }
   return false;
@@ -56,52 +56,51 @@ using FastMathFlags = arith::FastMathFlags;
 
 // select(cond, load(ptrs, splat(cond), ???), other)
 //   => load(ptrs, splat(cond), other)
-class CombineSelectMaskedLoadPattern : public mlir::RewritePattern {
+class CombineSelectMaskedLoadPattern : public RewritePattern {
 public:
-  CombineSelectMaskedLoadPattern(mlir::MLIRContext *context)
-      : mlir::RewritePattern(mlir::arith::SelectOp::getOperationName(), 3,
-                             context, {triton::LoadOp::getOperationName()}) {}
+  CombineSelectMaskedLoadPattern(MLIRContext *context)
+      : RewritePattern(arith::SelectOp::getOperationName(), 3, context,
+                       {LoadOp::getOperationName()}) {}
 
-  mlir::LogicalResult
-  matchAndRewrite(mlir::Operation *op,
-                  mlir::PatternRewriter &rewriter) const override {
-    auto selectOp = llvm::dyn_cast<mlir::arith::SelectOp>(op);
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    auto selectOp = llvm::dyn_cast<arith::SelectOp>(op);
     if (!selectOp)
-      return mlir::failure();
+      return failure();
 
-    mlir::Value trueValue = selectOp.getTrueValue();
-    mlir::Value falseValue = selectOp.getFalseValue();
-    mlir::Value condSelect = selectOp.getCondition();
+    Value trueValue = selectOp.getTrueValue();
+    Value falseValue = selectOp.getFalseValue();
+    Value condSelect = selectOp.getCondition();
 
     auto *loadOpCandidate = trueValue.getDefiningOp();
-    auto loadOp = llvm::dyn_cast_or_null<triton::LoadOp>(loadOpCandidate);
+    auto loadOp = llvm::dyn_cast_or_null<LoadOp>(loadOpCandidate);
     if (!loadOp)
-      return mlir::failure();
+      return failure();
 
-    mlir::Value mask = loadOp.getMask();
+    Value mask = loadOp.getMask();
     if (!mask)
-      return mlir::failure();
+      return failure();
 
     auto *splatOpCandidate = mask.getDefiningOp();
-    auto splatOp = llvm::dyn_cast_or_null<triton::SplatOp>(splatOpCandidate);
+    auto splatOp = llvm::dyn_cast_or_null<SplatOp>(splatOpCandidate);
     if (!splatOp)
-      return mlir::failure();
+      return failure();
 
     auto splatCond = splatOp.getSrc();
     if (splatCond != condSelect)
-      return mlir::failure();
+      return failure();
 
-    rewriter.replaceOpWithNewOp<triton::LoadOp>(
+    rewriter.replaceOpWithNewOp<LoadOp>(
         op, loadOp.getPtr(), loadOp.getMask(), falseValue,
         loadOp.getBoundaryCheck(), loadOp.getPadding(), loadOp.getCache(),
         loadOp.getEvict(), loadOp.getIsVolatile());
-    return mlir::success();
+    return success();
   }
 };
 
 // sum(x[:, :, None] * y[None, :, :], 1)
 // -> dot(x, y)
-class CombineBroadcastMulReducePattern : public mlir::RewritePattern {
+class CombineBroadcastMulReducePattern : public RewritePattern {
 private:
   static bool isAddF32(const Operation *op) {
     if (auto addf = dyn_cast_or_null<arith::AddFOp>(op))
@@ -119,79 +118,75 @@ private:
   }
 
 public:
-  CombineBroadcastMulReducePattern(mlir::MLIRContext *context)
-      : mlir::RewritePattern(triton::ReduceOp::getOperationName(), 1, context) {
-  }
+  CombineBroadcastMulReducePattern(MLIRContext *context)
+      : RewritePattern(ReduceOp::getOperationName(), 1, context) {}
 
-  mlir::LogicalResult matchAndRewrite(mlir::Operation *op,
-                                      mlir::PatternRewriter &rewriter) const {
-    auto reduceOp = llvm::dyn_cast<triton::ReduceOp>(op);
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const {
+    auto reduceOp = llvm::dyn_cast<ReduceOp>(op);
     if (!reduceOp)
-      return mlir::failure();
+      return failure();
     // only support reduce with simple addition
     Region &combineOp = reduceOp.getCombineOp();
     bool isReduceAdd = combineOp.hasOneBlock() &&
                        combineOp.front().getOperations().size() == 2 &&
                        isAddF32(&*combineOp.front().getOperations().begin());
     if (!isReduceAdd)
-      return mlir::failure();
+      return failure();
     // operand of reduce has to be mul
     auto mulOp = llvm::dyn_cast_or_null<arith::MulFOp>(
         reduceOp.getOperand(0).getDefiningOp());
     if (!mulOp)
-      return mlir::failure();
+      return failure();
     // mul operand has to be broadcast
-    auto broadcastLhsOp = llvm::dyn_cast_or_null<triton::BroadcastOp>(
+    auto broadcastLhsOp = llvm::dyn_cast_or_null<BroadcastOp>(
         mulOp.getOperand(0).getDefiningOp());
     if (!broadcastLhsOp)
-      return mlir::failure();
-    auto broadcastRhsOp = llvm::dyn_cast_or_null<triton::BroadcastOp>(
+      return failure();
+    auto broadcastRhsOp = llvm::dyn_cast_or_null<BroadcastOp>(
         mulOp.getOperand(1).getDefiningOp());
     if (!broadcastRhsOp)
-      return mlir::failure();
+      return failure();
     // broadcast operand is expand dims
-    auto expandLhsOp = llvm::dyn_cast_or_null<triton::ExpandDimsOp>(
+    auto expandLhsOp = llvm::dyn_cast_or_null<ExpandDimsOp>(
         broadcastLhsOp.getSrc().getDefiningOp());
     if (!expandLhsOp)
-      return mlir::failure();
-    auto expandRhsOp = llvm::dyn_cast_or_null<triton::ExpandDimsOp>(
+      return failure();
+    auto expandRhsOp = llvm::dyn_cast_or_null<ExpandDimsOp>(
         broadcastRhsOp.getSrc().getDefiningOp());
     if (!expandRhsOp)
-      return mlir::failure();
+      return failure();
     // get not-broadcast dimensions
     int expandLhsAxis = expandLhsOp.getAxis();
     int expandRhsAxis = expandRhsOp.getAxis();
     if (expandLhsAxis != 2 || expandRhsAxis != 0)
-      return mlir::failure();
+      return failure();
     auto broadcastLhsShape =
         broadcastLhsOp.getType().cast<ShapedType>().getShape();
     auto broadcastRhsShape =
         broadcastLhsOp.getType().cast<ShapedType>().getShape();
     if (broadcastLhsShape[2] < 16 || broadcastRhsShape[0] < 16)
-      return mlir::failure();
+      return failure();
     Type newAccType = RankedTensorType::get(
         {broadcastLhsShape[0], broadcastRhsShape[2]},
         broadcastLhsOp.getSrc().getType().cast<ShapedType>().getElementType());
     rewriter.setInsertionPoint(op);
-    auto newAcc = rewriter.create<triton::SplatOp>(
+    auto newAcc = rewriter.create<SplatOp>(
         op->getLoc(), newAccType,
         rewriter.create<arith::ConstantOp>(op->getLoc(),
                                            rewriter.getF32FloatAttr(0)));
-    rewriter.replaceOpWithNewOp<triton::DotOp>(
-        op, expandLhsOp.getSrc(), expandRhsOp.getSrc(), newAcc, true, 0);
-    return mlir::success();
+    rewriter.replaceOpWithNewOp<DotOp>(op, expandLhsOp.getSrc(),
+                                       expandRhsOp.getSrc(), newAcc, true, 0);
+    return success();
   }
 };
-
-#define GEN_PASS_CLASSES
-#include "triton/Dialect/Triton/Transforms/Passes.h.inc"
 
 class CombineOpsPass : public TritonCombineOpsBase<CombineOpsPass> {
 public:
   void runOnOperation() override {
-    mlir::MLIRContext *context = &getContext();
-    mlir::RewritePatternSet patterns(context);
-    mlir::ModuleOp m = getOperation();
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    ModuleOp m = getOperation();
 
     // Dot Add %{
     patterns.add<CombineDotAddIPattern>(context);
@@ -211,6 +206,8 @@ public:
 
 } // anonymous namespace
 
-std::unique_ptr<mlir::Pass> mlir::triton::createCombineOpsPass() {
+std::unique_ptr<mlir::Pass> createCombineOpsPass() {
   return std::make_unique<CombineOpsPass>();
 }
+
+} // namespace mlir::triton

--- a/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
+++ b/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
@@ -10,13 +10,12 @@
 
 #include <memory>
 
-namespace mlir {
+// TODO(jlebar): Move this and all other generatede code into namespace
+// mlir::triton.
 #define GEN_PASS_DEF_TRITONREORDERBROADCAST
 #include "triton/Dialect/Triton/Transforms/Passes.h.inc"
-} // namespace mlir
 
-using namespace mlir;
-
+namespace mlir::triton {
 namespace {
 
 Operation *cloneWithNewArgsAndResultTypes(PatternRewriter &rewriter,
@@ -30,7 +29,7 @@ Operation *cloneWithNewArgsAndResultTypes(PatternRewriter &rewriter,
 }
 
 bool isSplat(Operation *op) {
-  if (auto splatOp = llvm::dyn_cast<triton::SplatOp>(op)) {
+  if (auto splatOp = llvm::dyn_cast<SplatOp>(op)) {
     return true;
   }
   DenseElementsAttr constAttr;
@@ -39,29 +38,29 @@ bool isSplat(Operation *op) {
 
 // elementwise(splat(a), splat(b), ...) => splat(elementwise(a, b, ...))
 struct MoveSplatAfterElementwisePattern
-    : public mlir::OpTraitRewritePattern<mlir::OpTrait::Elementwise> {
+    : public OpTraitRewritePattern<OpTrait::Elementwise> {
 
-  MoveSplatAfterElementwisePattern(mlir::MLIRContext *context)
+  MoveSplatAfterElementwisePattern(MLIRContext *context)
       : OpTraitRewritePattern(context) {}
 
-  mlir::LogicalResult match(Operation *op) const override {
+  LogicalResult match(Operation *op) const override {
     if (!isMemoryEffectFree(op)) {
-      return mlir::failure();
+      return failure();
     }
 
     for (auto operand : op->getOperands()) {
       auto definingOp = operand.getDefiningOp();
       if (!definingOp)
-        return mlir::failure();
+        return failure();
 
       if (!isSplat(definingOp)) {
-        return mlir::failure();
+        return failure();
       }
     }
-    return mlir::success(op->getNumOperands() > 0);
+    return success(op->getNumOperands() > 0);
   }
 
-  void rewrite(Operation *op, mlir::PatternRewriter &rewriter) const override {
+  void rewrite(Operation *op, PatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
     auto operands = op->getOperands();
 
@@ -70,7 +69,7 @@ struct MoveSplatAfterElementwisePattern
       auto definingOp = operands[iOp].getDefiningOp();
 
       DenseElementsAttr constAttr;
-      if (auto splatOp = llvm::dyn_cast<triton::SplatOp>(definingOp)) {
+      if (auto splatOp = llvm::dyn_cast<SplatOp>(definingOp)) {
         scalarOperands[iOp] = splatOp.getSrc();
       } else if (matchPattern(definingOp, m_Constant(&constAttr)) &&
                  constAttr.isSplat()) {
@@ -93,8 +92,8 @@ struct MoveSplatAfterElementwisePattern
                                                 scalarResultTys);
 
     for (unsigned iRes = 0; iRes < resultTypes.size(); ++iRes) {
-      auto newResult = rewriter.create<triton::SplatOp>(loc, resultTypes[iRes],
-                                                        newOp->getResult(iRes));
+      auto newResult = rewriter.create<SplatOp>(loc, resultTypes[iRes],
+                                                newOp->getResult(iRes));
       rewriter.replaceAllUsesWith(op->getResult(iRes), newResult);
     }
   }
@@ -104,14 +103,14 @@ struct MoveSplatAfterElementwisePattern
 // This also generalizes to multiple arguments when the rest are splat-like
 // Not handled: multiple broadcasted arguments
 struct MoveBroadcastAfterElementwisePattern
-    : public mlir::OpTraitRewritePattern<mlir::OpTrait::Elementwise> {
+    : public OpTraitRewritePattern<OpTrait::Elementwise> {
 
-  MoveBroadcastAfterElementwisePattern(mlir::MLIRContext *context)
+  MoveBroadcastAfterElementwisePattern(MLIRContext *context)
       : OpTraitRewritePattern(context) {}
 
-  mlir::LogicalResult match(Operation *op) const override {
+  LogicalResult match(Operation *op) const override {
     if (!isMemoryEffectFree(op)) {
-      return mlir::failure();
+      return failure();
     }
 
     auto operands = op->getOperands();
@@ -120,35 +119,35 @@ struct MoveBroadcastAfterElementwisePattern
     for (auto operand : operands) {
       auto definingOp = operand.getDefiningOp();
       if (!definingOp) {
-        return mlir::failure();
+        return failure();
       }
-      auto getSrcShape = [](triton::BroadcastOp b) {
+      auto getSrcShape = [](BroadcastOp b) {
         return b.getSrc().getType().getShape();
       };
-      if (auto broadcastOp = llvm::dyn_cast<triton::BroadcastOp>(definingOp)) {
+      if (auto broadcastOp = llvm::dyn_cast<BroadcastOp>(definingOp)) {
         if (!seenBroadcast) {
           seenBroadcast = true;
           srcShape = getSrcShape(broadcastOp);
         } else if (srcShape != getSrcShape(broadcastOp)) {
           // If the broadcast have different types we cannot re-order.
-          return mlir::failure();
+          return failure();
         }
       } else if (!isSplat(definingOp)) {
         // Not splat or broadcast
-        return mlir::failure();
+        return failure();
       }
     }
-    return mlir::success(seenBroadcast);
+    return success(seenBroadcast);
   }
 
-  void rewrite(Operation *op, mlir::PatternRewriter &rewriter) const override {
+  void rewrite(Operation *op, PatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
 
     // Find broadcast op
     auto operands = op->getOperands();
-    triton::BroadcastOp broadcastOp;
+    BroadcastOp broadcastOp;
     for (auto operand : operands) {
-      broadcastOp = operand.getDefiningOp<triton::BroadcastOp>();
+      broadcastOp = operand.getDefiningOp<BroadcastOp>();
       if (broadcastOp) {
         break;
       }
@@ -162,17 +161,15 @@ struct MoveBroadcastAfterElementwisePattern
     llvm::SmallVector<Value, 4> newOperands;
     for (auto operand : operands) {
       auto definingOp = operand.getDefiningOp();
-      if (auto broadcastSrcOp =
-              llvm::dyn_cast<triton::BroadcastOp>(definingOp)) {
+      if (auto broadcastSrcOp = llvm::dyn_cast<BroadcastOp>(definingOp)) {
         newOperands.push_back(broadcastSrcOp.getSrc());
         continue;
       }
       auto elemTy =
           operand.getType().dyn_cast<RankedTensorType>().getElementType();
       auto newTy = RankedTensorType::get(srcShape, elemTy, srcEncoding);
-      if (auto splatOp = llvm::dyn_cast<triton::SplatOp>(definingOp)) {
-        auto newSplat =
-            rewriter.create<triton::SplatOp>(loc, newTy, splatOp.getSrc());
+      if (auto splatOp = llvm::dyn_cast<SplatOp>(definingOp)) {
+        auto newSplat = rewriter.create<SplatOp>(loc, newTy, splatOp.getSrc());
         newOperands.push_back(newSplat);
         continue;
       }
@@ -202,35 +199,35 @@ struct MoveBroadcastAfterElementwisePattern
     auto newOp = cloneWithNewArgsAndResultTypes(rewriter, op, newOperands,
                                                 newResultTypes);
     for (unsigned iRes = 0; iRes < newResultTypes.size(); ++iRes) {
-      auto newResult = rewriter.create<triton::BroadcastOp>(
-          loc, resultTypes[iRes], newOp->getResult(iRes));
+      auto newResult = rewriter.create<BroadcastOp>(loc, resultTypes[iRes],
+                                                    newOp->getResult(iRes));
       rewriter.replaceAllUsesWith(op->getResult(iRes), newResult);
     }
   }
 };
 
 template <typename OpType>
-class CanonicalizePattern : public mlir::OpRewritePattern<OpType> {
+class CanonicalizePattern : public OpRewritePattern<OpType> {
 public:
-  explicit CanonicalizePattern(mlir::MLIRContext *context)
-      : mlir::OpRewritePattern<OpType>(context) {}
+  explicit CanonicalizePattern(MLIRContext *context)
+      : OpRewritePattern<OpType>(context) {}
 
-  mlir::LogicalResult
-  matchAndRewrite(OpType op, mlir::PatternRewriter &rewriter) const override {
+  LogicalResult matchAndRewrite(OpType op,
+                                PatternRewriter &rewriter) const override {
     return OpType::canonicalize(op, rewriter);
   }
 };
 
 class ReorderBroadcastPass
-    : public mlir::impl::TritonReorderBroadcastBase<ReorderBroadcastPass> {
+    : public ::impl::TritonReorderBroadcastBase<ReorderBroadcastPass> {
 public:
   void runOnOperation() override {
-    mlir::MLIRContext *context = &getContext();
-    mlir::RewritePatternSet patterns(context);
-    mlir::ModuleOp m = getOperation();
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    ModuleOp m = getOperation();
 
-    patterns.add<CanonicalizePattern<triton::BroadcastOp>>(context);
-    patterns.add<CanonicalizePattern<triton::ExpandDimsOp>>(context);
+    patterns.add<CanonicalizePattern<BroadcastOp>>(context);
+    patterns.add<CanonicalizePattern<ExpandDimsOp>>(context);
     // elementwise(broadcast(a)) => broadcast(elementwise(a))
     patterns.add<MoveBroadcastAfterElementwisePattern>(context);
     // elementwise(splat(a), splat(b), ...) => splat(elementwise(a, b, ...))
@@ -243,6 +240,8 @@ public:
 
 } // namespace
 
-std::unique_ptr<mlir::Pass> mlir::triton::createReorderBroadcastPass() {
+std::unique_ptr<mlir::Pass> createReorderBroadcastPass() {
   return std::make_unique<ReorderBroadcastPass>();
 }
+
+} // namespace mlir::triton

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -226,7 +226,7 @@ public:
                                     triton::MakeTensorPtrOp op,
                                     std::stack<Operation *> &eraser) {
     // Save info for later use
-    auto ptrType = op.getResult().getType().cast<triton::PointerType>();
+    auto ptrType = op.getType().cast<triton::PointerType>();
     auto tensorType = ptrType.getPointeeType().cast<RankedTensorType>();
 
     // Cast I32 offsets into I64

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -408,7 +408,7 @@ bool isExpensiveCat(CatOp cat, Attribute targetEncoding) {
   // If the new elements per thread is less than the old one, we will need to do
   // convert encoding that goes through shared memory anyway. So we consider it
   // as expensive.
-  auto tensorTy = cat.getResult().getType();
+  RankedTensorType tensorTy = cat.getType();
   auto totalElemsPerThread = gpu::getTotalElemsPerThread(tensorTy);
   auto shape = tensorTy.getShape();
   auto elemTy = tensorTy.getElementType();
@@ -2347,7 +2347,7 @@ struct CanonicalizeConvertFromReshape
       return failure();
 
     rewriter.replaceOpWithNewOp<triton::ReshapeOp>(
-        op, op.getResult().getType(), convert.getSrc(), op.getAllowReorder());
+        op, op.getType(), convert.getSrc(), op.getAllowReorder());
     return mlir::success();
   }
 };

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -226,7 +226,7 @@ public:
     auto dotOp = cast<tt::DotOp>(op);
     auto ctx = op->getContext();
     // TODO: Check data-types and SM compatibility
-    auto oldRetType = dotOp.getResult().getType();
+    RankedTensorType oldRetType = dotOp.getType();
     if (!oldRetType.getEncoding() ||
         oldRetType.getEncoding().isa<ttg::NvidiaMmaEncodingAttr>())
       return failure();

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -229,9 +229,9 @@ public:
     if (!innerCvt)
       return failure();
 
-    auto srcTy = innerCvt.getSrc().getType().cast<RankedTensorType>();
-    auto innerCvtTy = innerCvt.getType().cast<RankedTensorType>();
-    auto outerCvtTy = outerCvt.getResult().getType().cast<RankedTensorType>();
+    RankedTensorType srcTy = innerCvt.getSrc().getType();
+    RankedTensorType innerCvtTy = innerCvt.getType();
+    RankedTensorType outerCvtTy = outerCvt.getType();
 
     auto innerCvtEnc = innerCvtTy.getEncoding().dyn_cast<SharedEncodingAttr>();
     auto outerCvtEnc = outerCvtTy.getEncoding().dyn_cast<SharedEncodingAttr>();

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -38,7 +38,7 @@ struct OptimizeReshapeLayoutPattern
     }
     if (!reductionAxis)
       return failure();
-    auto tensorType = viewOp.getResult().getType().cast<RankedTensorType>();
+    RankedTensorType tensorType = viewOp.getType();
     if (auto blocked = tensorType.getEncoding()
                            .dyn_cast<triton::gpu::BlockedEncodingAttr>()) {
       // If the layout already has all the elements along the reduction

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -118,12 +118,9 @@ allTransitiveUsesHaveDotEncoding(Value val, bool &needTrans) {
       auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(user);
       if (!convertLayout)
         return nullptr;
-      auto tensorType =
-          convertLayout.getResult().getType().dyn_cast<RankedTensorType>();
-      if (!tensorType)
-        return nullptr;
-      tempAttr =
-          tensorType.getEncoding().dyn_cast<ttg::DotOperandEncodingAttr>();
+      tempAttr = convertLayout.getType()
+                     .getEncoding()
+                     .dyn_cast<ttg::DotOperandEncodingAttr>();
     }
     if (!tempAttr || (attr != nullptr && attr != tempAttr))
       return nullptr;
@@ -139,8 +136,7 @@ static std::optional<LoadDotOperand> loadDotOperand(tt::LoadOp loadOp,
   if (loadOp.getResult().hasOneUse()) {
     Operation *use = *loadOp.getResult().getUsers().begin();
     if (auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(use)) {
-      auto tensorType =
-          convertLayout.getResult().getType().cast<RankedTensorType>();
+      auto tensorType = convertLayout.getType().cast<RankedTensorType>();
       if (auto sharedEnc =
               tensorType.getEncoding().dyn_cast<ttg::SharedEncodingAttr>()) {
         if (sharedEnc.getHasLeadingOffset()) {
@@ -657,7 +653,7 @@ void mlir::triton::asyncLaunchDots(scf::ForOp forOp) {
   }
   for (Operation &op : *loop) {
     if (auto dotOp = dyn_cast<tt::DotOp>(&op)) {
-      auto resTy = dotOp.getResult().getType().dyn_cast<RankedTensorType>();
+      RankedTensorType resTy = dotOp.getType();
       if (auto resEnc =
               resTy.getEncoding().dyn_cast<ttg::NvidiaMmaEncodingAttr>()) {
         if (resEnc && resEnc.isHopper()) {

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -19,64 +19,56 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include <memory>
 
+#define GEN_PASS_CLASSES
+#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
+
 #define DEBUG_TYPE "tritongpu-remove-layout-conversions"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
+namespace mlir::triton::gpu {
 namespace {
-
-using namespace mlir;
-using triton::DotOp;
-using triton::gpu::ConvertLayoutOp;
-using triton::gpu::DotOperandEncodingAttr;
-using triton::gpu::NvidiaMmaEncodingAttr;
-using triton::gpu::SliceEncodingAttr;
 
 // -----------------------------------------------------------------------------
 //
 // -----------------------------------------------------------------------------
 
 // dot(a, b, load(ptr)) -> add(load(ptr), dot(a, b, 0))
-class ConvertDotConvert : public mlir::RewritePattern {
+class ConvertDotConvert : public RewritePattern {
 public:
-  ConvertDotConvert(mlir::MLIRContext *context)
-      : mlir::RewritePattern(triton::gpu::ConvertLayoutOp::getOperationName(),
-                             1, context) {}
+  ConvertDotConvert(MLIRContext *context)
+      : RewritePattern(ConvertLayoutOp::getOperationName(), 1, context) {}
 
-  LogicalResult
-  matchAndRewrite(mlir::Operation *op,
-                  mlir::PatternRewriter &rewriter) const override {
-    auto dstOp = cast<triton::gpu::ConvertLayoutOp>(op);
-    auto dotOp = dstOp.getSrc().getDefiningOp<triton::DotOp>();
+  LogicalResult matchAndRewrite(Operation *op,
+                                PatternRewriter &rewriter) const override {
+    auto dstOp = cast<ConvertLayoutOp>(op);
+    auto dotOp = dstOp.getSrc().getDefiningOp<DotOp>();
     if (!dotOp)
-      return mlir::failure();
+      return failure();
     if (std::distance(dstOp->user_begin(), dstOp->user_end()) != 1 ||
         std::distance(dotOp->user_begin(), dotOp->user_end()) != 1)
-      return mlir::failure();
-    auto cvtOp =
-        dotOp.getOperand(2).getDefiningOp<triton::gpu::ConvertLayoutOp>();
-    if (!cvtOp)
-      return mlir::failure();
-    if (!cvtOp.getSrc().getDefiningOp<triton::LoadOp>())
       return failure();
-    auto dstTy = dstOp.getResult().getType();
-    auto srcTy = cvtOp.getSrc().getType();
+    auto cvtOp = dotOp.getOperand(2).getDefiningOp<ConvertLayoutOp>();
+    if (!cvtOp)
+      return failure();
+    if (!cvtOp.getSrc().getDefiningOp<LoadOp>())
+      return failure();
+    RankedTensorType dstTy = dstOp.getType();
+    RankedTensorType srcTy = cvtOp.getSrc().getType();
     if (dstTy != srcTy)
-      return mlir::failure();
+      return failure();
 
     auto _0f = rewriter.create<arith::ConstantOp>(
         op->getLoc(), dstTy.getElementType(),
         rewriter.getZeroAttr(dstTy.getElementType()));
-    auto _0 = rewriter.create<triton::SplatOp>(
-        op->getLoc(), dotOp.getResult().getType(), _0f);
-    auto newDot = rewriter.create<triton::DotOp>(
-        op->getLoc(), dotOp.getResult().getType(), dotOp.getOperand(0),
-        dotOp.getOperand(1), _0, dotOp.getAllowTF32(),
-        dotOp.getMaxNumImpreciseAcc());
-    auto newCvt = rewriter.create<triton::gpu::ConvertLayoutOp>(
-        op->getLoc(), dstTy, newDot.getResult());
+    auto _0 = rewriter.create<SplatOp>(op->getLoc(), dotOp.getType(), _0f);
+    auto newDot = rewriter.create<DotOp>(
+        op->getLoc(), dotOp.getType(), dotOp.getOperand(0), dotOp.getOperand(1),
+        _0, dotOp.getAllowTF32(), dotOp.getMaxNumImpreciseAcc());
+    auto newCvt = rewriter.create<ConvertLayoutOp>(op->getLoc(), dstTy,
+                                                   newDot.getResult());
     rewriter.replaceOpWithNewOp<arith::AddFOp>(op, newCvt, cvtOp.getSrc());
-    return mlir::success();
+    return success();
   }
 };
 
@@ -106,7 +98,7 @@ public:
     LayoutInfo() {}
     llvm::SmallSetVector<Attribute, 8> encodings;
   };
-  LayoutPropagation(triton::FuncOp F) : funcOp(F) {}
+  LayoutPropagation(FuncOp F) : funcOp(F) {}
   // Find the anchor ops and set their layout in the data structure.
   void initAnchorLayout();
   // Recursively Propagate the layout to all the users of the anchor ops until
@@ -149,14 +141,12 @@ private:
   // map of the values rewrite based on their encoding.
   DenseMap<std::pair<Value, Attribute>, Value> rewriteMapping;
   SetVector<Operation *> opToDelete;
-  triton::FuncOp funcOp;
+  FuncOp funcOp;
 };
-
-} // namespace
 
 // Look ahead to at the transitive uses and see if there is a convert to mma
 // operations.
-static bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
+bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
   SmallVector<Value> queue = {op->getResult(0)};
   SetVector<Operation *> forwardSlice;
   llvm::SmallDenseSet<Value> seen;
@@ -165,15 +155,13 @@ static bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
     queue.pop_back();
     getForwardSlice(currentValue, &forwardSlice);
     for (Operation *op : forwardSlice) {
-      if (auto convertOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
-        Attribute dstEncoding = convertOp.getResult().getType().getEncoding();
-        if (auto mmaLayout =
-                dstEncoding.dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>())
+      if (auto convertOp = dyn_cast<ConvertLayoutOp>(op)) {
+        Attribute dstEncoding = convertOp.getType().getEncoding();
+        if (auto mmaLayout = dstEncoding.dyn_cast<NvidiaMmaEncodingAttr>())
           return (mmaLayout.getVersionMajor() > 1) ? true
                                                    : mmaLayout == encoding;
-        if (dstEncoding.isa<triton::gpu::DotOperandEncodingAttr>())
-          return encoding.cast<triton::gpu::NvidiaMmaEncodingAttr>()
-                     .getVersionMajor() > 1;
+        if (dstEncoding.isa<DotOperandEncodingAttr>())
+          return encoding.cast<NvidiaMmaEncodingAttr>().getVersionMajor() > 1;
       }
       auto yield = dyn_cast<scf::YieldOp>(op);
       if (!yield)
@@ -194,10 +182,10 @@ static bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
 
 // Return true if the op is an op with a layout we don't want to change. We will
 // propagate the layout starting from anchor ops.
-static bool isLayoutAnchor(Operation *op) {
-  if (isa<triton::LoadOp, triton::StoreOp>(op))
+bool isLayoutAnchor(Operation *op) {
+  if (isa<LoadOp, StoreOp>(op))
     return isExpensiveLoadOrStore(op);
-  if (isa<triton::DotOp, triton::AtomicRMWOp, triton::AtomicCASOp>(op))
+  if (isa<DotOp, AtomicRMWOp, AtomicCASOp>(op))
     return true;
 
   // Heuristic: Mark permuting reshape as a layout anchor.  Its dst can be
@@ -205,7 +193,7 @@ static bool isLayoutAnchor(Operation *op) {
   // backwards pass to fix it up if necessary.  (If we didn't do this, then
   // anything following the reshape won't be covered by the forward pass at
   // all.)
-  if (auto reshape = dyn_cast<triton::ReshapeOp>(op))
+  if (auto reshape = dyn_cast<ReshapeOp>(op))
     return reshape.getAllowReorder();
 
   return false;
@@ -218,7 +206,7 @@ void LayoutPropagation::initAnchorLayout() {
       // back to mma further down to avoid generating reduction with MMA
       // layout that may have lower performance.
       // This can be improved with more aggressive backward propagation.
-      if (tensorType.getEncoding().isa<triton::gpu::NvidiaMmaEncodingAttr>() &&
+      if (tensorType.getEncoding().isa<NvidiaMmaEncodingAttr>() &&
           v.getDefiningOp() &&
           !hasConvertToMMATransisitiveUse(v.getDefiningOp(),
                                           tensorType.getEncoding())) {
@@ -253,7 +241,7 @@ void LayoutPropagation::setEncoding(ValueRange values, LayoutInfo &info,
     bool hasChanged = false;
     for (auto encoding : info.encodings) {
       std::optional<Attribute> dstEncoding;
-      if (isa<triton::gpu::ConvertLayoutOp>(op)) {
+      if (isa<ConvertLayoutOp>(op)) {
         // Try to remove the convert by making the dst encoding match the source
         // encoding.
         dstEncoding = encoding;
@@ -311,13 +299,12 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
       setEncoding({afterArg, result}, info, changed, user);
       continue;
     }
-    if (user->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
-        user->hasTrait<mlir::OpTrait::Elementwise>() ||
+    if (user->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
+        user->hasTrait<OpTrait::Elementwise>() ||
         // TODO(jlebar): Add TransOp to this list, but we have to force it into
         // shared memory if it's used by a dot operand.
-        isa<triton::ReduceOp, triton::ExpandDimsOp, triton::ReshapeOp,
-            triton::ExperimentalInterleaveOp, triton::gpu::ConvertLayoutOp>(
-            user)) {
+        isa<ReduceOp, ExpandDimsOp, ReshapeOp, ExperimentalInterleaveOp,
+            ConvertLayoutOp>(user)) {
       setEncoding(user->getResults(), info, changed, user);
       continue;
     }
@@ -357,11 +344,10 @@ void LayoutPropagation::resolveConflicts() {
     // TODO: add a proper heuristic.
     Attribute encoding = *info.encodings.begin();
     bool isLoadOrStore =
-        op && isa<triton::LoadOp, triton::StoreOp, triton::AtomicRMWOp,
-                  triton::AtomicCASOp>(op);
+        op && isa<LoadOp, StoreOp, AtomicRMWOp, AtomicCASOp>(op);
     for (Attribute e : info.encodings) {
-      if ((isLoadOrStore && e.isa<triton::gpu::BlockedEncodingAttr>()) ||
-          (!isLoadOrStore && e.isa<triton::gpu::NvidiaMmaEncodingAttr>())) {
+      if ((isLoadOrStore && e.isa<BlockedEncodingAttr>()) ||
+          (!isLoadOrStore && e.isa<NvidiaMmaEncodingAttr>())) {
         encoding = e;
         break;
       }
@@ -388,11 +374,10 @@ void LayoutPropagation::dump() {
 
 void LayoutPropagation::rewrite() { rewriteRegion(funcOp->getRegion(0)); }
 
-static bool reduceToScalar(Operation *op) {
+bool reduceToScalar(Operation *op) {
   // For reductions returning a scalar we can change the src encoding without
   // affecting the output.
-  return isa<triton::ReduceOp>(op) &&
-         !op->getResultTypes()[0].isa<RankedTensorType>();
+  return isa<ReduceOp>(op) && !op->getResultTypes()[0].isa<RankedTensorType>();
 }
 
 void LayoutPropagation::rewriteRegion(Region &region) {
@@ -476,8 +461,8 @@ Value LayoutPropagation::getValueAs(Value value, Attribute encoding) {
     rewriter.setInsertionPointAfterValue(rewrittenValue);
     auto tmpType = RankedTensorType::get(tensorType.getShape(),
                                          tensorType.getElementType(), encoding);
-    Value converted = rewriter.create<triton::gpu::ConvertLayoutOp>(
-        value.getLoc(), tmpType, rewrittenValue);
+    Value converted = rewriter.create<ConvertLayoutOp>(value.getLoc(), tmpType,
+                                                       rewrittenValue);
     // TODO: we could cache the conversion.
     return converted;
   }
@@ -690,7 +675,7 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     return rewriteIfOp(ifOp);
   OpBuilder rewriter(op);
   Attribute encoding = *layouts[op->getResult(0)].encodings.begin();
-  if (auto convertOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
+  if (auto convertOp = dyn_cast<ConvertLayoutOp>(op)) {
     Attribute srcEncoding = convertOp.getSrc().getType().getEncoding();
     auto it = layouts.find(convertOp.getSrc());
     if (it != layouts.end())
@@ -699,8 +684,7 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     auto tensorType = op->getResult(0).getType().cast<RankedTensorType>();
     auto newType = RankedTensorType::get(tensorType.getShape(),
                                          tensorType.getElementType(), encoding);
-    auto cvt = rewriter.create<triton::gpu::ConvertLayoutOp>(op->getLoc(),
-                                                             newType, src);
+    auto cvt = rewriter.create<ConvertLayoutOp>(op->getLoc(), newType, src);
     map(op->getResult(0), cvt.getResult());
     return cvt.getOperation();
   }
@@ -709,17 +693,17 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     auto tensorType = op->getResult(0).getType().cast<RankedTensorType>();
     auto newType = RankedTensorType::get(tensorType.getShape(),
                                          tensorType.getElementType(), encoding);
-    auto cvt = rewriter.create<triton::gpu::ConvertLayoutOp>(
-        op->getLoc(), newType, newOp->getResult(0));
+    auto cvt = rewriter.create<ConvertLayoutOp>(op->getLoc(), newType,
+                                                newOp->getResult(0));
     map(op->getResult(0), cvt.getResult());
     return cvt.getOperation();
   }
-  if (op->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
-      op->hasTrait<mlir::OpTrait::Elementwise>() ||
+  if (op->hasTrait<OpTrait::SameOperandsAndResultEncoding>() ||
+      op->hasTrait<OpTrait::Elementwise>() ||
       // TODO(jlebar): Add TransOp to this list, but we have to force it into
       // shared memory if it's used by a dot operand.
-      isa<triton::ReduceOp, triton::ExpandDimsOp, triton::ReshapeOp,
-          triton::ExperimentalInterleaveOp, triton::gpu::ConvertLayoutOp>(op)) {
+      isa<ReduceOp, ExpandDimsOp, ReshapeOp, ExperimentalInterleaveOp,
+          ConvertLayoutOp>(op)) {
     Operation *newOp = cloneElementwise(rewriter, op, encoding);
     for (auto [oldResult, newResult] :
          llvm::zip(op->getResults(), newOp->getResults()))
@@ -730,12 +714,11 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
   return nullptr;
 }
 
-static bool canBeRemat(Operation *op) {
-  if (isa<triton::LoadOp, triton::StoreOp>(op))
+bool canBeRemat(Operation *op) {
+  if (isa<LoadOp, StoreOp>(op))
     return !isExpensiveLoadOrStore(op);
-  if (isa<tensor::ExtractSliceOp, triton::gpu::AllocTensorOp,
-          triton::gpu::InsertSliceAsyncOp, triton::AtomicRMWOp,
-          triton::AtomicCASOp, triton::DotOp>(op))
+  if (isa<tensor::ExtractSliceOp, AllocTensorOp, InsertSliceAsyncOp,
+          AtomicRMWOp, AtomicCASOp, DotOp>(op))
     return false;
   if (isa<scf::IfOp, scf::WhileOp, scf::ConditionOp>(op))
     return false;
@@ -743,9 +726,8 @@ static bool canBeRemat(Operation *op) {
   return true;
 }
 
-static void rewriteSlice(SetVector<Value> &slice,
-                         DenseMap<Value, Attribute> &layout,
-                         ConvertLayoutOp convertOp, IRMapping &mapping) {
+void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
+                  ConvertLayoutOp convertOp, IRMapping &mapping) {
   SetVector<Operation *> opsToRewrite;
   for (Value v : slice) {
     if (v.getDefiningOp()) {
@@ -805,8 +787,8 @@ static void rewriteSlice(SetVector<Value> &slice,
       auto newType = RankedTensorType::get(tensorType.getShape(),
                                            tensorType.getElementType(),
                                            layout[op->getResult(0)]);
-      auto cvt = builder.create<triton::gpu::ConvertLayoutOp>(
-          op->getLoc(), newType, newOp->getResult(0));
+      auto cvt = builder.create<ConvertLayoutOp>(op->getLoc(), newType,
+                                                 newOp->getResult(0));
       mapping.map(op->getResult(0), cvt.getResult());
       continue;
     }
@@ -827,14 +809,13 @@ static void rewriteSlice(SetVector<Value> &slice,
     op->erase();
 }
 
-static void rewriteSlice(SetVector<Value> &slice,
-                         DenseMap<Value, Attribute> &layout,
-                         ConvertLayoutOp convertOp) {
+void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
+                  ConvertLayoutOp convertOp) {
   IRMapping mapping;
   rewriteSlice(slice, layout, convertOp, mapping);
 }
 
-static LogicalResult getRematerializableSlice(
+LogicalResult getRematerializableSlice(
     Value root, Attribute rootEncoding, SetVector<Value> &slice,
     DenseMap<Value, Attribute> &layout,
     std::function<bool(Operation *)> stopPropagation = nullptr) {
@@ -853,15 +834,15 @@ static LogicalResult getRematerializableSlice(
   return success();
 }
 
-static void backwardRematerialization(ConvertLayoutOp convertOp) {
+void backwardRematerialization(ConvertLayoutOp convertOp) {
   // we don't want to rematerialize any conversion to/from shared
-  if (triton::gpu::hasSharedEncoding(convertOp.getResult()) ||
-      triton::gpu::hasSharedEncoding(convertOp.getSrc()))
+  if (hasSharedEncoding(convertOp.getResult()) ||
+      hasSharedEncoding(convertOp.getSrc()))
     return;
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristic to accommodate fused attention
-  auto targetType = convertOp.getResult().getType();
-  if (targetType.getEncoding().isa<triton::gpu::DotOperandEncodingAttr>())
+  RankedTensorType targetType = convertOp.getType();
+  if (targetType.getEncoding().isa<DotOperandEncodingAttr>())
     return;
 
   // 1. Take a backward slice of all the tensor dependencies that can be
@@ -879,20 +860,20 @@ static void backwardRematerialization(ConvertLayoutOp convertOp) {
 
 // For convert left we try to hoist them above type extension to reduce the cost
 // of the convert.
-static void hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp) {
+void hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp) {
   // we don't want to rematerialize any conversion to/from shared
-  if (triton::gpu::hasSharedEncoding(convertOp.getResult()) ||
-      triton::gpu::hasSharedEncoding(convertOp.getSrc()))
+  if (hasSharedEncoding(convertOp.getResult()) ||
+      hasSharedEncoding(convertOp.getSrc()))
     return;
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristics to accommodate fused attention
-  auto targetType = convertOp.getResult().getType();
-  if (targetType.getEncoding().isa<triton::gpu::DotOperandEncodingAttr>())
+  RankedTensorType targetType = convertOp.getType();
+  if (targetType.getEncoding().isa<DotOperandEncodingAttr>())
     return;
 
   auto isExtOrBroadcastOp = [](Operation *op) {
-    return isa<arith::ExtSIOp, arith::ExtUIOp, arith::ExtFOp,
-               triton::BroadcastOp, triton::ExpandDimsOp>(op);
+    return isa<arith::ExtSIOp, arith::ExtUIOp, arith::ExtFOp, BroadcastOp,
+               ExpandDimsOp>(op);
   };
   // 1. Take a backward slice of all the tensor dependencies.
   SetVector<Value> slice;
@@ -963,7 +944,7 @@ static void hoistConvertOnTopOfExtOrBroadcast(ConvertLayoutOp convertOp) {
   rewriteSlice(slice, layout, convertOp, mapping);
 }
 
-static void backwardRematerialization(ModuleOp module) {
+void backwardRematerialization(ModuleOp module) {
   SmallVector<ConvertLayoutOp> convertOps;
   module.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
@@ -972,7 +953,7 @@ static void backwardRematerialization(ModuleOp module) {
   }
 }
 
-static void hoistConvert(ModuleOp module) {
+void hoistConvert(ModuleOp module) {
   SmallVector<ConvertLayoutOp> convertOps;
   module.walk(
       [&](ConvertLayoutOp convertOp) { convertOps.push_back(convertOp); });
@@ -980,9 +961,6 @@ static void hoistConvert(ModuleOp module) {
     hoistConvertOnTopOfExtOrBroadcast(convertOp);
   }
 }
-
-#define GEN_PASS_CLASSES
-#include "triton/Dialect/TritonGPU/Transforms/Passes.h.inc"
 
 class TritonGPURemoveLayoutConversionsPass
     : public TritonGPURemoveLayoutConversionsBase<
@@ -995,7 +973,7 @@ public:
     ModuleOp m = getOperation();
 
     // 1. Propagate layout forward starting from "anchor" ops.
-    m.walk([](triton::FuncOp funcOp) {
+    m.walk([](FuncOp funcOp) {
       LayoutPropagation layoutPropagation(funcOp);
       layoutPropagation.initAnchorLayout();
       layoutPropagation.propagateLayout();
@@ -1008,10 +986,9 @@ public:
       m.dump();
     });
 
-    mlir::RewritePatternSet cleanUpPatterns(context);
+    RewritePatternSet cleanUpPatterns(context);
     ConvertLayoutOp::getCanonicalizationPatterns(cleanUpPatterns, context);
-    if (mlir::applyPatternsAndFoldGreedily(m, std::move(cleanUpPatterns))
-            .failed()) {
+    if (applyPatternsAndFoldGreedily(m, std::move(cleanUpPatterns)).failed()) {
       signalPassFailure();
     }
 
@@ -1036,9 +1013,9 @@ public:
       m.dump();
     });
 
-    mlir::RewritePatternSet decomposePatterns(context);
+    RewritePatternSet decomposePatterns(context);
     decomposePatterns.add<ConvertDotConvert>(context);
-    if (mlir::applyPatternsAndFoldGreedily(m, std::move(decomposePatterns))
+    if (applyPatternsAndFoldGreedily(m, std::move(decomposePatterns))
             .failed()) {
       signalPassFailure();
     }
@@ -1049,12 +1026,11 @@ public:
 
     // 4. Apply clean up patterns to remove remove dead convert and dead code
     // generated by the previous transformations.
-    mlir::RewritePatternSet cleanUpPatterns2(context);
+    RewritePatternSet cleanUpPatterns2(context);
     populateForOpDeadArgumentElimination(cleanUpPatterns2);
     scf::ForOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
     ConvertLayoutOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
-    if (mlir::applyPatternsAndFoldGreedily(m, std::move(cleanUpPatterns2))
-            .failed()) {
+    if (applyPatternsAndFoldGreedily(m, std::move(cleanUpPatterns2)).failed()) {
       signalPassFailure();
     }
     LLVM_DEBUG({
@@ -1064,6 +1040,10 @@ public:
   }
 };
 
-std::unique_ptr<Pass> mlir::triton::gpu::createRemoveLayoutConversionsPass() {
+} // namespace
+
+std::unique_ptr<Pass> createRemoveLayoutConversionsPass() {
   return std::make_unique<TritonGPURemoveLayoutConversionsPass>();
 }
+
+} // namespace mlir::triton::gpu

--- a/lib/Dialect/TritonGPU/Transforms/ReorderInstructions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReorderInstructions.cpp
@@ -23,15 +23,13 @@
 
 using namespace mlir;
 
-static inline bool
-willIncreaseRegisterPressure(triton::gpu::ConvertLayoutOp op) {
-  auto srcType = op.getSrc().getType().cast<RankedTensorType>();
-  auto dstType = op.getResult().getType().cast<RankedTensorType>();
-  auto srcEncoding = srcType.getEncoding();
-  auto dstEncoding = dstType.getEncoding();
-  if (srcEncoding.isa<triton::gpu::SharedEncodingAttr>())
+static bool willIncreaseRegisterPressure(triton::gpu::ConvertLayoutOp op) {
+  if (op.getSrc()
+          .getType()
+          .getEncoding()
+          .isa<triton::gpu::SharedEncodingAttr>())
     return true;
-  if (dstEncoding.isa<triton::gpu::DotOperandEncodingAttr>())
+  if (op.getType().getEncoding().isa<triton::gpu::DotOperandEncodingAttr>())
     return true;
   return false;
 }
@@ -88,9 +86,7 @@ public:
       kv.first->moveBefore(kv.second);
     // Move convert(load) immediately after dependent load
     m.walk([&](triton::gpu::ConvertLayoutOp op) {
-      auto dstType = op.getResult().getType().cast<RankedTensorType>();
-      auto dstEncoding = dstType.getEncoding();
-      if (!dstEncoding.isa<triton::gpu::SharedEncodingAttr>())
+      if (!op.getType().getEncoding().isa<triton::gpu::SharedEncodingAttr>())
         return;
       Operation *argOp = op.getSrc().getDefiningOp();
       if (!argOp)
@@ -108,9 +104,9 @@ public:
     // Move `dot` operand so that conversions to opIdx=1 happens after
     // conversions to opIdx=0
     m.walk([&](triton::gpu::ConvertLayoutOp op) {
-      auto dstType = op.getResult().getType().cast<RankedTensorType>();
-      auto dstEncoding =
-          dstType.getEncoding().dyn_cast<triton::gpu::DotOperandEncodingAttr>();
+      auto dstEncoding = op.getType()
+                             .getEncoding()
+                             .dyn_cast<triton::gpu::DotOperandEncodingAttr>();
       if (!dstEncoding)
         return;
       int opIdx = dstEncoding.getOpIdx();

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -672,8 +672,7 @@ bool CTAPlanner::processElementwise(Operation *op, Attribute layout) {
 }
 
 bool CTAPlanner::processConstant(arith::ConstantOp constant, Attribute layout) {
-  if (auto tensorTy =
-          constant.getResult().getType().dyn_cast<RankedTensorType>()) {
+  if (auto tensorTy = constant.getType().dyn_cast<RankedTensorType>()) {
     if (auto attr = constant.getValue().dyn_cast<SplatElementsAttr>()) {
 
       auto newTensorTy = RankedTensorType::get(

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -23,36 +23,40 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
+namespace {
+
 namespace py = pybind11;
+using namespace mlir;
+using namespace triton;
 
 // A custom op builder that keeps track of the last location
 class TritonOpBuilder {
 public:
-  TritonOpBuilder(mlir::MLIRContext *context) {
-    builder = std::make_unique<mlir::OpBuilder>(context);
-    lastLoc = std::make_unique<mlir::Location>(builder->getUnknownLoc());
+  TritonOpBuilder(MLIRContext *context) {
+    builder = std::make_unique<OpBuilder>(context);
+    lastLoc = std::make_unique<Location>(builder->getUnknownLoc());
   }
 
-  mlir::OpBuilder &getBuilder() { return *builder; }
+  OpBuilder &getBuilder() { return *builder; }
 
   bool isLineInfoEnabled() { return lineInfoEnabled; }
 
-  void setLastLoc(mlir::Location loc) {
+  void setLastLoc(Location loc) {
     if (lineInfoEnabled)
-      lastLoc = std::make_unique<mlir::Location>(loc);
+      lastLoc = std::make_unique<Location>(loc);
   }
 
   void setLastLoc(const std::string &fileName, int line, int column) {
     auto context = builder->getContext();
-    setLastLoc(mlir::FileLineColLoc::get(context, fileName, line, column));
+    setLastLoc(FileLineColLoc::get(context, fileName, line, column));
   }
 
-  mlir::Location getLastLoc() {
+  Location getLastLoc() {
     assert(lastLoc);
     return *lastLoc;
   }
 
-  void setInsertionPointToStart(mlir::Block &block) {
+  void setInsertionPointToStart(Block &block) {
     if (!block.empty())
       setLastLoc(block.begin()->getLoc());
     else
@@ -60,7 +64,7 @@ public:
     builder->setInsertionPointToStart(&block);
   }
 
-  void setInsertionPointToEnd(mlir::Block &block) {
+  void setInsertionPointToEnd(Block &block) {
     if (!block.empty())
       setLastLoc(block.back().getLoc());
     else
@@ -68,12 +72,12 @@ public:
     builder->setInsertionPointToEnd(&block);
   }
 
-  void setInsertionPointAfter(mlir::Operation &op) {
+  void setInsertionPointAfter(Operation &op) {
     setLastLoc(op.getLoc());
     builder->setInsertionPointAfter(&op);
   }
 
-  void restoreInsertionPoint(mlir::OpBuilder::InsertPoint pt) {
+  void restoreInsertionPoint(OpBuilder::InsertPoint pt) {
     if (pt.isSet() && pt.getPoint() != pt.getBlock()->end())
       setLastLoc(pt.getPoint()->getLoc());
     else
@@ -88,8 +92,7 @@ public:
 
   // Overload to create or fold a single result operation.
   template <typename OpTy, typename... Args>
-  std::enable_if_t<OpTy::template hasTrait<mlir::OpTrait::OneResult>(),
-                   mlir::Value>
+  std::enable_if_t<OpTy::template hasTrait<OpTrait::OneResult>(), Value>
   createOrFold(Args &&...args) {
     auto loc = getLastLoc();
     return builder->createOrFold<OpTy>(loc, std::forward<Args>(args)...);
@@ -97,20 +100,19 @@ public:
 
   // Overload to create or fold a zero result operation.
   template <typename OpTy, typename... Args>
-  std::enable_if_t<OpTy::template hasTrait<mlir::OpTrait::ZeroResults>(), OpTy>
+  std::enable_if_t<OpTy::template hasTrait<OpTrait::ZeroResults>(), OpTy>
   createOrFold(Args &&...args) {
     auto loc = getLastLoc();
     return builder->createOrFold<OpTy>(loc, std::forward<Args>(args)...);
   }
 
 private:
-  std::unique_ptr<mlir::OpBuilder> builder;
-  std::unique_ptr<mlir::Location> lastLoc;
-  bool lineInfoEnabled =
-      !mlir::triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO");
+  std::unique_ptr<OpBuilder> builder;
+  std::unique_ptr<Location> lastLoc;
+  bool lineInfoEnabled = !triton::tools::getBoolEnv("TRITON_DISABLE_LINE_INFO");
 };
 
-static std::string locationToString(mlir::Location loc) {
+std::string locationToString(Location loc) {
   std::string str;
   llvm::raw_string_ostream os(str);
   loc.print(os);
@@ -118,167 +120,162 @@ static std::string locationToString(mlir::Location loc) {
   return str;
 }
 
-static void outputWarning(mlir::Location loc, const std::string &msg) {
+void outputWarning(Location loc, const std::string &msg) {
   std::string locStr = locationToString(loc);
 
   PyErr_WarnEx(PyExc_UserWarning, (locStr + ": " + msg).c_str(),
                /*stack_level=*/2);
 }
 
+} // anonymous namespace
+
 /*****************************************************************************/
-/* Python bindings for triton::ir                                            */
+/* Python bindings for ir                                                    */
 /*****************************************************************************/
 
 void init_triton_ir(py::module &&m) {
   using ret = py::return_value_policy;
   using namespace pybind11::literals;
 
-  py::enum_<mlir::triton::PaddingOption>(m, "PADDING_OPTION",
-                                         py::module_local())
-      .value("PAD_ZERO", mlir::triton::PaddingOption::PAD_ZERO)
-      .value("PAD_NAN", mlir::triton::PaddingOption::PAD_NAN)
+  py::enum_<PaddingOption>(m, "PADDING_OPTION", py::module_local())
+      .value("PAD_ZERO", PaddingOption::PAD_ZERO)
+      .value("PAD_NAN", PaddingOption::PAD_NAN)
       .export_values();
 
-  py::enum_<mlir::triton::CacheModifier>(m, "CACHE_MODIFIER",
-                                         py::module_local())
-      .value("NONE", mlir::triton::CacheModifier::NONE)
-      .value("CA", mlir::triton::CacheModifier::CA)
-      .value("CG", mlir::triton::CacheModifier::CG)
-      .value("WB", mlir::triton::CacheModifier::WB)
-      .value("CS", mlir::triton::CacheModifier::CS)
-      .value("WT", mlir::triton::CacheModifier::WT)
+  py::enum_<CacheModifier>(m, "CACHE_MODIFIER", py::module_local())
+      .value("NONE", CacheModifier::NONE)
+      .value("CA", CacheModifier::CA)
+      .value("CG", CacheModifier::CG)
+      .value("WB", CacheModifier::WB)
+      .value("CS", CacheModifier::CS)
+      .value("WT", CacheModifier::WT)
       .export_values();
 
-  py::enum_<mlir::triton::MemSemantic>(m, "MEM_SEMANTIC", py::module_local())
-      .value("ACQUIRE_RELEASE", mlir::triton::MemSemantic::ACQUIRE_RELEASE)
-      .value("ACQUIRE", mlir::triton::MemSemantic::ACQUIRE)
-      .value("RELEASE", mlir::triton::MemSemantic::RELEASE)
-      .value("RELAXED", mlir::triton::MemSemantic::RELAXED)
+  py::enum_<MemSemantic>(m, "MEM_SEMANTIC", py::module_local())
+      .value("ACQUIRE_RELEASE", MemSemantic::ACQUIRE_RELEASE)
+      .value("ACQUIRE", MemSemantic::ACQUIRE)
+      .value("RELEASE", MemSemantic::RELEASE)
+      .value("RELAXED", MemSemantic::RELAXED)
       .export_values();
 
-  py::enum_<mlir::triton::MemSyncScope>(m, "MEM_SYNC_SCOPE", py::module_local())
-      .value("GPU", mlir::triton::MemSyncScope::GPU)
-      .value("CTA", mlir::triton::MemSyncScope::CTA)
-      .value("SYSTEM", mlir::triton::MemSyncScope::SYSTEM)
+  py::enum_<MemSyncScope>(m, "MEM_SYNC_SCOPE", py::module_local())
+      .value("GPU", MemSyncScope::GPU)
+      .value("CTA", MemSyncScope::CTA)
+      .value("SYSTEM", MemSyncScope::SYSTEM)
       .export_values();
 
-  py::enum_<mlir::triton::EvictionPolicy>(m, "EVICTION_POLICY",
-                                          py::module_local())
-      .value("NORMAL", mlir::triton::EvictionPolicy::NORMAL)
-      .value("EVICT_FIRST", mlir::triton::EvictionPolicy::EVICT_FIRST)
-      .value("EVICT_LAST", mlir::triton::EvictionPolicy::EVICT_LAST)
+  py::enum_<EvictionPolicy>(m, "EVICTION_POLICY", py::module_local())
+      .value("NORMAL", EvictionPolicy::NORMAL)
+      .value("EVICT_FIRST", EvictionPolicy::EVICT_FIRST)
+      .value("EVICT_LAST", EvictionPolicy::EVICT_LAST)
       .export_values();
 
-  py::enum_<mlir::triton::RMWOp>(m, "ATOMIC_OP", py::module_local())
-      .value("ADD", mlir::triton::RMWOp::ADD)
-      .value("FADD", mlir::triton::RMWOp::FADD)
-      .value("AND", mlir::triton::RMWOp::AND)
-      .value("OR", mlir::triton::RMWOp::OR)
-      .value("XOR", mlir::triton::RMWOp::XOR)
-      .value("XCHG", mlir::triton::RMWOp::XCHG)
-      .value("MAX", mlir::triton::RMWOp::MAX)
-      .value("MIN", mlir::triton::RMWOp::MIN)
-      .value("UMIN", mlir::triton::RMWOp::UMIN)
-      .value("UMAX", mlir::triton::RMWOp::UMAX);
+  py::enum_<RMWOp>(m, "ATOMIC_OP", py::module_local())
+      .value("ADD", RMWOp::ADD)
+      .value("FADD", RMWOp::FADD)
+      .value("AND", RMWOp::AND)
+      .value("OR", RMWOp::OR)
+      .value("XOR", RMWOp::XOR)
+      .value("XCHG", RMWOp::XCHG)
+      .value("MAX", RMWOp::MAX)
+      .value("MIN", RMWOp::MIN)
+      .value("UMIN", RMWOp::UMIN)
+      .value("UMAX", RMWOp::UMAX);
 
-  py::enum_<mlir::triton::RoundingMode>(m, "ROUNDING_MODE", py::module_local())
-      .value("RTZ", mlir::triton::RoundingMode::RTZ)
-      .value("RTNE", mlir::triton::RoundingMode::RTNE);
+  py::enum_<RoundingMode>(m, "ROUNDING_MODE", py::module_local())
+      .value("RTZ", RoundingMode::RTZ)
+      .value("RTNE", RoundingMode::RTNE);
 
-  py::enum_<mlir::triton::PropagateNan>(m, "PROPAGATE_NAN", py::module_local())
-      .value("NONE", mlir::triton::PropagateNan::NONE)
-      .value("ALL", mlir::triton::PropagateNan::ALL);
+  py::enum_<PropagateNan>(m, "PROPAGATE_NAN", py::module_local())
+      .value("NONE", PropagateNan::NONE)
+      .value("ALL", PropagateNan::ALL);
 
-  py::class_<mlir::MLIRContext>(m, "context", py::module_local())
-      .def(py::init<>());
+  py::class_<MLIRContext>(m, "context", py::module_local()).def(py::init<>());
 
-  m.def("load_dialects", [](mlir::MLIRContext &context) {
-    mlir::DialectRegistry registry;
-    registry.insert<
-        mlir::triton::TritonDialect, mlir::triton::gpu::TritonGPUDialect,
-        mlir::math::MathDialect, mlir::arith::ArithDialect,
-        mlir::index::IndexDialect, mlir::scf::SCFDialect, mlir::gpu::GPUDialect,
-        mlir::cf::ControlFlowDialect, mlir::LLVM::LLVMDialect>();
-    mlir::registerBuiltinDialectTranslation(registry);
-    mlir::registerLLVMDialectTranslation(registry);
+  m.def("load_dialects", [](MLIRContext &context) {
+    DialectRegistry registry;
+    registry.insert<TritonDialect, ::mlir::triton::gpu::TritonGPUDialect,
+                    math::MathDialect, arith::ArithDialect, index::IndexDialect,
+                    scf::SCFDialect, ::mlir::gpu::GPUDialect,
+                    cf::ControlFlowDialect, LLVM::LLVMDialect>();
+    registerBuiltinDialectTranslation(registry);
+    registerLLVMDialectTranslation(registry);
     context.appendDialectRegistry(registry);
     context.loadAllAvailableDialects();
   });
 
-  py::class_<mlir::Type>(m, "type", py::module_local())
-      .def("is_integer", &mlir::Type::isInteger)
-      .def("is_fp16", &mlir::Type::isF16)
-      .def("__str__", [](mlir::Type &self) {
+  py::class_<Type>(m, "type", py::module_local())
+      .def("is_integer", &Type::isInteger)
+      .def("is_fp16", &Type::isF16)
+      .def("__str__", [](Type &self) {
         std::string str;
         llvm::raw_string_ostream os(str);
         self.print(os);
         return os.str();
       });
 
-  py::class_<mlir::FunctionType>(m, "function_type", py::module_local())
-      .def("param_types", [](mlir::FunctionType &self) {
-        return std::vector<mlir::Type>(self.getInputs().begin(),
-                                       self.getInputs().end());
+  py::class_<FunctionType>(m, "function_type", py::module_local())
+      .def("param_types", [](FunctionType &self) {
+        return std::vector<Type>(self.getInputs().begin(),
+                                 self.getInputs().end());
       });
 
-  py::class_<mlir::Location>(m, "location", py::module_local())
-      .def("__str__", [](mlir::Location &self) {
+  py::class_<Location>(m, "location", py::module_local())
+      .def("__str__", [](Location &self) {
         std::string str;
         llvm::raw_string_ostream os(str);
         self.print(os);
         return os.str();
       });
 
-  py::class_<mlir::Value>(m, "value", py::module_local())
+  py::class_<Value>(m, "value", py::module_local())
       .def("set_attr",
-           [](mlir::Value &self, std::string &name,
-              mlir::Attribute &attr) -> void {
-             if (mlir::Operation *definingOp = self.getDefiningOp())
+           [](Value &self, std::string &name, Attribute &attr) -> void {
+             if (Operation *definingOp = self.getDefiningOp())
                definingOp->setAttr(name, attr);
              else {
-               auto arg = self.cast<mlir::BlockArgument>();
+               auto arg = self.cast<BlockArgument>();
                int id = arg.getArgNumber();
                std::string attrName = name + "_arg" + std::to_string(id);
-               mlir::Block *owner = arg.getOwner();
+               Block *owner = arg.getOwner();
                if (owner->isEntryBlock() &&
-                   !mlir::isa<mlir::triton::FuncOp>(owner->getParentOp())) {
+                   !isa<FuncOp>(owner->getParentOp())) {
                  owner->getParentOp()->setAttr(attrName, attr);
                }
              }
            })
-      .def("get_context", &mlir::Value::getContext)
+      .def("get_context", &Value::getContext)
       .def("replace_all_uses_with",
-           [](mlir::Value &self, mlir::Value &newValue) {
+           [](Value &self, Value &newValue) {
              self.replaceAllUsesWith(newValue);
            })
-      .def("get_type", &mlir::Value::getType);
+      .def("get_type", &Value::getType);
 
-  py::class_<mlir::BlockArgument, mlir::Value>(m, "block_argument",
-                                               py::module_local());
+  py::class_<BlockArgument, Value>(m, "block_argument", py::module_local());
 
-  py::class_<mlir::Region>(m, "region", py::module_local())
-      .def("get_parent_region", &mlir::Region::getParentRegion, ret::reference)
-      .def("size", [](mlir::Region &self) { return self.getBlocks().size(); })
-      .def("empty", &mlir::Region::empty);
+  py::class_<Region>(m, "region", py::module_local())
+      .def("get_parent_region", &Region::getParentRegion, ret::reference)
+      .def("size", [](Region &self) { return self.getBlocks().size(); })
+      .def("empty", &Region::empty);
 
-  py::class_<mlir::Block>(m, "block", py::module_local())
+  py::class_<Block>(m, "block", py::module_local())
       .def("arg",
-           [](mlir::Block &self, int index) -> mlir::BlockArgument {
+           [](Block &self, int index) -> BlockArgument {
              return self.getArgument(index);
            })
       .def("add_argument",
-           [](mlir::Block &self, mlir::Type ty) {
-             auto loc = mlir::UnknownLoc::get(ty.getContext());
+           [](Block &self, Type ty) {
+             auto loc = UnknownLoc::get(ty.getContext());
              self.addArgument(ty, loc);
            })
-      .def("get_num_arguments", &mlir::Block::getNumArguments)
-      .def("dump", &mlir::Block::dump)
+      .def("get_num_arguments", &Block::getNumArguments)
+      .def("dump", &Block::dump)
       .def("move_before",
-           [](mlir::Block &self, mlir::Block &dst) { self.moveBefore(&dst); })
-      .def("insert_before", &mlir::Block::insertBefore)
-      .def("get_parent", &mlir::Block::getParent, ret::reference)
+           [](Block &self, Block &dst) { self.moveBefore(&dst); })
+      .def("insert_before", &Block::insertBefore)
+      .def("get_parent", &Block::getParent, ret::reference)
       .def("merge_block_before",
-           [](mlir::Block &self, mlir::Block &dst) {
+           [](Block &self, Block &dst) {
              // ref: RewriterBase::mergeBlocks()
              if (self.getNumArguments() != 0)
                throw std::runtime_error(
@@ -288,10 +285,10 @@ void init_triton_ir(py::module &&m) {
              self.erase();
            })
       .def("replace_use_in_block_with",
-           [](mlir::Block &self, mlir::Value &v, mlir::Value &newVal) {
-             v.replaceUsesWithIf(newVal, [&](mlir::OpOperand &operand) {
-               mlir::Operation *user = operand.getOwner();
-               mlir::Block *currentBlock = user->getBlock();
+           [](Block &self, Value &v, Value &newVal) {
+             v.replaceUsesWithIf(newVal, [&](OpOperand &operand) {
+               Operation *user = operand.getOwner();
+               Block *currentBlock = user->getBlock();
                while (currentBlock) {
                  if (currentBlock == &self)
                    return true;
@@ -303,187 +300,174 @@ void init_triton_ir(py::module &&m) {
              });
            })
       .def("__str__",
-           [](mlir::Block &self) {
+           [](Block &self) {
              std::string str;
              llvm::raw_string_ostream os(str);
              self.print(os);
              return str;
            })
       .def("has_terminator",
-           [](mlir::Block &self) {
+           [](Block &self) {
              return !self.empty() &&
-                    self.back().hasTrait<mlir::OpTrait::IsTerminator>();
+                    self.back().hasTrait<OpTrait::IsTerminator>();
            })
       .def("has_return",
-           [](mlir::Block &self) {
+           [](Block &self) {
              return !self.empty() &&
-                    self.back().hasTrait<mlir::OpTrait::ReturnLike>();
+                    self.back().hasTrait<OpTrait::ReturnLike>();
            })
-      .def("erase", [](mlir::Block &self) { self.erase(); });
+      .def("erase", [](Block &self) { self.erase(); });
 
-  py::class_<mlir::Attribute>(m, "attribute", py::module_local());
-  py::class_<mlir::IntegerAttr, mlir::Attribute>(m, "integer_attr",
-                                                 py::module_local());
-  py::class_<mlir::BoolAttr, mlir::Attribute>(m, "bool_attr",
-                                              py::module_local());
+  py::class_<Attribute>(m, "attribute", py::module_local());
+  py::class_<IntegerAttr, Attribute>(m, "integer_attr", py::module_local());
+  py::class_<BoolAttr, Attribute>(m, "bool_attr", py::module_local());
 
   // Ops
-  py::class_<mlir::OpState>(m, "OpState", py::module_local())
+  py::class_<OpState>(m, "OpState", py::module_local())
       .def("set_attr",
-           [](mlir::OpState &self, std::string &name,
-              mlir::Attribute &attr) -> void { self->setAttr(name, attr); })
-      .def(
-          "get_num_results",
-          [](mlir::OpState &self) -> unsigned { return self->getNumResults(); })
+           [](OpState &self, std::string &name, Attribute &attr) -> void {
+             self->setAttr(name, attr);
+           })
+      .def("get_num_results",
+           [](OpState &self) -> unsigned { return self->getNumResults(); })
       .def("get_result",
-           [](mlir::OpState &self, unsigned idx) -> mlir::Value {
+           [](OpState &self, unsigned idx) -> Value {
              return self->getResult(idx);
            })
       .def(
           "get_region",
-          [](mlir::OpState &self, unsigned idx) -> mlir::Region & {
+          [](OpState &self, unsigned idx) -> Region & {
             return self->getRegion(idx);
           },
           ret::reference)
       .def(
           "get_body",
-          [](mlir::scf::ForOp &self, unsigned idx) -> mlir::Block * {
+          [](scf::ForOp &self, unsigned idx) -> Block * {
             return self.getBody(idx);
           },
           ret::reference)
-      .def("dump", [](mlir::OpState &self) { self->dump(); })
+      .def("dump", [](OpState &self) { self->dump(); })
       .def("__str__",
-           [](mlir::OpState &self) -> std::string {
+           [](OpState &self) -> std::string {
              std::string str;
              llvm::raw_string_ostream os(str);
-             auto printingFlags = mlir::OpPrintingFlags();
+             auto printingFlags = OpPrintingFlags();
              printingFlags.enableDebugInfo();
              self->print(os, printingFlags);
              return str;
            })
       .def("append_operand",
-           [](mlir::OpState &self, mlir::Value &val) {
+           [](OpState &self, Value &val) {
              self->insertOperands(self->getNumOperands(), val);
            })
-      .def("verify", [](mlir::OpState &self) -> bool {
-        return mlir::succeeded(mlir::verify(self.getOperation()));
+      .def("verify", [](OpState &self) -> bool {
+        return succeeded(verify(self.getOperation()));
       });
   // scf Ops
-  py::class_<mlir::scf::ForOp, mlir::OpState>(m, "ForOp", py::module_local())
-      .def("get_induction_var", &mlir::scf::ForOp::getInductionVar);
+  py::class_<scf::ForOp, OpState>(m, "ForOp", py::module_local())
+      .def("get_induction_var", &scf::ForOp::getInductionVar);
 
-  py::class_<mlir::scf::IfOp, mlir::OpState>(m, "IfOp", py::module_local())
-      .def("get_then_block", &mlir::scf::IfOp::thenBlock, ret::reference)
-      .def("get_else_block", &mlir::scf::IfOp::elseBlock, ret::reference)
-      .def("get_then_yield", &mlir::scf::IfOp::thenYield)
-      .def("get_else_yield", &mlir::scf::IfOp::elseYield);
-  py::class_<mlir::scf::YieldOp, mlir::OpState>(m, "YieldOp",
-                                                py::module_local());
-  py::class_<mlir::scf::WhileOp, mlir::OpState>(m, "WhileOp",
-                                                py::module_local())
-      .def("get_before", &mlir::scf::WhileOp::getBefore, ret::reference)
-      .def("get_after", &mlir::scf::WhileOp::getAfter, ret::reference);
-  py::class_<mlir::scf::ConditionOp, mlir::OpState>(m, "ConditionOp",
-                                                    py::module_local());
+  py::class_<scf::IfOp, OpState>(m, "IfOp", py::module_local())
+      .def("get_then_block", &scf::IfOp::thenBlock, ret::reference)
+      .def("get_else_block", &scf::IfOp::elseBlock, ret::reference)
+      .def("get_then_yield", &scf::IfOp::thenYield)
+      .def("get_else_yield", &scf::IfOp::elseYield);
+  py::class_<scf::YieldOp, OpState>(m, "YieldOp", py::module_local());
+  py::class_<scf::WhileOp, OpState>(m, "WhileOp", py::module_local())
+      .def("get_before", &scf::WhileOp::getBefore, ret::reference)
+      .def("get_after", &scf::WhileOp::getAfter, ret::reference);
+  py::class_<scf::ConditionOp, OpState>(m, "ConditionOp", py::module_local());
 
   // dynamic_attr is used to transfer ownership of the MLIR context to the
   // module
-  py::class_<mlir::ModuleOp, mlir::OpState>(m, "module", py::module_local(),
-                                            py::dynamic_attr())
-      .def("dump", &mlir::ModuleOp::dump)
+  py::class_<ModuleOp, OpState>(m, "module", py::module_local(),
+                                py::dynamic_attr())
+      .def("dump", &ModuleOp::dump)
       .def("str",
-           [](mlir::ModuleOp &self) -> std::string {
+           [](ModuleOp &self) -> std::string {
              std::string str;
              llvm::raw_string_ostream os(str);
-             auto printingFlags = mlir::OpPrintingFlags();
+             auto printingFlags = OpPrintingFlags();
              printingFlags.enableDebugInfo();
              self.print(os, printingFlags);
              return str;
            })
       .def("push_back",
-           [](mlir::ModuleOp &self, mlir::triton::FuncOp &funcOp) -> void {
+           [](ModuleOp &self, FuncOp &funcOp) -> void {
              self.push_back(funcOp);
            })
       .def("has_function",
-           [](mlir::ModuleOp &self, std::string &funcName) -> bool {
+           [](ModuleOp &self, std::string &funcName) -> bool {
              if (self.lookupSymbol(funcName))
                return true;
              return false;
            })
       .def("get_function",
-           [](mlir::ModuleOp &self,
-              std::string &funcName) -> mlir::triton::FuncOp {
-             return self.lookupSymbol<mlir::triton::FuncOp>(funcName);
+           [](ModuleOp &self, std::string &funcName) -> FuncOp {
+             return self.lookupSymbol<FuncOp>(funcName);
            })
-      .def("get_int_attr",
-           [](mlir::ModuleOp &self, std::string name) -> py::object {
-             auto ret = self->getAttrOfType<mlir::IntegerAttr>(name);
-             if (!ret)
-               return py::none();
-             return py::int_(ret.getInt());
-           });
+      .def("get_int_attr", [](ModuleOp &self, std::string name) -> py::object {
+        auto ret = self->getAttrOfType<IntegerAttr>(name);
+        if (!ret)
+          return py::none();
+        return py::int_(ret.getInt());
+      });
 
-  m.def("make_attr",
-        [](const std::vector<int> &values, mlir::MLIRContext &context) {
-          return mlir::DenseIntElementsAttr::get(
-                     mlir::RankedTensorType::get(
-                         {static_cast<int64_t>(values.size())},
-                         mlir::IntegerType::get(&context, 32)),
-                     values)
-              .cast<mlir::Attribute>();
-        });
+  m.def("make_attr", [](const std::vector<int> &values, MLIRContext &context) {
+    return DenseIntElementsAttr::get(
+               RankedTensorType::get({static_cast<int64_t>(values.size())},
+                                     IntegerType::get(&context, 32)),
+               values)
+        .cast<Attribute>();
+  });
 
   m.def(
       "parse_mlir_module",
-      [](const std::string &inputFilename, mlir::MLIRContext &context) {
+      [](const std::string &inputFilename, MLIRContext &context) {
         // parse module
-        mlir::OwningOpRef<mlir::ModuleOp> module =
-            mlir::parseSourceFile<mlir::ModuleOp>(inputFilename, &context);
+        OwningOpRef<ModuleOp> module =
+            parseSourceFile<ModuleOp>(inputFilename, &context);
         if (!module)
           throw std::runtime_error("Parse MLIR file failed.");
         // locations are incompatible with ptx < 7.5 !
-        module->walk([](mlir::Operation *op) {
-          op->setLoc(mlir::UnknownLoc::get(op->getContext()));
+        module->walk([](Operation *op) {
+          op->setLoc(UnknownLoc::get(op->getContext()));
         });
 
         return module->clone();
       },
       ret::take_ownership);
 
-  py::class_<mlir::triton::FuncOp, mlir::OpState>(m, "function",
-                                                  py::module_local())
+  py::class_<FuncOp, OpState>(m, "function", py::module_local())
       // .def_property_readonly("attrs", &ir::function::attrs)
       // .def("add_attr", &ir::function::add_attr);
       .def("args",
-           [](mlir::triton::FuncOp &self, unsigned idx) -> mlir::BlockArgument {
+           [](FuncOp &self, unsigned idx) -> BlockArgument {
              return self.getArgument(idx);
            })
       .def(
           "add_entry_block",
-          [](mlir::triton::FuncOp &self) -> mlir::Block * {
-            return self.addEntryBlock();
-          },
+          [](FuncOp &self) -> Block * { return self.addEntryBlock(); },
           ret::reference)
       .def(
           "set_arg_attr",
-          [](mlir::triton::FuncOp &self, int arg_no, const std::string &name,
-             int val) {
+          [](FuncOp &self, int arg_no, const std::string &name, int val) {
             // set arg attributes "name" to value "val"
-            auto attrTy = mlir::IntegerType::get(self.getContext(), 32);
-            self.setArgAttr(arg_no, name, mlir::IntegerAttr::get(attrTy, val));
+            auto attrTy = IntegerType::get(self.getContext(), 32);
+            self.setArgAttr(arg_no, name, IntegerAttr::get(attrTy, val));
           },
           ret::reference)
-      //  .def("has_attr", &mlir::::FuncOp::hasAttr)
+      //  .def("has_attr", &::FuncOp::hasAttr)
       .def("finalize",
-           [](mlir::triton::FuncOp &self) -> void {
+           [](FuncOp &self) -> void {
              // Remove dead code
              // 1. Unreachable code after return
-             self.walk([&](mlir::Block *block) {
-               mlir::Operation *retOp = nullptr;
+             self.walk([&](Block *block) {
+               Operation *retOp = nullptr;
                // It's better to not use walk here because we only want to
                // check operations in the current block
                for (auto &op : block->getOperations()) {
-                 if (mlir::isa<mlir::triton::ReturnOp>(op))
+                 if (isa<ReturnOp>(op))
                    if (retOp == nullptr) {
                      retOp = &op;
                      break;
@@ -497,9 +481,8 @@ void init_triton_ir(py::module &&m) {
                }
              });
              // 2. Check if the result of tl.advance is used
-             self.walk([&](mlir::Operation *op) {
-               if (mlir::isa<mlir::triton::AdvanceOp>(op) &&
-                   op->getResult(0).use_empty())
+             self.walk([&](Operation *op) {
+               if (isa<AdvanceOp>(op) && op->getResult(0).use_empty())
                  outputWarning(op->getLoc(), "The result of tl.advance is not "
                                              "being used. Note that tl.advance "
                                              "does not have any side effects. "
@@ -508,36 +491,35 @@ void init_triton_ir(py::module &&m) {
                                              "tl.advance to a variable.");
              });
            })
-      .def_property_readonly("type", &mlir::triton::FuncOp::getFunctionType)
-      .def("reset_type", &mlir::triton::FuncOp::setType);
+      .def_property_readonly("type", &FuncOp::getFunctionType)
+      .def("reset_type", &FuncOp::setType);
 
-  py::class_<mlir::OpBuilder::InsertPoint>(m, "InsertPoint",
-                                           py::module_local());
+  py::class_<OpBuilder::InsertPoint>(m, "InsertPoint", py::module_local());
 
   py::class_<TritonOpBuilder>(m, "builder", py::module_local(),
                               py::dynamic_attr())
-      .def(py::init<mlir::MLIRContext *>())
+      .def(py::init<MLIRContext *>())
       // getters
       .def("create_module",
-           [](TritonOpBuilder &self) -> mlir::ModuleOp {
-             return self.create<mlir::ModuleOp>();
+           [](TritonOpBuilder &self) -> ModuleOp {
+             return self.create<ModuleOp>();
            })
       // insertion block/point
       .def("set_insertion_point_to_start",
-           [](TritonOpBuilder &self, mlir::Block &block) -> void {
+           [](TritonOpBuilder &self, Block &block) -> void {
              self.setInsertionPointToStart(block);
            })
       .def("set_insertion_point_to_end",
-           [](TritonOpBuilder &self, mlir::Block &block) {
+           [](TritonOpBuilder &self, Block &block) {
              self.setInsertionPointToEnd(block);
            })
       .def("set_insertion_point_after",
-           [](TritonOpBuilder &self, mlir::Operation &op) {
+           [](TritonOpBuilder &self, Operation &op) {
              self.setInsertionPointAfter(op);
            })
       .def(
           "get_insertion_block",
-          [](TritonOpBuilder &self) -> mlir::Block * {
+          [](TritonOpBuilder &self) -> Block * {
             return self.getBuilder().getInsertionBlock();
           },
           ret::reference)
@@ -546,7 +528,7 @@ void init_triton_ir(py::module &&m) {
              return self.getBuilder().saveInsertionPoint();
            })
       .def("restore_insertion_point",
-           [](TritonOpBuilder &self, mlir::OpBuilder::InsertPoint pt) {
+           [](TritonOpBuilder &self, OpBuilder::InsertPoint pt) {
              self.restoreInsertionPoint(pt);
            })
       // Attr
@@ -561,340 +543,316 @@ void init_triton_ir(py::module &&m) {
       // Use arith.ConstantOp to create constants
       // Constants
       .def("get_int1",
-           [](TritonOpBuilder &self, bool v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, bool v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI1Type()));
            })
       .def("get_int8",
-           [](TritonOpBuilder &self, int64_t v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, int64_t v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI8Type()));
            })
       .def("get_int16",
-           [](TritonOpBuilder &self, int64_t v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, int64_t v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI16Type()));
            })
       .def("get_int32",
-           [](TritonOpBuilder &self, int64_t v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, int64_t v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI32Type()));
            })
       .def("get_int64",
-           [](TritonOpBuilder &self, int64_t v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, int64_t v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI64Type()));
            })
       .def("get_uint8",
-           [](TritonOpBuilder &self, uint64_t v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, uint64_t v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI8Type()));
            })
       .def("get_uint16",
-           [](TritonOpBuilder &self, uint64_t v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, uint64_t v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI16Type()));
            })
       .def("get_uint32",
-           [](TritonOpBuilder &self, uint64_t v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, uint64_t v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI32Type()));
            })
       .def("get_uint64",
-           [](TritonOpBuilder &self, uint64_t v) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ConstantIntOp>(
+           [](TritonOpBuilder &self, uint64_t v) -> Value {
+             return Value(self.create<arith::ConstantIntOp>(
                  v, self.getBuilder().getI64Type()));
            })
       .def("get_bf16",
-           [](TritonOpBuilder &self, float v) -> mlir::Value {
+           [](TritonOpBuilder &self, float v) -> Value {
              auto type = self.getBuilder().getBF16Type();
-             return self.create<mlir::arith::ConstantFloatOp>(
-                 mlir::APFloat(type.getFloatSemantics(), std::to_string(v)),
-                 type);
+             return self.create<arith::ConstantFloatOp>(
+                 APFloat(type.getFloatSemantics(), std::to_string(v)), type);
            })
       .def("get_fp16",
-           [](TritonOpBuilder &self, float v) -> mlir::Value {
-             return self.create<mlir::arith::ConstantOp>(
+           [](TritonOpBuilder &self, float v) -> Value {
+             return self.create<arith::ConstantOp>(
                  self.getBuilder().getF16FloatAttr(v));
            })
       .def("get_fp32",
-           [](TritonOpBuilder &self, float v) -> mlir::Value {
-             return self.create<mlir::arith::ConstantOp>(
+           [](TritonOpBuilder &self, float v) -> Value {
+             return self.create<arith::ConstantOp>(
                  self.getBuilder().getF32FloatAttr(v));
            })
       .def("get_fp64",
-           [](TritonOpBuilder &self, double v) -> mlir::Value {
-             return self.create<mlir::arith::ConstantOp>(
+           [](TritonOpBuilder &self, double v) -> Value {
+             return self.create<arith::ConstantOp>(
                  self.getBuilder().getF64FloatAttr(v));
            })
       .def("get_null_value",
-           [](TritonOpBuilder &self, mlir::Type type) -> mlir::Value {
-             if (auto floatTy = type.dyn_cast<mlir::FloatType>())
-               return self.create<mlir::arith::ConstantFloatOp>(
-                   mlir::APFloat(floatTy.getFloatSemantics(), 0), floatTy);
-             else if (auto intTy = type.dyn_cast<mlir::IntegerType>())
-               return self.create<mlir::arith::ConstantIntOp>(0, intTy);
+           [](TritonOpBuilder &self, Type type) -> Value {
+             if (auto floatTy = type.dyn_cast<FloatType>())
+               return self.create<arith::ConstantFloatOp>(
+                   APFloat(floatTy.getFloatSemantics(), 0), floatTy);
+             else if (auto intTy = type.dyn_cast<IntegerType>())
+               return self.create<arith::ConstantIntOp>(0, intTy);
              else
                throw std::runtime_error("Not implemented");
            })
       .def("get_all_ones_value",
-           [](TritonOpBuilder &self, mlir::Type type) -> mlir::Value {
+           [](TritonOpBuilder &self, Type type) -> Value {
              uint64_t val = 0xFFFFFFFFFFFFFFFF;
-             if (auto intTy = type.dyn_cast<mlir::IntegerType>())
-               return self.create<mlir::arith::ConstantIntOp>(val, intTy);
+             if (auto intTy = type.dyn_cast<IntegerType>())
+               return self.create<arith::ConstantIntOp>(val, intTy);
              else
                throw std::runtime_error("Not implemented");
            })
 
       // Types
       .def("get_void_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getNoneType();
            })
       .def("get_int1_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getI1Type();
            }) // or ret::copy?
       .def("get_int8_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getI8Type();
            })
       .def("get_int16_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
-             return self.getBuilder().getType<mlir::IntegerType>(16);
+           [](TritonOpBuilder &self) -> Type {
+             return self.getBuilder().getType<IntegerType>(16);
            })
       .def("get_int32_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getI32Type();
            })
       .def("get_int64_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getI64Type();
            })
       .def("get_fp8e4nv_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
-             return self.getBuilder().getType<mlir::Float8E4M3FNUZType>();
+           [](TritonOpBuilder &self) -> Type {
+             return self.getBuilder().getType<Float8E4M3FNUZType>();
            })
       .def("get_fp8e4b15_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              // TODO: upstream FP8E4B15 into MLIR, or find a way to externally
              // have a float-like type compatible with float only native ops
-             return self.getBuilder().getType<mlir::Float8E4M3B11FNUZType>();
+             return self.getBuilder().getType<Float8E4M3B11FNUZType>();
            })
       .def("get_fp8e4b15x4_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              // TODO: upstream FP8E4B15 into MLIR, or find a way to externally
              // have a float-like type compatible with float only native ops
-             return self.getBuilder().getType<mlir::Float8E4M3FNType>();
+             return self.getBuilder().getType<Float8E4M3FNType>();
            })
       .def("get_fp8e5_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
-             return self.getBuilder().getType<mlir::Float8E5M2Type>();
+           [](TritonOpBuilder &self) -> Type {
+             return self.getBuilder().getType<Float8E5M2Type>();
            })
       .def("get_half_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getF16Type();
            })
       .def("get_bf16_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getBF16Type();
            })
       .def("get_float_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getF32Type();
            })
       .def("get_double_ty",
-           [](TritonOpBuilder &self) -> mlir::Type {
+           [](TritonOpBuilder &self) -> Type {
              return self.getBuilder().getF64Type();
            })
       .def("get_ptr_ty",
-           [](TritonOpBuilder &self, mlir::Type &type,
-              int addrSpace) -> mlir::Type {
-             return mlir::triton::PointerType::get(type, addrSpace);
+           [](TritonOpBuilder &self, Type &type, int addrSpace) -> Type {
+             return PointerType::get(type, addrSpace);
            })
       .def("get_block_ty",
-           [](TritonOpBuilder &self, mlir::Type &elementType,
-              std::vector<int64_t> &shape) -> mlir::Type {
-             return mlir::RankedTensorType::get(shape, elementType);
+           [](TritonOpBuilder &self, Type &elementType,
+              std::vector<int64_t> &shape) -> Type {
+             return RankedTensorType::get(shape, elementType);
            })
       .def("get_function_ty",
-           [](TritonOpBuilder &self, std::vector<mlir::Type> inTypes,
-              std::vector<mlir::Type> outTypes) -> mlir::Type {
+           [](TritonOpBuilder &self, std::vector<Type> inTypes,
+              std::vector<Type> outTypes) -> Type {
              return self.getBuilder().getFunctionType(inTypes, outTypes);
            })
       // locs
-      .def("set_loc", [](TritonOpBuilder &self,
-                         mlir::Location loc) { self.setLastLoc(loc); })
+      .def("set_loc",
+           [](TritonOpBuilder &self, Location loc) { self.setLastLoc(loc); })
       .def("set_loc",
            [](TritonOpBuilder &self, const std::string &fileName, int line,
               int column) { self.setLastLoc(fileName, line, column); })
       .def("get_loc",
-           [](TritonOpBuilder &self) -> mlir::Location {
-             return self.getLastLoc();
-           })
+           [](TritonOpBuilder &self) -> Location { return self.getLastLoc(); })
 
       // Ops
       .def("get_or_insert_function",
-           [](TritonOpBuilder &self, mlir::ModuleOp &module,
-              std::string &funcName, mlir::Type &funcType,
-              std::string &visibility, bool noinline) -> mlir::triton::FuncOp {
-             if (mlir::Operation *funcOperation = module.lookupSymbol(funcName))
-               return llvm::dyn_cast<mlir::triton::FuncOp>(funcOperation);
-             if (auto funcTy = funcType.dyn_cast<mlir::FunctionType>()) {
-               llvm::SmallVector<mlir::NamedAttribute> attrs = {
-                   mlir::NamedAttribute(
+           [](TritonOpBuilder &self, ModuleOp &module, std::string &funcName,
+              Type &funcType, std::string &visibility,
+              bool noinline) -> FuncOp {
+             if (Operation *funcOperation = module.lookupSymbol(funcName))
+               return llvm::dyn_cast<FuncOp>(funcOperation);
+             if (auto funcTy = funcType.dyn_cast<FunctionType>()) {
+               llvm::SmallVector<NamedAttribute> attrs = {
+                   NamedAttribute(
                        self.getBuilder().getStringAttr("sym_visibility"),
                        self.getBuilder().getStringAttr(visibility)),
-                   mlir::NamedAttribute(
-                       self.getBuilder().getStringAttr("noinline"),
-                       self.getBuilder().getBoolAttr(noinline))};
-               return self.create<mlir::triton::FuncOp>(funcName, funcTy,
-                                                        attrs);
+                   NamedAttribute(self.getBuilder().getStringAttr("noinline"),
+                                  self.getBuilder().getBoolAttr(noinline))};
+               return self.create<FuncOp>(funcName, funcTy, attrs);
              }
              throw std::runtime_error("invalid function type");
            })
       .def(
           "create_block",
-          [](TritonOpBuilder &self) -> mlir::Block * {
-            mlir::Region *parent = self.getBuilder().getBlock()->getParent();
+          [](TritonOpBuilder &self) -> Block * {
+            Region *parent = self.getBuilder().getBlock()->getParent();
             return self.getBuilder().createBlock(parent);
           },
           ret::reference)
       .def(
           "create_block_with_parent",
-          [](TritonOpBuilder &self, mlir::Region &parent,
-             std::vector<mlir::Type> &argTypes) -> mlir::Block * {
+          [](TritonOpBuilder &self, Region &parent,
+             std::vector<Type> &argTypes) -> Block * {
             // TODO: update arg loc
             auto loc = self.getBuilder().getUnknownLoc();
-            llvm::SmallVector<mlir::Location, 8> argLocs(argTypes.size(), loc);
+            llvm::SmallVector<Location, 8> argLocs(argTypes.size(), loc);
             return self.getBuilder().createBlock(&parent, {}, argTypes,
                                                  argLocs);
           },
           ret::reference)
       .def(
           "new_block",
-          [](TritonOpBuilder &self) -> mlir::Block * {
-            return new mlir::Block();
-          },
+          [](TritonOpBuilder &self) -> Block * { return new Block(); },
           ret::reference)
       // Function
       .def("ret",
-           [](TritonOpBuilder &self,
-              std::vector<mlir::Value> &vals) -> mlir::OpState {
-             return self.create<mlir::triton::ReturnOp>(vals);
+           [](TritonOpBuilder &self, std::vector<Value> &vals) -> OpState {
+             return self.create<ReturnOp>(vals);
            })
       .def("call",
-           [](TritonOpBuilder &self, mlir::triton::FuncOp &func,
-              std::vector<mlir::Value> &args) -> mlir::OpState {
-             return self.create<mlir::triton::CallOp>(func, args);
-           })
+           [](TritonOpBuilder &self, FuncOp &func, std::vector<Value> &args)
+               -> OpState { return self.create<CallOp>(func, args); })
       // Unstructured control flow
       .def("create_cond_branch",
-           [](TritonOpBuilder &self, mlir::Value condition,
-              mlir::Block *trueDest, mlir::Block *falseDest) -> mlir::OpState {
-             return self.create<mlir::cf::CondBranchOp>(condition, trueDest,
-                                                        falseDest);
+           [](TritonOpBuilder &self, Value condition, Block *trueDest,
+              Block *falseDest) -> OpState {
+             return self.create<cf::CondBranchOp>(condition, trueDest,
+                                                  falseDest);
            })
       .def("create_branch",
-           [](TritonOpBuilder &self, mlir::Block *dest,
-              std::vector<mlir::Value> &args) -> mlir::OpState {
-             return self.create<mlir::cf::BranchOp>(dest, args);
-           })
+           [](TritonOpBuilder &self, Block *dest, std::vector<Value> &args)
+               -> OpState { return self.create<cf::BranchOp>(dest, args); })
       // Structured control flow
       .def("create_for_op",
-           [](TritonOpBuilder &self, mlir::Value &lb, mlir::Value &ub,
-              mlir::Value &step,
-              std::vector<mlir::Value> &initArgs) -> mlir::scf::ForOp {
-             return self.create<mlir::scf::ForOp>(lb, ub, step, initArgs);
+           [](TritonOpBuilder &self, Value &lb, Value &ub, Value &step,
+              std::vector<Value> &initArgs) -> scf::ForOp {
+             return self.create<scf::ForOp>(lb, ub, step, initArgs);
            })
       .def("create_if_op",
-           [](TritonOpBuilder &self, std::vector<mlir::Type> &retTypes,
-              mlir::Value &condition, bool withElse) -> mlir::scf::IfOp {
-             return self.create<mlir::scf::IfOp>(retTypes, condition, withElse);
+           [](TritonOpBuilder &self, std::vector<Type> &retTypes,
+              Value &condition, bool withElse) -> scf::IfOp {
+             return self.create<scf::IfOp>(retTypes, condition, withElse);
            })
       .def("create_yield_op",
-           [](TritonOpBuilder &self,
-              std::vector<mlir::Value> &yields) -> mlir::scf::YieldOp {
-             return self.create<mlir::scf::YieldOp>(yields);
-           })
+           [](TritonOpBuilder &self, std::vector<Value> &yields)
+               -> scf::YieldOp { return self.create<scf::YieldOp>(yields); })
       .def("create_while_op",
-           [](TritonOpBuilder &self, std::vector<mlir::Type> &retTypes,
-              std::vector<mlir::Value> &initArgs) -> mlir::scf::WhileOp {
-             return self.create<mlir::scf::WhileOp>(retTypes, initArgs);
+           [](TritonOpBuilder &self, std::vector<Type> &retTypes,
+              std::vector<Value> &initArgs) -> scf::WhileOp {
+             return self.create<scf::WhileOp>(retTypes, initArgs);
            })
       .def("create_condition_op",
-           [](TritonOpBuilder &self, mlir::Value &cond,
-              std::vector<mlir::Value> &args) -> mlir::scf::ConditionOp {
-             return self.create<mlir::scf::ConditionOp>(cond, args);
+           [](TritonOpBuilder &self, Value &cond,
+              std::vector<Value> &args) -> scf::ConditionOp {
+             return self.create<scf::ConditionOp>(cond, args);
            })
 
       // miscellaneous
       .def("create_make_range",
-           [](TritonOpBuilder &self, int start, int end) -> mlir::Value {
-             auto retType = mlir::RankedTensorType::get(
+           [](TritonOpBuilder &self, int start, int end) -> Value {
+             auto retType = RankedTensorType::get(
                  {end - start}, self.getBuilder().getI32Type());
-             return self.create<mlir::triton::MakeRangeOp>(retType, start, end);
+             return self.create<MakeRangeOp>(retType, start, end);
            })
 
       // Cast instructions
       // Conversions for custom FP types (FP8 and non-standard rounding modes)
       .def("create_fp_to_fp",
-           [](TritonOpBuilder &self, mlir::Value &src, mlir::Type &dstType,
-              std::optional<::mlir::triton::RoundingMode> roundingMode)
-               -> mlir::Value {
+           [](TritonOpBuilder &self, Value &src, Type &dstType,
+              std::optional<RoundingMode> roundingMode) -> Value {
              if (roundingMode.has_value())
-               return self.create<mlir::triton::FpToFpOp>(
+               return self.create<FpToFpOp>(
                    dstType, src,
-                   mlir::triton::RoundingModeAttr::get(
-                       self.getBuilder().getContext(), roundingMode.value()));
+                   RoundingModeAttr::get(self.getBuilder().getContext(),
+                                         roundingMode.value()));
              else
-               return self.create<mlir::triton::FpToFpOp>(dstType, src);
+               return self.create<FpToFpOp>(dstType, src);
            })
       // Conversions for standard LLVM builtin types
       .def("create_bitcast",
-           [](TritonOpBuilder &self, mlir::Value &src,
-              mlir::Type &dstType) -> mlir::Value {
-             return self.create<mlir::triton::BitcastOp>(dstType, src);
+           [](TritonOpBuilder &self, Value &src, Type &dstType) -> Value {
+             return self.create<BitcastOp>(dstType, src);
            })
       .def("create_si_to_fp",
-           [](TritonOpBuilder &self, mlir::Value &src,
-              mlir::Type &dstType) -> mlir::Value {
-             return self.create<mlir::arith::SIToFPOp>(dstType, src);
+           [](TritonOpBuilder &self, Value &src, Type &dstType) -> Value {
+             return self.create<arith::SIToFPOp>(dstType, src);
            })
       .def("create_ui_to_fp",
-           [](TritonOpBuilder &self, mlir::Value &src,
-              mlir::Type &dstType) -> mlir::Value {
-             return self.create<mlir::arith::UIToFPOp>(dstType, src);
+           [](TritonOpBuilder &self, Value &src, Type &dstType) -> Value {
+             return self.create<arith::UIToFPOp>(dstType, src);
            })
       .def("create_fp_to_si",
-           [](TritonOpBuilder &self, mlir::Value &src,
-              mlir::Type &dstType) -> mlir::Value {
-             return self.create<mlir::arith::FPToSIOp>(dstType, src);
+           [](TritonOpBuilder &self, Value &src, Type &dstType) -> Value {
+             return self.create<arith::FPToSIOp>(dstType, src);
            })
       .def("create_fp_to_ui",
-           [](TritonOpBuilder &self, mlir::Value &src,
-              mlir::Type &dstType) -> mlir::Value {
-             return self.create<mlir::arith::FPToUIOp>(dstType, src);
+           [](TritonOpBuilder &self, Value &src, Type &dstType) -> Value {
+             return self.create<arith::FPToUIOp>(dstType, src);
            })
       .def("create_fp_ext",
-           [](TritonOpBuilder &self, mlir::Value &src,
-              mlir::Type &dstType) -> mlir::Value {
-             return self.create<mlir::arith::ExtFOp>(dstType, src);
+           [](TritonOpBuilder &self, Value &src, Type &dstType) -> Value {
+             return self.create<arith::ExtFOp>(dstType, src);
            })
       .def("create_fp_trunc",
-           [](TritonOpBuilder &self, mlir::Value &src,
-              mlir::Type &dstType) -> mlir::Value {
-             return self.create<mlir::arith::TruncFOp>(dstType, src);
+           [](TritonOpBuilder &self, Value &src, Type &dstType) -> Value {
+             return self.create<arith::TruncFOp>(dstType, src);
            })
       .def("create_int_cast",
-           [](TritonOpBuilder &self, mlir::Value &src, mlir::Type &dstType,
-              bool isSigned) -> mlir::Value {
+           [](TritonOpBuilder &self, Value &src, Type &dstType,
+              bool isSigned) -> Value {
              // get element type if necessary
-             mlir::Type srcType = src.getType();
-             auto srcTensorType = srcType.dyn_cast<mlir::RankedTensorType>();
-             auto dstTensorType = dstType.dyn_cast<mlir::RankedTensorType>();
-             mlir::Type srcEltType = srcType;
-             mlir::Type dstEltType = dstType;
+             Type srcType = src.getType();
+             auto srcTensorType = srcType.dyn_cast<RankedTensorType>();
+             auto dstTensorType = dstType.dyn_cast<RankedTensorType>();
+             Type srcEltType = srcType;
+             Type dstEltType = dstType;
              if (dstTensorType && srcTensorType) {
                dstEltType = dstTensorType.getElementType();
                srcEltType = srcTensorType.getElementType();
@@ -902,627 +860,543 @@ void init_triton_ir(py::module &&m) {
              unsigned srcWidth = srcEltType.getIntOrFloatBitWidth();
              unsigned dstWidth = dstEltType.getIntOrFloatBitWidth();
              if (srcWidth == dstWidth)
-               return self.create<mlir::arith::BitcastOp>(dstType, src);
+               return self.create<arith::BitcastOp>(dstType, src);
              else if (srcWidth > dstWidth)
-               return self.create<mlir::arith::TruncIOp>(dstType, src);
+               return self.create<arith::TruncIOp>(dstType, src);
              else if (isSigned)
-               return self.create<mlir::arith::ExtSIOp>(dstType, src);
+               return self.create<arith::ExtSIOp>(dstType, src);
              else
-               return self.create<mlir::arith::ExtUIOp>(dstType, src);
+               return self.create<arith::ExtUIOp>(dstType, src);
            })
       .def("create_to_index",
-           [](TritonOpBuilder &self, mlir::Value &input) -> mlir::Value {
-             return self.create<mlir::arith::IndexCastOp>(
+           [](TritonOpBuilder &self, Value &input) -> Value {
+             return self.create<arith::IndexCastOp>(
                  self.getBuilder().getIndexType(), input);
            })
       .def("create_index_to_si",
-           [](TritonOpBuilder &self, mlir::Value &input) -> mlir::Value {
-             return self.create<mlir::arith::IndexCastOp>(
+           [](TritonOpBuilder &self, Value &input) -> Value {
+             return self.create<arith::IndexCastOp>(
                  self.getBuilder().getI64Type(), input);
            })
       .def("create_fmul",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::MulFOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::MulFOp>(lhs, rhs);
            })
       .def("create_fdiv",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::DivFOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::DivFOp>(lhs, rhs);
            })
       .def("create_frem",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::RemFOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::RemFOp>(lhs, rhs);
            })
       .def("create_fadd",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::AddFOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::AddFOp>(lhs, rhs);
            })
       .def("create_fsub",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::SubFOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::SubFOp>(lhs, rhs);
            })
       .def("create_mul",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::MulIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::MulIOp>(lhs, rhs);
            })
       .def("create_sdiv",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::DivSIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::DivSIOp>(lhs, rhs);
            })
       .def("create_udiv",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::DivUIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::DivUIOp>(lhs, rhs);
            })
       .def("create_srem",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::RemSIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::RemSIOp>(lhs, rhs);
            })
       .def("create_urem",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::RemUIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::RemUIOp>(lhs, rhs);
            })
       .def("create_add",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::AddIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::AddIOp>(lhs, rhs);
            })
       .def("create_sub",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::SubIOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::SubIOp>(lhs, rhs));
            })
       .def("create_shl",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ShLIOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::ShLIOp>(lhs, rhs));
            })
       .def("create_lshr",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ShRUIOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::ShRUIOp>(lhs, rhs));
            })
       .def("create_ashr",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::ShRSIOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::ShRSIOp>(lhs, rhs));
            })
       .def("create_minsi",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::MinSIOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::MinSIOp>(lhs, rhs));
            })
       .def("create_minui",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::MinUIOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::MinUIOp>(lhs, rhs));
            })
       // minimumf follows the torch.minimum convention and returns NaN if either
       // operand is NaN
       .def("create_minimumf",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::MinimumFOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::MinimumFOp>(lhs, rhs));
            })
       // minnumf follows the torch.fmin convention and returns the non-NaN
       // operand
       .def("create_minnumf",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::MinNumFOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::MinNumFOp>(lhs, rhs));
            })
       .def("create_maxsi",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::MaxSIOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::MaxSIOp>(lhs, rhs));
            })
       .def("create_maxui",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::MaxUIOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::MaxUIOp>(lhs, rhs));
            })
       // maximumf follows the torch.maximum convention and returns NaN if either
       // operand is NaN
       .def("create_maximumf",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::MaximumFOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::MaximumFOp>(lhs, rhs));
            })
       // maxnumf follows the torch.fmax convention and returns the non-NaN
       // operand
       .def("create_maxnumf",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return mlir::Value(self.create<mlir::arith::MaxNumFOp>(lhs, rhs));
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return Value(self.create<arith::MaxNumFOp>(lhs, rhs));
            })
       .def("create_clampf",
-           [](TritonOpBuilder &self, mlir::Value &input, mlir::Value &min,
-              mlir::Value &max,
-              mlir::triton::PropagateNan propagateNan) -> mlir::Value {
-             return mlir::Value(self.create<mlir::triton::ClampFOp>(
-                 input, min, max, propagateNan));
+           [](TritonOpBuilder &self, Value &input, Value &min, Value &max,
+              PropagateNan propagateNan) -> Value {
+             return Value(self.create<ClampFOp>(input, min, max, propagateNan));
            })
       // AddPtr (similar to GEP)
       .def("create_addptr",
-           [](TritonOpBuilder &self, mlir::Value &ptr,
-              mlir::Value &offset) -> mlir::Value {
-             return self.create<mlir::triton::AddPtrOp>(ptr.getType(), ptr,
-                                                        offset);
+           [](TritonOpBuilder &self, Value &ptr, Value &offset) -> Value {
+             return self.create<AddPtrOp>(ptr.getType(), ptr, offset);
            })
       // Comparison (int)
       .def("create_icmpSLE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::sle, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::sle, lhs,
+                                               rhs);
            })
       .def("create_icmpSLT",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::slt, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::slt, lhs,
+                                               rhs);
            })
       .def("create_icmpSGE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::sge, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::sge, lhs,
+                                               rhs);
            })
       .def("create_icmpSGT",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::sgt, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::sgt, lhs,
+                                               rhs);
            })
       .def("create_icmpULE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::ule, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::ule, lhs,
+                                               rhs);
            })
       .def("create_icmpULT",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::ult, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::ult, lhs,
+                                               rhs);
            })
       .def("create_icmpUGE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::uge, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::uge, lhs,
+                                               rhs);
            })
       .def("create_icmpUGT",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::ugt, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::ugt, lhs,
+                                               rhs);
            })
       .def("create_icmpEQ",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::eq, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::eq, lhs,
+                                               rhs);
            })
       .def("create_icmpNE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpIOp>(
-                 mlir::arith::CmpIPredicate::ne, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpIOp>(arith::CmpIPredicate::ne, lhs,
+                                               rhs);
            })
       // Comparison (float)
       .def("create_fcmpOLT",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::OLT, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::OLT, lhs,
+                                               rhs);
            })
       .def("create_fcmpOGT",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::OGT, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::OGT, lhs,
+                                               rhs);
            })
       .def("create_fcmpOLE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::OLE, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::OLE, lhs,
+                                               rhs);
            })
       .def("create_fcmpOGE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::OGE, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::OGE, lhs,
+                                               rhs);
            })
       .def("create_fcmpOEQ",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::OEQ, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::OEQ, lhs,
+                                               rhs);
            })
       .def("create_fcmpONE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::ONE, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::ONE, lhs,
+                                               rhs);
            })
       .def("create_fcmpULT",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::ULT, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::ULT, lhs,
+                                               rhs);
            })
       .def("create_fcmpUGT",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::UGT, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::UGT, lhs,
+                                               rhs);
            })
       .def("create_fcmpULE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::ULE, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::ULE, lhs,
+                                               rhs);
            })
       .def("create_fcmpUGE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::UGE, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::UGE, lhs,
+                                               rhs);
            })
       .def("create_fcmpUEQ",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::UEQ, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::UEQ, lhs,
+                                               rhs);
            })
       .def("create_fcmpUNE",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::CmpFOp>(
-                 mlir::arith::CmpFPredicate::UNE, lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::CmpFOp>(arith::CmpFPredicate::UNE, lhs,
+                                               rhs);
            })
       // // Logical
       .def("create_and",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::AndIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::AndIOp>(lhs, rhs);
            })
       .def("create_xor",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::XOrIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::XOrIOp>(lhs, rhs);
            })
       .def("create_or",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             return self.create<mlir::arith::OrIOp>(lhs, rhs);
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             return self.create<arith::OrIOp>(lhs, rhs);
            })
       // Input/Output
       .def("create_load",
-           [](TritonOpBuilder &self, mlir::Value &ptrs,
-              mlir::triton::CacheModifier cacheModifier,
-              mlir::triton::EvictionPolicy evictionPolicy,
-              bool isVolatile) -> mlir::Value {
-             return self.create<mlir::triton::LoadOp>(
-                 ptrs, cacheModifier, evictionPolicy, isVolatile);
+           [](TritonOpBuilder &self, Value &ptrs, CacheModifier cacheModifier,
+              EvictionPolicy evictionPolicy, bool isVolatile) -> Value {
+             return self.create<LoadOp>(ptrs, cacheModifier, evictionPolicy,
+                                        isVolatile);
            })
       .def("create_store",
-           [](TritonOpBuilder &self, mlir::Value &ptrs, mlir::Value &value,
-              mlir::triton::CacheModifier cacheModifier,
-              mlir::triton::EvictionPolicy evictionPolicy) -> void {
-             self.create<mlir::triton::StoreOp>(ptrs, value, cacheModifier,
-                                                evictionPolicy);
+           [](TritonOpBuilder &self, Value &ptrs, Value &value,
+              CacheModifier cacheModifier,
+              EvictionPolicy evictionPolicy) -> void {
+             self.create<StoreOp>(ptrs, value, cacheModifier, evictionPolicy);
            })
       .def("create_tensor_pointer_load",
-           [](TritonOpBuilder &self, mlir::Value &ptr,
+           [](TritonOpBuilder &self, Value &ptr,
               std::vector<int32_t> &boundaryCheck,
-              std::optional<mlir::triton::PaddingOption> paddingOption,
-              mlir::triton::CacheModifier cacheModifier,
-              mlir::triton::EvictionPolicy evictionPolicy,
-              bool isVolatile) -> mlir::Value {
-             return self.create<mlir::triton::LoadOp>(
-                 ptr, boundaryCheck, paddingOption, cacheModifier,
-                 evictionPolicy, isVolatile);
+              std::optional<PaddingOption> paddingOption,
+              CacheModifier cacheModifier, EvictionPolicy evictionPolicy,
+              bool isVolatile) -> Value {
+             return self.create<LoadOp>(ptr, boundaryCheck, paddingOption,
+                                        cacheModifier, evictionPolicy,
+                                        isVolatile);
            })
       .def("create_tensor_pointer_store",
-           [](TritonOpBuilder &self, mlir::Value &ptr, mlir::Value &val,
-              std::vector<int32_t> &boundaryCheck,
-              mlir::triton::CacheModifier cacheModifier,
-              mlir::triton::EvictionPolicy evictionPolicy) -> void {
-             self.create<mlir::triton::StoreOp>(ptr, val, boundaryCheck,
-                                                cacheModifier, evictionPolicy);
+           [](TritonOpBuilder &self, Value &ptr, Value &val,
+              std::vector<int32_t> &boundaryCheck, CacheModifier cacheModifier,
+              EvictionPolicy evictionPolicy) -> void {
+             self.create<StoreOp>(ptr, val, boundaryCheck, cacheModifier,
+                                  evictionPolicy);
            })
       .def("create_masked_load",
-           [](TritonOpBuilder &self, mlir::Value &ptrs, mlir::Value &mask,
-              std::optional<mlir::Value> &other,
-              mlir::triton::CacheModifier cacheModifier,
-              mlir::triton::EvictionPolicy evictionPolicy,
-              bool isVolatile) -> mlir::Value {
-             return self.create<mlir::triton::LoadOp>(
-                 ptrs, mask, other.value_or(mlir::Value()), cacheModifier,
-                 evictionPolicy, isVolatile);
+           [](TritonOpBuilder &self, Value &ptrs, Value &mask,
+              std::optional<Value> &other, CacheModifier cacheModifier,
+              EvictionPolicy evictionPolicy, bool isVolatile) -> Value {
+             return self.create<LoadOp>(ptrs, mask, other.value_or(Value()),
+                                        cacheModifier, evictionPolicy,
+                                        isVolatile);
            })
       .def("create_masked_store",
-           [](TritonOpBuilder &self, mlir::Value &ptrs, mlir::Value &val,
-              mlir::Value &mask, mlir::triton::CacheModifier cacheModifier,
-              mlir::triton::EvictionPolicy evictionPolicy) -> void {
-             self.create<mlir::triton::StoreOp>(ptrs, val, mask, cacheModifier,
-                                                evictionPolicy);
+           [](TritonOpBuilder &self, Value &ptrs, Value &val, Value &mask,
+              CacheModifier cacheModifier,
+              EvictionPolicy evictionPolicy) -> void {
+             self.create<StoreOp>(ptrs, val, mask, cacheModifier,
+                                  evictionPolicy);
            })
       .def("create_reshape",
-           [](TritonOpBuilder &self, mlir::Value &arg,
-              std::vector<int64_t> &shape, bool allowReorder) -> mlir::Value {
+           [](TritonOpBuilder &self, Value &arg, std::vector<int64_t> &shape,
+              bool allowReorder) -> Value {
              auto argType =
-                 arg.getType().cast<mlir::RankedTensorType>().getElementType();
-             return self.create<mlir::triton::ReshapeOp>(
-                 mlir::RankedTensorType::get(shape, argType), arg,
-                 allowReorder);
+                 arg.getType().cast<RankedTensorType>().getElementType();
+             return self.create<ReshapeOp>(
+                 RankedTensorType::get(shape, argType), arg, allowReorder);
            })
-      .def(
-          "create_expand_dims",
-          [](TritonOpBuilder &self, mlir::Value &arg, int axis) -> mlir::Value {
-            auto argType = arg.getType().dyn_cast<mlir::RankedTensorType>();
-            auto argEltType = argType.getElementType();
-            std::vector<int64_t> retShape = argType.getShape();
-            retShape.insert(retShape.begin() + axis, 1);
-            return self.create<mlir::triton::ExpandDimsOp>(
-                mlir::RankedTensorType::get(retShape, argEltType), arg, axis);
-          })
+      .def("create_expand_dims",
+           [](TritonOpBuilder &self, Value &arg, int axis) -> Value {
+             auto argType = arg.getType().dyn_cast<RankedTensorType>();
+             auto argEltType = argType.getElementType();
+             std::vector<int64_t> retShape = argType.getShape();
+             retShape.insert(retShape.begin() + axis, 1);
+             return self.create<ExpandDimsOp>(
+                 RankedTensorType::get(retShape, argEltType), arg, axis);
+           })
       .def("create_cat",
-           [](TritonOpBuilder &self, mlir::Value &lhs,
-              mlir::Value &rhs) -> mlir::Value {
-             auto lhsType = lhs.getType().dyn_cast<mlir::RankedTensorType>();
-             auto rhsType = rhs.getType().dyn_cast<mlir::RankedTensorType>();
+           [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
+             auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
+             auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
              if (!(lhsType.getShape().size() == 1 &&
                    rhsType.getShape().size() == 1))
                throw std::runtime_error(
                    "shape not supported by cat. Expecting rank-1 inputs");
              std::vector<int64_t> shape{lhsType.getShape()[0] +
                                         rhsType.getShape()[0]};
-             return self.create<mlir::triton::CatOp>(
-                 mlir::RankedTensorType::get(shape, lhsType.getElementType()),
-                 lhs, rhs);
+             return self.create<CatOp>(
+                 RankedTensorType::get(shape, lhsType.getElementType()), lhs,
+                 rhs);
            })
       .def("create_interleave",
-           [](TritonOpBuilder &self, mlir::Value &a,
-              mlir::Value &b) -> mlir::Value {
-             auto aTy = a.getType().cast<mlir::RankedTensorType>();
+           [](TritonOpBuilder &self, Value &a, Value &b) -> Value {
+             auto aTy = a.getType().cast<RankedTensorType>();
              llvm::SmallVector<int64_t> shape(aTy.getShape().begin(),
                                               aTy.getShape().end());
              shape[shape.size() - 1] *= 2;
-             return self.create<mlir::triton::ExperimentalInterleaveOp>(
-                 mlir::RankedTensorType::get(shape, aTy.getElementType()), a,
-                 b);
+             return self.create<ExperimentalInterleaveOp>(
+                 RankedTensorType::get(shape, aTy.getElementType()), a, b);
            })
       // Implements tl.trans and tl.permute.
       .def("create_trans",
-           [](TritonOpBuilder &self, mlir::Value &arg,
-              std::vector<int> &order) -> mlir::Value {
-             auto argType = arg.getType().dyn_cast<mlir::RankedTensorType>();
+           [](TritonOpBuilder &self, Value &arg,
+              std::vector<int> &order) -> Value {
+             auto argType = arg.getType().dyn_cast<RankedTensorType>();
              auto argEltType = argType.getElementType();
-             auto retShape =
-                 mlir::triton::applyPermutation(argType.getShape(), order);
-             return self.create<mlir::triton::TransOp>(
-                 mlir::RankedTensorType::get(retShape, argEltType), arg, order);
+             auto retShape = applyPermutation(argType.getShape(), order);
+             return self.create<TransOp>(
+                 RankedTensorType::get(retShape, argEltType), arg, order);
            })
       .def("create_broadcast",
-           [](TritonOpBuilder &self, mlir::Value &arg,
-              std::vector<int64_t> &shape) -> mlir::Value {
-             if (auto argType =
-                     arg.getType().dyn_cast<mlir::RankedTensorType>())
-               return self.createOrFold<mlir::triton::BroadcastOp>(
-                   mlir::RankedTensorType::get(shape, argType.getElementType()),
-                   arg);
+           [](TritonOpBuilder &self, Value &arg,
+              std::vector<int64_t> &shape) -> Value {
+             if (auto argType = arg.getType().dyn_cast<RankedTensorType>())
+               return self.createOrFold<BroadcastOp>(
+                   RankedTensorType::get(shape, argType.getElementType()), arg);
              throw std::runtime_error(
                  "arg is not of RankedTensorType, use create_splat");
            })
       .def("create_splat",
-           [](TritonOpBuilder &self, mlir::Value &arg,
-              std::vector<int64_t> &shape) -> mlir::Value {
+           [](TritonOpBuilder &self, Value &arg,
+              std::vector<int64_t> &shape) -> Value {
              auto argType = arg.getType();
-             auto ret = self.createOrFold<mlir::triton::SplatOp>(
-                 mlir::RankedTensorType::get(shape, argType), arg);
+             auto ret = self.createOrFold<SplatOp>(
+                 RankedTensorType::get(shape, argType), arg);
              return ret;
            })
       // // atomic
       .def("create_atomic_cas",
-           [](TritonOpBuilder &self, mlir::Value &ptr, mlir::Value &cmp,
-              mlir::Value &val, mlir::triton::MemSemantic sem,
-              mlir::triton::MemSyncScope scope) -> mlir::Value {
-             mlir::Type dstType;
+           [](TritonOpBuilder &self, Value &ptr, Value &cmp, Value &val,
+              MemSemantic sem, MemSyncScope scope) -> Value {
+             Type dstType;
              if (auto srcTensorType =
-                     ptr.getType().dyn_cast<mlir::RankedTensorType>()) {
-               mlir::Type dstElemType = srcTensorType.getElementType()
-                                            .cast<mlir::triton::PointerType>()
-                                            .getPointeeType();
-               dstType = mlir::RankedTensorType::get(srcTensorType.getShape(),
-                                                     dstElemType);
+                     ptr.getType().dyn_cast<RankedTensorType>()) {
+               Type dstElemType = srcTensorType.getElementType()
+                                      .cast<PointerType>()
+                                      .getPointeeType();
+               dstType =
+                   RankedTensorType::get(srcTensorType.getShape(), dstElemType);
              } else {
-               auto ptrType = mlir::getElementTypeOrSelf(ptr)
-                                  .cast<mlir::triton::PointerType>();
+               auto ptrType = getElementTypeOrSelf(ptr).cast<PointerType>();
                dstType = ptrType.getPointeeType();
              }
-             return self.create<mlir::triton::AtomicCASOp>(dstType, ptr, cmp,
-                                                           val, sem, scope);
+             return self.create<AtomicCASOp>(dstType, ptr, cmp, val, sem,
+                                             scope);
            })
       .def("create_atomic_rmw",
-           [](TritonOpBuilder &self, mlir::triton::RMWOp rmwOp,
-              mlir::Value &ptr, mlir::Value &val, mlir::Value &mask,
-              mlir::triton::MemSemantic sem,
-              mlir::triton::MemSyncScope scope) -> mlir::Value {
-             mlir::Type dstType;
+           [](TritonOpBuilder &self, RMWOp rmwOp, Value &ptr, Value &val,
+              Value &mask, MemSemantic sem, MemSyncScope scope) -> Value {
+             Type dstType;
              if (auto srcTensorType =
-                     ptr.getType().dyn_cast<mlir::RankedTensorType>()) {
-               mlir::Type dstElemType = srcTensorType.getElementType()
-                                            .cast<mlir::triton::PointerType>()
-                                            .getPointeeType();
-               dstType = mlir::RankedTensorType::get(srcTensorType.getShape(),
-                                                     dstElemType);
+                     ptr.getType().dyn_cast<RankedTensorType>()) {
+               Type dstElemType = srcTensorType.getElementType()
+                                      .cast<PointerType>()
+                                      .getPointeeType();
+               dstType =
+                   RankedTensorType::get(srcTensorType.getShape(), dstElemType);
              } else {
-               auto ptrType = mlir::getElementTypeOrSelf(ptr)
-                                  .cast<mlir::triton::PointerType>();
+               auto ptrType = getElementTypeOrSelf(ptr).cast<PointerType>();
                dstType = ptrType.getPointeeType();
              }
-             return self.create<mlir::triton::AtomicRMWOp>(
-                 dstType, rmwOp, ptr, val, mask, sem, scope);
+             return self.create<AtomicRMWOp>(dstType, rmwOp, ptr, val, mask,
+                                             sem, scope);
            })
       // External
       .def("create_extern_elementwise",
            [](TritonOpBuilder &self, const std::string &libName,
               const std::string &libPath, const std::string &symbol,
-              std::vector<mlir::Value> &argList, mlir::Type retType,
-              bool isPure) -> mlir::Value {
-             return self.create<mlir::triton::ExternElementwiseOp>(
-                 retType, argList, libName, libPath, symbol, isPure);
+              std::vector<Value> &argList, Type retType, bool isPure) -> Value {
+             return self.create<ExternElementwiseOp>(retType, argList, libName,
+                                                     libPath, symbol, isPure);
            })
       // Built-in instruction
       .def("create_get_program_id",
-           [](TritonOpBuilder &self, int axis) -> mlir::Value {
+           [](TritonOpBuilder &self, int axis) -> Value {
              if (axis < 0 || axis > 3)
                throw std::runtime_error("program_id must be in [0,3]");
-             return self.create<mlir::triton::GetProgramIdOp>(
+             return self.create<GetProgramIdOp>(
                  self.getBuilder().getI32Type(),
-                 mlir::triton::ProgramIDDimAttr::get(
-                     self.getBuilder().getContext(),
-                     mlir::triton::ProgramIDDim(axis)));
+                 ProgramIDDimAttr::get(self.getBuilder().getContext(),
+                                       ProgramIDDim(axis)));
            })
       .def("create_get_num_programs",
-           [](TritonOpBuilder &self, int axis) -> mlir::Value {
-             return self.create<mlir::triton::GetNumProgramsOp>(
+           [](TritonOpBuilder &self, int axis) -> Value {
+             return self.create<GetNumProgramsOp>(
                  self.getBuilder().getI32Type(),
                  self.getBuilder().getI32IntegerAttr(axis));
            })
       .def("create_dot",
-           [](TritonOpBuilder &self, mlir::Value &a, mlir::Value &b,
-              mlir::Value &c, bool allowTF32,
-              int maxNumImpreciseAcc) -> mlir::Value {
-             return self.create<mlir::triton::DotOp>(
-                 c.getType(), a, b, c, allowTF32, maxNumImpreciseAcc);
+           [](TritonOpBuilder &self, Value &a, Value &b, Value &c,
+              bool allowTF32, int maxNumImpreciseAcc) -> Value {
+             return self.create<DotOp>(c.getType(), a, b, c, allowTF32,
+                                       maxNumImpreciseAcc);
            })
       .def("create_exp",
-           [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
-             return self.create<mlir::math::ExpOp>(val);
+           [](TritonOpBuilder &self, Value &val) -> Value {
+             return self.create<math::ExpOp>(val);
            })
       .def("create_cos",
-           [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
-             return self.create<mlir::math::CosOp>(val);
+           [](TritonOpBuilder &self, Value &val) -> Value {
+             return self.create<math::CosOp>(val);
            })
       .def("create_sin",
-           [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
-             return self.create<mlir::math::SinOp>(val);
+           [](TritonOpBuilder &self, Value &val) -> Value {
+             return self.create<math::SinOp>(val);
            })
       .def("create_log",
-           [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
-             return self.create<mlir::math::LogOp>(val);
+           [](TritonOpBuilder &self, Value &val) -> Value {
+             return self.create<math::LogOp>(val);
            })
       .def("create_sqrt",
-           [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
-             return self.create<mlir::math::SqrtOp>(val);
+           [](TritonOpBuilder &self, Value &val) -> Value {
+             return self.create<math::SqrtOp>(val);
            })
       .def("create_fabs",
-           [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
-             return self.create<mlir::math::AbsFOp>(val);
+           [](TritonOpBuilder &self, Value &val) -> Value {
+             return self.create<math::AbsFOp>(val);
            })
       .def("create_iabs",
-           [](TritonOpBuilder &self, mlir::Value &val) -> mlir::Value {
-             return self.create<mlir::math::AbsIOp>(val);
+           [](TritonOpBuilder &self, Value &val) -> Value {
+             return self.create<math::AbsIOp>(val);
            })
       .def("create_reduce",
-           [](TritonOpBuilder &self, std::vector<mlir::Value> operands,
-              int axis) -> mlir::OpState {
-             return self.create<mlir::triton::ReduceOp>(operands, axis);
-           })
+           [](TritonOpBuilder &self, std::vector<Value> operands, int axis)
+               -> OpState { return self.create<ReduceOp>(operands, axis); })
       .def("create_reduce_ret",
-           [](TritonOpBuilder &self, py::args args) -> mlir::OpState {
-             llvm::SmallVector<mlir::Value> return_values;
+           [](TritonOpBuilder &self, py::args args) -> OpState {
+             llvm::SmallVector<Value> return_values;
              for (const auto &arg : args) {
-               return_values.push_back(py::cast<mlir::Value>(arg));
+               return_values.push_back(py::cast<Value>(arg));
              }
-             return self.create<mlir::triton::ReduceReturnOp>(return_values);
+             return self.create<ReduceReturnOp>(return_values);
            })
       .def("create_scan",
-           [](TritonOpBuilder &self, std::vector<mlir::Value> operands,
-              int axis) -> mlir::OpState {
-             return self.create<mlir::triton::ScanOp>(operands, axis);
-           })
+           [](TritonOpBuilder &self, std::vector<Value> operands, int axis)
+               -> OpState { return self.create<ScanOp>(operands, axis); })
       .def("create_scan_ret",
-           [](TritonOpBuilder &self, py::args args) -> mlir::OpState {
-             llvm::SmallVector<mlir::Value> return_values;
+           [](TritonOpBuilder &self, py::args args) -> OpState {
+             llvm::SmallVector<Value> return_values;
              for (const auto &arg : args) {
-               return_values.push_back(py::cast<mlir::Value>(arg));
+               return_values.push_back(py::cast<Value>(arg));
              }
-             return self.create<mlir::triton::ScanReturnOp>(return_values);
+             return self.create<ScanReturnOp>(return_values);
            })
       .def("create_ptr_to_int",
-           [](TritonOpBuilder &self, mlir::Value &val,
-              mlir::Type &type) -> mlir::Value {
-             return self.create<mlir::triton::PtrToIntOp>(type, val);
+           [](TritonOpBuilder &self, Value &val, Type &type) -> Value {
+             return self.create<PtrToIntOp>(type, val);
            })
       .def("create_int_to_ptr",
-           [](TritonOpBuilder &self, mlir::Value &val,
-              mlir::Type &type) -> mlir::Value {
-             return self.create<mlir::triton::IntToPtrOp>(type, val);
+           [](TritonOpBuilder &self, Value &val, Type &type) -> Value {
+             return self.create<IntToPtrOp>(type, val);
            })
       .def("create_select",
-           [](TritonOpBuilder &self, mlir::Value &condition,
-              mlir::Value &trueValue, mlir::Value &falseValue) -> mlir::Value {
-             return self.create<mlir::arith::SelectOp>(condition, trueValue,
-                                                       falseValue);
+           [](TritonOpBuilder &self, Value &condition, Value &trueValue,
+              Value &falseValue) -> Value {
+             return self.create<arith::SelectOp>(condition, trueValue,
+                                                 falseValue);
            })
       .def("create_inline_asm",
            [](TritonOpBuilder &self, const std::string &inlineAsm,
-              const std::string &constraints,
-              const std::vector<mlir::Value> &values,
-              const std::vector<mlir::Type> &types, bool isPure,
-              int pack) -> mlir::OpState {
-             return self.create<mlir::triton::ElementwiseInlineAsmOp>(
+              const std::string &constraints, const std::vector<Value> &values,
+              const std::vector<Type> &types, bool isPure,
+              int pack) -> OpState {
+             return self.create<ElementwiseInlineAsmOp>(
                  types, inlineAsm, constraints, isPure, pack, values);
            })
       .def("create_print",
            [](TritonOpBuilder &self, const std::string &prefix,
-              const std::vector<mlir::Value> &values) -> void {
-             self.create<mlir::triton::PrintOp>(
-                 mlir::StringAttr::get(self.getBuilder().getContext(),
-                                       llvm::StringRef(prefix)),
+              const std::vector<Value> &values) -> void {
+             self.create<PrintOp>(
+                 StringAttr::get(self.getBuilder().getContext(),
+                                 llvm::StringRef(prefix)),
                  values);
            })
       .def("create_assert",
-           [](TritonOpBuilder &self, mlir::Value &condition,
+           [](TritonOpBuilder &self, Value &condition,
               const std::string &message, const std::string &fileName,
               const std::string &funcName, unsigned lineNo) -> void {
-             auto messageAttr = mlir::StringAttr::get(
-                 self.getBuilder().getContext(), llvm::StringRef(message));
-             auto fileNameAttr = mlir::StringAttr::get(
-                 self.getBuilder().getContext(), llvm::StringRef(fileName));
-             auto funcNameAttr = mlir::StringAttr::get(
-                 self.getBuilder().getContext(), llvm::StringRef(funcName));
+             auto messageAttr = StringAttr::get(self.getBuilder().getContext(),
+                                                llvm::StringRef(message));
+             auto fileNameAttr = StringAttr::get(self.getBuilder().getContext(),
+                                                 llvm::StringRef(fileName));
+             auto funcNameAttr = StringAttr::get(self.getBuilder().getContext(),
+                                                 llvm::StringRef(funcName));
              auto lineNoAttr = self.getBuilder().getI32IntegerAttr(lineNo);
-             self.create<mlir::triton::AssertOp>(condition, messageAttr,
-                                                 fileNameAttr, funcNameAttr,
-                                                 lineNoAttr);
+             self.create<AssertOp>(condition, messageAttr, fileNameAttr,
+                                   funcNameAttr, lineNoAttr);
            })
       // Undef
       .def("create_undef",
-           [](TritonOpBuilder &self, mlir::Type &type) -> mlir::Value {
-             return self.create<::mlir::LLVM::UndefOp>(type);
+           [](TritonOpBuilder &self, Type &type) -> Value {
+             return self.create<LLVM::UndefOp>(type);
            })
       .def("create_histogram",
-           [](TritonOpBuilder &self, mlir::Value operand,
-              int numBins) -> mlir::OpState {
-             return self.create<mlir::triton::HistogramOp>(
-                 mlir::RankedTensorType::get(
+           [](TritonOpBuilder &self, Value operand, int numBins) -> OpState {
+             return self.create<HistogramOp>(
+                 RankedTensorType::get(
                      {static_cast<int64_t>(numBins)},
-                     mlir::IntegerType::get(operand.getContext(), 32)),
+                     IntegerType::get(operand.getContext(), 32)),
                  operand);
            })
       // Force GPU barrier
@@ -1530,45 +1404,39 @@ void init_triton_ir(py::module &&m) {
            [](TritonOpBuilder &self) { self.create<mlir::gpu::BarrierOp>(); })
       // Make a block pointer (tensor pointer in Triton IR)
       .def("create_make_block_ptr",
-           [](TritonOpBuilder &self, mlir::Value &base,
-              std::vector<mlir::Value> &shape,
-              std::vector<mlir::Value> &strides,
-              std::vector<mlir::Value> &offsets,
+           [](TritonOpBuilder &self, Value &base, std::vector<Value> &shape,
+              std::vector<Value> &strides, std::vector<Value> &offsets,
               std::vector<int32_t> &tensorShape,
-              std::vector<int32_t> &order) -> mlir::Value {
-             return self.create<mlir::triton::MakeTensorPtrOp>(
-                 base, shape, strides, offsets, tensorShape, order);
+              std::vector<int32_t> &order) -> Value {
+             return self.create<MakeTensorPtrOp>(base, shape, strides, offsets,
+                                                 tensorShape, order);
            })
       // Advance a block pointer
       .def("create_advance",
-           [](TritonOpBuilder &self, mlir::Value &ptr,
-              std::vector<mlir::Value> &offsets) -> mlir::Value {
-             return self.create<mlir::triton::AdvanceOp>(ptr.getType(), ptr,
-                                                         offsets);
+           [](TritonOpBuilder &self, Value &ptr,
+              std::vector<Value> &offsets) -> Value {
+             return self.create<AdvanceOp>(ptr.getType(), ptr, offsets);
            });
 
-  py::class_<mlir::PassManager>(m, "pass_manager", py::module_local())
-      .def(py::init<mlir::MLIRContext *>())
+  py::class_<PassManager>(m, "pass_manager", py::module_local())
+      .def(py::init<MLIRContext *>())
       .def("enable_debug",
-           [](mlir::PassManager &self) {
+           [](PassManager &self) {
              auto *context = self.getContext();
              context->printOpOnDiagnostic(true);
              context->printStackTraceOnDiagnostic(true);
              context->disableMultithreading();
-             context->getDiagEngine().registerHandler(
-                 [](mlir::Diagnostic &diag) {
-                   llvm::outs() << diag << "\n";
-                   return mlir::success();
-                 });
+             context->getDiagEngine().registerHandler([](Diagnostic &diag) {
+               llvm::outs() << diag << "\n";
+               return success();
+             });
 
-             if (!mlir::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP"))
+             if (!triton::tools::getBoolEnv("MLIR_ENABLE_DUMP"))
                return;
-             auto printingFlags = mlir::OpPrintingFlags();
+             auto printingFlags = OpPrintingFlags();
              printingFlags.elideLargeElementsAttrs(16);
              printingFlags.enableDebugInfo();
-             auto print_always = [](mlir::Pass *, mlir::Operation *) {
-               return true;
-             };
+             auto print_always = [](Pass *, Operation *) { return true; };
              self.enableIRPrinting(
                  /*shouldPrintBeforePass=*/print_always,
                  /*shouldPrintAfterPass=*/print_always,
@@ -1576,19 +1444,18 @@ void init_triton_ir(py::module &&m) {
                  /*printAfterOnlyOnChange=*/false,
                  /*printAfterOnlyOnFailure*/ true, llvm::dbgs(), printingFlags);
            })
-      .def("run", [](mlir::PassManager &self, mlir::ModuleOp &mod) {
+      .def("run", [](PassManager &self, ModuleOp &mod) {
         // TODO: maybe dump module to file and print error for better
         // diagnostics
-        auto reproducerPath =
-            mlir::triton::tools::getenv("TRITON_REPRODUCER_PATH");
+        auto reproducerPath = triton::tools::getenv("TRITON_REPRODUCER_PATH");
         if (!reproducerPath.empty()) {
           auto anchorName = self.getOpAnchorName();
           auto passes = self.getPasses();
-          mlir::Operation *op = mod.getOperation();
-          mlir::makeReproducer(anchorName, passes, op, reproducerPath);
+          Operation *op = mod.getOperation();
+          makeReproducer(anchorName, passes, op, reproducerPath);
         }
 
-        if (mlir::failed(self.run(mod.getOperation())))
+        if (failed(self.run(mod.getOperation())))
           throw std::runtime_error("PassManager::run failed");
       });
 }
@@ -1596,8 +1463,8 @@ void init_triton_ir(py::module &&m) {
 void init_triton_env_vars(py::module &m) {
   m.def("get_env_vars", []() -> std::map<std::string, bool> {
     std::map<std::string, bool> envVars;
-    for (const auto &envVar : mlir::triton::ENV_VARS) {
-      envVars[envVar] = mlir::triton::tools::getBoolEnv(envVar);
+    for (const auto &envVar : ENV_VARS) {
+      envVars[envVar] = triton::tools::getBoolEnv(envVar);
     }
     return envVars;
   });

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -824,8 +824,8 @@ private:
   lowerMfmaToDotOperand(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
                         ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
-    auto dstTy = op.getResult().getType().cast<RankedTensorType>();
+    RankedTensorType srcTy = op.getSrc().getType();
+    RankedTensorType dstTy = op.getType();
     if (isMfmaToDotShortcut(srcTy, dstTy)) {
       // get source values
       auto vals =
@@ -871,8 +871,8 @@ private:
   lowerMmaToDotOperand(triton::gpu::ConvertLayoutOp op, OpAdaptor adaptor,
                        ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
-    auto dstTy = op.getResult().getType().cast<RankedTensorType>();
+    RankedTensorType srcTy = op.getSrc().getType();
+    RankedTensorType dstTy = op.getType();
     if (matchMmaV3AndDotOperandLayout(srcTy, dstTy)) {
       rewriter.replaceOp(op, adaptor.getSrc());
       return success();
@@ -979,8 +979,8 @@ private:
                               OpAdaptor adaptor,
                               ConversionPatternRewriter &rewriter) const {
     auto loc = op.getLoc();
-    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
-    auto dstTy = op.getResult().getType().cast<RankedTensorType>();
+    RankedTensorType srcTy = op.getSrc().getType();
+    RankedTensorType dstTy = op.getType();
     if (triton::gpu::getTotalElemsPerThread(srcTy) ==
         triton::gpu::getTotalElemsPerThread(dstTy)) {
       rewriter.replaceOp(op, adaptor.getSrc());

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -522,14 +522,14 @@ struct MakeRangeOpConversion
   matchAndRewrite(triton::MakeRangeOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
-    auto rankedTy = op.getResult().getType().cast<RankedTensorType>();
-    auto shape = rankedTy.getShape();
-    auto layout = rankedTy.getEncoding();
+    RankedTensorType ty = op.getType();
+    auto shape = ty.getShape();
+    auto layout = ty.getEncoding();
 
-    auto elemTy = rankedTy.getElementType();
+    auto elemTy = ty.getElementType();
     assert(elemTy.isInteger(32));
     Value start = createIndexAttrConstant(rewriter, loc, elemTy, op.getStart());
-    auto idxs = emitIndices(loc, rewriter, layout, rankedTy);
+    auto idxs = emitIndices(loc, rewriter, layout, ty);
     unsigned elems = idxs.size();
     SmallVector<Value> retVals(elems);
     // TODO: slice layout has more elements than expected.
@@ -540,7 +540,7 @@ struct MakeRangeOpConversion
       retVals[multiDim.index()] = add(multiDim.value()[0], start);
     }
     Value result =
-        getTypeConverter()->packLLElements(loc, retVals, rewriter, rankedTy);
+        getTypeConverter()->packLLElements(loc, retVals, rewriter, ty);
     rewriter.replaceOp(op, result);
     return success();
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -266,7 +266,7 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     auto dotOp = cast<tt::DotOp>(op);
 
-    auto oldRetType = dotOp.getResult().getType().cast<RankedTensorType>();
+    RankedTensorType oldRetType = dotOp.getType();
     if (!oldRetType.getEncoding() ||
         !oldRetType.getEncoding().isa<ttg::BlockedEncodingAttr>())
       return failure();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
@@ -54,8 +54,8 @@ public:
       return mlir::failure();
     if (!cvtOp.getSrc().getDefiningOp<triton::LoadOp>())
       return failure();
-    auto dstTy = dstOp.getResult().getType().cast<RankedTensorType>();
-    auto srcTy = cvtOp.getSrc().getType().cast<RankedTensorType>();
+    RankedTensorType dstTy = dstOp.getType();
+    RankedTensorType srcTy = cvtOp.getSrc().getType();
     if (dstTy != srcTy)
       return mlir::failure();
 
@@ -63,9 +63,9 @@ public:
         op->getLoc(), dstTy.getElementType(),
         rewriter.getZeroAttr(dstTy.getElementType()));
     auto _0 = rewriter.create<triton::SplatOp>(
-        op->getLoc(), dotOp.getResult().getType(), _0f);
+        op->getLoc(), dotOp.getType(), _0f);
     auto newDot = rewriter.create<triton::DotOp>(
-        op->getLoc(), dotOp.getResult().getType(), dotOp.getOperand(0),
+        op->getLoc(), dotOp.getType(), dotOp.getOperand(0),
         dotOp.getOperand(1), _0, dotOp.getAllowTF32(),
         dotOp.getMaxNumImpreciseAcc());
     auto newCvt = rewriter.create<triton::gpu::ConvertLayoutOp>(

--- a/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/StreamPipeline.cpp
@@ -503,8 +503,7 @@ bool LoopPipeliner::isLoadChain(Operation *op) const {
     if (auto f2fOp = dyn_cast<triton::FpToFpOp>(op))
       loadVal = f2fOp.getSrc();
     if (validLoads.contains(loadVal.getDefiningOp())) {
-      auto cvtDstTy = cvtOp.getResult().getType().cast<RankedTensorType>();
-      if (cvtDstTy.getEncoding().isa<ttg::DotOperandEncodingAttr>())
+      if (cvtOp.getType().getEncoding().isa<ttg::DotOperandEncodingAttr>())
         return true;
     }
   }


### PR DESCRIPTION
- Eliminate mlir:: and triton:: in a few files, starting with the worst
  offenders.

- Replace op.getResult().getType() with op.getType().

- Write out some `auto` types to better match MLIR's coding conventions.

The overall goal is to (incrementally) make our code more concise.  We reduce
the 13kloc touched here to 11kloc, for a 1.2x improvement!  (It's a sus metric,
but still.)
