### PR TITLE
Increase test timeouts to 30m.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Build-Documentation:
     runs-on: [self-hosted, A100]
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout branch

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,7 +38,7 @@ jobs:
     needs: Runner-Preparation
 
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -24,7 +24,7 @@ jobs:
   Integration-Tests-Shared-Middle-Layer:
     if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
   Integration-Tests-AMD:
     if: (github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     needs: Runner-Preparation
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     runs-on: ${{ matrix.runner }}
 
@@ -115,7 +115,7 @@ jobs:
 
   Integration-Tests-Intel:
     needs: Runner-Preparation
-    timeout-minutes: 20
+    timeout-minutes: 30
     if: false && ((github.event_name == 'workflow_dispatch') || (github.event_name == 'push' && github.ref == 'refs/heads/main'))
 
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
Tests run in about 6m on a warm test runner, but
https://github.com/openai/triton/actions/runs/7967953226/job/21751471651?pr=3154
shows that 20m is not enough on a cold runner.  (At least, I *think* that's
the problem here.)

Now that we have auto-restarts of runners, we care more about test runs on
cold runners.
