### PR TITLE
[OPTIMIZER] Allow rematerializing through scf.if ops

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -123,8 +123,17 @@ bool canFoldIntoConversion(Operation *op, Attribute targetEncoding);
 
 // Replace ForOp with a new ForOp with extra operands. The YieldOp is not
 // updated and needs to be updated separately for the loop to be correct.
-scf::ForOp replaceForOpWithNewSignature(OpBuilder &rewriter, scf::ForOp loop,
+scf::ForOp replaceForOpWithNewSignature(
+    RewriterBase &rewriter, scf::ForOp loop, ValueRange newIterOperands,
+    SmallVectorImpl<std::tuple<Value, Value>> &replacements);
+scf::ForOp replaceForOpWithNewSignature(RewriterBase &rewriter, scf::ForOp loop,
                                         ValueRange newIterOperands);
+
+// Replace IfOp with a new IfOp with extra results operands. The YieldOp is not
+// updated and needs to be updated separately for the bodies to be correct.
+scf::IfOp replaceIfOpWithNewSignature(
+    RewriterBase &rewriter, scf::IfOp loop, TypeRange newResultTypes,
+    SmallVectorImpl<std::tuple<Value, Value>> &replacements);
 
 Operation *cloneWithInferType(mlir::OpBuilder &rewriter, Operation *op,
                               IRMapping &mapping);

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -148,8 +148,9 @@ class TritonGPUOptimizeThreadLocalityPass
       reduceOps.insert(reduce);
     });
 
+    IRRewriter builder(&getContext());
     for (auto reduce : reduceOps) {
-      OpBuilder builder(reduce);
+      builder.setInsertionPoint(reduce);
       auto srcType = reduce.getOperands()[0].getType().cast<RankedTensorType>();
       auto srcShape = srcType.getShape();
       auto srcEncoding = srcType.getEncoding();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -438,7 +438,9 @@ createAsynOps(scf::ForOp &forOp,
     }
   }
 
-  OpBuilder builder(forOp);
+  IRRewriter builder(forOp.getContext());
+  builder.setInsertionPoint(forOp);
+
   Location loc = forOp.getLoc();
   // Create two new counters to index into the allocs.
   Value minusOne = builder.create<arith::ConstantIntOp>(loc, -1, 32);

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -724,7 +724,7 @@ bool canBeRemat(Operation *op) {
   if (isa<tensor::ExtractSliceOp, AllocTensorOp, InsertSliceAsyncOp,
           AtomicRMWOp, AtomicCASOp, DotOp>(op))
     return false;
-  if (isa<scf::IfOp, scf::WhileOp, scf::ConditionOp>(op))
+  if (isa<scf::WhileOp, scf::ConditionOp>(op))
     return false;
 
   return true;
@@ -736,6 +736,10 @@ void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
   for (Value v : slice) {
     if (v.getDefiningOp()) {
       opsToRewrite.insert(v.getDefiningOp());
+      if (auto ifOp = v.getDefiningOp<scf::IfOp>()) {
+        opsToRewrite.insert(ifOp.thenYield().getOperation());
+        opsToRewrite.insert(ifOp.elseYield().getOperation());
+      }
     } else {
       opsToRewrite.insert(v.cast<BlockArgument>().getOwner()->getParentOp());
       // We also need to rewrite the yield op.
@@ -744,8 +748,12 @@ void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
   }
   opsToRewrite = multiRootTopologicalSort(opsToRewrite);
 
-  SmallVector<Operation *> deadLoops;
-  OpBuilder builder(slice.begin()->getContext());
+  // replaceAllUsesWith calls delayed until after initial rewrite.
+  // This is required for slice.count(value) to work mid rewrite.
+  SmallVector<std::tuple<Value, Value>> replacements;
+
+  SmallVector<Operation *> deadOps;
+  IRRewriter builder(slice.begin()->getContext());
   for (Operation *op : opsToRewrite) {
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       // Keep a mapping of the operands index to the new operands index.
@@ -761,16 +769,43 @@ void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
         }
       }
       // Create a new for loop with the new operands.
-      scf::ForOp newForOp =
-          replaceForOpWithNewSignature(builder, forOp, newOperands);
-      deadLoops.push_back(forOp.getOperation());
+      scf::ForOp newForOp = replaceForOpWithNewSignature(
+          builder, forOp, newOperands, replacements);
+      deadOps.push_back(forOp.getOperation());
       Block &loopBody = *newForOp.getBody();
       for (auto m : argMapping) {
-        mapping.map(newForOp.getResult(m.first), newForOp.getResult(m.second));
+        mapping.map(forOp.getResult(m.first), newForOp.getResult(m.second));
         int numIndVars = newForOp.getNumInductionVars();
         mapping.map(loopBody.getArgument(m.first + numIndVars),
                     loopBody.getArgument(m.second + numIndVars));
       }
+      continue;
+    }
+    if (auto ifOp = dyn_cast<scf::IfOp>(op)) {
+      SmallVector<Type> newTypes;
+      for (auto res : ifOp.getResults()) {
+        if (slice.count(res)) {
+          auto it = layout.find(res);
+          assert(it != layout.end());
+
+          auto oldType = res.getType().cast<RankedTensorType>();
+          auto newType = RankedTensorType::get(
+              oldType.getShape(), oldType.getElementType(), it->second);
+          newTypes.push_back(newType);
+        }
+      }
+      scf::IfOp newIfOp =
+          replaceIfOpWithNewSignature(builder, ifOp, newTypes, replacements);
+      unsigned oldIdx = 0;
+      unsigned newIdx = ifOp.getNumResults();
+      for (auto res : ifOp.getResults()) {
+        if (slice.count(res)) {
+          mapping.map(ifOp.getResult(oldIdx), newIfOp.getResult(newIdx));
+          ++newIdx;
+        }
+        ++oldIdx;
+      }
+      deadOps.push_back(ifOp.getOperation());
       continue;
     }
     builder.setInsertionPoint(op);
@@ -809,7 +844,12 @@ void rewriteSlice(SetVector<Value> &slice, DenseMap<Value, Attribute> &layout,
   }
   convertOp.replaceAllUsesWith(mapping.lookup(convertOp.getSrc()));
   convertOp.erase();
-  for (Operation *op : deadLoops)
+
+  for (auto &kv : replacements) {
+    builder.replaceAllUsesWith(std::get<0>(kv), std::get<1>(kv));
+  }
+
+  for (Operation *op : deadOps)
     op->erase();
 }
 
@@ -1033,6 +1073,7 @@ public:
     RewritePatternSet cleanUpPatterns2(context);
     populateForOpDeadArgumentElimination(cleanUpPatterns2);
     scf::ForOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
+    scf::IfOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
     ConvertLayoutOp::getCanonicalizationPatterns(cleanUpPatterns2, context);
     if (applyPatternsAndFoldGreedily(m, std::move(cleanUpPatterns2)).failed()) {
       signalPassFailure();

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -673,12 +673,7 @@ getConvertBackwardSlice(Value root, SetVector<Value> &slice,
 
     if (auto ifOp = currentValue.getDefiningOp<scf::IfOp>()) {
       auto results = ifOp.getResults();
-      unsigned argIdx = 0;
-      for (; argIdx != results.size(); ++argIdx) {
-        if (results[argIdx] == currentValue) {
-          break;
-        }
-      }
+      unsigned argIdx = currentValue.cast<OpResult>().getResultNumber();
 
       auto thenValue = ifOp.thenYield().getOperand(argIdx);
       auto elseValue = ifOp.elseYield().getOperand(argIdx);

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -553,8 +553,9 @@ bool canFoldIntoConversion(Operation *op, Attribute targetEncoding) {
              triton::MakeRangeOp, triton::SplatOp, triton::HistogramOp>(op);
 }
 
-scf::ForOp replaceForOpWithNewSignature(OpBuilder &rewriter, scf::ForOp loop,
-                                        ValueRange newIterOperands) {
+scf::ForOp replaceForOpWithNewSignature(
+    RewriterBase &rewriter, scf::ForOp loop, ValueRange newIterOperands,
+    SmallVectorImpl<std::tuple<Value, Value>> &replacements) {
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(loop);
 
@@ -573,8 +574,43 @@ scf::ForOp replaceForOpWithNewSignature(OpBuilder &rewriter, scf::ForOp loop,
 
   for (auto it : llvm::zip(loop.getResults(), newLoop.getResults().take_front(
                                                   loop.getNumResults())))
-    std::get<0>(it).replaceAllUsesWith(std::get<1>(it));
+    replacements.push_back(it);
   return newLoop;
+}
+
+scf::ForOp replaceForOpWithNewSignature(RewriterBase &rewriter, scf::ForOp loop,
+                                        ValueRange newIterOperands) {
+  SmallVector<std::tuple<Value, Value>> replacements;
+  auto newForOp = replaceForOpWithNewSignature(rewriter, loop, newIterOperands,
+                                               replacements);
+  for (auto &kv : replacements) {
+    rewriter.replaceAllUsesWith(std::get<0>(kv), std::get<1>(kv));
+  }
+  return newForOp;
+}
+
+scf::IfOp replaceIfOpWithNewSignature(
+    RewriterBase &rewriter, scf::IfOp ifOp, TypeRange newResultTypes,
+    SmallVectorImpl<std::tuple<Value, Value>> &replacements) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(ifOp);
+
+  // Create a new loop before the existing one, with the extra operands.
+  auto resultTypes = llvm::to_vector<4>(ifOp.getResults().getTypes());
+  resultTypes.append(newResultTypes.begin(), newResultTypes.end());
+  scf::IfOp newIf = rewriter.create<scf::IfOp>(
+      ifOp.getLoc(), resultTypes, ifOp.getCondition(), /*withElse=*/true);
+  newIf->setAttrs(ifOp->getAttrs());
+
+  rewriter.inlineBlockBefore(ifOp.thenBlock(), newIf.thenBlock(),
+                             newIf.thenBlock()->begin());
+  rewriter.inlineBlockBefore(ifOp.elseBlock(), newIf.elseBlock(),
+                             newIf.elseBlock()->begin());
+
+  for (auto it : llvm::zip(ifOp.getResults(),
+                           newIf.getResults().take_front(ifOp.getNumResults())))
+    replacements.push_back(it);
+  return newIf;
 }
 
 Operation *cloneWithInferType(mlir::OpBuilder &rewriter, Operation *op,
@@ -634,6 +670,24 @@ getConvertBackwardSlice(Value root, SetVector<Value> &slice,
         return failure();
     }
     layout[currentValue] = encoding;
+
+    if (auto ifOp = currentValue.getDefiningOp<scf::IfOp>()) {
+      auto results = ifOp.getResults();
+      unsigned argIdx = 0;
+      for (; argIdx != results.size(); ++argIdx) {
+        if (results[argIdx] == currentValue) {
+          break;
+        }
+      }
+
+      auto thenValue = ifOp.thenYield().getOperand(argIdx);
+      auto elseValue = ifOp.elseYield().getOperand(argIdx);
+
+      queue.push_back({thenValue, encoding});
+      queue.push_back({elseValue, encoding});
+
+      continue;
+    }
     if (auto *definingOp = currentValue.getDefiningOp()) {
       // If the op has multiple results we need to update all results layout.
       for (Value result : definingOp->getResults()) {

--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -363,7 +363,7 @@ tt.func @loop_if(%arg0: !tt.ptr<f32>, %arg1: i32, %arg2: !tt.ptr<f32>, %arg3: i3
   %9 = triton_gpu.convert_layout %8 : tensor<64x64xi32, #blocked2> -> tensor<64x64xi32, #blocked1>
   %10 = tt.addptr %7, %9 : tensor<64x64x!tt.ptr<f32>, #blocked1>, tensor<64x64xi32, #blocked1>
   %11:2 = scf.for %arg5 = %c0 to %c32 step %c1 iter_args(%arg6 = %cst_1, %arg7 = %10) -> (tensor<64x64xf32, #blocked1>, tensor<64x64x!tt.ptr<f32>, #blocked1>) {
-    %33 = arith.cmpi "sgt", %i0, %i0 : i32
+    %33 = arith.cmpi "sgt", %arg5, %c0 : index
     %34 = scf.if %33 -> (tensor<64x64xf32, #blocked1>) {
       %23 = triton_gpu.convert_layout %arg7 : tensor<64x64x!tt.ptr<f32>, #blocked1> -> tensor<64x64x!tt.ptr<f32>, #blocked3>
       %24 = triton_gpu.convert_layout %cst : tensor<64x64xi1, #blocked1> -> tensor<64x64xi1, #blocked3>
@@ -2168,5 +2168,74 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
     }
     tt.store %arg1, %2 {cache = 1 : i32, evict = 1 : i32} : tensor<1024x4xi32, #blocked1>
     tt.return
+  }
+}
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @rematerialize_through_if
+  tt.func public @rematerialize_through_if(%arg0: i1, %arg1: f32) -> tensor<32xf32, #blocked> {
+    // CHECK: arith.constant {{.*}} : tensor<32xf32, #blocked>
+    // CHECK: arith.constant {{.*}} : tensor<32xf32, #blocked>
+    // CHECK: scf.if %arg0 -> (tensor<32xf32, #blocked>) {
+    // CHECK-NOT: triton_gpu.convert_layout
+    %cst = arith.constant dense<1.000000e+00> : tensor<32xf32, #blocked1>
+    %cst_0 = arith.constant dense<2.000000e+00> : tensor<32xf32, #blocked1>
+    %0 = tt.splat %arg1 : f32 -> tensor<32xf32, #blocked1>
+    %3 = scf.if %arg0 -> (tensor<32xf32, #blocked1>) {
+      %1 = arith.addf %cst, %0 : tensor<32xf32, #blocked1>
+      scf.yield %1 : tensor<32xf32, #blocked1>
+    } else {
+      %2 = arith.addf %cst_0, %0 : tensor<32xf32, #blocked1>
+      scf.yield %2 : tensor<32xf32, #blocked1>
+    }
+    %4 = triton_gpu.convert_layout %3 : tensor<32xf32, #blocked1> -> tensor<32xf32, #blocked>
+    tt.return %4 : tensor<32xf32, #blocked>
+  }
+}
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: @rematerialize_if_inside_loop
+  tt.func public @rematerialize_if_inside_loop() -> (tensor<32xf32, #blocked>, tensor<32xf32, #blocked>) {
+    // CHECK: arith.constant {{.*}} : tensor<32xf32, #blocked>
+    // CHECK: arith.constant {{.*}} : tensor<32xf32, #blocked>
+    // CHECK-NOT: triton_gpu.convert_layout
+    // CHECK: %[[for:[0-9]*]]:3 = scf.for {{.*}} -> (tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>, tensor<32xf32, #blocked>)
+
+    // CHECK-NOT: triton_gpu.convert_layout
+    // CHECK: scf.if %{{.*}} -> (tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>, tensor<32xf32, #blocked>)
+    // CHECK-NOT: triton_gpu.convert_layout
+    // CHECK: scf.yield {{.*}} : tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>, tensor<32xf32, #blocked>
+    // CHECK: scf.yield {{.*}} : tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>, tensor<32xf32, #blocked>
+    // TODO: This should be rematerialized as %1#2
+    // CHECK: triton_gpu.convert_layout %[[for]]#0
+    %cst = arith.constant dense<1.000000e+00> : tensor<32xf32, #blocked1>
+    %cst_0 = arith.constant dense<2.000000e+00> : tensor<32xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c4096_i32 = arith.constant 4096 : i32
+    %1:2 = scf.for %arg0 = %c0_i32 to %c4096_i32 step %c32_i32 iter_args(%arg1 = %cst, %arg3 = %cst_0) -> (tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>) : i32 {
+      %2 = arith.cmpi eq, %arg0, %c0_i32 : i32
+      %3:2 = scf.if %2 -> (tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>) {
+        scf.yield %cst, %cst_0 : tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>
+      } else {
+        %4 = arith.addf %arg1, %cst : tensor<32xf32, #blocked1>
+        %5 = triton_gpu.convert_layout %4 : tensor<32xf32, #blocked1> -> tensor<32xf32, #blocked>
+        %6 = arith.mulf %arg3, %5 : tensor<32xf32, #blocked>
+        scf.yield %4, %6 : tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>
+      }
+      scf.yield %3#0, %3#1 : tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>
+    }
+    %7 = triton_gpu.convert_layout %1#0 : tensor<32xf32, #blocked1> -> tensor<32xf32, #blocked>
+    tt.return %7, %1#1 : tensor<32xf32, #blocked>, tensor<32xf32, #blocked>
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
@@ -776,7 +776,7 @@ static void rewriteSlice(SetVector<Value> &slice,
   opsToRewrite = multiRootTopologicalSort(opsToRewrite);
 
   SmallVector<Operation *> deadLoops;
-  OpBuilder builder(slice.begin()->getContext());
+  IRRewriter builder(slice.begin()->getContext());
   for (Operation *op : opsToRewrite) {
     if (auto forOp = dyn_cast<scf::ForOp>(op)) {
       // Keep a mapping of the operands index to the new operands index.


### PR DESCRIPTION
This allows the remove layout conversion pass to rematerialize values through an `scf.if` block. This is done by adding new return types to the if block and letting the `IfOp` canonicalization patterns remove any resulting dead code. 

Testing this also uncovered a quirk in the `ForOp` rematerialization process. It calls `replaceForOpWithNewSignature` which eagerly replaces all users of the pre-exiting for-loop. However, we can get the case like:

```mlir
%1 = scf.for ... {
    %2 = scf.for ... {
        scf.yield ...
    }
    scf.yield %2
}
```

The inner for loop `%2` is rewritten before the outer yield, so when `rewriteSlice` checks `slice.count(operand)` it can never match because the operand has been updated to the new loop, but the slice still has the old loop result.

I fix this by delaying the `replaceAllUsersWith` call until the very end of `rewriteSlice`. This also allows mixtures of `scf.for` and `scf.if` to be nested.