### PR TITLE
[BACKEND] Prevent creating incompatible shared layouts in pipeliner

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -37,9 +37,6 @@ struct PipelineOpInfo {
   ttg::SharedEncodingAttr sharedEncoding = nullptr;
   // Blocked encoding is used for loads feeding into other loads.
   ttg::BlockedEncodingAttr blockedEncoding = nullptr;
-  // Dot operand encoding is used for loads feeding into dot ops.
-  ttg::DotOperandEncodingAttr dotOperandEncoding = nullptr;
-  bool needTrans = false;
 };
 
 }; // namespace
@@ -132,40 +129,57 @@ createAsyncLoad(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
 }
 
 // If all the transitive uses of the given value have are used by a convert to
-// the same dot operand encoding, return the encoding. Otherwise return nullptr.
-// Negate `needTrans` when a TransOp is seen on the transitive use chain.
-static ttg::DotOperandEncodingAttr
-allTransitiveUsesHaveDotEncoding(Value val, bool &needTrans) {
-  ttg::DotOperandEncodingAttr attr;
+// the same dot operand encoding, return true and set the shared encoding that
+// needs to be used to be compatible with users' layouts.
+static bool
+allTransitiveUsesHaveDotEncoding(Value val,
+                                 ttg::SharedEncodingAttr &sharedEnc) {
+  ttg::SharedEncodingAttr attr;
   for (Operation *user : val.getUsers()) {
+    ttg::SharedEncodingAttr tempAttr;
     if (user->getNumResults() != 1)
-      return nullptr;
+      return false;
     auto tensorType = user->getResult(0).getType().dyn_cast<RankedTensorType>();
     if (!tensorType)
-      return nullptr;
-    if (isa<triton::TransOp>(user))
-      needTrans = !needTrans;
-    ttg::DotOperandEncodingAttr tempAttr;
+      return false;
     if (tensorType.getEncoding().isa<ttg::SharedEncodingAttr>()) {
-      tempAttr =
-          allTransitiveUsesHaveDotEncoding(user->getResult(0), needTrans);
+      // First time we find a shared encoding in the chain, save it and try to
+      // use it if it is compatible with the other users.
+      if (!tempAttr)
+        tempAttr = tensorType.getEncoding().cast<ttg::SharedEncodingAttr>();
+      ttg::SharedEncodingAttr nextEncoding;
+      bool hasDotEncodingUse =
+          allTransitiveUsesHaveDotEncoding(user->getResult(0), nextEncoding);
+      if (!hasDotEncodingUse)
+        return false;
     } else {
       auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(user);
       if (!convertLayout)
-        return nullptr;
-      tempAttr = convertLayout.getType()
-                     .getEncoding()
-                     .dyn_cast<ttg::DotOperandEncodingAttr>();
+        return false;
+      auto dotOpEnc = convertLayout.getType()
+                          .getEncoding()
+                          .dyn_cast<ttg::DotOperandEncodingAttr>();
+      auto srcTensorType = val.getType().cast<RankedTensorType>();
+      auto CTALayout = ttg::getCTALayout(srcTensorType.getEncoding());
+      auto order = ttg::getOrder(srcTensorType.getEncoding());
+      unsigned bitWidth =
+          srcTensorType.getElementType().getIntOrFloatBitWidth();
+      tempAttr = ttg::SharedEncodingAttr::get(
+          val.getContext(), dotOpEnc, srcTensorType.getShape(), order,
+          CTALayout, bitWidth, /*needTrans=*/false);
     }
+    // We need to check that the shared encoding needed by the users are
+    // compatible.
     if (!tempAttr || (attr != nullptr && attr != tempAttr))
-      return nullptr;
+      return false;
     attr = tempAttr;
   }
-  return attr;
+  sharedEnc = attr;
+  return true;
 }
 
-static std::optional<std::pair<ttg::DotOperandEncodingAttr, bool>>
-loadDotOperand(tt::LoadOp loadOp, bool &hasMMAV3) {
+bool loadDotOperand(tt::LoadOp loadOp, bool &hasMMAV3,
+                    ttg::SharedEncodingAttr &enc) {
   if (loadOp.getResult().hasOneUse()) {
     Operation *use = *loadOp.getResult().getUsers().begin();
     if (auto convertLayout = llvm::dyn_cast<ttg::ConvertLayoutOp>(use)) {
@@ -185,18 +199,15 @@ loadDotOperand(tt::LoadOp loadOp, bool &hasMMAV3) {
             // TODO: remove this constraint once the LoadOp supports transpose
             // fusion
             hasMMAV3 = true;
-            return std::make_pair(nullptr, false);
+            return true;
           }
         }
       }
     }
   }
-  bool needTrans = false;
-  ttg::DotOperandEncodingAttr attr =
-      allTransitiveUsesHaveDotEncoding(loadOp.getResult(), needTrans);
-  if (!attr)
-    return std::nullopt;
-  return std::make_pair(attr, needTrans);
+  if (allTransitiveUsesHaveDotEncoding(loadOp.getResult(), enc))
+    return true;
+  return false;
 };
 
 static ttg::BlockedEncodingAttr
@@ -215,9 +226,8 @@ getBlockedEncoding(tt::LoadOp loadOp, ModuleAxisInfoAnalysis &axisInfo) {
                                        threadsPerWarp, CTALayout);
 }
 
-static ttg::SharedEncodingAttr
-getSharedEncoding(tt::LoadOp loadOp, Operation *use, bool isMMAV3,
-                  ttg::DotOperandEncodingAttr dotOpEnc, bool needTrans) {
+static ttg::SharedEncodingAttr getSharedEncoding(tt::LoadOp loadOp,
+                                                 Operation *use, bool isMMAV3) {
 
   auto ty = loadOp.getType().cast<RankedTensorType>();
   auto CTALayout = ttg::getCTALayout(ty.getEncoding());
@@ -234,23 +244,12 @@ getSharedEncoding(tt::LoadOp loadOp, Operation *use, bool isMMAV3,
     order = blockedOrder;
   }
   if (isa<tt::DotOp>(use)) {
-    if (dotOpEnc) {
-      assert(!isMMAV3 && "MMAv3 should not have dotOperandEncoding");
-      unsigned bitWidth = ty.getElementType().getIntOrFloatBitWidth();
-      // set needTrans to avoid unnecessary conversion between shared encodings.
-      return ttg::SharedEncodingAttr::get(ty.getContext(), dotOpEnc,
-                                          ty.getShape(), order, CTALayout,
-                                          bitWidth, needTrans);
-    } else {
-      assert(isMMAV3 && "Load used by dot op should be either MMAv3 or have "
-                        "dotOperandEncoding.");
-      return ttg::SharedEncodingAttr::get(ty.getContext(), ty.getShape(), order,
-                                          CTALayout, ty.getElementType());
-    }
+    assert(isMMAV3 && "Load used by dot op should be either MMAv3 or have a "
+                      "shared encoding already picked based on users layouts.");
+    return ttg::SharedEncodingAttr::get(ty.getContext(), ty.getShape(), order,
+                                        CTALayout, ty.getElementType());
   } else {
-    assert(!dotOpEnc && !isMMAV3 &&
-           "Load used by non-dot op should not have dotOperandEncoding or be "
-           "MMAv3.");
+    assert(!isMMAV3 && "Load used by non-dot op should not be MMAv3.");
     // Use non-swizzled layout for loads that do not feed into dot ops.
     // TODO: This won't be optimal for 2D tensors.
     return ttg::SharedEncodingAttr::get(ty.getContext(), 1, 1, 1, order,
@@ -362,19 +361,19 @@ collectOpsToPipeline(scf::ForOp forOp,
     PipelineOpInfo loadInfo;
     bool loadIsMMAV3 = false;
     if (isa<tt::DotOp>(distAndUse.second)) {
-      std::optional<std::pair<ttg::DotOperandEncodingAttr, bool>> loadDotAttr =
-          loadDotOperand(loadOp, loadIsMMAV3);
+      ttg::SharedEncodingAttr sharedEnc;
+      bool isLoadDotOperand = loadDotOperand(loadOp, loadIsMMAV3, sharedEnc);
       hasMMAV3 |= loadIsMMAV3;
-      if (!loadDotAttr.has_value())
+      if (!isLoadDotOperand)
         continue;
-      loadInfo.dotOperandEncoding = loadDotAttr.value().first;
-      loadInfo.needTrans = loadDotAttr.value().second;
+      loadInfo.sharedEncoding = sharedEnc;
     } else {
       loadInfo.blockedEncoding = getBlockedEncoding(loadOp, axisInfoAnalysis);
     }
-    loadInfo.sharedEncoding =
-        getSharedEncoding(loadOp, distAndUse.second, loadIsMMAV3,
-                          loadInfo.dotOperandEncoding, loadInfo.needTrans);
+    // If we haven't already assigned a layout do it now.
+    if (!loadInfo.sharedEncoding)
+      loadInfo.sharedEncoding =
+          getSharedEncoding(loadOp, distAndUse.second, loadIsMMAV3);
     int stage = (maxDistance - distAndUse.first) * stagesBetweenLoads;
     loadInfo.stage = stage;
     loadInfo.use = distAndUse.second;

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -614,6 +614,60 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
 
 // -----
 
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+#shared = #triton_gpu.shared<{vec = 4, perPhase = 1, maxPhase = 2, order = [0, 1], hasLeadingOffset = false}>
+#shared1 = #triton_gpu.shared<{vec = 4, perPhase = 1, maxPhase = 2, order = [1, 0], hasLeadingOffset = false}>
+module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: tt.func @load_two_users_incompatible_layouts
+  tt.func @load_two_users_incompatible_layouts(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}) -> (tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>) {
+    %cst = arith.constant dense<0> : tensor<1x16xi32, #blocked>
+    %cst_0 = arith.constant dense<0> : tensor<128x1xi32, #blocked1>
+    %c0_i64 = arith.constant 0 : i64
+    %c0_i32 = arith.constant 0 : i32
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma>
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.addptr %arg0, %c0_i64 : !tt.ptr<f16, 1>, i64
+    %1 = tt.addptr %arg1, %c0_i64 : !tt.ptr<f16, 1>, i64
+    %2 = tt.splat %1 : !tt.ptr<f16, 1> -> tensor<128x1x!tt.ptr<f16, 1>, #blocked1>
+    %3 = tt.addptr %2, %cst_0 : tensor<128x1x!tt.ptr<f16, 1>, #blocked1>, tensor<128x1xi32, #blocked1>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x64xi32, #blocked1>
+    %6 = tt.broadcast %3 : tensor<128x1x!tt.ptr<f16, 1>, #blocked1> -> tensor<128x64x!tt.ptr<f16, 1>, #blocked1>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked1> -> tensor<128x64xi32, #blocked1>
+    %8 = tt.addptr %6, %7 : tensor<128x64x!tt.ptr<f16, 1>, #blocked1>, tensor<128x64xi32, #blocked1>
+    %9 = tt.load %8 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xf16, #blocked1>
+    %10 = tt.splat %0 : !tt.ptr<f16, 1> -> tensor<1x16x!tt.ptr<f16, 1>, #blocked>
+    %11 = tt.addptr %10, %cst : tensor<1x16x!tt.ptr<f16, 1>, #blocked>, tensor<1x16xi32, #blocked>
+    %12 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %13 = tt.expand_dims %12 {axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %14 = tt.broadcast %11 : tensor<1x16x!tt.ptr<f16, 1>, #blocked> -> tensor<64x16x!tt.ptr<f16, 1>, #blocked>
+    %15 = tt.broadcast %13 : tensor<64x1xi32, #blocked> -> tensor<64x16xi32, #blocked>
+    %16 = tt.addptr %14, %15 : tensor<64x16x!tt.ptr<f16, 1>, #blocked>, tensor<64x16xi32, #blocked>
+    // CHECK-NOT: triton_gpu.insert_slice_async
+    // CHECK: scf.for
+    %17:2 = scf.for %arg2 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg3 = %cst_1, %arg4 = %cst_2) -> (tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>)  : i32 {
+      %18 = tt.load %16 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x16xf16, #blocked>
+      %19 = triton_gpu.convert_layout %9 : tensor<128x64xf16, #blocked1> -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+      %20 = triton_gpu.convert_layout %18 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %21 = tt.dot %19, %20, %cst_1 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x16xf32, #mma>
+      %22 = arith.truncf %21 : tensor<128x16xf32, #mma> to tensor<128x16xf16, #mma>
+      %23 = triton_gpu.convert_layout %22 : tensor<128x16xf16, #mma> -> tensor<128x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+      %24 = triton_gpu.convert_layout %18 : tensor<64x16xf16, #blocked> -> tensor<64x16xf16, #shared>
+      %25 = tt.trans %24 {order=array<i32: 1,0>} : tensor<64x16xf16, #shared> -> tensor<16x64xf16, #shared1>
+      %26 = triton_gpu.convert_layout %25 : tensor<16x64xf16, #shared1> -> tensor<16x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %27 = tt.dot %23, %26, %arg4 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<16x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x64xf32, #mma>
+      scf.yield %21, %27 : tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>
+    }
+    tt.return %17#0, %17#1 : tensor<128x16xf32, #mma>, tensor<128x64xf32, #mma>
+  }
+}
+
+// -----
+
 // CHECK-LABEL: nested_loops
 // CHECK: triton_gpu.alloc_tensor
 // CHECK: scf.for


### PR DESCRIPTION
When a load has multiple uses in software pipelining they may require different shared layout. Make sure the layout created is compatible with all uses, otherwise skip pipelining the load.