### PR TITLE
[frontend] Sort signature/constants when hashing

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -101,7 +101,9 @@ class ASTSource:
             self.attrs = AttrsDescriptor()
 
     def hash(self):
-        key = f"{self.fn.cache_key}-{self.attrs.hash()}-{self.signature.values()}-{self.constants}"
+        sorted_sig = [v for k, v in sorted(self.signature.items())]
+        sorted_constants = [(k, v) for k, v in sorted(self.constants.items())]
+        key = f"{self.fn.cache_key}-{self.attrs.hash()}-{sorted_sig}-{sorted_constants}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
     def make_ir(self, options, context):


### PR DESCRIPTION
I'm trying to maximize the number of (distributed) cache hits I'm getting on kernels, and dictionary iteration order seems like a possible randomizing factor.

I don't think there's *technically* a problem here, because Python now guarantees insertion ordering and I don't see a way the ordering here could vary, since they're argument-index ordered.

But it also feels like a reasonable sort of belt-and-suspenders protection against this being randomized, and this sort should be low-cost since it's just done at kernel compile time.