### PR TITLE
Adding FMA to triton math

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -129,7 +129,8 @@ void populateMathPatternsAndLegality(TritonGPUTypeConverter &typeConverter,
                GenericOpPattern<math::SinOp>, GenericOpPattern<math::LogOp>,
                GenericOpPattern<math::Log2Op>, GenericOpPattern<math::ErfOp>,
                GenericOpPattern<math::AbsFOp>, GenericOpPattern<math::AbsIOp>,
-               GenericOpPattern<math::SqrtOp>>(typeConverter, context);
+               GenericOpPattern<math::SqrtOp>, GenericOpPattern<math::FmaOp>>(
+      typeConverter, context);
 }
 
 //

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -930,6 +930,10 @@ void init_triton_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
              return Value(self.create<arith::SubIOp>(lhs, rhs));
            })
+      .def("create_fma",
+           [](TritonOpBuilder &self, Value &a, Value &b, Value &c) -> Value {
+             return Value(self.create<math::FmaOp>(a, b, c));
+           })
       .def("create_shl",
            [](TritonOpBuilder &self, Value &lhs, Value &rhs) -> Value {
              return Value(self.create<arith::ShLIOp>(lhs, rhs));

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -99,7 +99,7 @@ from .core import (
     void,
     where,
 )
-from .math import (umulhi, exp, exp2, log, log2, cos, sin, sqrt, sqrt_rn, abs, fdiv, div_rn, erf, floor)
+from .math import (umulhi, exp, exp2, fma, log, log2, cos, sin, sqrt, sqrt_rn, abs, fdiv, div_rn, erf, floor)
 from .random import (
     pair_uniform_to_normal,
     philox,
@@ -165,6 +165,7 @@ __all__ = [
     "float8e4nv",
     "float8e5",
     "floor",
+    "fma",
     "full",
     "function_type",
     "histogram",

--- a/python/triton/language/math.py
+++ b/python/triton/language/math.py
@@ -66,7 +66,6 @@ def _add_math_2arg_docstr(name: str) -> core.Callable[[T], T]:
 @core.builtin
 @_check_dtype(dtypes=["int32", "int64", "uint32", "uint64"])
 @_add_math_2arg_docstr("most significant N bits of the 2N-bit product")
-@core._tensor_member_fn
 def umulhi(x, y, _builder=None):
     x = core._to_tensor(x, _builder)
     y = core._to_tensor(y, _builder)
@@ -164,7 +163,6 @@ def abs(x, _builder=None):
 
 @core.builtin
 @_add_math_2arg_docstr("fast division")
-@core._tensor_member_fn
 def fdiv(x, y, ieee_rounding=False, _builder=None):
     ieee_rounding = core._constexpr_to_value(ieee_rounding)
     x = core._to_tensor(x, _builder)
@@ -175,7 +173,6 @@ def fdiv(x, y, ieee_rounding=False, _builder=None):
 @core.builtin
 @_check_dtype(dtypes=["fp32"])
 @_add_math_2arg_docstr("precise division (rounding to nearest)")
-@core._tensor_member_fn
 def div_rn(x, y, _builder=None):
     x = core._to_tensor(x, _builder)
     y = core._to_tensor(y, _builder)
@@ -199,3 +196,11 @@ def erf(x, _builder=None):
 def floor(x, _builder=None):
     x = core._to_tensor(x, _builder)
     return core.tensor(_builder.create_floor(x.handle), x.type)
+
+
+@core.builtin
+def fma(x, y, z, _builder=None):
+    x = core._to_tensor(x, _builder)
+    y = core._to_tensor(y, _builder)
+    z = core._to_tensor(z, _builder)
+    return core.tensor(_builder.create_fma(x.handle, y.handle, z.handle), x.type)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1554,6 +1554,9 @@ void populateElementwiseOpToLLVMPatterns(
   POPULATE_UNARY_OP(triton::PtrToIntOp, LLVM::PtrToIntOp)
 #undef POPULATE_UNARY_OP
 
+  patterns.add<ElementwiseOpConversion<math::FmaOp, LLVM::FMAOp>>(
+      typeConverter, axisInfoAnalysis, benefit);
+
   patterns.add<FDivOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<FSubOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<FAddOpConversion>(typeConverter, axisInfoAnalysis, benefit);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1127,6 +1127,9 @@ void mlir::triton::NVIDIA::populateElementwiseOpToLLVMPatterns(
   POPULATE_UNARY_OP(triton::PtrToIntOp, LLVM::PtrToIntOp)
 #undef POPULATE_UNARY_OP
 
+  patterns.add<ElementwiseOpConversion<math::FmaOp, LLVM::FMAOp>>(
+      typeConverter, axisInfoAnalysis, benefit);
+
   patterns.add<OpToExternCallConversion<triton::PreciseSqrtOp>>(
       typeConverter, axisInfoAnalysis, "__nv_fsqrt_rn", benefit);
   patterns.add<OpToExternCallConversion<triton::PreciseDivFOp>>(


### PR DESCRIPTION
Fma was removed during math refactor, bringing it back to math module.