### PR TITLE
[RUNTIME] Small fix for AST hashing

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -52,7 +52,7 @@ class DependenciesFinder(ast.NodeVisitor):
             if inspect.isbuiltin(node.func):
                 return True
             module = getattr(func, "__module__", "")
-            return module.startswith(TRITON_MODULE)
+            return module is None or module.startswith(TRITON_MODULE)
 
         func = self.visit(node.func)
         assert func is None or is_triton_builtin(func) or isinstance(


### PR DESCRIPTION
Visiting a method call like `x.to(tl.float32)` sometimes errors because `.to` has no module.