### PR TITLE
Add a fallback to the location of the ROCm linker

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -100,7 +100,13 @@ class HIPBackend(BaseBackend):
 
     @staticmethod
     def path_to_rocm_lld():
-        return "/opt/rocm/llvm/bin/ld.lld"
+        lld = Path("/opt/rocm/llvm/bin/ld.lld")
+        if lld.is_file():
+            return lld
+        lld = Path("/usr/bin/ld.lld")
+        if lld.is_file():
+            return lld
+        raise Exception("ROCm linker /opt/rocm/llvm/bin/ld.lld not found")
 
     @staticmethod
     def make_ttir(mod, metadata, opt):


### PR DESCRIPTION
On Fedora the ROCm linker is the system linker, /opt/rocm does not exist. So check if the linker exists before passing it back. Add a fallback to the sytem linker.
Raise an exception if neither are found.