### PR TITLE
[Frontend] Let tl.expand_dims handle "real" scalars.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -645,6 +645,10 @@ def test_expand_dims(device):
         t = tl.expand_dims(scalar, -1)
         tl.static_assert(t.shape == [1])
 
+        # N is a scalar that's not even a tl.tensor -- this should work too.
+        t = tl.expand_dims(N, -1)
+        tl.static_assert(t.shape == [1])
+
     N = 32
     dummy_tensor = torch.empty((), device=device)
     expand_dims_kernel[(1, )](dummy_tensor, N)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1100,6 +1100,7 @@ def expand_dims(input, axis, _builder=None):
     :type axis: int | Sequence[int]
 
     """
+    input = _to_tensor(input, _builder)
     axis = _constexpr_to_value(axis)
     axes = list(axis) if isinstance(axis, Sequence) else [axis]
     new_ndim = len(input.shape) + len(axes)


### PR DESCRIPTION
<git-pr-chain>


[Frontend] Let tl.expand_dims handle "real" scalars.

It handled 0D tensors, but not e.g. python int's.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3182 👈 **YOU ARE HERE**
1. #3184


</git-pr-chain>


