### PR TITLE
[FRONTEND] - Three improvements to tracebacks.

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -180,6 +180,40 @@ def parse(full_name, ext, context):
         return Path(full_name).read_bytes()
 
 
+def filter_traceback(e: BaseException):
+    """
+    Removes code_generator.py and related files from tracebacks.
+
+    These are uninteresting to the user -- "just show me *my* code!"
+    """
+    if e.__cause__ is not None:
+        filter_traceback(e.__cause__)
+    if e.__context__ is not None:
+        filter_traceback(e.__context__)
+
+    # If a user has a file that matches one of these, they're out of luck.
+    BAD_FILES = [
+        "/triton/compiler/code_generator.py",
+        "/ast.py",
+    ]
+
+    tb = e.__traceback__
+    frames = []
+    while tb is not None:
+        if not any(f for f in BAD_FILES if tb.tb_frame.f_code.co_filename.endswith(f)):
+            frames.append(tb)
+        tb = tb.tb_next
+
+    for (cur_frame, next_frame) in zip(frames, frames[1:]):
+        cur_frame.tb_next = next_frame
+
+    if not frames:
+        e.__traceback__ = None
+    else:
+        frames[-1].tb_next = None
+        e.__traceback__ = frames[0]
+
+
 def compile(src, target=None, options=None):
     if target is None:
         target = driver.active.get_current_target()
@@ -221,7 +255,11 @@ def compile(src, target=None, options=None):
     context = ir.context()
     ir.load_dialects(context)
     backend.load_dialects(context)
-    module = src.make_ir(options, context)
+    try:
+        module = src.make_ir(options, context)
+    except Exception as e:
+        filter_traceback(e)
+        raise
     for ext, compile_ir in list(stages.items())[first_stage:]:
         next_module = compile_ir(module, metadata)
         ir_filename = f"{src.name}.{ext}"

--- a/python/triton/compiler/errors.py
+++ b/python/triton/compiler/errors.py
@@ -17,7 +17,7 @@ class CompilationError(Exception):
             else:
                 source_excerpt = " <source empty>"
 
-        message = "at {}:{}:{}".format(node.lineno, node.col_offset, source_excerpt)
+        message = "at {}:{}:\n{}".format(node.lineno, node.col_offset, source_excerpt)
         if self.error_message:
             message += '\n' + self.error_message
         return message


### PR DESCRIPTION
- Report errors in nested @triton.jit'ed functions properly.

  Before, errors would only be reported in the top-level function.  If a nested
  function had an error, we'd only point to the top-level call that
  transitively leads to the function with the error.

- After fixing the above, tracebacks get unweildy, because you have *multiple*
  30+-frame tracebacks for each level of nesting.

  But most of these tracebacks are in code_generator.py, which is not relevant
  to the error.  It would be like if when regular Python code raised an
  exception, we reported not just the stacktrace in Python, but also the trace
  of the Python interpreter when it encountered the error!

  We now exclude code_generator.py and ast.py, making the stacks much more
  manageable.

- Print a newline between the file:line and the source excerpt.  If the excerpt
  were just one line it might make sense to put it on the same line as the
  file:line, but since it's almost always multiple lines, we really should wrap
  it.
