### PR TITLE
Add some missing cmake dependencies

### DIFF
--- a/lib/Dialect/Triton/IR/CMakeLists.txt
+++ b/lib/Dialect/Triton/IR/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonIR
   Traits.cpp
 
   DEPENDS
+  TritonGPUAttrDefsIncGen
   TritonTableGen
 
   LINK_LIBS PUBLIC

--- a/third_party/nvidia/lib/NVGPUToLLVM/CMakeLists.txt
+++ b/third_party/nvidia/lib/NVGPUToLLVM/CMakeLists.txt
@@ -3,4 +3,6 @@ add_triton_library(NVGPUToLLVM
 
     DEPENDS
     NVGPUConversionPassIncGen
+    NVGPUIR
+    TritonNvidiaGPUIR
 )


### PR DESCRIPTION
I were having some build errors.  Looks like using parallel builds masks cmake dependencies most(?) of the time and when I turned it off I found the following missing dependencies.