### PR TITLE
Implement associative scan with `reverse` arg

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -126,6 +126,7 @@ public:
 
   Location getLoc() { return scanOp.getLoc(); }
   unsigned getAxis() { return scanOp.getAxis(); }
+  bool getReverse() { return scanOp.getReverse(); }
   triton::gpu::BlockedEncodingAttr getEncoding();
   llvm::ArrayRef<int64_t> getShape() { return srcShape; }
   unsigned getNumOperands() { return scanOp.getNumOperands(); }

--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -558,12 +558,12 @@ def TT_ScanOp: TT_Op<"scan",
                         SameOperandsAndResultShape,
                         SingleBlock,
                         DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
-    let summary = "Associatve scan using generic combination algorithm";
-    let arguments = (ins Variadic<TT_Tensor>:$srcs, I32Attr:$axis);
+    let summary = "Associative scan using generic combination algorithm";
+    let arguments = (ins Variadic<TT_Tensor>:$srcs, I32Attr:$axis, BoolAttr:$reverse);
     let results = (outs Variadic<TT_Tensor>:$result);
     let regions = (region SizedRegion<1>:$combineOp);
     let builders = [
-        OpBuilder<(ins "ValueRange":$srcs, "int":$axis)>,
+        OpBuilder<(ins "ValueRange":$srcs, "int":$axis, "bool":$reverse)>,
     ];
     let hasVerifier = 1;
     let hasRegionVerifier = 1;

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -490,7 +490,7 @@ struct TritonScanPattern : public OpConversionPattern<triton::ScanOp> {
   matchAndRewrite(triton::ScanOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto newScan = rewriter.create<triton::ScanOp>(
-        op.getLoc(), adaptor.getOperands(), adaptor.getAxis());
+        op.getLoc(), adaptor.getOperands(), adaptor.getAxis(), op.getReverse());
     addNamedAttrs(newScan, adaptor.getAttributes());
 
     auto &newCombineOp = newScan.getCombineOp();

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -657,8 +657,9 @@ unsigned ReduceOp::getNumOperands() { return this->getOperands().size(); }
 
 //-- ScanOp --
 void ScanOp::build(OpBuilder &builder, OperationState &state,
-                   ValueRange operands, int axis) {
+                   ValueRange operands, int axis, bool reverse) {
   SmallVector<Type> inferredReturnTypes;
+  state.addAttribute("reverse", builder.getBoolAttr(reverse));
   for (auto arg : operands)
     inferredReturnTypes.push_back(arg.getType());
   ReduceOp::build(builder, state, inferredReturnTypes, operands, axis);

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1332,8 +1332,10 @@ void init_triton_ir(py::module &&m) {
              return self.create<ReduceReturnOp>(return_values);
            })
       .def("create_scan",
-           [](TritonOpBuilder &self, std::vector<Value> operands, int axis)
-               -> OpState { return self.create<ScanOp>(operands, axis); })
+           [](TritonOpBuilder &self, std::vector<Value> operands, int axis,
+              bool reverse) -> OpState {
+             return self.create<ScanOp>(operands, axis, reverse);
+           })
       .def("create_scan_ret",
            [](TritonOpBuilder &self, py::args args) -> OpState {
              llvm::SmallVector<Value> return_values;

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1850,13 +1850,14 @@ def test_reduce(op, dtype_str, shape, axis, keep_dims, num_ctas, device):
 
 scan2d_shapes = [(8, 32), (16, 32), (32, 16), (2, 1024), (1024, 2), (32, 32), (1, 1024)]
 
-scan_configs = [(op, type, shape, axis, num_warps)
+scan_configs = [(op, type, shape, axis, reverse, num_warps)
                 for num_warps in [4, 16]
                 for type in ['int32', 'float32']
                 for axis in [1, 0]
+                for reverse in [True, False]
                 for shape in scan2d_shapes
                 for op in ['cumsum', 'cumprod', 'get_first_element', 'linear_recurrence', 'cummax']]
-negative_config = [('cumsum', 'float32', (32, 32), -1, 4)]
+negative_config = [('cumsum', 'float32', (32, 32), -1, False, 4)]
 
 
 @triton.jit
@@ -1877,8 +1878,8 @@ def cummax(v0, i0, v1, i1):
     return tl.where(gt, v0, v1), tl.where(gt, i0, i1)
 
 
-@pytest.mark.parametrize("op, dtype_str, shape, axis, num_warps", scan_configs + negative_config)
-def test_scan2d(op, dtype_str, shape, axis, num_warps, device):
+@pytest.mark.parametrize("op, dtype_str, shape, axis, reverse, num_warps", scan_configs + negative_config)
+def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
     check_type_supported(dtype_str, device)
 
     # triton kernel
@@ -1892,19 +1893,24 @@ def test_scan2d(op, dtype_str, shape, axis, num_warps, device):
         tl.store(Z + range_m[:, None] * BLOCK_N + range_n[None, :], z)
 
     if op == 'cumsum' or op == 'cumprod':
-        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'z = tl.{op}(x, axis={axis})'})
+        kernel = patch_kernel(kernel, {'GENERATE_TEST_HERE': f'z = tl.{op}(x, axis={axis}, reverse={reverse})'})
     elif op == 'get_first_element':
-        kernel = patch_kernel(kernel,
-                              {'GENERATE_TEST_HERE': f'z = tl.associative_scan(x, axis={axis}, combine_fn={op})'})
+        kernel = patch_kernel(
+            kernel,
+            {'GENERATE_TEST_HERE': f'z = tl.associative_scan(x, axis={axis}, combine_fn={op}, reverse={reverse})'})
     elif op == 'cummax':
         rg = "range_m[:, None]" if axis == 0 else "range_n[None, :]"
         rg = f"tl.broadcast_to({rg}.to(tl.int64), [BLOCK_M, BLOCK_N])"
-        kernel = patch_kernel(
-            kernel, {'GENERATE_TEST_HERE': f'_, z = tl.associative_scan((x, {rg}), axis={axis}, combine_fn={op})'})
+        kernel = patch_kernel(kernel, {
+            'GENERATE_TEST_HERE':
+            f'_, z = tl.associative_scan((x, {rg}), axis={axis}, combine_fn={op}, reverse={reverse})'
+        })
     else:
         assert op == 'linear_recurrence'
-        kernel = patch_kernel(
-            kernel, {'GENERATE_TEST_HERE': f'_, z = tl.associative_scan((x, y), axis={axis}, combine_fn={op})'})
+        kernel = patch_kernel(kernel, {
+            'GENERATE_TEST_HERE':
+            f'_, z = tl.associative_scan((x, y), axis={axis}, combine_fn={op}, reverse={reverse})'
+        })
     # input
     rs = RandomState(17)
     if op == 'linear_recurrence' and dtype_str in int_dtypes:
@@ -1916,21 +1922,34 @@ def test_scan2d(op, dtype_str, shape, axis, num_warps, device):
         x = numpy_random(shape, dtype_str=dtype_str, rs=rs)
         # y is just used in linear_recurrence
         y = numpy_random(shape, dtype_str=dtype_str, rs=rs)
+    x_in = x
+    if reverse:
+        x_in = np.flip(x, axis)
     z = np.empty_like(x)
     x_tri = to_triton(x, device=device)
     y_tri = to_triton(y, device=device)
     if op == 'cumsum' or op == 'cumprod':
         numpy_op = {'cumsum': np.cumsum, 'cumprod': np.cumprod}[op]
         z_dtype_str = dtype_str
-        z_ref = numpy_op(x, axis=axis).astype(getattr(np, z_dtype_str))
+        z_ref = numpy_op(x_in, axis=axis).astype(getattr(np, z_dtype_str))
+        if reverse:
+            z_ref = np.flip(z_ref, axis)
+
     elif op == 'cummax':
         # NumPy does not have cummax
         z = z.astype(np.int64)
-        z_ref = torch.cummax(torch.from_numpy(x), axis=axis).indices.numpy()
+        z_ref = torch.cummax(torch.from_numpy(x_in.copy()), axis=axis).indices.numpy()
+        if reverse:
+            z_ref = x_in.shape[axis] - np.flip(z_ref, axis) - 1
+
     elif op == 'linear_recurrence':
         # Simplify to the axis=1 case
         x_ref = x.T if axis == 0 else x
         y_ref = y.T if axis == 0 else y
+        if reverse:
+            x_ref = np.flip(x_ref, 1)
+            y_ref = np.flip(y_ref, 1)
+
         result = []
         for x_refi, y_refi in zip(x_ref, y_ref):
             li = []
@@ -1940,18 +1959,29 @@ def test_scan2d(op, dtype_str, shape, axis, num_warps, device):
                 li.append(acc)
             result.append(li)
         z_ref = np.array(result)
+        if reverse:
+            z_ref = np.flip(z_ref, 1)
+
         if axis == 0:
             z_ref = z_ref.T
     else:
         assert op == 'get_first_element'
         z_ref = x
         if axis == 0:
-            z_ref[1:] = x[0]
+            if reverse:
+                z_ref[:-1] = x[-1]
+            else:
+                z_ref[1:] = x[0]
         else:
-            z_ref[:, 1:] = x[:, 0:1]
+            if reverse:
+                z_ref[:, :-1] = x[:, -1:]
+            else:
+                z_ref[:, 1:] = x[:, 0:1]
+
     # triton result
     z_tri = to_triton(z, device=device)
     kernel[(1, )](x_tri, y_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], AXIS=axis, num_warps=num_warps)
+
     z_tri = to_numpy(z_tri)
     # compare
     if dtype_str == 'float32':

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1632,7 +1632,7 @@ def _add_scan_docstr(name: str, return_indices_arg: str = None, tie_break_arg: s
 
 
 @builtin
-def associative_scan(input, axis, combine_fn, _builder=None, _generator=None):
+def associative_scan(input, axis, combine_fn, reverse=False, _builder=None, _generator=None):
     """Applies the combine_fn to each elements with a carry in :code:`input` tensors along the provided :code:`axis` and update the carry
 
     :param input: the input tensor, or tuple of tensors
@@ -1641,7 +1641,7 @@ def associative_scan(input, axis, combine_fn, _builder=None, _generator=None):
 
     """
     if isinstance(input, tensor):
-        return associative_scan((input, ), axis, combine_fn, _builder=_builder, _generator=_generator)[0]
+        return associative_scan((input, ), axis, combine_fn, reverse, _builder=_builder, _generator=_generator)[0]
 
     def make_combine_region(scan_op):
         in_scalar_tys = [t.type.scalar for t in input]
@@ -1662,7 +1662,7 @@ def associative_scan(input, axis, combine_fn, _builder=None, _generator=None):
     axis = _constexpr_to_value(axis)
     if axis is not None:
         axis = _wrap_axis(axis, len(input[0].shape))
-    return semantic.associative_scan(input, axis, make_combine_region, _builder)
+    return semantic.associative_scan(input, axis, make_combine_region, reverse, _builder)
 
 
 @builtin

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1379,7 +1379,7 @@ def reduction(inputs: Sequence[tl.tensor], axis: int, region_builder_fn, builder
 # ===----------------------------------------------------------------------===
 
 
-def associative_scan(inputs: Sequence[tl.tensor], axis: int, region_builder_fn,
+def associative_scan(inputs: Sequence[tl.tensor], axis: int, region_builder_fn, reverse: bool,
                      builder: ir.builder) -> Tuple[tl.tensor, ...]:
     shape = inputs[0].type.shape
     rank = len(shape)
@@ -1396,7 +1396,7 @@ def associative_scan(inputs: Sequence[tl.tensor], axis: int, region_builder_fn,
         res_ty = tl.block_type(scalar_ty, shape)
         return tl.tensor(x, res_ty)
 
-    scan_op = builder.create_scan([t.handle for t in inputs], axis)
+    scan_op = builder.create_scan([t.handle for t in inputs], axis, reverse)
     region_builder_fn(scan_op)
     scan_op.verify()
 

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -296,10 +296,10 @@ def xor_sum(input, axis=None, keep_dims=False, _builder=None, _generator=None):
 
 @jit
 @core._add_scan_docstr("cumsum")
-def cumsum(input, axis=0):
+def cumsum(input, axis=0, reverse=False):
     # todo rename this to a generic function name
     input = core._promote_bfloat16_to_float32(input)
-    return core.associative_scan(input, axis, _sum_combine)
+    return core.associative_scan(input, axis, _sum_combine, reverse)
 
 
 # cumprod
@@ -312,10 +312,10 @@ def _prod_combine(a, b):
 
 @jit
 @core._add_scan_docstr("cumprod")
-def cumprod(input, axis=0):
+def cumprod(input, axis=0, reverse=False):
     # todo rename this to a generic function name
     input = core._promote_bfloat16_to_float32(input)
-    return core.associative_scan(input, axis, _prod_combine)
+    return core.associative_scan(input, axis, _prod_combine, reverse)
 
 
 # sort

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ScanOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ScanOpToLLVM.cpp
@@ -8,6 +8,7 @@ using namespace mlir::triton;
 using ::mlir::LLVM::delinearize;
 using ::mlir::LLVM::linearize;
 using ::mlir::LLVM::shflIdxSync;
+using ::mlir::LLVM::shflSync;
 using ::mlir::LLVM::shflUpSync;
 using ::mlir::LLVM::NVIDIA::storeShared;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
@@ -119,6 +120,7 @@ static void storeWarpAccumulator(SmallVector<SmallVector<Value>> &srcValues,
   unsigned axisNumWarps = helper.getAxisNumWarpsWithUniqueData();
   unsigned chunkId = 0;
   unsigned elementStride = helper.getAxisElementStride();
+
   for (unsigned srcIndex = 0; srcIndex < srcValues.size(); srcIndex++) {
     unsigned elementIdx = (srcIndex / elementStride) % scanElementsPerThreads;
     // Only consider the last element of each contiguous chunk of elements.
@@ -128,7 +130,6 @@ static void storeWarpAccumulator(SmallVector<SmallVector<Value>> &srcValues,
     Value mask = icmp_eq(laneId, i32_val(scanDim - 1));
     Value index = add(parallelLaneId, mul(warpId, i32_val(numParallelLane)));
     index = add(index, i32_val(chunkId * numParallelLane * axisNumWarps));
-
     for (unsigned i = 0; i < lastElement.size(); ++i) {
       Value writePtr = gep(ptr_ty(rewriter.getContext(), 3), smemTypes[i],
                            smemBases[i], index);
@@ -439,6 +440,25 @@ unpackInputs(Location loc, triton::ScanOp op, triton::ScanOpAdaptor adaptor,
   return srcValues;
 }
 
+SmallVector<SmallVector<Value>> 
+flipSrcValues(Location loc, triton::ScanOp op, 
+                   ConversionPatternRewriter &rewriter,
+                   SmallVector<SmallVector<Value>> srcValues,
+                   int iWarpSize){
+    SmallVector<SmallVector<Value>> values(srcValues.size());
+    for (int i = 0; i < srcValues.size(); ++i) {
+        int revIndex = srcValues.size() - i - 1;
+        for (unsigned j = 0; j < op.getNumOperands(); ++j) {
+            for (unsigned k = iWarpSize / 2; k >= 1; k = k / 2){
+                srcValues[revIndex][j] = shflSync(loc, rewriter, srcValues[revIndex][j], k);
+            }
+            values[i].push_back(srcValues[revIndex][j]);
+        }
+    }
+    return values;
+}
+
+    
 // Lowering using warp shuffle operations to do warp level scan.
 LogicalResult
 ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
@@ -461,6 +481,11 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
   warpIdAxis = urem(warpIdAxis, i32_val(axisNumWarps));
   auto srcValues =
       unpackInputs(loc, op, adaptor, rewriter, *getTypeConverter());
+
+  if (op.getReverse()) {
+      warpIdAxis = sub(i32_val(axisNumWarps-1), warpIdAxis);
+      srcValues = flipSrcValues(loc, op, rewriter, srcValues, iWarpSize);
+  }
 
   // Scan contiguous elements in a thread and update `srcValues`.
   scanThreadContiguousElements(srcValues, rewriter, helper);
@@ -513,6 +538,10 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
   };
 
   SmallVector<Value> results(op.getNumOperands());
+  if (op.getReverse()) {
+      srcValues = flipSrcValues(loc, op, rewriter, srcValues, iWarpSize);
+  }
+
   auto valuesTransposed = transpose(srcValues);
   for (unsigned i = 0; i < op.getNumOperands(); ++i) {
     auto resultTy = op.getResult()[i].getType().dyn_cast<RankedTensorType>();


### PR DESCRIPTION
This PR implements a `reverse` argument for associative scan similar to the jax implementation. While this can be implemented using the tl.flip command, @Jokeren advised me that this would be very inefficient and that this should be done in the associative scan itself. 

The implementation can be summarized as `flip(scan(flip(x)))`. However the flip needs to happen along three axes: warp, lanes, chunks. To flip the chunks, I simply reverse the vector of values. To flip the lanes, I use a butterfly shuffle to efficiently reverse the lanes. To flip the warp (needed for the slow case) I flip the indexing of the warps themselves. 

I additionally modified the scan tests to include the new reverse implementation. 

## Why is this needed? 
This was needed originally for the implementation of the Mamba model (https://srush.github.io/annotated-mamba/hard.html)  to compute the backward pass of the models. I thought pretty hard about whether this could be done by any kind of recomputation, but it seems pretty necessary to be able to do a reverse accumulation in order to take a dot product in the kernel. (perhaps also relevant to https://github.com/pytorch/pytorch/issues/120189 )


