### PR TITLE
[DEBUG] Add support for a Triton envvar to enable LLVM's -debug/llvm::DebugFlag

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -41,6 +41,7 @@ inline const std::set<std::string> ENV_VARS = {
     "TRITON_DISABLE_LINE_INFO",
     "TRITON_DISABLE_RESHAPE_ENCODING_INFERENCE",
     "MLIR_ENABLE_DIAGNOSTICS",
+    "TRITON_ENABLE_LLVM_DEBUG",
 };
 
 namespace tools {

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -793,9 +793,6 @@ public:
     populateSCFPatterns(typeConverter, patterns);
     populateCFPatterns(typeConverter, patterns);
 
-    if (failed(applyPartialConversion(mod, target, std::move(patterns))))
-      return signalPassFailure();
-
     auto inti = llvm::APSInt(32, false);
     auto i32_ty = IntegerType::get(mod->getContext(), 32);
 
@@ -812,6 +809,9 @@ public:
     mod->setAttr(AttrComputeCapabilityName,
                  IntegerAttr::get(
                      i32_ty, llvm::APInt(32, computeCapability.getValue())));
+
+    if (failed(applyPartialConversion(mod, target, std::move(patterns))))
+      return signalPassFailure();
 
     // update layouts
     //  broadcast src => multicast, dst => broadcasted

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1464,6 +1464,9 @@ void init_triton_ir(py::module &&m) {
           makeReproducer(anchorName, passes, op, reproducerPath);
         }
 
+        if (triton::tools::getBoolEnv("TRITON_ENABLE_LLVM_DEBUG")) {
+          ::llvm::DebugFlag = true;
+        }
         if (failed(self.run(mod.getOperation())))
           throw std::runtime_error("PassManager::run failed");
       });


### PR DESCRIPTION
This patch uses TRITON_ENABLE_LLVM_DEBUG to enable LLVM's debug flag so that LLVM_DEBUG blocks can be enabled when running the Triton Python runtime.

I did have to add a workaround for getNumWarps for now, but once it is determined why a LLVM_DEBUG block is hitting getNumWarps before num_warps is set it should be dropped. 