### PR TITLE
Move generic utility functions from Analysis to Triton IR

### DIFF
--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -7,6 +7,7 @@
 #include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include <optional>

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -5,9 +5,6 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
-#include <algorithm>
-#include <numeric>
-#include <string>
 
 namespace mlir {
 
@@ -192,48 +189,6 @@ bool matchMmaV3AndDotOperandLayout(RankedTensorType srcTy,
 // ConvertLayoutOpHelper in the future
 bool shouldUseDistSmem(Attribute srcLayout, Attribute dstLayout);
 
-template <typename T, typename U> SmallVector<T> convertType(ArrayRef<U> in) {
-  SmallVector<T> out;
-  for (const auto &i : in)
-    out.push_back(T(i));
-  return out;
-}
-template <typename T, typename VecU>
-SmallVector<T> convertType(const VecU &in) {
-  return convertType<T>(ArrayRef(in));
-}
-
-template <typename Int> Int product(llvm::ArrayRef<Int> arr) {
-  return std::accumulate(arr.begin(), arr.end(), 1, std::multiplies{});
-}
-template <typename VecT> auto product(const VecT &vec) {
-  return product(llvm::ArrayRef(vec));
-}
-
-// TODO(jlebar): Rename to ceilOfRatio.
-template <typename Int> Int ceil(Int m, Int n) { return (m + n - 1) / n; }
-
-/// Get the highest power of 2 divisor of an integer.
-template <typename T> T highestPowOf2Divisor(T n) {
-  if (n == 0) {
-    return (static_cast<T>(1) << (sizeof(T) * 8 - 2));
-  }
-  return (n & (~(n - 1)));
-}
-
-/// Get the next power of 2 for an integer (or the integer itself if it is a
-/// power of 2).
-template <typename T> T nextPowOf2(T n) {
-  if (n == 0) {
-    return 1;
-  }
-  n--;
-  for (unsigned i = 1; i < sizeof(T) * 8; i <<= 1) {
-    n |= n >> i;
-  }
-  return n + 1;
-}
-
 /// Multi-root DAG topological sort.
 /// Performs a topological sort of the Operation in the `toSort` SetVector.
 /// Returns a topologically sorted SetVector.
@@ -393,140 +348,6 @@ std::unique_ptr<DataFlowSolver> createDataFlowSolver();
 
 triton::MakeTensorPtrOp getMakeTensorPtrOp(Value v);
 
-namespace triton {
-
-// Many functions here have two overloads, fn(ArrayRef<T>) and fn(const VecT&).
-// This is helpful because C++ won't both convert a vector to ArrayRef *and*
-// infer the proper type T in one step.  So without the second overload, we
-// would have to explicitly convert most arguments to ArrayRef at the callsite.
-
-// Better version of llvm::join.  This one works when T is an integer or any
-// other type which defines operator<<(raw_ostream).
-template <typename T> std::string join(ArrayRef<T> elems, StringRef sep) {
-  std::string ret;
-  llvm::raw_string_ostream s(ret);
-  if (elems.empty()) {
-    return ret;
-  }
-
-  s << elems[0];
-  for (int i = 1; i < elems.size(); i++) {
-    s << sep << elems[i];
-  }
-  return ret;
-}
-
-template <typename VecT> std::string join(const VecT &elems, StringRef sep) {
-  return join(ArrayRef(elems), sep);
-}
-
-template <typename T, typename U>
-SmallVector<T> applyPermutation(ArrayRef<T> vec, ArrayRef<U> permutation) {
-  static_assert(std::is_integral_v<U>);
-  assert(vec.size() == permutation.size());
-
-  // Check that `permutation` is actually a permutation.
-#ifndef NDEBUG
-  SmallVector<U> sortedPerm(permutation);
-  llvm::sort(sortedPerm);
-  for (U i = 0; i < static_cast<U>(sortedPerm.size()); i++) {
-    assert(sortedPerm[i] == i);
-  }
-#endif
-
-  SmallVector<T> ret;
-  ret.reserve(vec.size());
-  for (const U &i : permutation) {
-    ret.push_back(vec[i]);
-  }
-  return ret;
-}
-
-template <typename VecT, typename PermT>
-auto applyPermutation(const VecT &vec, const PermT &permutation) {
-  return applyPermutation(ArrayRef(vec), ArrayRef(permutation));
-}
-
-template <typename T>
-[[nodiscard]] SmallVector<T> inversePermutation(ArrayRef<T> permutation) {
-  // Check that `permutation` is actually a permutation.
-#ifndef NDEBUG
-  SmallVector<T> sortedPerm(permutation);
-  llvm::sort(sortedPerm);
-  for (int i = 0; i < sortedPerm.size(); ++i) {
-    assert(sortedPerm[i] == i);
-  }
-#endif
-
-  SmallVector<T> ret(permutation.size());
-  for (int i = 0; i < permutation.size(); ++i) {
-    ret[permutation[i]] = i;
-  }
-  return ret;
-}
-
-template <typename VecT>
-[[nodiscard]] auto inversePermutation(const VecT &permutation) {
-  return inversePermutation(ArrayRef(permutation));
-}
-
-template <typename T, typename U>
-[[nodiscard]] SmallVector<T> gather(ArrayRef<T> elems, ArrayRef<U> indices) {
-  SmallVector<T> ret;
-  ret.reserve(indices.size());
-  for (const U &i : indices) {
-    ret.push_back(elems[i]);
-  }
-  return ret;
-}
-
-template <typename VecT, typename IdxT>
-[[nodiscard]] auto gather(const VecT &elems, const IdxT &indices) {
-  return gather(ArrayRef(elems), ArrayRef(indices));
-}
-
-// Is `vec` [0, 1, ..., n]?  Returns true on empty list.
-template <typename T> bool isIota(ArrayRef<T> vec) {
-  static_assert(std::is_integral_v<T>);
-  for (T i = 0; i < vec.size(); ++i) {
-    if (vec[i] != i) {
-      return false;
-    }
-  }
-  return true;
-}
-
-template <typename VecT> bool isIota(const VecT &vec) {
-  return isIota(ArrayRef(vec));
-}
-
-// Is `vals` some permutation of the numbers 0..(vals.size()-1)?
-template <typename T> bool isPermutationOfIota(ArrayRef<T> vals) {
-  SmallVector<T> sorted(vals);
-  llvm::sort(sorted);
-  return isIota(sorted);
-}
-
-template <typename VecT> bool IsPermutationOfIota(const VecT &vec) {
-  return isPermutationOfIota(ArrayRef(vec));
-}
-
-// Is `vec` [i, i+1, ..., i+n]?  Returns true on empty list.
-template <typename T> bool isConsecutive(ArrayRef<T> vec) {
-  static_assert(std::is_integral_v<T>);
-  for (int i = 1; i < vec.size(); i++) {
-    if (vec[i] != vec[i - 1] + 1) {
-      return false;
-    }
-  }
-  return true;
-}
-
-template <typename VecT> bool isConsecutive(const VecT &vec) {
-  return isConsecutive(ArrayRef(vec));
-}
-
-} // namespace triton
 } // namespace mlir
 
 #endif // TRITON_ANALYSIS_UTILITY_H

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -6,6 +6,7 @@
 #include "triton/Analysis/Utility.h"
 #include "triton/Conversion/MLIRTypes.h"
 #include "triton/Dialect/NVGPU/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include <set>
 

--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -1,0 +1,190 @@
+#ifndef TRITON_IR_UTILITY_H_
+#define TRITON_IR_UTILITY_H_
+
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include <algorithm>
+#include <numeric>
+#include <string>
+
+namespace mlir {
+
+template <typename T, typename U> SmallVector<T> convertType(ArrayRef<U> in) {
+  SmallVector<T> out;
+  for (const auto &i : in)
+    out.push_back(T(i));
+  return out;
+}
+
+template <typename T, typename VecU>
+SmallVector<T> convertType(const VecU &in) {
+  return convertType<T>(ArrayRef(in));
+}
+
+template <typename Int> Int product(llvm::ArrayRef<Int> arr) {
+  return std::accumulate(arr.begin(), arr.end(), 1, std::multiplies{});
+}
+template <typename VecT> auto product(const VecT &vec) {
+  return product(llvm::ArrayRef(vec));
+}
+
+// TODO(jlebar): Rename to ceilOfRatio.
+template <typename Int> Int ceil(Int m, Int n) { return (m + n - 1) / n; }
+
+/// Get the highest power of 2 divisor of an integer.
+template <typename T> T highestPowOf2Divisor(T n) {
+  if (n == 0) {
+    return (static_cast<T>(1) << (sizeof(T) * 8 - 2));
+  }
+  return (n & (~(n - 1)));
+}
+
+/// Get the next power of 2 for an integer (or the integer itself if it is a
+/// power of 2).
+template <typename T> T nextPowOf2(T n) {
+  if (n == 0) {
+    return 1;
+  }
+  n--;
+  for (unsigned i = 1; i < sizeof(T) * 8; i <<= 1) {
+    n |= n >> i;
+  }
+  return n + 1;
+}
+
+namespace triton {
+
+// Many functions here have two overloads, fn(ArrayRef<T>) and fn(const VecT&).
+// This is helpful because C++ won't both convert a vector to ArrayRef *and*
+// infer the proper type T in one step.  So without the second overload, we
+// would have to explicitly convert most arguments to ArrayRef at the callsite.
+
+// Better version of llvm::join.  This one works when T is an integer or any
+// other type which defines operator<<(raw_ostream).
+template <typename T> std::string join(ArrayRef<T> elems, StringRef sep) {
+  std::string ret;
+  llvm::raw_string_ostream s(ret);
+  if (elems.empty()) {
+    return ret;
+  }
+
+  s << elems[0];
+  for (int i = 1; i < elems.size(); i++) {
+    s << sep << elems[i];
+  }
+  return ret;
+}
+
+template <typename VecT> std::string join(const VecT &elems, StringRef sep) {
+  return join(ArrayRef(elems), sep);
+}
+
+template <typename T, typename U>
+SmallVector<T> applyPermutation(ArrayRef<T> vec, ArrayRef<U> permutation) {
+  static_assert(std::is_integral_v<U>);
+  assert(vec.size() == permutation.size());
+
+  // Check that `permutation` is actually a permutation.
+#ifndef NDEBUG
+  SmallVector<U> sortedPerm(permutation);
+  llvm::sort(sortedPerm);
+  for (U i = 0; i < static_cast<U>(sortedPerm.size()); i++) {
+    assert(sortedPerm[i] == i);
+  }
+#endif
+
+  SmallVector<T> ret;
+  ret.reserve(vec.size());
+  for (const U &i : permutation) {
+    ret.push_back(vec[i]);
+  }
+  return ret;
+}
+
+template <typename VecT, typename PermT>
+auto applyPermutation(const VecT &vec, const PermT &permutation) {
+  return applyPermutation(ArrayRef(vec), ArrayRef(permutation));
+}
+
+template <typename T>
+[[nodiscard]] SmallVector<T> inversePermutation(ArrayRef<T> permutation) {
+  // Check that `permutation` is actually a permutation.
+#ifndef NDEBUG
+  SmallVector<T> sortedPerm(permutation);
+  llvm::sort(sortedPerm);
+  for (int i = 0; i < sortedPerm.size(); ++i) {
+    assert(sortedPerm[i] == i);
+  }
+#endif
+
+  SmallVector<T> ret(permutation.size());
+  for (int i = 0; i < permutation.size(); ++i) {
+    ret[permutation[i]] = i;
+  }
+  return ret;
+}
+
+template <typename VecT>
+[[nodiscard]] auto inversePermutation(const VecT &permutation) {
+  return inversePermutation(ArrayRef(permutation));
+}
+
+template <typename T, typename U>
+[[nodiscard]] SmallVector<T> gather(ArrayRef<T> elems, ArrayRef<U> indices) {
+  SmallVector<T> ret;
+  ret.reserve(indices.size());
+  for (const U &i : indices) {
+    ret.push_back(elems[i]);
+  }
+  return ret;
+}
+
+template <typename VecT, typename IdxT>
+[[nodiscard]] auto gather(const VecT &elems, const IdxT &indices) {
+  return gather(ArrayRef(elems), ArrayRef(indices));
+}
+
+// Is `vec` [0, 1, ..., n]?  Returns true on empty list.
+template <typename T> bool isIota(ArrayRef<T> vec) {
+  static_assert(std::is_integral_v<T>);
+  for (T i = 0; i < vec.size(); ++i) {
+    if (vec[i] != i) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename VecT> bool isIota(const VecT &vec) {
+  return isIota(ArrayRef(vec));
+}
+
+// Is `vals` some permutation of the numbers 0..(vals.size()-1)?
+template <typename T> bool isPermutationOfIota(ArrayRef<T> vals) {
+  SmallVector<T> sorted(vals);
+  llvm::sort(sorted);
+  return isIota(sorted);
+}
+
+template <typename VecT> bool IsPermutationOfIota(const VecT &vec) {
+  return isPermutationOfIota(ArrayRef(vec));
+}
+
+// Is `vec` [i, i+1, ..., i+n]?  Returns true on empty list.
+template <typename T> bool isConsecutive(ArrayRef<T> vec) {
+  static_assert(std::is_integral_v<T>);
+  for (int i = 1; i < vec.size(); i++) {
+    if (vec[i] != vec[i - 1] + 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename VecT> bool isConsecutive(const VecT &vec) {
+  return isConsecutive(ArrayRef(vec));
+}
+
+} // namespace triton
+} // namespace mlir
+
+#endif

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -4,6 +4,7 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "triton/Analysis/Alias.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "llvm/ADT/SmallVector.h"
 

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -7,6 +7,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/Matchers.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/Sys/GetEnv.hpp"

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
 #include "llvm/ADT/APSInt.h"

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -4,9 +4,9 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
 
 namespace mlir {
@@ -153,7 +153,6 @@ void StoreOp::print(OpAsmPrinter &printer) {
 
 // enum attribute definitions
 #include "triton/Dialect/Triton/IR/OpsEnums.cpp.inc"
-#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 namespace mlir {
 namespace triton {

--- a/lib/Dialect/Triton/IR/Traits.cpp
+++ b/lib/Dialect/Triton/IR/Traits.cpp
@@ -3,8 +3,8 @@
 #include <numeric>
 
 #include "mlir/IR/TypeUtilities.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 using namespace mlir;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -5,6 +5,7 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.cpp.inc"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Tools/Sys/GetEnv.hpp"

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -1,6 +1,6 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "triton/Analysis/AxisInfo.h"
-#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -6,7 +6,7 @@
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Analysis/AxisInfo.h"
-#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -4,8 +4,8 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Analysis/AxisInfo.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -16,9 +16,9 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Analysis/Allocation.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -3,7 +3,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include <gtest/gtest.h>
 
 namespace mlir {

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -1,6 +1,6 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "mlir/AsmParser/AsmParser.h"
-#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/Triton/IR/Utility.h"
 #include <algorithm>
 #include <gtest/gtest.h>
 #include <random>


### PR DESCRIPTION
This is done to reduce the dependency from Triton IR to TritonGPUAttrDefsIncGen.

This was discussed in https://github.com/openai/triton/pull/3200. I moved more than was strictly needed to drop the `#include triton/Analysis/Utility.h` from Trition IR since I thought the original file had a pretty clear divide between generic functions and ones that require touching Triton's own classes.