### PR TITLE
[BACKEND] Fixing the stages of loads distance 1

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -596,7 +596,7 @@ createSchedule(scf::ForOp forOp, int numStages,
             Operation *defOp = v.getDefiningOp();
             if (defOp && group.count(defOp) == 0) {
               // Schedule distance 1 users in the next stage.
-              distanceOneUsers[stage + 1].insert(defOp);
+              distanceOneUsers[stage].insert(defOp);
             }
           }
         }
@@ -624,11 +624,11 @@ createSchedule(scf::ForOp forOp, int numStages,
   // Rest of the distance 1 dependencies will be scheduled one
   // stage after the insert ops.
   SmallVector<DenseSet<Operation *>> stage1deps(numStages);
-  for (unsigned i = 0; i < distanceOneUsers.size(); i++) {
+  for (unsigned i = 0; i < distanceOneUsers.size()-1; i++) {
     auto &group = distanceOneUsers[i];
     for (auto op : group) {
       if (!isa<tt::LoadOp>(op))
-        tt::addDep(op, stage1deps[i], true, &allInsertAndDeps);
+        tt::addDep(op, stage1deps[i+1], true, &allInsertAndDeps);
     }
     LLVM_DEBUG({
       LDBG("\nstage1deps " << i);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -624,11 +624,11 @@ createSchedule(scf::ForOp forOp, int numStages,
   // Rest of the distance 1 dependencies will be scheduled one
   // stage after the insert ops.
   SmallVector<DenseSet<Operation *>> stage1deps(numStages);
-  for (unsigned i = 0; i < distanceOneUsers.size()-1; i++) {
+  for (unsigned i = 0; i < distanceOneUsers.size() - 1; i++) {
     auto &group = distanceOneUsers[i];
     for (auto op : group) {
       if (!isa<tt::LoadOp>(op))
-        tt::addDep(op, stage1deps[i+1], true, &allInsertAndDeps);
+        tt::addDep(op, stage1deps[i + 1], true, &allInsertAndDeps);
     }
     LLVM_DEBUG({
       LDBG("\nstage1deps " << i);


### PR DESCRIPTION
Non-pipelined loads of distance from the pipelined loads should be scheduled to the same stage that the pipelined loads are. Due to bug in the code they were scheduled to the stage after that, which might have caused performance problems.