### PR TITLE
[FRONTEND] Enable debug mode only when the options say so

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -91,7 +91,8 @@ class HIPBackend(BaseBackend):
     @staticmethod
     def make_ttir(mod, metadata, opt):
         pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
+        if opt.debug:
+            pm.enable_debug()
         passes.common.add_inliner(pm)
         passes.ttir.add_rewrite_tensor_pointer(pm)
         passes.ttir.add_combine(pm)
@@ -106,12 +107,14 @@ class HIPBackend(BaseBackend):
     @staticmethod
     def make_ttgir(mod, metadata, opt):
         pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
+        if opt.debug:
+            pm.enable_debug()
         # TODO: capability
         passes.ttir.add_convert_to_ttgpuir(pm, opt.num_warps, 64, opt.num_ctas, 90)
         pm.run(mod)
         pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
+        if opt.debug:
+            pm.enable_debug()
         passes.ttgpuir.add_coalesce(pm)
         amd.passes.ttgpuir.add_remove_layout_conversions(pm)
         amd.passes.ttgpuir.add_accelerate_matmul(pm, opt.matrix_core_version, opt.matrix_inst_shape)
@@ -137,12 +140,14 @@ class HIPBackend(BaseBackend):
         mod = src
         # TritonGPU -> LLVM-IR (MLIR)
         pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
+        if options.debug:
+            pm.enable_debug()
         passes.convert.add_scf_to_cf(pm)
         passes.convert.add_index_to_llvmir(pm)
         pm.run(mod)
         pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
+        if options.debug:
+            pm.enable_debug()
         amd.passes.ttgpuir.add_to_llvmir(pm)
         pm.run(mod)
         pm = ir.pass_manager(mod.context)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -102,7 +102,8 @@ class CUDABackend(BaseBackend):
     @staticmethod
     def make_ttir(mod, metadata, opt):
         pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
+        if opt.debug:
+            pm.enable_debug()
         passes.common.add_inliner(pm)
         passes.ttir.add_rewrite_tensor_pointer(pm)
         passes.ttir.add_combine(pm)
@@ -123,7 +124,8 @@ class CUDABackend(BaseBackend):
             cluster_info.clusterDimZ = opt.cluster_dims[2]
         # TTIR -> TTGIR
         pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
+        if opt.debug:
+          pm.enable_debug()
         passes.ttir.add_convert_to_ttgpuir(pm, opt.num_warps, 32, opt.num_ctas, capability)
         # optimize TTGIR
         passes.ttgpuir.add_coalesce(pm)
@@ -161,7 +163,8 @@ class CUDABackend(BaseBackend):
         mod = src
         # TritonGPU -> LLVM-IR (MLIR)
         pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
+        if options.debug:
+          pm.enable_debug()
         passes.ttgpuir.add_decompose_unsupported_conversions(pm)
         passes.convert.add_scf_to_cf(pm)
         passes.convert.add_index_to_llvmir(pm)


### PR DESCRIPTION
Prior to this commit `make_*` functions in the `CUDABackend` enabled debug mode unconditionally. This led to slower-than-necessary compile times, even when the caller passed `CUDAOptions` with `debug=False`.

I mirrored this change in `HIPBackend` for consistency.