### PR TITLE
[easy][nfc] Consistently use sha256 for hashing

### DIFF
--- a/python/test/backend/test_device_backend.py
+++ b/python/test/backend/test_device_backend.py
@@ -89,7 +89,7 @@ class ExtensionUtils:
     def __init__(self):
         dirname = os.path.dirname(os.path.realpath(__file__))
         src = Path(os.path.join(dirname, "extension_backend.c")).read_text()
-        key = hashlib.md5(src.encode("utf-8")).hexdigest()
+        key = hashlib.sha256(src.encode("utf-8")).hexdigest()
         cache = get_cache_manager(key)
         fname = "ext_utils.so"
         cache_path = cache.get_file(fname)

--- a/python/triton/runtime/cache.py
+++ b/python/triton/runtime/cache.py
@@ -166,5 +166,5 @@ def make_so_cache_key(version_hash, signature, constants, ids, **kwargs):
     key = f"{version_hash}-{''.join(signature.values())}-{constants}-{ids}"
     for kw in kwargs:
         key = f"{key}-{kwargs.get(kw)}"
-    key = hashlib.md5(key.encode("utf-8")).hexdigest()
+    key = hashlib.sha256(key.encode("utf-8")).hexdigest()
     return key

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -28,7 +28,7 @@ class DependenciesFinder(ast.NodeVisitor):
 
     def __init__(self, globals, src) -> None:
         super().__init__()
-        self.hasher = hashlib.sha1(src.encode("utf-8"))
+        self.hasher = hashlib.sha256(src.encode("utf-8"))
         self.globals = globals
 
     @property

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -76,7 +76,7 @@ class HIPOptions:
 
     def hash(self):
         key = '_'.join([f'{name}-{val}' for name, val in self.__dict__.items()])
-        return hashlib.md5(key.encode("utf-8")).hexdigest()
+        return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 
 class HIPBackend(BaseBackend):

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -12,7 +12,7 @@ library_dir = [os.path.join(dirname, "lib")]
 libraries = ['amdhip64']
 
 def compile_module_from_src(src, name):
-    key = hashlib.md5(src.encode("utf-8")).hexdigest()
+    key = hashlib.sha256(src.encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
     cache_path = cache.get_file(f"{name}.so")
     if cache_path is None:
@@ -241,7 +241,7 @@ PyMODINIT_FUNC PyInit___triton_launcher(void) {{
 
 
 class HIPLauncher(object):
-    
+
     def __init__(self, src, metadata):
         ids = {
             "ids_of_const_exprs": src.fn.constexprs if hasattr(src, "fn") else tuple()
@@ -250,7 +250,7 @@ class HIPLauncher(object):
         src = make_launcher(constants, src.signature, ids, metadata.warp_size)
         mod = compile_module_from_src(src, "__triton_launcher")
         self.launch = mod.launch
-    
+
     def __call__(self, *args, **kwargs):
         self.launch(*args, **kwargs)
 

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -45,7 +45,7 @@ def library_dirs():
 
 
 def compile_module_from_src(src, name):
-    key = hashlib.md5(src.encode("utf-8")).hexdigest()
+    key = hashlib.sha256(src.encode("utf-8")).hexdigest()
     cache = get_cache_manager(key)
     cache_path = cache.get_file(f"{name}.so")
     if cache_path is None:


### PR DESCRIPTION
It's a better hash than e.g. md5, and using it consistently makes it more likely to avoid cargo-cult uses of md5.  See discussion on https://github.com/openai/triton/pull/3224