### PR TITLE
[DEBUG] Only print out diagnostic messages if an environment variable is set

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -40,6 +40,7 @@ inline const std::set<std::string> ENV_VARS = {
     "MLIR_ENABLE_DUMP",
     "TRITON_DISABLE_LINE_INFO",
     "TRITON_DISABLE_RESHAPE_ENCODING_INFERENCE",
+    "MLIR_ENABLE_DIAGNOSTICS",
 };
 
 namespace tools {

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1423,13 +1423,13 @@ void init_triton_ir(py::module &&m) {
       .def("enable_debug",
            [](PassManager &self) {
              auto *context = self.getContext();
-             bool have_diagnostics =
+             bool haveDiagnostics =
                  ::triton::tools::getBoolEnv("MLIR_ENABLE_DIAGNOSTICS");
-             bool have_dump = ::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
-             if (have_diagnostics || have_dump) {
+             bool haveDump = ::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
+             if (haveDiagnostics || haveDump) {
                context->disableMultithreading();
              }
-             if (have_diagnostics) {
+             if (haveDiagnostics) {
                context->printOpOnDiagnostic(true);
                context->printStackTraceOnDiagnostic(true);
                context->getDiagEngine().registerHandler([](Diagnostic &diag) {
@@ -1437,14 +1437,14 @@ void init_triton_ir(py::module &&m) {
                  return success();
                });
              }
-             if (have_dump) {
+             if (haveDump) {
                auto printingFlags = OpPrintingFlags();
                printingFlags.elideLargeElementsAttrs(16);
                printingFlags.enableDebugInfo();
-               auto print_always = [](Pass *, Operation *) { return true; };
+               auto printAlways = [](Pass *, Operation *) { return true; };
                self.enableIRPrinting(
-                   /*shouldPrintBeforePass=*/print_always,
-                   /*shouldPrintAfterPass=*/print_always,
+                   /*shouldPrintBeforePass=*/printAlways,
+                   /*shouldPrintAfterPass=*/printAlways,
                    /*printModuleScope=*/true,
                    /*printAfterOnlyOnChange=*/false,
                    /*printAfterOnlyOnFailure*/ true, llvm::dbgs(),

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1423,26 +1423,33 @@ void init_triton_ir(py::module &&m) {
       .def("enable_debug",
            [](PassManager &self) {
              auto *context = self.getContext();
-             context->printOpOnDiagnostic(true);
-             context->printStackTraceOnDiagnostic(true);
-             context->disableMultithreading();
-             context->getDiagEngine().registerHandler([](Diagnostic &diag) {
-               llvm::outs() << diag << "\n";
-               return success();
-             });
-
-             if (!triton::tools::getBoolEnv("MLIR_ENABLE_DUMP"))
-               return;
-             auto printingFlags = OpPrintingFlags();
-             printingFlags.elideLargeElementsAttrs(16);
-             printingFlags.enableDebugInfo();
-             auto print_always = [](Pass *, Operation *) { return true; };
-             self.enableIRPrinting(
-                 /*shouldPrintBeforePass=*/print_always,
-                 /*shouldPrintAfterPass=*/print_always,
-                 /*printModuleScope=*/true,
-                 /*printAfterOnlyOnChange=*/false,
-                 /*printAfterOnlyOnFailure*/ true, llvm::dbgs(), printingFlags);
+             bool have_diagnostics =
+                 ::triton::tools::getBoolEnv("MLIR_ENABLE_DIAGNOSTICS");
+             bool have_dump = ::triton::tools::getBoolEnv("MLIR_ENABLE_DUMP");
+             if (have_diagnostics || have_dump) {
+               context->disableMultithreading();
+             }
+             if (have_diagnostics) {
+               context->printOpOnDiagnostic(true);
+               context->printStackTraceOnDiagnostic(true);
+               context->getDiagEngine().registerHandler([](Diagnostic &diag) {
+                 llvm::outs() << diag << "\n";
+                 return success();
+               });
+             }
+             if (have_dump) {
+               auto printingFlags = OpPrintingFlags();
+               printingFlags.elideLargeElementsAttrs(16);
+               printingFlags.enableDebugInfo();
+               auto print_always = [](Pass *, Operation *) { return true; };
+               self.enableIRPrinting(
+                   /*shouldPrintBeforePass=*/print_always,
+                   /*shouldPrintAfterPass=*/print_always,
+                   /*printModuleScope=*/true,
+                   /*printAfterOnlyOnChange=*/false,
+                   /*printAfterOnlyOnFailure*/ true, llvm::dbgs(),
+                   printingFlags);
+             }
            })
       .def("run", [](PassManager &self, ModuleOp &mod) {
         // TODO: maybe dump module to file and print error for better


### PR DESCRIPTION
This prevents crashes in test_core.py due to too many diagnostics emitted in https://github.com/llvm/llvm-project/pull/78228 It should also speed up compile times, as we can use multithreading, and avoid handling diagnostic messages.