### PR TITLE
Add top level permissions to the workflows

### DIFF
--- a/.github/workflows/compare-artifacts.yml
+++ b/.github/workflows/compare-artifacts.yml
@@ -6,6 +6,8 @@ on:
     types:
       - completed
 
+permissions: read-all
+
 jobs:
   Compare-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions: read-all
+
 jobs:
   Build-Documentation:
     runs-on: [self-hosted, A100]

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,6 +13,8 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
+permissions: read-all
+
 env:
   TRITON_USE_ASSERT_ENABLED_LLVM: "TRUE"
 

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [main]
 
+permissions: read-all
+
 jobs:
   Runner-Preparation:
     runs-on: ubuntu-latest

--- a/.github/workflows/torch-inductor-tests.yml
+++ b/.github/workflows/torch-inductor-tests.yml
@@ -5,6 +5,8 @@ on:
     workflows: ["Wheels"]
     types: [completed]
 
+permissions: read-all
+
 jobs:
   Runner-Preparation:
     runs-on: ubuntu-latest

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
+permissions: read-all
+
 jobs:
 
   Build-Wheels:


### PR DESCRIPTION
[OpenSSF Scorecard Report](https://securityscorecards.dev/viewer/?uri=github.com/openai/triton) shows zero score for "Token-Permissions", which can be easily fixed by adding a top level permissions to the existing workflows.

This report can be also generated locally with

```
$ docker run --rm gcr.io/openssf/scorecard:stable  \
  --show-details --checks Token-Permissions --repo=openai/triton --format json | jq -r '.checks[].details[]' | grep -e '^Warn:'
Warn: no topLevel permission defined: .github/workflows/compare-artifacts.yml:1
Warn: no topLevel permission defined: .github/workflows/documentation.yml:1
Warn: no topLevel permission defined: .github/workflows/integration-tests.yml:1
Warn: no topLevel permission defined: .github/workflows/test-backends.yml:1
Warn: no topLevel permission defined: .github/workflows/torch-inductor-tests.yml:1
Warn: no topLevel permission defined: .github/workflows/wheels.yml:1
```



