### PR TITLE
[amd backend] fix unit tests test_chain_reduce and test_tensor_atomic_cas

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2481,11 +2481,13 @@ def _welford_combine(mean_1, m2_1, weight_1, mean_2, m2_2, weight_2):
     )
 
 
+    # def __init__(self, size_per_thread, threads_per_warp, warps_per_cta, order, ctas_per_cga, cta_split_num, cta_order):
+
 layouts = [
-    BlockedLayout([1, 4], [1, 32], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([1, 4], [1, 32], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([1, 4], [1, 32], [1, 4], [1, 0], [1, 1], [1, 1], [0, 1]),
-    BlockedLayout([1, 4], [8, 4], [2, 2], [0, 1], [1, 1], [1, 1], [0, 1])
+    BlockedLayout([1, 4], [1, 64], [4, 1], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [1, 64], [2, 2], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [2, 32], [1, 4], [1, 0], [1, 1], [1, 1], [0, 1]),
+    BlockedLayout([1, 4], [8, 8], [2, 2], [0, 1], [1, 1], [1, 1], [0, 1])
 ]
 
 
@@ -2494,9 +2496,6 @@ layouts = [
 @pytest.mark.parametrize("op", ["sum", "max"])
 @pytest.mark.parametrize("first_axis", [0, 1])
 def test_chain_reduce(M, N, src_layout, op, device, first_axis):
-    if is_hip():
-        pytest.skip("test_chain_reduce is not supported in HIP")
-
     op_str = ""
     if op == "sum":
         op_str = """

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1335,10 +1335,10 @@ def test_atomic_cas(sem, num_ctas, device):
 @pytest.mark.parametrize("sem", [None, 'acquire', 'release', 'acq_rel', 'relaxed'])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_tensor_atomic_cas(sem, num_ctas, device):
-    if is_hip():
-        pytest.skip(
-            'test_tensor_atomic_cas for HIP currently broken in https://github.com/openai/triton. Use https://github.com/ROCmSoftwarePlatform/triton'
-        )
+    # if is_hip():
+    #     pytest.skip(
+    #         'test_tensor_atomic_cas for HIP currently broken in https://github.com/openai/triton. Use https://github.com/ROCmSoftwarePlatform/triton'
+    #     )
 
     @triton.jit
     def change_value(X, BLOCK_SIZE: tl.constexpr):

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -322,6 +322,7 @@ struct AtomicCASOpConversion
   LogicalResult
   matchAndRewrite(triton::AtomicCASOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
+    // extract relevant info from Module
     auto loc = op.getLoc();
     MLIRContext *ctx = rewriter.getContext();
     Value ptr = op.getPtr();
@@ -330,59 +331,114 @@ struct AtomicCASOpConversion
     Value llCmp = adaptor.getCmp();
     Value llVal = adaptor.getVal();
 
-    auto ptrElements =
-        getTypeConverter()->unpackLLElements(loc, llPtr, rewriter);
-    auto cmpElements =
-        getTypeConverter()->unpackLLElements(loc, llCmp, rewriter);
-    auto valElements =
-        getTypeConverter()->unpackLLElements(loc, llVal, rewriter);
+    // prep data by unpacking to get data ready
+    auto ptrElements = getTypeConverter()->unpackLLElements(
+        loc, llPtr, rewriter);
+    auto cmpElements = getTypeConverter()->unpackLLElements(
+        loc, llCmp, rewriter);
+    auto valElements = getTypeConverter()->unpackLLElements(
+        loc, llVal, rewriter);
 
-    auto tensorTy = op.getType().dyn_cast<RankedTensorType>();
+    // deal with tensor or scalar
+    auto valueTy = op.getResult().getType();
+    auto TensorTy = valueTy.dyn_cast<RankedTensorType>();
     Type valueElemTy =
-        tensorTy ? getTypeConverter()->convertType(tensorTy.getElementType())
-                 : op.getType();
-    auto tid = tid_val();
-    Value pred = icmp_eq(tid, i32_val(0));
+        TensorTy ? getTypeConverter()->convertType(TensorTy.getElementType())
+                 : valueTy;
+    auto valueElemNBits = valueElemTy.getIntOrFloatBitWidth();
+    auto elemsPerThread = getTotalElemsPerThread(op.getVal().getType());
+    // vec = 1 for scalar
+    auto vec = getVectorSize(op.getPtr());
+    // tensor
+    if (TensorTy) {
+      auto valTy = op.getVal().getType().cast<RankedTensorType>();
+      vec = std::min<unsigned>(vec, valTy.getElementType().isF16() ? 2 : 1);
+    }
 
-    Value casPtr = ptrElements[0];
-    Value casCmp = cmpElements[0];
-    Value casVal = valElements[0];
+    Value mask = getMask(valueTy, rewriter, loc);
+    auto vecTy = vec_ty(valueElemTy, vec);
+    SmallVector<Value> resultVals(elemsPerThread);
 
-    // Build blocks to bypass the atomic instruction for ~rmwMask.
-    auto *curBlock = rewriter.getInsertionBlock();
-    auto *endBlock = curBlock->splitBlock(rewriter.getInsertionPoint());
-    auto *atomicBlock = rewriter.createBlock(
-        curBlock->getParent(), std::next(Region::iterator(curBlock)));
+    // atomic ops
+    for (size_t i = 0; i < elemsPerThread; i += vec) {
+      Value casVal = undef(vecTy);
+      for (int ii = 0; ii < vec; ++ii) {
+        Value iiVal = createIndexAttrConstant(
+            rewriter, loc, getTypeConverter()->getIndexType(), ii);
+        casVal = insert_element(vecTy, casVal, valElements[i + ii], iiVal);
+      }
 
-    // Fill entry block with global memory barrier and conditional branch.
-    rewriter.setInsertionPointToEnd(curBlock);
-    Value atomPtr = getSharedMemoryBase(loc, rewriter, op.getOperation());
-    rewriter.create<LLVM::CondBrOp>(loc, pred, atomicBlock, endBlock);
+      Value casPtr = ptrElements[i];
+      Value casCmp = cmpElements[i];
+      casVal = valElements[i];
 
-    // Build main block with atomic_cmpxchg.
-    rewriter.setInsertionPointToEnd(atomicBlock);
+      // use op
+      if (TensorTy) { // for tensor
+        auto retType = vec == 1 ? valueElemTy : vecTy;
+        // TODO: USE ATOMIC CAS OP on Tensor
+        auto successOrdering = LLVM::AtomicOrdering::acq_rel;
+        auto failureOrdering = LLVM::AtomicOrdering::monotonic;
+        auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
+            loc, casPtr, casCmp, casVal, successOrdering, failureOrdering,
+            StringRef("agent"));
 
-    auto successOrdering = LLVM::AtomicOrdering::acq_rel;
-    auto failureOrdering = LLVM::AtomicOrdering::monotonic;
-    auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
-        loc, casPtr, casCmp, casVal, successOrdering, failureOrdering,
-        StringRef("agent"));
-    // Extract the new_loaded value from the pair.
-    Value newLoaded = extract_val(valueElemTy, cmpxchg, 0);
+        // Extract the new_loaded value from the pair.
+        Value ret = extract_val(valueElemTy, cmpxchg, i);
 
-    store(newLoaded, atomPtr);
+        for (int ii = 0; ii < vec; ++ii) {
+          resultVals[i + ii] =
+              vec == 1 ? ret : extract_element(valueElemTy, ret, i32_val(ii));
+        }
+      } else { // for scalar
+        // Build blocks to bypass the atomic instruction for ~rmwMask.
+        auto *curBlock = rewriter.getInsertionBlock();
+        auto *endBlock = curBlock->splitBlock(rewriter.getInsertionPoint());
+        auto *atomicBlock = rewriter.createBlock(
+            curBlock->getParent(), std::next(Region::iterator(curBlock)));
 
-    rewriter.create<LLVM::BrOp>(loc, ValueRange(), endBlock);
+        // Fill entry block with global memory barrier and conditional branch.
+        rewriter.setInsertionPointToEnd(curBlock);
+        Value atomPtr = getSharedMemoryBase(loc, rewriter, op.getOperation());
+        atomPtr = bitcast(atomPtr, ptr_ty(rewriter.getContext(), 3));
+        auto tid = tid_val();
+        Value pred = icmp_eq(tid, i32_val(i));
+        rewriter.create<LLVM::CondBrOp>(loc, pred, atomicBlock, endBlock);
 
-    // Build the last block: synced load from shared memory, exit.
-    rewriter.setInsertionPointToStart(endBlock);
+        // Build main block with atomic_cmpxchg.
+        rewriter.setInsertionPointToEnd(atomicBlock);
 
-    GCNBuilder BuilderMemfenceLDS;
-    BuilderMemfenceLDS.create<>("s_waitcnt lgkmcnt(0)")->operator()();
-    BuilderMemfenceLDS.launch(rewriter, loc, void_ty(ctx));
-    barrier();
-    Value ret = load(valueElemTy, atomPtr);
-    rewriter.replaceOp(op, {ret});
+        auto successOrdering = LLVM::AtomicOrdering::acq_rel;
+        auto failureOrdering = LLVM::AtomicOrdering::monotonic;
+        auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
+            loc, casPtr, casCmp, casVal, successOrdering, failureOrdering,
+            StringRef("agent"));
+
+        // Extract the new_loaded value from the pair.
+        Value newLoaded = extract_val(valueElemTy, cmpxchg, 0);
+
+        store(newLoaded, atomPtr);
+
+        rewriter.create<LLVM::BrOp>(loc, ValueRange(), endBlock);
+
+        // Build the last block: synced load from shared memory, exit.
+        rewriter.setInsertionPointToStart(endBlock);
+
+        GCNBuilder BuilderMemfenceLDS;
+        BuilderMemfenceLDS.create<>("s_waitcnt lgkmcnt(0)")->operator()();
+        BuilderMemfenceLDS.launch(rewriter, loc, void_ty(ctx));
+        barrier();
+        Value ret = load(valueElemTy, atomPtr);
+        rewriter.replaceOp(op, {ret});
+      }
+    }
+
+    // replace op
+    if (TensorTy) {
+      Type structTy = getTypeConverter()->convertType(TensorTy);
+      Value resultStruct = getTypeConverter()->packLLElements(
+          loc, resultVals, rewriter, structTy);
+      rewriter.replaceOp(op, {resultStruct});
+    }
     return success();
   }
 };

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ReduceOpToLLVM.cpp
@@ -441,7 +441,6 @@ private:
       Value laneIdModSizeInterWarpsIsZero =
           icmp_eq(laneIdModSizeInterWarps, zero);
       Value pred = and_(threadIsNeeded, laneIdModSizeInterWarpsIsZero);
-      unsigned wavefront_size = triton::gpu::getWarpSize(srcLayout);
 
       for (unsigned i = 0; i < op.getNumOperands(); ++i) {
 #if USE_ROCM


### PR DESCRIPTION
This PR is to turn on the test cases `test_chain_reduce` and `test_tensor_atomic_cas` for amd backend.