### PR TITLE
fix: correctly fallback to setuptools

### DIFF
--- a/python/test/backend/test_device_backend.py
+++ b/python/test/backend/test_device_backend.py
@@ -1,3 +1,4 @@
+import contextlib
 import functools
 import hashlib
 import importlib
@@ -43,9 +44,10 @@ def build_for_backend(name, src, srcdir):
         scheme = 'posix_prefix'
     py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
 
-    ret = subprocess.check_call([cc, src, f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", "-o", so])
-    if ret == 0:
-        return so
+    with contextlib.suppress(subprocess.CalledProcessError):
+        ret = subprocess.check_call([cc, src, f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", "-o", so])
+        if ret == 0:
+            return so
     # fallback on setuptools
     extra_compile_args = []
     library_dirs = []

--- a/python/test/backend/test_device_backend.py
+++ b/python/test/backend/test_device_backend.py
@@ -1,4 +1,3 @@
-import contextlib
 import functools
 import hashlib
 import importlib
@@ -44,10 +43,9 @@ def build_for_backend(name, src, srcdir):
         scheme = 'posix_prefix'
     py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
 
-    with contextlib.suppress(subprocess.CalledProcessError):
-        ret = subprocess.check_call([cc, src, f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", "-o", so])
-        if ret == 0:
-            return so
+    ret = subprocess.run([cc, src, f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", "-o", so])
+    if ret == 0:
+        return so
     # fallback on setuptools
     extra_compile_args = []
     library_dirs = []

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -45,9 +45,10 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
     cc_cmd += [f'-l{lib}' for lib in libraries]
     cc_cmd += [f"-L{dir}" for dir in library_dirs]
     cc_cmd += [f"-I{dir}" for dir in include_dirs]
-    ret = subprocess.check_call(cc_cmd)
-    if ret == 0:
-        return so
+    with contextlib.suppress(subprocess.CalledProcessError):
+        ret = subprocess.check_call(cc_cmd)
+        if ret == 0:
+            return so
     # fallback on setuptools
     extra_compile_args = []
     # extra arguments

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -45,10 +45,9 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
     cc_cmd += [f'-l{lib}' for lib in libraries]
     cc_cmd += [f"-L{dir}" for dir in library_dirs]
     cc_cmd += [f"-I{dir}" for dir in include_dirs]
-    with contextlib.suppress(subprocess.CalledProcessError):
-        ret = subprocess.check_call(cc_cmd)
-        if ret == 0:
-            return so
+    ret = subprocess.run(cc_cmd)
+    if ret == 0:
+        return so
     # fallback on setuptools
     extra_compile_args = []
     # extra arguments


### PR DESCRIPTION
subprocess.check_call throws on failure instead of returning non-zero.

This fallback is required in conda environments, since `CFLAGS` is how the system headers are setup (eg, `CFLAGS=... -I $CONDA_PREFIX/include`). In particular, python <3.9 has a `#include <crypt.h>` line in `Python.h`: https://github.com/python/cpython/commit/9626ac8b7421aa5fc04a30359521d24f40105141

An alternative is to respect CFLAGS in the build for the setuptools avoidance.