### PR TITLE
[Frontend] Add tensor.permute(2,1,0) etc.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -884,6 +884,33 @@ def test_abs_fp8(in_dtype, device):
 
 
 # ----------------
+# test passing shapes as individual params rather than tuples
+# ----------------
+
+
+def test_shapes_as_params(device):
+
+    @triton.jit
+    def kernel():
+        a = tl.arange(0, 32).expand_dims(-1).broadcast_to(32, 32)
+        tl.static_assert(a.shape == [tl.constexpr(32), tl.constexpr(32)])
+
+        a = tl.arange(0, 32).reshape(4, 8).permute(1, 0)
+        tl.static_assert(a.shape == [tl.constexpr(8), tl.constexpr(4)])
+
+        a = tl.arange(0, 32).reshape(4, 8).reshape(32)
+        tl.static_assert(a.shape == [tl.constexpr(32)])
+
+        a = tl.arange(0, 64).reshape(2, 4, 8).trans(2, 1, 0)
+        tl.static_assert(a.shape == [tl.constexpr(8), tl.constexpr(4), tl.constexpr(2)])
+
+        a = tl.arange(0, 64).view(2, 4, 8)
+        tl.static_assert(a.shape == [tl.constexpr(2), tl.constexpr(4), tl.constexpr(8)])
+
+    kernel[(1, )]()
+
+
+# ----------------
 # test transpose
 # ----------------
 
@@ -2639,7 +2666,7 @@ def test_trans_4d(dtype_str, shape, perm, device):
             block_shape=(ou_shape1, ou_shape2, ou_shape3, ou_shape4),
             order=(3, 2, 1, 0),
         )
-        tl.store(out_ptr, tl.permute(tl.load(in_ptr), (trans1, trans2, trans3, trans4)))
+        tl.store(out_ptr, tl.load(in_ptr).permute((trans1, trans2, trans3, trans4)))
 
     input = torch.arange(math.prod(shape), dtype=getattr(torch, dtype_str), device=device).reshape(shape)
     expected = torch.permute(input, perm)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -7,6 +7,7 @@ from functools import partial, wraps
 from typing import Union, Callable, List, Sequence, TypeVar, cast
 import builtins
 from ..runtime.jit import jit
+import inspect
 
 from .._C.libtriton import ir
 from . import semantic
@@ -34,6 +35,69 @@ def builtin(fn: T) -> T:
     setattr(wrapper, TRITON_BUILTIN, True)
 
     return wrapper
+
+
+def _tensor_member_fn(fn: T) -> T:
+    """Decorator that adds this free function as a member fn on class tensor.
+
+    When called as a member function on class tensor, the first argument to `fn`
+    is `self`, i.e. the tensor object.
+
+    If there are multiple decorators on a function, you probably want this one
+    to be the highest one (i.e. furthest from the function's `def`), so it's
+    applied last.
+
+    Unfortunately you still need to add a type stub to the body of class tensor
+    in order for pytype to know about it.
+    """
+    assert callable(fn)
+    orig_sig = inspect.signature(fn)
+    # Does fn take args other than _builder, _generator, and the tensor itself?
+    has_args = len(orig_sig.parameters.keys() - {"_builder", "_generator"}) > 1
+
+    if not fn.__doc__:
+        fn.__doc__ = ""
+    fn.__doc__ += f"""
+    This function can also be called as a member function on :py:class:`tensor`,
+    as :code:`x.{fn.__name__}({"..." if has_args else ""})` instead of
+    :code:`{fn.__name__}(x{", ..." if has_args else ""})`.
+    """
+
+    def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    # Match the signature of `fn`, but change the first arg to `self` so the
+    # docs are a little less weird.
+    new_params = list(orig_sig.parameters.values())
+    new_params[0] = new_params[0].replace(name='self')
+    new_sig = orig_sig.replace(parameters=new_params)
+    wrapper.__signature__ = new_sig
+    wrapper.__doc__ = f"Forwards to :py:func:`{fn.__name__}` free function"
+
+    setattr(tensor, fn.__name__, wrapper)
+    return fn
+
+
+def _unwrap_iterable(x):
+    """Returns x[0] if x has one element and x[0] is iterable."""
+    if len(x) == 1:
+        # Determine whether x[0] is iterable.
+        #
+        # You might want to use collections.abc.Iterable instead of this
+        # try/except block.  Unfortunately, this doesn't work with constexpr.
+        #
+        # The problem is that abc.Iterable checks for __iter__ on the *class*.
+        # But we want constexpr to expose an __iter__ method if and only if the
+        # wrapped *object* (i.e. self.value) is iterable.  Therefore there's no
+        # right answer for whether the class constexpr defines __iter__, and
+        # abc.Iterable doesn't work (at least not without some metaclass magic).
+        try:
+            iter(x[0])
+            return x[0]
+        except TypeError:
+            pass
+
+    return x
 
 
 def is_builtin(fn) -> bool:
@@ -536,6 +600,9 @@ class constexpr:
     def __not__(self):
         return constexpr(not self.value)
 
+    def __iter__(self):
+        return iter(self.value)
+
     def __call__(self, *args, **kwds):
         return self.value(*args, **kwds)
 
@@ -550,8 +617,31 @@ def check_bit_width(value, shift_value):
 
 
 class tensor:
+    """Represents an N-dimensional array of values or pointers.
+
+    :code:`tensor` is the fundamental data structure in Triton programs.  Most
+    functions in :py:mod:`triton.language` operate on and return tensors.
+
+    Most of the named member functions here are duplicates of the free functions
+    in :code:`triton.language`.  For example, :code:`triton.language.sqrt(x)` is
+    equivalent to :code:`x.sqrt()`.  An exception is :py:meth:`to()`, which has
+    no equivalent free function.
+
+    :code:`tensor` also defines most of the magic/dunder methods, so you can
+    write :code:`x+y`, :code:`x << 2`, etc.
+
+    .. rubric:: Nontrivial methods
+    .. automethod:: to
+
+    .. rubric:: Constructors
+    ..
+       For some reason Sphinx includes __init__ before printing the full table
+       of methods.  Not what I want, but I can't figure out how to fix it.  Give
+       it its own section so it looks intentional. :)
+    """
 
     def __init__(self, handle, type: dtype):
+        """Not called by user code."""
         # IR handle
         self.handle = handle
         # Block shape
@@ -818,6 +908,131 @@ class tensor:
             return semantic.bitcast(self, dtype, _builder)
         return semantic.cast(self, dtype, _builder, fp_downcast_rounding)
 
+    # Type stubs for functions added by the _tensor_member_fn decorator.
+    # (Unfortunately these can't be created automatically.)
+    #
+    # We couldn't write these definitions out even if we wanted to, because some
+    # of these functions are defined in standard.py.
+    def broadcast_to(self, *shape) -> tensor:
+        ...
+
+    def trans(self, *dims) -> tensor:
+        ...
+
+    def permute(self, *dims) -> tensor:
+        ...
+
+    def _experimental_split(self) -> tuple[tensor, tensor]:
+        ...
+
+    def view(self, *shape) -> tensor:
+        ...
+
+    def reshape(self, *shape) -> tensor:
+        ...
+
+    def expand_dims(self, axis) -> tensor:
+        ...
+
+    def store(self, value, mask=None, boundary_check=(), cache_modifier="", eviction_policy="") -> tensor:
+        ...
+
+    def advance(self, offsets) -> tensor:
+        ...
+
+    def atomic_cas(self, cmp, val, sem=None, scope=None) -> tensor:
+        ...
+
+    def atomic_xchg(self, val, mask=None, sem=None, scope=None) -> tensor:
+        ...
+
+    def atomic_add(self, val, mask=None, sem=None, scope=None) -> tensor:
+        ...
+
+    def atomic_max(self, val, mask=None, sem=None, scope=None) -> tensor:
+        ...
+
+    def atomic_min(self, val, mask=None, sem=None, scope=None) -> tensor:
+        ...
+
+    def atomic_and(self, val, mask=None, sem=None, scope=None) -> tensor:
+        ...
+
+    def atomic_or(self, val, mask=None, sem=None, scope=None) -> tensor:
+        ...
+
+    def atomic_xor(self, val, mask=None, sem=None, scope=None) -> tensor:
+        ...
+
+    def exp(self) -> tensor:
+        ...
+
+    def log(self) -> tensor:
+        ...
+
+    def cos(self) -> tensor:
+        ...
+
+    def sin(self) -> tensor:
+        ...
+
+    def sqrt(self) -> tensor:
+        ...
+
+    def abs(self) -> tensor:
+        ...
+
+    def reduce(self, axis, combine_fn, keep_dims=False) -> tensor:
+        ...
+
+    def associative_scan(self, axis, combine_fn, reverse=False) -> tensor:
+        ...
+
+    def histogram(self, num_bins) -> tensor:
+        ...
+
+    def cdiv(self, div) -> tensor:
+        ...
+
+    def sigmoid(self) -> tensor:
+        ...
+
+    def softmax(self, ieee_rounding=False) -> tensor:
+        ...
+
+    def ravel(self) -> tensor:
+        ...
+
+    def max(self, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False) -> tensor:
+        ...
+
+    def argmax(self, axis, tie_break_left=True, keep_dims=False) -> tensor:
+        ...
+
+    def min(self, axis=None, return_indices=False, return_indices_tie_break_left=True, keep_dims=False) -> tensor:
+        ...
+
+    def argmin(self, axis, tie_break_left=True, keep_dims=False) -> tensor:
+        ...
+
+    def sum(self, axis=None, keep_dims=False) -> tensor:
+        ...
+
+    def xor_sum(self, axis=None, keep_dims=False) -> tensor:
+        ...
+
+    def cumsum(self, axis=0, reverse=False) -> tensor:
+        ...
+
+    def cumprod(self, axis=0, reverse=False) -> tensor:
+        ...
+
+    def sort(self, dim: constexpr = None, descending: constexpr = constexpr(0)) -> tensor:
+        ...
+
+    def flip(self, dim=None) -> tensor:
+        ...
+
 
 # -----------------------
 # SPMD Programming Model
@@ -929,44 +1144,75 @@ def broadcast(input, other, _builder=None):
     return semantic.broadcast_impl_value(input, other, _builder)
 
 
+@_tensor_member_fn
 @builtin
-def broadcast_to(input, shape, _builder=None):
+def broadcast_to(input, *shape, _builder=None):
     """
     Tries to broadcast the given tensor to a new :code:`shape`.
 
     :param input: The input tensor.
     :type input: Block
     :param shape: The desired shape.
-    :type shape: Tuple[int]
+    :type shape:
+
+    :code:`shape` can be passed as a tuple or as individual parameters: ::
+
+        # These are equivalent
+        broadcast_to(x, (32, 32))
+        broadcast_to(x, 32, 32)
     """
-    shape = _shape_check_impl(shape)
+    shape = _shape_check_impl(_unwrap_iterable(shape))
     return semantic.broadcast_impl_shape(input, shape, _builder)
 
 
+@_tensor_member_fn
 @builtin
-def trans(input, _builder=None):
+def trans(input: tensor, *dims, _builder=None):
     """
-    Transposes a 2D tensor.
+    Permutes the dimensions of a tensor.
+
+    If no permutation is specified, tries to do a (1,0) permutation, i.e. tries
+    to transpose a 2D tensor.
 
     :param input: The input tensor.
-    :type input:
+    :param dims: The desired ordering of dimensions.  For example,
+        :code:`(2, 1, 0)` reverses the order dims in a a 3D tensor.
+
+    :code:`dims` can be passed as a tuple or as individual parameters: ::
+
+        # These are equivalent
+        trans(x, (2, 1, 0))
+        trans(x, 2, 1, 0)
+
+    :py:func:`permute` is equivalent to this function, except it doesn't
+    have the special case when no permutation is specified.
     """
-    if len(input.shape) != 2:
-        raise ValueError("Only 2D tensors can be transposed")
-    return semantic.permute(input, (1, 0), _builder)
+    if not dims:
+        dims = (1, 0)
+    return semantic.permute(input, dims, _builder)
 
 
+@_tensor_member_fn
 @builtin
-def permute(input, dims, _builder=None):
+def permute(input, *dims, _builder=None):
     """
     Permutes the dimensions of a tensor.
 
     :param input: The input tensor.
-    :type input:
+    :type input: Block
     :param dims: The desired ordering of dimensions.  For example,
         :code:`(2, 1, 0)` reverses the order dims in a a 3D tensor.
-    :type dims: Tuple[int]
+
+    :code:`dims` can be passed as a tuple or as individual parameters: ::
+
+        # These are equivalent
+        permute(x, (2, 1, 0))
+        permute(x, 2, 1, 0)
+
+    :py:func:`trans` is equivalent to this function, except when
+    :code:`dims` is empty, it tries to do a (1,0) permutation.
     """
+    dims = _unwrap_iterable(dims)
     return semantic.permute(input, dims, _builder)
 
 
@@ -1015,6 +1261,7 @@ def _take_first(a, b):
     return a
 
 
+@_tensor_member_fn
 @builtin
 def _experimental_split(a, _builder=None, _generator=None) -> tuple[tensor, tensor]:
     """
@@ -1049,34 +1296,45 @@ def _experimental_split(a, _builder=None, _generator=None) -> tuple[tensor, tens
     return out_lhs, out_rhs
 
 
+@_tensor_member_fn
 @builtin
-def view(input, shape, _builder=None):
+def view(input, *shape, _builder=None):
     """
     Returns a tensor with the same elements as `input` but a different shape.
     The order of the elements may not be preserved.
 
     :param input: The input tensor.
-    :type input:
+    :type input: Block
     :param shape: The desired shape.
-    :type shape: Tuple[int]
 
+    :code:`shape` can be passed as a tuple or as individual parameters: ::
+
+        # These are equivalent
+        view(x, (32, 32))
+        view(x, 32, 32)
     """
-    shape = _shape_check_impl(shape)
+    shape = _shape_check_impl(_unwrap_iterable(shape))
     return semantic.view(input, shape, _builder)
 
 
+@_tensor_member_fn
 @builtin
-def reshape(input, shape, _builder=None):
+def reshape(input, *shape, _builder=None):
     """
     Returns a tensor with the same number of elements as input but with the
     provided shape.
 
     :param input: The input tensor.
-    :type input:
+    :type input: Block
     :param shape: The new shape.
-    :type shape: Tuple[int]
+
+    :code:`shape ` can be passed as a tuple or as individual parameters: ::
+
+        # These are equivalent
+        reshape(x, (32, 32))
+        reshape(x, 32, 32)
     """
-    shape = _shape_check_impl(shape)
+    shape = _shape_check_impl(_unwrap_iterable(shape))
     return semantic.reshape(input, shape, _builder)
 
 
@@ -1087,6 +1345,7 @@ def _wrap_axis(axis, ndim):
     return axis if axis >= 0 else axis + ndim
 
 
+@_tensor_member_fn
 @builtin
 def expand_dims(input, axis, _builder=None):
     """
@@ -1201,6 +1460,7 @@ def load(pointer, mask=None, other=None, boundary_check=tuple(), padding_option=
                          volatile, _builder)
 
 
+@_tensor_member_fn
 @builtin
 def store(pointer, value, mask=None, boundary_check=(), cache_modifier="", eviction_policy="", _builder=None):
     """
@@ -1263,8 +1523,9 @@ def make_block_ptr(base: tensor, shape, strides, offsets, block_shape, order, _b
     return semantic.make_block_ptr(base, shape, strides, offsets, block_shape, order, _builder)
 
 
+@_tensor_member_fn
 @builtin
-def advance(base: tensor, offsets, _builder=None):
+def advance(base, offsets, _builder=None):
     """
     Advance a block pointer
 
@@ -1309,6 +1570,7 @@ def _add_atomic_docstr(name: str, has_cmp: bool = False) -> Callable[[T], T]:
     return _decorator
 
 
+@_tensor_member_fn
 @builtin
 @_add_atomic_docstr("compare-and-swap", has_cmp=True)
 def atomic_cas(pointer, cmp, val, sem=None, scope=None, _builder=None):
@@ -1319,6 +1581,7 @@ def atomic_cas(pointer, cmp, val, sem=None, scope=None, _builder=None):
     return semantic.atomic_cas(pointer, cmp, val, sem, scope, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_atomic_docstr("exchange")
 def atomic_xchg(pointer, val, mask=None, sem=None, scope=None, _builder=None):
@@ -1328,6 +1591,7 @@ def atomic_xchg(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     return semantic.atomic_xchg(pointer, val, mask, sem, scope, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_atomic_docstr("add")
 def atomic_add(pointer, val, mask=None, sem=None, scope=None, _builder=None):
@@ -1337,6 +1601,7 @@ def atomic_add(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     return semantic.atomic_add(pointer, val, mask, sem, scope, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_atomic_docstr("max")
 def atomic_max(pointer, val, mask=None, sem=None, scope=None, _builder=None):
@@ -1346,6 +1611,7 @@ def atomic_max(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     return semantic.atomic_max(pointer, val, mask, sem, scope, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_atomic_docstr("min")
 def atomic_min(pointer, val, mask=None, sem=None, scope=None, _builder=None):
@@ -1355,6 +1621,7 @@ def atomic_min(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     return semantic.atomic_min(pointer, val, mask, sem, scope, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_atomic_docstr("logical and")
 def atomic_and(pointer, val, mask=None, sem=None, scope=None, _builder=None):
@@ -1364,6 +1631,7 @@ def atomic_and(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     return semantic.atomic_and(pointer, val, mask, sem, scope, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_atomic_docstr("logical or")
 def atomic_or(pointer, val, mask=None, sem=None, scope=None, _builder=None):
@@ -1373,6 +1641,7 @@ def atomic_or(pointer, val, mask=None, sem=None, scope=None, _builder=None):
     return semantic.atomic_or(pointer, val, mask, sem, scope, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_atomic_docstr("logical xor")
 def atomic_xor(pointer, val, mask=None, sem=None, scope=None, _builder=None):
@@ -1536,6 +1805,7 @@ def _add_math_1arg_docstr(name: str) -> Callable[[T], T]:
     return _decorator
 
 
+@_tensor_member_fn
 @builtin
 @_add_math_1arg_docstr("exponential")
 def exp(x, _builder=None):
@@ -1543,6 +1813,7 @@ def exp(x, _builder=None):
     return semantic.exp(x, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_math_1arg_docstr("natural logarithm")
 def log(x, _builder=None):
@@ -1550,6 +1821,7 @@ def log(x, _builder=None):
     return semantic.log(x, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_math_1arg_docstr("cosine")
 def cos(x, _builder=None):
@@ -1557,6 +1829,7 @@ def cos(x, _builder=None):
     return semantic.cos(x, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_math_1arg_docstr("sine")
 def sin(x, _builder=None):
@@ -1564,6 +1837,7 @@ def sin(x, _builder=None):
     return semantic.sin(x, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_math_1arg_docstr("square root")
 def sqrt(x, _builder=None):
@@ -1571,6 +1845,7 @@ def sqrt(x, _builder=None):
     return semantic.sqrt(x, _builder)
 
 
+@_tensor_member_fn
 @builtin
 @_add_math_1arg_docstr("absolute value")
 def abs(x, _builder=None):
@@ -1612,6 +1887,7 @@ def _insertion_guard(builder):
     builder.restore_insertion_point(ip)
 
 
+@_tensor_member_fn
 @builtin
 def reduce(input, axis, combine_fn, keep_dims=False, _builder=None, _generator=None):
     """Applies the combine_fn to all elements in :code:`input` tensors along the provided :code:`axis`
@@ -1706,6 +1982,7 @@ def _add_scan_docstr(name: str, return_indices_arg: str = None, tie_break_arg: s
     return _decorator
 
 
+@_tensor_member_fn
 @builtin
 def associative_scan(input, axis, combine_fn, reverse=False, _builder=None, _generator=None):
     """Applies the combine_fn to each elements with a carry in :code:`input` tensors along the provided :code:`axis` and update the carry
@@ -1741,6 +2018,7 @@ def associative_scan(input, axis, combine_fn, reverse=False, _builder=None, _gen
     return semantic.associative_scan(input, axis, make_combine_region, reverse, _builder)
 
 
+@_tensor_member_fn
 @builtin
 def histogram(input, num_bins, _builder=None, _generator=None):
     """computes an histogram based on input tensor with num_bins bins the bins have a width of 1 and start at 0.

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -29,6 +29,7 @@ def _is_power_of_two(i: core.constexpr):
 # -----------------------
 
 
+@core._tensor_member_fn
 @jit
 def cdiv(x, div):
     """
@@ -42,12 +43,14 @@ def cdiv(x, div):
     return (x + div - 1) // div
 
 
+@core._tensor_member_fn
 @jit
 @core._add_math_1arg_docstr("sigmoid")
 def sigmoid(x):
     return 1 / (1 + core.exp(-x))
 
 
+@core._tensor_member_fn
 @jit
 @core._add_math_1arg_docstr("softmax")
 def softmax(x, ieee_rounding=False):
@@ -57,6 +60,7 @@ def softmax(x, ieee_rounding=False):
     return core.fdiv(num, den, ieee_rounding)
 
 
+@core._tensor_member_fn
 @jit
 def ravel(x):
     """
@@ -158,6 +162,7 @@ def _elementwise_max(a, b):
     return core.maximum(a, b)
 
 
+@core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("maximum", return_indices_arg="return_indices",
                             tie_break_arg="return_indices_tie_break_left")
@@ -178,6 +183,7 @@ def max(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
         return core.reduce(input, axis, _elementwise_max, keep_dims=keep_dims)
 
 
+@core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("maximum index", tie_break_arg="tie_break_left")
 def argmax(input, axis, tie_break_left=True, keep_dims=False):
@@ -215,6 +221,7 @@ def _elementwise_min(a, b):
     return core.minimum(a, b)
 
 
+@core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("minimum", return_indices_arg="return_indices",
                             tie_break_arg="return_indices_tie_break_left")
@@ -235,6 +242,7 @@ def min(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
         return core.reduce(input, axis, _elementwise_min, keep_dims=keep_dims)
 
 
+@core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("minimum index", tie_break_arg="tie_break_left")
 def argmin(input, axis, tie_break_left=True, keep_dims=False):
@@ -250,6 +258,7 @@ def _sum_combine(a, b):
 # sum
 
 
+@core._tensor_member_fn
 @jit
 @core._add_reduction_docstr("sum")
 def sum(input, axis=None, keep_dims=False):
@@ -265,6 +274,7 @@ def _xor_combine(a, b):
 # xor sum
 
 
+@core._tensor_member_fn
 @core.builtin
 @core._add_reduction_docstr("xor sum")
 def xor_sum(input, axis=None, keep_dims=False, _builder=None, _generator=None):
@@ -279,6 +289,7 @@ def xor_sum(input, axis=None, keep_dims=False, _builder=None, _generator=None):
 # cumsum
 
 
+@core._tensor_member_fn
 @jit
 @core._add_scan_docstr("cumsum")
 def cumsum(input, axis=0, reverse=False):
@@ -295,6 +306,7 @@ def _prod_combine(a, b):
     return a * b
 
 
+@core._tensor_member_fn
 @jit
 @core._add_scan_docstr("cumprod")
 def cumprod(input, axis=0, reverse=False):
@@ -351,8 +363,9 @@ def _bitonic_merge(x, stage: core.constexpr, order: core.constexpr, n_dims: core
     return x
 
 
+@core._tensor_member_fn
 @jit
-def sort(x, dim: core.constexpr = None, descending: core.constexpr = 0):
+def sort(x, dim: core.constexpr = None, descending: core.constexpr = core.constexpr(0)):
     # handle default dimension or check that it is the most minor dim
     _dim: core.constexpr = len(x.shape) - 1 if dim is None else dim
     core.static_assert(_dim == len(x.shape) - 1, "only minor dimension is currently supported")
@@ -375,6 +388,7 @@ def _get_flip_dim(dim, shape):
     return core.constexpr(dim)
 
 
+@core._tensor_member_fn
 @jit
 def flip(x, dim=None):
     """

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -620,6 +620,10 @@ class InterpretedFunction:
         signature = inspect.signature(fn)
         self.arg_names = [v.name for v in signature.parameters.values()]
 
+    @property
+    def __name__(self):
+        return self.fn.__name__
+
     def __getitem__(self, grid):
         return GridExecutor(self.fn, self.arg_names, grid)
 


### PR DESCRIPTION
<git-pr-chain>


[Frontend] Add member fns on tensor, and let us omit tuples in reshape etc.

Three QoL changes to the Triton language.

1. For most tl.foo functions which take one tensor, add a function tensor.foo
   that does the same thing.  For example, instead of `tl.permute(x, (2,1,0))`,
   you can write x.permute((2,1,0)).

2. Allow tl.trans to take a list of dimensions, making it a near-synonym for
   tl.permute.

3. For functions that take a shape or a list of dims, allow the shape/dims to
   be passed as individual args.

   This applies to tl.broadcast_to, tl.reshape, tl.permute, tl.reshape, and
   tl.trans, and to the equivalent functions on tl.tensor.

Probably the hardest thing about this was making Sphinx generate nice-looking
docs.

All three of these changes make the Triton language closer to torch and numpy.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3194 👈 **YOU ARE HERE**
1. #3204


</git-pr-chain>














