### PR TITLE
[Frontend] Stop parsing after we hit a `return` statement.

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -300,8 +300,12 @@ class CodeGenerator(ast.NodeVisitor):
             stmts = [stmts]
         for stmt in stmts:
             ret_type = self.visit(stmt)
-            if ret_type is not None and isinstance(stmt, ast.Return):
+
+            # Stop parsing as soon as we hit a `return` statement; everything
+            # after this is dead code.
+            if isinstance(stmt, ast.Return):
                 self.last_ret_type = ret_type
+                break
 
     def visit_Module(self, node):
         ast.NodeVisitor.generic_visit(self, node)


### PR DESCRIPTION
<git-pr-chain>


[Frontend] Stop parsing after we hit a `return` statement.

Suppose you have something like the following.

```
@jit
def fn(x, y):
  return x
  return y
```

Clearly this function returns `x` and not `y`, but before this patch, we'd say
that the function's last_ret_type was `y`.  This would cause assertions inside
the C++ side of code generation.  The IR would correctly return x, but the type
of `fn` would match the shape of y.

DO NOT SUBMIT - Needs a test.
DO NOT SUBMIT - Can I get rid of this logic altogether and just use the type of
the returned value?


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #3182
1. 👉 #3184 👈 **YOU ARE HERE**

⚠️⚠️ Please **do not click the green "merge" button** unless you know what
you're doing.  This PR is part of a chain of PRs, and clicking the merge
button will not merge it into master. ⚠️⚠️ 
</git-pr-chain>
