### PR TITLE
The get_ptxas_version cannot be called concurrently in multiple threa…

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -32,7 +32,7 @@ def _path_to_binary(binary: str):
 
 @functools.lru_cache()
 def get_ptxas_version():
-    version = subprocess.check_output([_path_to_binary("ptxas")[0], "--version"])
+    version = subprocess.check_output([_path_to_binary("ptxas")[0], "--version"]).decode("utf-8")
     return version
 
 
@@ -267,5 +267,5 @@ class CUDABackend(BaseBackend):
 
     @functools.lru_cache()
     def hash(self):
-        version = subprocess.check_output([_path_to_binary("ptxas")[0], "--version"]).decode("utf-8")
+        version = get_ptxas_version()
         return f'{version}-{self.capability}'


### PR DESCRIPTION
…ds, we call this function directly to cache. this other sub process call caused the issue to recreate

Moving to call the existing method in the file should fix it i believe