### PR TITLE
[IR] Implement join and split ops.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ $ ninja test
 $ lit test
 ```
 
+You may find it helpful to make a symlink to the builddir and tell your local
+git to ignore it.
+
+```
+$ ln -s python/build/cmake<...> build
+$ echo build >> .git/info/exclude
+```
+
+Then you can e.g. rebuild and run lit with the following command.
+
+```
+$ ninja -C build && ( cd build ; lit test )
+```
+
 # Changelog
 
 Version 2.0 is out! New features include:

--- a/include/triton/Dialect/Triton/IR/Dialect.h
+++ b/include/triton/Dialect/Triton/IR/Dialect.h
@@ -62,6 +62,14 @@ public:
                                   ArrayRef<int64_t> dstShape, Attribute &dstEnc,
                                   std::optional<Location> loc) const = 0;
 
+  virtual LogicalResult
+  inferJoinOpEncoding(Attribute srcEnc, Attribute &dstEnc,
+                      std::optional<Location> loc) const = 0;
+
+  virtual LogicalResult
+  inferSplitOpEncoding(Attribute srcEnc, Attribute &dstEnc,
+                       std::optional<Location> loc) const = 0;
+
   // Verify that the encoding are compatible to be used together in a dot
   // operation
   virtual LogicalResult

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -383,17 +383,42 @@ def TT_CatOp : TT_Op<"cat", [NoMemoryEffect,
     let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
 }
 
-def TT_ExperimentalInterleaveOp : TT_Op<"experimental_interleave", [NoMemoryEffect, SameTypeOperands, SameOperandsAndResultElementType]> {
-    let summary = "interleave two tensors in their minor dimension";
+def TT_ExperimentalJoinOp : TT_Op<"experimental_join", [
+    NoMemoryEffect, SameTypeOperands,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>,
+]> {
+    let summary = "join two tensors along a new, minor dimension";
     let description = [{
-        For example, if the two input tensors are [1,2,3] and [4,5,6],
-        interleaving them returns [1,4,2,5,3,6].
+        For example, if the two input tensors are 4x8xf32, returns a tensor of
+        shape 4x8x2xf32.
+
+        Because Triton tensors always have a power-of-two number of elements,
+        the two input tensors must have the same shape.
     }];
 
     let arguments = (ins TT_Tensor:$lhs, TT_Tensor:$rhs);
     let results = (outs TT_Tensor:$result);
     let assemblyFormat = "$lhs `,` $rhs attr-dict `:` type($lhs) `->` type($result)";
-    let hasVerifier = 1;
+}
+
+def TT_ExperimentalSplitOp : TT_Op<"experimental_split", [
+  NoMemoryEffect,
+  DeclareOpInterfaceMethods<InferTypeOpInterface>,
+  TypesMatchWith<"outLHS and outRHS types match",
+                  "outLHS", "outRHS", "$_self">,
+]> {
+    let summary = "splits a tensor into two, along its last dimension";
+    let description = [{
+        The input must be a tensor whose last dimension has size 2.  Returns two
+        tensors, src[..., 0] and src[..., 1].
+
+        For example, if the input shape is 4x8x2xf32, returns two tensors of
+        shape 4x8xf32.
+    }];
+
+    let arguments = (ins TT_Tensor:$src);
+    let results = (outs TT_Tensor:$outLHS, TT_Tensor:$outRHS);
+    let assemblyFormat = "$src attr-dict `:` type($src) `->` type($outLHS)";
 }
 
 def TT_TransOp : TT_Op<"trans", [Pure,

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1189,14 +1189,14 @@ void init_triton_ir(py::module &&m) {
                  RankedTensorType::get(shape, lhsType.getElementType()), lhs,
                  rhs);
            })
-      .def("create_interleave",
+      .def("create_join",
            [](TritonOpBuilder &self, Value &a, Value &b) -> Value {
-             auto aTy = a.getType().cast<RankedTensorType>();
-             llvm::SmallVector<int64_t> shape(aTy.getShape().begin(),
-                                              aTy.getShape().end());
-             shape[shape.size() - 1] *= 2;
-             return self.create<ExperimentalInterleaveOp>(
-                 RankedTensorType::get(shape, aTy.getElementType()), a, b);
+             return self.create<ExperimentalJoinOp>(a, b);
+           })
+      .def("create_split",
+           [](TritonOpBuilder &self, Value &a) -> std::vector<Value> {
+             auto op = self.create<ExperimentalSplitOp>(a);
+             return std::vector<Value>(op->result_begin(), op->result_end());
            })
       // Implements tl.trans and tl.permute.
       .def("create_trans",

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1444,32 +1444,33 @@ def test_load_store_same_ptr(device):
         assert torch.all(x == 2)
 
 
-def test_interleave(device):
+def test_join(device):
 
     @triton.jit
     def kernel(X, Y, Z, N: tl.constexpr):
         offs = tl.arange(0, N)
         x = tl.load(X + offs)
         y = tl.load(Y + offs)
-        z = tl._experimental_interleave(x, y)
-        tl.store(Z + tl.arange(0, 2 * N), z)
+        z = tl._experimental_join(x, y)
+        tl.store(Z + tl.arange(0, N)[:, None] * 2 + tl.arange(0, 2)[None, :], z)
 
     x = torch.arange(0, 128, device=device).to(torch.int32)
     y = torch.arange(-128, 0, device=device).to(torch.int32)
-    z_ref = torch.stack([x, y], dim=-1).reshape((256, ))
+    z_ref = torch.stack([x, y], dim=-1)
     z = torch.zeros_like(z_ref)
     kernel[(1, )](x, y, z, N=128)
 
     np.testing.assert_equal(to_numpy(z_ref), to_numpy(z))
 
 
-def test_interleave_with_mma(device):
+def test_join_with_mma(device):
 
     @triton.jit
     def kernel(X, Z):
         x = tl.load(X + 16 * tl.arange(0, 32)[:, None] + tl.arange(0, 16)[None, :])  # (32,16)
-        x2 = tl._experimental_interleave(x, 2 * x)  # (32,32)
-        z = tl.dot(x2, x2)  # (32,32)
+        x2 = tl._experimental_join(x, 2 * x)  # (32,16,2)
+        x3 = tl.reshape(x2, (32, 32))
+        z = tl.dot(x3, x3)  # (32,32)
         tl.store(Z + 32 * tl.arange(0, 32)[:, None] + tl.arange(0, 32)[None, :], z)
 
     x = torch.arange(0, 32 * 16, device=device, dtype=torch.float32).reshape((32, 16))
@@ -1479,6 +1480,27 @@ def test_interleave_with_mma(device):
     kernel[(1, )](x, z)
 
     torch.testing.assert_close(z, z_ref)
+
+
+def test_split(device):
+
+    @triton.jit
+    def kernel(X, Z1, Z2, N: tl.constexpr):
+        offs = tl.arange(0, N)
+        x = tl.load(X + offs)
+        x1 = tl.reshape(x, (N // 2, 2))
+        z1, z2 = tl._experimental_split(x1)
+        tl.store(Z1 + tl.arange(0, N // 2), z1)
+        tl.store(Z2 + tl.arange(0, N // 2), z2)
+
+    x = torch.arange(0, 256, device=device).to(torch.int32).reshape((128, 2))
+    z1_ref, z2_ref = (x[:, 0], x[:, 1])
+    z1 = torch.zeros_like(z1_ref)
+    z2 = torch.zeros_like(z2_ref)
+    kernel[(1, )](x, z1, z2, N=256)
+
+    np.testing.assert_equal(to_numpy(z1_ref), to_numpy(z1))
+    np.testing.assert_equal(to_numpy(z2_ref), to_numpy(z2))
 
 
 def convert_float_to_float32(fp: torch.tensor, dtype=None):

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -102,7 +102,8 @@ from .core import (
     view,
     void,
     where,
-    _experimental_interleave,
+    _experimental_join,
+    _experimental_split,
 )
 from .random import (
     pair_uniform_to_normal,
@@ -228,5 +229,6 @@ __all__ = [
     "xor_sum",
     "zeros",
     "zeros_like",
-    _experimental_interleave,
+    _experimental_join,
+    _experimental_split,
 ]

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -985,25 +985,47 @@ def cat(input, other, can_reorder=False, _builder=None):
 
 
 @builtin
-def _experimental_interleave(a, b, _builder=None):
+def _experimental_join(a, b, _builder=None):
     """
-    Interleave the given tensors in their minor dimension.
+    Join the given tensors in a new, minor dimension.
 
-    For example, given :code:`a=[1,2,3]` and :code:`b=[4,5,6]`, the result is
-    :code:`[1,4,2,5,3,6]`.
+    For example, given two tensors of shape (4,8), produces a new tensor of
+    shape (4,8,2).
 
     The two inputs are broadcasted to be the same shape.
 
-    If you want to interleave more than two elements, you can use multiple calls
-    to this function.  This reflects the constraint in Triton that tensors must
+    If you want to join more than two elements, you can use multiple calls to
+    this function.  This reflects the constraint in Triton that tensors must
     have power-of-two sizes.
+
+    join is the inverse of split.
 
     :param a: The first input tensor.
     :type a: Tensor
     :param b: The second input tensor.
     :type b: Tensor
     """
-    return semantic.interleave(a, b, _builder)
+    return semantic.join(a, b, _builder)
+
+
+@builtin
+def _experimental_split(a, _builder=None):
+    """
+    Split a tensor in two along its last dim, which must have size 2.
+
+    For example, given a tensor of shape (4,8,2), produces two tensors of shape
+    (4,8).
+
+    If you want to split into more than two pieces, you can use multiple calls
+    to this function (probably plus calling reshape).  This reflects the
+    constraint in Triton that tensors must have power-of-two sizes.
+
+    split is the inverse of join.
+
+    :param a: The tensor to split.
+    :type a: Tensor
+    """
+    return semantic.split(a, _builder)
 
 
 @builtin

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
@@ -339,14 +339,13 @@ SmallVector<Value> LayoutPropagation::propagateToUsers(Value value,
           continue;
       }
 #endif
-    if (user->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
-        user->hasTrait<mlir::OpTrait::Elementwise>() ||
-        isa<triton::ReduceOp, triton::ExpandDimsOp,
-            triton::ExperimentalInterleaveOp, triton::gpu::ConvertLayoutOp>(
-            user)) {
-      setEncoding(user->getResults(), info, changed, user);
-      continue;
-    }
+      if (user->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
+          user->hasTrait<mlir::OpTrait::Elementwise>() ||
+          isa<triton::ReduceOp, triton::ExpandDimsOp,
+              triton::gpu::ConvertLayoutOp>(user)) {
+        setEncoding(user->getResults(), info, changed, user);
+        continue;
+      }
   }
   return changed;
 }
@@ -737,7 +736,7 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
   if (op->hasTrait<mlir::OpTrait::SameOperandsAndResultEncoding>() ||
       op->hasTrait<mlir::OpTrait::Elementwise>() ||
       isa<triton::ReduceOp, triton::ExpandDimsOp,
-          triton::ExperimentalInterleaveOp, triton::gpu::ConvertLayoutOp>(op)) {
+          triton::gpu::ConvertLayoutOp>(op)) {
     Operation *newOp = cloneElementwise(rewriter, op, encoding);
     for (auto [oldResult, newResult] :
          llvm::zip(op->getResults(), newOp->getResults()))


### PR DESCRIPTION
Also remove experimental_interleave.  This is now equivalent to join + reshape.

The eventual intent is to remove the concat op and instead implement it using join+reshape.

Also add some additional tips to README.
