### PR TITLE
[Frontend] More fixes to compilation error reporting.

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -1,0 +1,101 @@
+import pytest
+
+import triton
+import triton.language as tl
+from triton.compiler.errors import CompilationError, CompileTimeAssertionFailure
+
+
+def test_err_in_binary_operator():
+
+    @triton.jit
+    def kernel():
+        0 + "a"
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
+
+    try:
+        assert "at 2:8:" in str(e.value), "error should point to the opening \" of the string"
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_static_assert():
+
+    @triton.jit
+    def kernel():
+        tl.static_assert(isinstance(0, tl.tensor))
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
+
+    try:
+        assert isinstance(e.value, CompileTimeAssertionFailure)
+        assert e.value.__cause__ is None
+        assert "at 2:4:" in str(e.value), "error should point to the static_assert call"
+        assert "<source unavailable>" not in str(e.value)
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_in_unary_op():
+    # Currently Triton can't evaluate `not` of a tuple at compile time.  That's
+    # ok, but the error message needs to point to the correct spot.
+    @triton.jit
+    def kernel():
+        not (0, 0)
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
+
+    try:
+        assert e.value.__cause__ is None
+        assert "at 2:4:" in str(e.value), "error should point to the `not`"
+        assert "<source unavailable>" not in str(e.value)
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+def test_err_in_binary_op():
+
+    @triton.jit
+    def kernel():
+        1.0 << 1
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
+
+    try:
+        assert "at 2:11:" in str(e.value), "error should point to the 1"
+        assert "<source unavailable>" not in str(e.value)
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value
+
+
+# This has to be defined as a top-level function; jit'ed functions can't call
+# nested functions.
+@triton.jit
+def nested_call():
+    xyz  # noqa
+
+
+def test_err_in_nested_call():
+
+    @triton.jit
+    def kernel():
+        # this is a comment to push nested_call() onto the next line
+        nested_call()
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
+
+    try:
+        inner = e.value.__cause__
+        outer = e.value
+        assert "at 2:4:" in str(inner), "error should point to xyz"
+        assert "<source unavailable>" not in str(inner)
+
+        assert "at 3:4" in str(outer), "error should point to the nested_call"
+        assert "<source unavailable>" not in str(outer)
+    except AssertionError as assertion_err:
+        raise assertion_err from e.value

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -381,10 +381,8 @@ def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
     elif (op in ('%', '/') and ((dtype_x in int_dtypes and dtype_y in uint_dtypes) or
                                 (dtype_x in uint_dtypes and dtype_y in int_dtypes))):
         error_class = ValueError if is_interpreter() else triton.CompilationError
-        with pytest.raises(error_class) as exc_info:
+        with pytest.raises(error_class, match='Cannot use .* because they have different signedness'):
             _test_binary(dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas)
-        assert re.match('Cannot use .* because they have different signedness',
-                        str(exc_info.value) if is_interpreter() else str(exc_info.value.__cause__))
     else:
         _test_binary(dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas)
 
@@ -479,10 +477,9 @@ def test_bitwise_op(dtype_x, dtype_y, op, num_ctas, device):
     else:
         numpy_expr = None
     if 'float' in dtype_x + dtype_y:
-        with pytest.raises(triton.CompilationError) as exc_info:
-            _test_binary(dtype_x, dtype_y, expr, numpy_expr='np.array([])', device=device, num_ctas=num_ctas)
         # The CompilationError must have been caused by a C++ exception with this text.
-        assert re.match('invalid operands of type', str(exc_info.value.__cause__))
+        with pytest.raises(triton.CompilationError, match='invalid operands of type'):
+            _test_binary(dtype_x, dtype_y, expr, numpy_expr='np.array([])', device=device, num_ctas=num_ctas)
     else:
         _test_binary(dtype_x, dtype_y, expr, numpy_expr, device=device, num_ctas=num_ctas)
 

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -207,8 +207,8 @@ class ContainsReturnChecker(ast.NodeVisitor):
 
 class CodeGenerator(ast.NodeVisitor):
 
-    def __init__(self, context, prototype, gscope, attributes, constants, function_name, options, debug=None,
-                 module=None, is_kernel=False, function_types: Optional[Dict] = None, noinline=False,
+    def __init__(self, context, prototype, gscope, attributes, constants, function_name, jit_fn: JITFunction, options,
+                 debug=None, module=None, is_kernel=False, function_types: Optional[Dict] = None, noinline=False,
                  file_name: Optional[str] = None, begin_line=0):
         self.context = context
         self.builder = ir.builder(context)
@@ -224,6 +224,7 @@ class CodeGenerator(ast.NodeVisitor):
         self.lscope = dict()
         self.attributes = attributes
         self.constants = constants
+        self.jit_fn = jit_fn
         self.function_name = function_name
         self.is_kernel = is_kernel
         self.last_node = None
@@ -244,6 +245,9 @@ class CodeGenerator(ast.NodeVisitor):
         ('min', language.minimum),
         ('max', language.maximum),
     ))
+
+    def _unsupported(self, node, message):
+        return UnsupportedLanguageConstruct(self.jit_fn.src, node, message)
 
     def _define_name_lookup(self):
 
@@ -334,7 +338,7 @@ class CodeGenerator(ast.NodeVisitor):
     def visit_FunctionDef(self, node):
         arg_names, kwarg_names = self.visit(node.args)
         if self.fn:
-            raise UnsupportedLanguageConstruct(None, node, "nested function definition is not supported.")
+            raise self._unsupported(node, "nested function definition is not supported.")
         # initialize defaults
         for i, default_value in enumerate(node.args.defaults):
             arg_node = node.args.args[-i - 1]
@@ -423,7 +427,7 @@ class CodeGenerator(ast.NodeVisitor):
         for target in node.targets:
             _names += [self.visit(target)]
         if len(_names) > 1:
-            raise UnsupportedLanguageConstruct(None, node, "simultaneous multiple assignment is not supported.")
+            raise self._unsupported(node, "simultaneous multiple assignment is not supported.")
         names = _names[0]
         values = self.visit(node.value)
         if not _is_list_like(names):
@@ -477,8 +481,8 @@ class CodeGenerator(ast.NodeVisitor):
         rhs = self.visit(node.right)
         method_name = self._method_name_for_bin_op.get(type(node.op))
         if method_name is None:
-            raise UnsupportedLanguageConstruct(
-                None, node, "AST binary operator '{}' is not (currently) implemented.".format(node.op.__name__))
+            raise self._unsupported(node,
+                                    "AST binary operator '{}' is not (currently) implemented.".format(node.op.__name__))
         return self._apply_binary_method(method_name, lhs, rhs)
 
     _method_name_for_bin_op: Dict[Type[ast.operator], str] = {
@@ -621,8 +625,8 @@ class CodeGenerator(ast.NodeVisitor):
             cond = cond.to(language.int1, _builder=self.builder)
             contains_return = ContainsReturnChecker(self.gscope).visit(node)
             if self.scf_stack and contains_return:
-                raise UnsupportedLanguageConstruct(
-                    None, node, "Cannot have `return` statements inside `while` or `for` statements in triton "
+                raise self._unsupported(
+                    node, "Cannot have `return` statements inside `while` or `for` statements in triton "
                     "(note that this also applies to `return` statements that are inside functions "
                     "transitively called from within `while`/`for` statements)")
             elif self.scf_stack or not contains_return:
@@ -633,9 +637,8 @@ class CodeGenerator(ast.NodeVisitor):
             cond = _unwrap_if_constexpr(cond)
             # not isinstance - we insist the real thing, no subclasses and no ducks
             if type(cond) not in _condition_types:
-                raise UnsupportedLanguageConstruct(
-                    None, node,
-                    "`if` conditionals can only accept values of type {{{}}}, not objects of type {}".format(
+                raise self._unsupported(
+                    node, "`if` conditionals can only accept values of type {{{}}}, not objects of type {}".format(
                         ', '.join(_.__name__ for _ in _condition_types),
                         type(cond).__name__))
             if cond:
@@ -687,9 +690,8 @@ class CodeGenerator(ast.NodeVisitor):
 
             # not isinstance - we insist the real thing, no subclasses and no ducks
             if type(cond) not in _condition_types:
-                raise UnsupportedLanguageConstruct(
-                    None, node,
-                    "`if` conditionals can only accept values of type {{{}}}, not objects of type {}".format(
+                raise self._unsupported(
+                    node, "`if` conditionals can only accept values of type {{{}}}, not objects of type {}".format(
                         ', '.join(_.__name__ for _ in _condition_types),
                         type(cond).__name__))
             if cond:
@@ -702,7 +704,7 @@ class CodeGenerator(ast.NodeVisitor):
 
     def visit_Compare(self, node):
         if not (len(node.comparators) == 1 and len(node.ops) == 1):
-            raise UnsupportedLanguageConstruct(None, node, "simultaneous multiple comparison is not supported")
+            raise self._unsupported(node, "simultaneous multiple comparison is not supported")
         lhs = self.visit(node.left)
         rhs = self.visit(node.comparators[0])
         lhs_value = _unwrap_if_constexpr(lhs)
@@ -713,8 +715,8 @@ class CodeGenerator(ast.NodeVisitor):
             return constexpr(lhs_value is not rhs_value)
         method_name = self._method_name_for_comp_op.get(type(node.ops[0]))
         if method_name is None:
-            raise UnsupportedLanguageConstruct(
-                None, node, "AST comparison operator '{}' is not (currently) implemented.".format(node.ops[0].__name__))
+            raise self._unsupported(
+                node, "AST comparison operator '{}' is not (currently) implemented.".format(node.ops[0].__name__))
         return self._apply_binary_method(method_name, lhs, rhs)
 
     _method_name_for_comp_op: Dict[Type[ast.cmpop], str] = {
@@ -722,14 +724,17 @@ class CodeGenerator(ast.NodeVisitor):
     }
 
     def visit_UnaryOp(self, node):
-        op = self.visit(node.operand)
+        operand = self.visit(node.operand)
         fn = self._method_name_for_unary_op.get(type(node.op))
         if fn is None:
-            raise UnsupportedLanguageConstruct(
-                None, node, "AST unary operator '{}' is not (currently) implemented.".format(node.op.__name__))
-        if _is_triton_tensor(op):
-            return getattr(op, fn)(_builder=self.builder)
-        return getattr(op, fn)()
+            raise self._unsupported(node, f"AST unary operator '{node.op.__name__}' is not (currently) implemented.")
+        if _is_triton_tensor(operand):
+            return getattr(operand, fn)(_builder=self.builder)
+        try:
+            return getattr(operand, fn)()
+        except AttributeError:
+            raise self._unsupported(
+                node, f"AST unary operator '{fn}' is not (currently) implemented on type {type(operand).__name__}")
 
     _method_name_for_unary_op: Dict[Type[ast.unaryop], str] = {
         ast.USub: '__neg__', ast.UAdd: '__pos__', ast.Not: '__not__', ast.Invert: '__invert__'
@@ -995,10 +1000,16 @@ class CodeGenerator(ast.NodeVisitor):
             file_name, begin_line = _get_fn_file_line(fn)
             debug = self.debug if fn.debug is None else fn.debug
             generator = CodeGenerator(self.context, prototype, gscope, attributes, constants, module=self.module,
-                                      function_name=fn_name, function_types=self.function_ret_types,
+                                      jit_fn=fn, function_name=fn_name, function_types=self.function_ret_types,
                                       noinline=fn.noinline, file_name=file_name, begin_line=begin_line,
                                       options=self.builder.options, debug=debug)
-            generator.visit(fn.parse())
+            try:
+                generator.visit(fn.parse())
+            except Exception as e:
+                # Wrap the error in the callee with the location of the call
+                # (self.last_node).
+                raise CompilationError(self.jit_fn.src, self.last_node, None) from e
+
             callee_ret_type = generator.last_ret_type
             self.function_ret_types[fn_name] = callee_ret_type
         else:
@@ -1018,20 +1029,6 @@ class CodeGenerator(ast.NodeVisitor):
 
     def visit_Call(self, node):
         fn = _unwrap_if_constexpr(self.visit(node.func))
-        try:
-            return self.visit_Call_Impl(fn, node)
-        except CompilationError as e:
-            # Fill in the callee's source code, and rely on our caller to do the
-            # same.
-            if hasattr(fn, 'src') and fn.src and e.src is None:
-                e.set_source_code(fn.src)
-            raise CompilationError(None, node, None) from e
-        except Exception as e:
-            if hasattr(fn, 'src'):
-                raise CompilationError(fn.src, node, repr(e)) from e
-            raise
-
-    def visit_Call_Impl(self, fn, node):
         static_implementation = self.statically_implemented_functions.get(fn)
         if static_implementation is not None:
             return static_implementation(self, node)
@@ -1059,15 +1056,14 @@ class CodeGenerator(ast.NodeVisitor):
 
     def visit_BoolOp(self, node: ast.BoolOp):
         if len(node.values) != 2:
-            raise UnsupportedLanguageConstruct(
-                None, node,
-                "chained boolean operators (A or B or C) are not supported; use parentheses to split the chain.")
+            raise self._unsupported(
+                node, "chained boolean operators (A or B or C) are not supported; use parentheses to split the chain.")
         lhs = self.visit(node.values[0])
         rhs = self.visit(node.values[1])
         method_name = self._method_name_for_bool_op.get(type(node.op))
         if method_name is None:
-            raise UnsupportedLanguageConstruct(
-                None, node, "AST boolean operator '{}' is not (currently) implemented.".format(node.op.__name__))
+            raise self._unsupported(
+                node, "AST boolean operator '{}' is not (currently) implemented.".format(node.op.__name__))
         return self._apply_binary_method(method_name, lhs, rhs)
 
     _method_name_for_bool_op: Dict[Type[ast.boolop], str] = {ast.And: 'logical_and', ast.Or: 'logical_or'}
@@ -1105,8 +1101,8 @@ class CodeGenerator(ast.NodeVisitor):
                 conversion_code = value.conversion
                 evaluated = self.visit(value.value)
                 if not _is_constexpr(evaluated):
-                    raise UnsupportedLanguageConstruct(
-                        None, node,
+                    raise self._unsupported(
+                        node,
                         "Cannot evaluate f-string containing non-constexpr conversion values, found conversion of type "
                         + str(type(evaluated)))
                 values[i] = ("{}" if conversion_code < 0 else "{!" + chr(conversion_code) + "}").format(evaluated.value)
@@ -1127,14 +1123,22 @@ class CodeGenerator(ast.NodeVisitor):
             if hasattr(node, 'lineno') and hasattr(node, 'col_offset'):
                 self.builder.set_loc(self.file_name, self.begin_line + node.lineno, node.col_offset)
                 last_loc = self.builder.get_loc()
-            ret = super().visit(node)
+            try:
+                ret = super().visit(node)
+            except CompilationError:
+                raise
+            except Exception as e:
+                # Wrap the error in a CompilationError which contains the source
+                # of the @jit function.
+                raise CompilationError(self.jit_fn.src, self.last_node, repr(e)) from None
+
             # Reset the location to the last one before the visit
             if last_loc:
                 self.builder.set_loc(last_loc)
             return ret
 
     def generic_visit(self, node):
-        raise UnsupportedLanguageConstruct(None, node, "unsupported AST node type: {}".format(type(node).__name__))
+        raise self._unsupported(node, "unsupported AST node type: {}".format(type(node).__name__))
 
     def execute_static_assert(self, node: ast.Call) -> None:
         arg_count = len(node.args)
@@ -1155,7 +1159,7 @@ class CodeGenerator(ast.NodeVisitor):
                 except Exception as e:
                     message = "<failed to evaluate assertion message: " + repr(e) + ">"
 
-            raise CompileTimeAssertionFailure(None, node, _unwrap_if_constexpr(message))
+            raise CompileTimeAssertionFailure(self.jit_fn.src, node, _unwrap_if_constexpr(message))
         return None
 
     def static_executor(python_fn):
@@ -1210,19 +1214,10 @@ def ast_to_ttir(fn, specialization, context, options):
 
     prototype = language.function_type([], arg_types)
     generator = CodeGenerator(context, prototype, gscope=gscope, constants=all_constants, function_name=function_name,
-                              attributes=new_attrs, is_kernel=True, file_name=file_name, begin_line=begin_line,
-                              options=options)
-    try:
-        generator.visit(fn.parse())
-    except CompilationError as e:
-        if e.src is None:
-            e.set_source_code(fn.src)
-        raise
-    except Exception as e:
-        node = generator.last_node
-        if node is None:
-            raise
-        raise CompilationError(fn.src, node, repr(e)) from e
+                              jit_fn=fn, attributes=new_attrs, is_kernel=True, file_name=file_name,
+                              begin_line=begin_line, options=options)
+    generator.visit(fn.parse())
+
     ret = generator.module
     # module takes ownership of the context
     ret.context = context


### PR DESCRIPTION
- Failed tl.static_assert's were generating an extra stackframe; get rid of
  this.

- We were not reporting the correct location for errors in unary and binary
  ops.

- Nested functions were not handled properly, despite my last attempt.

Now with tests!
