### PR TITLE
[AMD] Enable AMD backend CI

### DIFF
--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -15,7 +15,7 @@ jobs:
         id: set-matrix
         run: |
           if [ x"${{ github.repository }}" == x"openai/triton" ]; then
-            echo '::set-output name=matrix-optional::[["self-hosted", "rocm"], ["self-hosted", "arc770"]]'
+            echo '::set-output name=matrix-optional::[["self-hosted", "gfx90a"], ["self-hosted", "arc770"]]'
           else
             echo '::set-output name=matrix-optional::["ubuntu-latest"]'
           fi
@@ -64,7 +64,7 @@ jobs:
 
     strategy:
       matrix:
-        runner: ["rocm"]
+        runner: ["gfx90a"]
 
     container:
       image: rocm/pytorch:rocm5.7_ubuntu22.04_py3.10_pytorch_2.0.1

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -15,7 +15,7 @@ jobs:
         id: set-matrix
         run: |
           if [ x"${{ github.repository }}" == x"openai/triton" ]; then
-            echo '::set-output name=matrix-optional::[["self-hosted", "gfx908"], ["self-hosted", "arc770"]]'
+            echo '::set-output name=matrix-optional::[["self-hosted", "rocm"], ["self-hosted", "arc770"]]'
           else
             echo '::set-output name=matrix-optional::["ubuntu-latest"]'
           fi
@@ -64,7 +64,11 @@ jobs:
 
     strategy:
       matrix:
-        runner: ["gfx908"]
+        runner: ["rocm"]
+
+    container:
+      image: rocm/pytorch:rocm5.7_ubuntu22.04_py3.10_pytorch_2.0.1
+      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --user root
 
     steps:
       - name: Checkout PR
@@ -92,26 +96,21 @@ jobs:
         run: |
           echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
 
-      - name: Install Dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install ninja wheel pytest pytest-xdist numpy lit autopep8 flake8 isort
-          python3 -m pip install scipy>=1.7.1
-          python3 -m pip install cmake==3.24
-          python3 -m pip install torch==1.13.1 --index-url https://download.pytorch.org/whl/rocm5.2 # important for detecting ROCM!
-
       - name: Check pre-commit
         run: |
           python3 -m pip install --upgrade pre-commit
+          git config --global --add safe.directory /__w/triton/triton
           python3 -m pre_commit run --all-files --verbose
 
       - name: Install Triton on ROCM
         run: |
+          pip uninstall -y triton
           cd python
-          python3 -m pip install .
+          pip install -e .
       - name: Run python tests on ROCM
         run: |
-          python3 -m pytest -n 32 --capture=tee-sys -rfs --verbose "python/test/unit/language/test_core.py" -k "not test_flip"
+          cd python
+          pytest --capture=tee-sys -rfs -v ./test/unit/language/test_core.py
 
   Integration-Tests-Intel:
     needs: Runner-Preparation

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -358,8 +358,6 @@ def _mod_operation_ill_conditioned(dtype_x, dtype_y) -> bool:
 ])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_bin_op(dtype_x, dtype_y, op, num_ctas, device):
-    if is_hip() and op == '%':
-        pytest.skip("TODO some tests for % has compilation error on HIP")
     expr = f' x {op} y'
     if op == '%' and dtype_x in int_dtypes + uint_dtypes and dtype_y in int_dtypes + uint_dtypes:
         # LLVM has 'numpy.fmod', not 'numpy.remainder', semantics on integer remainders.
@@ -1336,9 +1334,7 @@ def test_atomic_cas(sem, num_ctas, device):
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_tensor_atomic_cas(sem, num_ctas, device):
     if is_hip():
-        pytest.skip(
-            'test_tensor_atomic_cas for HIP currently broken in https://github.com/openai/triton. Use https://github.com/ROCmSoftwarePlatform/triton'
-        )
+        pytest.skip('TODO test_tensor_atomic_cas for HIP currently broken')
 
     @triton.jit
     def change_value(X, BLOCK_SIZE: tl.constexpr):
@@ -1982,8 +1978,8 @@ def roll(a1, b1_last, b1_cur, a2, b2_last, b2_cur):
 def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
     check_type_supported(dtype_str, device)
 
-    if is_hip():
-        pytest.skip("TODO some tests fail on HIP due to https://github.com/openai/triton/pull/3177")
+    if is_hip() and reverse:
+        pytest.skip("TODO reverse scan (added in https://github.com/openai/triton/pull/3177) not support on HIP")
 
     # triton kernel
     @triton.jit
@@ -2113,16 +2109,16 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
 
 
 scan_layouts = [
-    BlockedLayout([1, 4], [4, 8], [4, 1], [0, 1], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([1, 4], [8, 4], [4, 1], [0, 1], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([4, 1], [4, 8], [1, 4], [0, 1], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([2, 2], [4, 8], [2, 2], [0, 1], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([2, 2], [8, 4], [2, 2], [0, 1], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([1, 4], [4, 8], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([1, 4], [8, 4], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([4, 1], [4, 8], [1, 4], [1, 0], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([2, 2], [4, 8], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([2, 2], [8, 4], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [4, THREADS_PER_WARP // 4], [4, 1], [0, 1], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [8, THREADS_PER_WARP // 8], [4, 1], [0, 1], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([4, 1], [4, THREADS_PER_WARP // 4], [1, 4], [0, 1], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([2, 2], [4, THREADS_PER_WARP // 4], [2, 2], [0, 1], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([2, 2], [8, THREADS_PER_WARP // 8], [2, 2], [0, 1], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [4, THREADS_PER_WARP // 4], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [8, THREADS_PER_WARP // 8], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([4, 1], [4, THREADS_PER_WARP // 4], [1, 4], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([2, 2], [4, THREADS_PER_WARP // 4], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([2, 2], [8, THREADS_PER_WARP // 8], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
 ]
 
 # ---------------
@@ -2159,9 +2155,7 @@ def test_histogram(M, N, device):
 @pytest.mark.parametrize("num_pid_n", [2, 4])
 def test_locality(op, BLOCK_N, N, num_pid_n, device):
     if is_hip():
-        pytest.skip(
-            'test_locality for HIP currently broken in https://github.com/openai/triton. Use https://github.com/ROCmSoftwarePlatform/triton'
-        )
+        pytest.skip('TODO test_locality is WIP on HIP')
 
     @triton.jit
     def kernel(X, Y, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
@@ -2209,12 +2203,10 @@ def test_locality(op, BLOCK_N, N, num_pid_n, device):
 @pytest.mark.parametrize("src_layout", scan_layouts)
 @pytest.mark.parametrize("axis", [0, 1])
 def test_scan_layouts(M, N, src_layout, axis, device):
-    if is_hip():
-        pytest.skip("test_scan_layouts is not supported in HIP")
 
     ir = f"""
     #blocked = {src_layout}
-    module attributes {{"triton_gpu.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = 32 : i32}} {{
+    module attributes {{"triton_gpu.num-warps" = 4 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.threads-per-warp" = {THREADS_PER_WARP} : i32}} {{
     tt.func public @kernel_0d1d(%arg0: !tt.ptr<i32, 1> {{tt.divisibility = 16 : i32}}, %arg1: !tt.ptr<i32, 1> {{tt.divisibility = 16 : i32}}) {{
       %cst = arith.constant dense<{N}> : tensor<{M}x1xi32, #blocked>
       %0 = tt.make_range {{end = {M} : i32, start = 0 : i32}} : tensor<{M}xi32, #triton_gpu.slice<{{dim = 1, parent = #blocked}}>>
@@ -2283,7 +2275,7 @@ layouts = [
 @pytest.mark.parametrize("reduce_op", ["sum", "max"])
 def test_reduce_layouts(M, N, src_layout, axis, reduce2d, dtype_str, reduce_op, device):
     if is_hip():
-        pytest.skip("test_reduce_layouts is not supported in HIP")
+        pytest.skip("TODO test_reduce_layouts is not supported in HIP")
     if reduce_op == "sum" and dtype_str == "float16" and M * N > 1024:
         pytest.skip("Skipping sum reduction on float16 due to accuracy issues")
 
@@ -2367,8 +2359,8 @@ def test_reduce_layouts(M, N, src_layout, axis, reduce2d, dtype_str, reduce_op, 
 
 
 layouts = [
-    BlockedLayout([1, 4], [1, 32], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([1, 4], [1, 32], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [1, THREADS_PER_WARP], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [1, THREADS_PER_WARP], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
     MmaLayout(version=(2, 0), warps_per_cta=[4, 1], ctas_per_cga=[1, 1], cta_split_num=[1, 1], cta_order=[0, 1],
               instr_shape=[16, 8])
 ]
@@ -2377,8 +2369,6 @@ layouts = [
 @pytest.mark.parametrize("M", [32, 64, 128, 256])
 @pytest.mark.parametrize("src_layout", layouts)
 def test_store_op(M, src_layout, device):
-    if is_hip():
-        pytest.skip("test_store_op is not supported yet in HIP")
 
     ir = f"""
     #src = {src_layout}
@@ -2494,7 +2484,7 @@ layouts = [
 @pytest.mark.parametrize("first_axis", [0, 1])
 def test_chain_reduce(M, N, src_layout, op, device, first_axis):
     if is_hip():
-        pytest.skip("test_chain_reduce is not supported in HIP")
+        pytest.skip("TODO test_chain_reduce is WIP on HIP")
 
     op_str = ""
     if op == "sum":
@@ -2596,8 +2586,8 @@ def test_generic_reduction(device):
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_permute(dtype_str, shape, perm, num_ctas, device):
     check_type_supported(dtype_str, device)  # bfloat16 on cc < 80 will not be tested
-    if is_hip():
-        pytest.skip("test_permute is not supported in HIP")
+    if is_hip() and shape == (128, 128) and dtype_str == 'float32':
+        pytest.skip("TODO Out of LDS for float32 with shape 128x128")
 
     # triton kernel
     @triton.jit
@@ -2922,7 +2912,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
                                                          ('float16', 'float32'), ('float32', 'float32')])
 def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
     if is_hip():
-        pytest.skip('test_dot3d not supported on HIP.')
+        pytest.skip('TODO test_dot3d not supported on HIP.')
 
     @triton.jit
     def kernel(
@@ -3170,7 +3160,7 @@ def test_dot_without_load(dtype_str, device):
         allow_tf32 = True
 
     if is_hip() and dtype_str == "float16":
-        pytest.skip("test_dot_without_load[float16] not supported in HIP")
+        pytest.skip("TODO test_dot_without_load[float16] not supported in HIP")
 
     @triton.jit
     def _kernel(out, ALLOW_TF32: tl.constexpr):
@@ -3259,8 +3249,6 @@ def test_masked_load(dtype_str, size, size_diff, num_ctas, device):
 # FIXME: Shape too small for ldmatrix when num_ctas=4
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16, torch.float32])
 def test_masked_load_shared_memory(dtype, device):
-    if is_hip():
-        pytest.skip("test_masked_load_shared_memory is not supported in HIP")
 
     check_type_supported(dtype, device)  # bfloat16 on cc < 80 will not be tested
 


### PR DESCRIPTION
This PR enables AMD backend CI, specifically
- The self-hosted node is MI210 (gfx90a)
- The runner brings up a docker on the server and run tests
- Add "TODO" to tests that are WIP
- Fixed some tests related to warpSize and layout