### PR TITLE
[AMD] Refactor SharedToDotOperandMFMA 

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -819,9 +819,8 @@ V [ 0,4,8...60   1,5...61     2,6...62     3,7...63    ]   [ 128,132...188  129,
     SmallVector<unsigned> getSizePerThreadForOperands(unsigned opIdx) const;
     SmallVector<unsigned> getShapePerCTATileForDotOperands(ArrayRef<int64_t> shape, int opIdx) const;
     unsigned getTotalElemsPerThreadForOperands(ArrayRef<int64_t> shape, Type eltTy, int kWidth, int opIdx) const;
-    SmallVector<int64_t> getMFMAElemsPerInstrForOperands(int kWidth, int opIdx) const;
-    SmallVector<int64_t> getMFMARepForOperands(ArrayRef<int64_t> operandShape,
-                                      Type elemType, int kWidth, int opIdx) const;
+    SmallVector<int64_t> getMFMAInstrShapeForOperands(int kWidth, int opIdx) const;
+    SmallVector<int64_t> getMFMARepForOperands(ArrayRef<int64_t> operandShape, int kWidth, int opIdx) const;
 
 
   }];

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1465,24 +1465,29 @@ SmallVector<unsigned> AMDMfmaEncodingAttr::getSizePerThread() const {
 }
 
 SmallVector<int64_t>
-AMDMfmaEncodingAttr::getMFMAElemsPerInstrForOperands(int kWidth,
-                                                     int opIdx) const {
-  int64_t nonKDim = getMDim();
-  assert(nonKDim == 32 || nonKDim == 16);
-  int64_t kDim = kWidth * (nonKDim == 32 ? 2 : 4);
+AMDMfmaEncodingAttr::getMFMAInstrShapeForOperands(int kWidth, int opIdx) const {
+  unsigned mDim = getMDim();
+  unsigned nDim = getNDim();
+  assert((mDim == nDim) && (mDim == 32 || mDim == 16 || mDim == 4) ||
+         (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
+  constexpr int waveSize = 64; // MFMA is used on wave64 architectures only
+  int kGroups = -1;
+  if (mDim == nDim)
+    kGroups = waveSize / mDim;
+  if (mDim == 64 && nDim == 4 || mDim == 4 && nDim == 64)
+    kGroups = 1;
+  int64_t kDim = kWidth * kGroups;
   if (opIdx == 0)
-    return {nonKDim, kDim};
-  else {
+    return {mDim, kDim};
+  else
     assert(opIdx == 1);
-    return {kDim, nonKDim};
-  }
+  return {kDim, nDim};
 }
 
 SmallVector<int64_t>
 AMDMfmaEncodingAttr::getMFMARepForOperands(ArrayRef<int64_t> operandShape,
-                                           Type elemType, int kWidth,
-                                           int opIdx) const {
-  auto operandTileShape = getMFMAElemsPerInstrForOperands(kWidth, opIdx);
+                                           int kWidth, int opIdx) const {
+  auto operandTileShape = getMFMAInstrShapeForOperands(kWidth, opIdx);
   auto warpsPerCTA = getWarpsPerCTA();
   if (opIdx == 0)
     return {std::max<int64_t>(1, operandShape[0] /
@@ -1501,8 +1506,8 @@ unsigned AMDMfmaEncodingAttr::getTotalElemsPerThreadForOperands(
   int warpsPerCTAM = getWarpsPerCTA()[0];
   int warpsPerCTAN = getWarpsPerCTA()[1];
   constexpr int waveSize = 64;
-  auto tileSize = getMFMAElemsPerInstrForOperands(kWidth, opIdx);
-  auto rep = getMFMARepForOperands(shape, eltTy, kWidth, opIdx);
+  auto tileSize = getMFMAInstrShapeForOperands(kWidth, opIdx);
+  auto rep = getMFMARepForOperands(shape, kWidth, opIdx);
   return rep[0] * rep[1];
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -23,7 +23,6 @@
 #ifdef USE_ROCM
 
 #include "../ConvertLayoutOpToLLVM.h"
-#include "Utility.h"
 
 using ::mlir::triton::gpu::AMDMfmaEncodingAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
@@ -34,16 +33,14 @@ using ::AMD::TritonGPUToLLVMTypeConverter;
 
 namespace {
 
-// Get a waveId for M axis.
-Value getWaveM(ConversionPatternRewriter &rewriter, Location loc, Value wave,
-               const ArrayRef<unsigned int> &wpt, int elemPerInstr, int M) {
-  return urem(urem(wave, i32_val(wpt[0])), i32_val(M / elemPerInstr));
-}
-// Get a waveId for N axis.
-Value getWaveN(ConversionPatternRewriter &rewriter, Location loc, Value wave,
-               const ArrayRef<unsigned int> &wpt, int elemPerInstr, int N) {
-  Value waveMN = udiv(wave, i32_val(wpt[0]));
-  return urem(urem(waveMN, i32_val(wpt[1])), i32_val(N / elemPerInstr));
+// Get waveId inside block of waves.
+Value getWaveIdInBlock(ConversionPatternRewriter &rewriter, Location loc,
+                       Value waveId, const ArrayRef<unsigned int> &wpt,
+                       int elemPerInstrNonK, int tensorSizeNonK, int nonKIdx) {
+  if (nonKIdx == 1)
+    waveId = udiv(waveId, i32_val(wpt[0]));
+  return urem(urem(waveId, i32_val(wpt[nonKIdx])),
+              i32_val(tensorSizeNonK / elemPerInstrNonK));
 }
 
 } // namespace
@@ -104,13 +101,17 @@ swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
  * elemsPerInstr[1].
  *
  * Total offset of element is a sum of following values:
- * 1. Offset of wave block in tensor
- * 2. Offset of wave inside one wave block
+ * 1. Offset of wave-block in tensor
+ * 2. Offset of wave inside one wave-block
  * 3. Offset of tile in one wave
  * 4. Offset of one lane data in a tile
  * 5. Offset of particular element of tensor processed by one lane
  *
  * This function computes these offsets for axies independently
+ * Note that this function returns the offsets of elements in the first
+ * wave-block. The offsets of elements in later wave-blocks can be computed
+ * by adding a constant stride to the xor-ed offsets of elements in the
+ * first wave-block.
  *
  * @param rewriter
  * @param loc
@@ -122,7 +123,8 @@ swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
  * @param reps number of instructions repretition to fully cover dot operand
  * @param smemStrides strides in LDS tensor
  * @param loadVecSize number of elements loaded by one operation
- * @param iNonKDim non-K dimension of dot operand
+ * @param iNonKDim non-K dimension size of one MFMA instruction
+ * @param iKDim K dimension size of one MFMA instruction
  * @return vector (i-th element corresponds to i-th load instruction) of
  * 2-element vectors(tensor row and col).
  */
@@ -131,50 +133,48 @@ computeTensorElemMapping(ConversionPatternRewriter &rewriter, Location loc,
                          const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                          Value laneId, int warpsPerGroup, int numOfElems,
                          ArrayRef<int64_t> reps, ArrayRef<Value> smemOffsets,
-                         int loadVecSize, unsigned iNonKDim) {
+                         int loadVecSize, unsigned iNonKDim, unsigned iKDim) {
   auto numM = reps[0];
   auto numK = reps[1];
   const int loadsPerThread = numOfElems / loadVecSize;
-  llvm::SmallVector<llvm::SmallVector<Value>> mapping(numM * numK *
-                                                      loadsPerThread);
+  llvm::SmallVector<llvm::SmallVector<Value>> mapping(numK * loadsPerThread);
 
   Value _0 = i32_val(0);
   Value _32 = i32_val(32);
   Value nonKDim = i32_val(iNonKDim);
+  Value waveVOffset = mul(waveId, i32_val(elemsPerInstr[0]));
 
-  for (int block = 0; block < numM; ++block) {
-    Value blockVOffset = i32_val(block * elemsPerInstr[0] * warpsPerGroup);
-    Value blockHOffset = _0;
-    Value waveVOffset = mul(waveId, i32_val(elemsPerInstr[0]));
-    Value waveHOffset = _0;
-    for (int tile = 0; tile < numK; ++tile) {
-      Value tileVOffset = _0;
-      Value tileHOffset = i32_val(tile * elemsPerInstr[1]);
+  for (int tile = 0; tile < numK; ++tile) {
+    Value tileVOffset = _0;
+    Value tileHOffset = i32_val(tile * elemsPerInstr[1]);
 
-      Value laneVOffset = urem(laneId, nonKDim);
-      Value laneHOffset;
-      if (iNonKDim == 32)
-        laneHOffset = select(icmp_uge(laneId, _32), i32_val(numOfElems), _0);
-      else
+    Value laneVOffset = urem(laneId, nonKDim);
+    Value laneHOffset;
+    if (iNonKDim == 32)
+      laneHOffset = select(icmp_uge(laneId, _32), i32_val(numOfElems), _0);
+    else {
+      // In this configuration wave contains 16 copies of same data
+      if ((iKDim == 1 || iKDim == 4) && iNonKDim == 4) {
+        laneHOffset = i32_val(0);
+      } else {
+        assert(iKDim * iNonKDim / numOfElems == 64 &&
+               "seems no all threads in wave contain unique elements");
         laneHOffset = mul(udiv(laneId, nonKDim), i32_val(numOfElems));
-
-      for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
-        Value elemVOffset = _0;
-        Value elemHOffset = i32_val(loadId * loadVecSize);
-
-        Value sliceVOffset = add(
-            add(add(add(blockVOffset, waveVOffset), tileVOffset), laneVOffset),
-            elemVOffset);
-        Value sliceHOffset = add(
-            add(add(add(blockHOffset, waveHOffset), tileHOffset), laneHOffset),
-            elemHOffset);
-
-        Value row = add(sliceVOffset, smemOffsets[0]);
-        Value col = add(sliceHOffset, smemOffsets[1]);
-
-        mapping[numK * loadsPerThread * block + loadsPerThread * tile +
-                loadId] = {row, col};
       }
+    }
+
+    for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
+      Value elemVOffset = _0;
+      Value elemHOffset = i32_val(loadId * loadVecSize);
+
+      Value sliceVOffset =
+          add(add(add(tileVOffset, laneVOffset), elemVOffset), waveVOffset);
+      Value sliceHOffset = add(add(tileHOffset, laneHOffset), elemHOffset);
+
+      Value row = add(sliceVOffset, smemOffsets[0]);
+      Value col = add(sliceHOffset, smemOffsets[1]);
+
+      mapping[loadsPerThread * tile + loadId] = {row, col};
     }
   }
   return mapping;
@@ -198,7 +198,8 @@ computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
                     const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                     Value laneId, int warpsPerGroup, int numOfElems,
                     ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout, unsigned nonKDim) {
+                    SharedEncodingAttr srcLayout, unsigned nonKDim,
+                    unsigned kDim) {
   SmallVector<Value> strides{smemObj.strides[0], smemObj.strides[1]};
   SmallVector<Value> offsets{smemObj.offsets[0], smemObj.offsets[1]};
 
@@ -210,9 +211,9 @@ computeOffsetsAType(ConversionPatternRewriter &rewriter, Location loc,
       vectorSize = numOfElems;
   }
 
-  auto mapping = computeTensorElemMapping(rewriter, loc, elemsPerInstr, waveId,
-                                          laneId, warpsPerGroup, numOfElems,
-                                          reps, offsets, vectorSize, nonKDim);
+  auto mapping = computeTensorElemMapping(
+      rewriter, loc, elemsPerInstr, waveId, laneId, warpsPerGroup, numOfElems,
+      reps, offsets, vectorSize, nonKDim, kDim);
   llvm::SmallVector<Value> aOffsets(mapping.size());
   for (int i = 0; i < mapping.size(); ++i) {
     Value row = mapping[i][0];
@@ -227,7 +228,8 @@ computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
                     const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
                     Value laneId, int warpsPerGroup, int numOfElems,
                     ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout, unsigned nonKDim) {
+                    SharedEncodingAttr srcLayout, unsigned nonKDim,
+                    unsigned kDim) {
   // transpose reps and offsets, because operand B has layout equal to
   // transposed operand A layout
   SmallVector<int64_t> tElemsPerInstr{elemsPerInstr[1], elemsPerInstr[0]};
@@ -242,9 +244,9 @@ computeOffsetsBType(ConversionPatternRewriter &rewriter, Location loc,
       vectorSize = numOfElems;
   }
 
-  auto mapping = computeTensorElemMapping(rewriter, loc, tElemsPerInstr, waveId,
-                                          laneId, warpsPerGroup, numOfElems,
-                                          tReps, toffsets, vectorSize, nonKDim);
+  auto mapping = computeTensorElemMapping(
+      rewriter, loc, tElemsPerInstr, waveId, laneId, warpsPerGroup, numOfElems,
+      tReps, toffsets, vectorSize, nonKDim, kDim);
   llvm::SmallVector<Value> bOffsets(mapping.size());
   for (int i = 0; i < mapping.size(); ++i) {
     // swap row and col, because operand B layout is a transposed operand A
@@ -262,7 +264,7 @@ Value computeBasePtr(ConversionPatternRewriter &rewriter, Location loc,
   Type type = base.getType();
   for (int i = 0; i < smemObj.strides.size(); ++i) {
     Value offset = sub(i32_val(0), mul(smemObj.offsets[i], smemObj.strides[i]));
-    base = gep(type, smemObj.baseElemType, base, offset);
+    base = gep(ptr_ty(rewriter.getContext(), 3), type, base, offset);
   }
   return base;
 }
@@ -313,76 +315,15 @@ std::optional<int> findConstValue(Value val) {
   return intAttr.getInt();
 }
 
-bool fastPathAvailable(const SharedMemoryObject &smemObj,
-                       const SharedEncodingAttr &srcEncoding,
-                       const AMDMfmaEncodingAttr &dstEncoding) {
-  if (dstEncoding.getMDim() != 32)
-    return false;
-  if (srcEncoding.getMaxPhase() > 1)
-    return false;
-  auto stride0 = findConstValue(smemObj.strides[0]);
-  auto stride1 = findConstValue(smemObj.strides[1]);
-  auto offset0 = findConstValue(smemObj.offsets[0]);
-  auto offset1 = findConstValue(smemObj.offsets[1]);
-  bool allValuesDefined = stride0.has_value() && stride1.has_value() &&
-                          offset0.has_value() && offset1.has_value();
-  if (!allValuesDefined)
-    return false;
-  if (offset0.value() != 0 || offset1.value() != 0)
-    return false;
-  return true;
-}
-
-// Computes offsets for operand A or transposed operand B
-// @param rewriter
-// @param loc
-// @param elemsPerInstr operand tile shape consumed by one MFMA instruction
-// @param waveM wave id for the "non K" axis
-// @param laneId lane id in warp [0..63]
-// @param warpsPerGroup number of warps in one block
-// @param numOfElems number of elements accessed by thread per repetition
-// @param reps number of instructions repretition to fully cover dot operand
-// @param cSwizzleOffset
-llvm::SmallVector<Value>
-fastPathComputeOffsetsTy1(ConversionPatternRewriter &rewriter, Location loc,
-                  const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
-                  Value laneId, int warpsPerGroup, int numOfElems,
-                  ArrayRef<int64_t> reps, Value cSwizzleOffset) {
-  const int loadVecSize = numOfElems;
-  const int loadsPerThread = 1; // 1 is just in case if we decide to use different loadVecSize
-  auto numM = reps[0];
-  auto numK = reps[1];
-  SmallVector<Value> offsets(numM * numK * loadsPerThread);
-  int lineSize = elemsPerInstr[1] * numK;
-  int blockSize = elemsPerInstr[0] * warpsPerGroup * lineSize;
-  Value _0 = i32_val(0);
-  Value _32 = i32_val(32);
-  Value waveHalf = udiv(laneId, _32);
-
-  Value waveOffset = mul(waveId, i32_val(elemsPerInstr[0] * lineSize));
-  Value colOffset = select(icmp_uge(laneId, _32), i32_val(numOfElems), _0);
-
-  for (int block = 0; block < numM; ++block) {
-    Value blockOffset = i32_val(block * blockSize);
-    for (int tile = 0; tile < numK; ++tile) {
-      Value tileOffset = i32_val(tile * elemsPerInstr[1]);
-      for (int loadId = 0; loadId < loadsPerThread; ++loadId) {
-        Value rowOffset =
-            add(mul(urem(laneId, _32), i32_val(lineSize)), i32_val(loadId * loadVecSize));
-        Value elemOffset = add(rowOffset, colOffset);
-        Value offset =
-            add(add(add(waveOffset, blockOffset), tileOffset), elemOffset);
-        offsets[numK * loadsPerThread * block + loadsPerThread * tile + loadId] = offset;
-      }
-    }
-  }
-  return offsets;
+bool hasSwizzleEnabled(const SharedEncodingAttr &srcEncoding) {
+  return srcEncoding.getMaxPhase() > 1;
 }
 
 // Computes offsets for operand B or transposed operand A
 // @param rewriter
 // @param loc
-// @param elemsPerInstr operand tile shape consumed by one MFMA instruction
+// @param elemsPerInstr operand tile shape [K, nonK] consumed by one MFMA
+// instruction
 // @param waveId wave id for the "non K" axis
 // @param laneId lane id in warp [0..63]
 // @param warpsPerGroup number of warps per horizontal axis
@@ -390,27 +331,44 @@ fastPathComputeOffsetsTy1(ConversionPatternRewriter &rewriter, Location loc,
 // @param reps number of instructions repretition to fully cover dot operand
 // @param cSwizzleOffset
 llvm::SmallVector<Value>
-fastPathComputeOffsetsTy2(ConversionPatternRewriter &rewriter, Location loc,
-                          const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
-                          Value laneId, int warpsPerGroup, int numOfElems,
-                          ArrayRef<int64_t> reps, Value cSwizzleOffset) {
+fastPathComputeOffsets(ConversionPatternRewriter &rewriter, Location loc,
+                       const ArrayRef<int64_t> &elemsPerInstr, Value waveId,
+                       Value laneId, int warpsPerGroup, int numOfElems,
+                       ArrayRef<int64_t> reps, Value cSwizzleOffset) {
   auto numK = reps[0];
   auto numN = reps[1];
   SmallVector<Value> offsets(numK * numN * numOfElems);
 
-  int lineSize = warpsPerGroup * elemsPerInstr[1] * numN;
-  Value _0 = i32_val(0);
-  Value _32 = i32_val(32);
-  Value waveOffset = mul(waveId, i32_val(elemsPerInstr[1]));
-  Value colOffset = urem(laneId, _32);
+  auto iKDim = elemsPerInstr[0];
+  auto iNonKDim = elemsPerInstr[1];
+  int lineSize = warpsPerGroup * iNonKDim * numN;
+  Value _nonKDim = i32_val(iNonKDim);
+  Value waveOffset = mul(waveId, i32_val(iNonKDim));
+  Value colOffset = urem(laneId, _nonKDim);
 
   for (int block = 0; block < numN; ++block) {
-    Value blockOffset = i32_val(block * elemsPerInstr[1] * warpsPerGroup);
+    Value blockOffset = i32_val(block * iNonKDim * warpsPerGroup);
     for (int tile = 0; tile < numK; ++tile) {
-      Value tileOffset = i32_val(tile * elemsPerInstr[0] * lineSize);
+      Value tileOffset = i32_val(tile * iKDim * lineSize);
       for (int elem = 0; elem < numOfElems; ++elem) {
-        Value halfOffset =
-            select(icmp_uge(laneId, _32), i32_val(numOfElems * lineSize), _0);
+        // halfOffset is an offset related to wrapping of wave in the tile.
+        // for example, mfma 32 case (mapping of tensor elements to lane ids in
+        // wave):
+        //
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        //  0  1  2  3 ... 31
+        // 32 33 34 35 ... 63  <- at this point wave is wrapping
+        // 32 33 34 35 ... 63
+        // 32 33 34 35 ... 63
+        // 32 33 34 35 ... 63
+        Value halfOffset;
+        if ((iKDim == 1 || iKDim == 4) && iNonKDim == 4)
+          halfOffset = i32_val(0);
+        else
+          halfOffset =
+              mul(udiv(laneId, _nonKDim), i32_val(numOfElems * lineSize));
         Value rowOffset = add(i32_val(elem * lineSize), halfOffset);
         Value elemOffset = add(rowOffset, colOffset);
         Value offset =
@@ -422,321 +380,173 @@ fastPathComputeOffsetsTy2(ConversionPatternRewriter &rewriter, Location loc,
   return offsets;
 }
 
-bool isTransposed(::llvm::ArrayRef<unsigned> order) {
+bool isColMajor(::llvm::ArrayRef<unsigned> order) {
   assert(order.size() == 2 && (order[0] & ~1ul) == 0 &&
          order[0] + order[1] == 1);
   return order[0] == 0;
 }
 
-Value loadA(ConversionPatternRewriter &rewriter, Location loc, Value thread,
-            DotOperandEncodingAttr encoding,
-            TritonGPUToLLVMTypeConverter *typeConverter, Value tensor,
-            const SharedMemoryObject &smemObj) {
-  auto mfmaLayout = encoding.getParent().cast<AMDMfmaEncodingAttr>();
-  auto nonKDim = mfmaLayout.getMDim();
-  assert(nonKDim == 32 || nonKDim == 16 || nonKDim == 4);
-  auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
-
-  auto aTensorTy = tensor.getType().cast<RankedTensorType>();
-  SmallVector<int64_t> shape(aTensorTy.getShape().begin(),
-                             aTensorTy.getShape().end());
-  auto sharedLayout = aTensorTy.getEncoding().cast<SharedEncodingAttr>();
-  auto order = sharedLayout.getOrder();
-
-  auto aElemTy = aTensorTy.getElementType();
-  int kWidth = encoding.getKWidth();
-  auto aElemsPerInstr = mfmaLayout.getMFMAElemsPerInstrForOperands(kWidth, 0);
-  auto mfmaInstrM = aElemsPerInstr[0];
-  auto mfmaInstrK = aElemsPerInstr[1];
-
-  auto numReps = mfmaLayout.getMFMARepForOperands(shape, aElemTy, kWidth, 0);
-  auto numRepM = numReps[0];
-  auto numRepK = numReps[1];
-
-  unsigned iWaveSize = triton::gpu::getWarpSize(mfmaLayout);
-  assert(iWaveSize == 64);
-  Value waveSize = i32_val(iWaveSize);
-  Value wave = udiv(thread, waveSize);
-  Value lane = urem(thread, waveSize);
-
-  Value waveM =
-      getWaveM(rewriter, loc, wave, warpsPerCTA, mfmaInstrM, shape[0]);
-  int numOfElems = mfmaInstrM * mfmaInstrK / iWaveSize;
-  assert(numOfElems >= 1);
-  unsigned int maxNumWarps = shape[0] / mfmaInstrM;
-  int warpsPerGroupM = std::min(warpsPerCTA[0], maxNumWarps);
-  aElemTy = typeConverter->convertType(aElemTy);
-  Type smemPtrTy = ptr_ty(rewriter.getContext(), 3);
-  Type smemElemTy = aElemTy;
-
-  SmallVector<Value> ha;
-  if (fastPathAvailable(smemObj, sharedLayout, mfmaLayout)) {
-    Value cSwizzleOffset = smemObj.getCSwizzleOffset(order[0]);
-    SmallVector<Value> offsets;
-    if (isTransposed(order)) {
-      SmallVector<int64_t> elemsPerInstr{mfmaInstrK, mfmaInstrM};
-      SmallVector<int64_t> reps{numReps[1], numReps[0]};
-      offsets = fastPathComputeOffsetsTy2(rewriter, loc, elemsPerInstr, waveM,
-                                          lane, warpsPerGroupM, numOfElems,
-                                          reps, cSwizzleOffset);
-    } else {
-      offsets = fastPathComputeOffsetsTy1(rewriter, loc, aElemsPerInstr, waveM,
-                                          lane, warpsPerGroupM, numOfElems,
-                                          numReps, cSwizzleOffset);
-    }
-    Value smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
-
-    Type resElemTy = typeConverter->convertType(aElemTy);
-
-    int loadsPerThread = offsets.size() / (numRepM * numRepK);
-    const int elemsPerLoad = numOfElems / loadsPerThread;
-    assert(numOfElems % loadsPerThread == 0);
-
-    for (int m = 0; m < numRepM; ++m) {
-      for (int k = 0; k < numRepK; ++k) {
-        auto vecTy = vec_ty(resElemTy, numOfElems);
-        Value valVec = undef(vecTy);
-        for (unsigned loadId = 0; loadId < loadsPerThread; ++loadId) {
-          auto loadVecTy = vec_ty(aElemTy, elemsPerLoad);
-          Value loadOffset =
-              offsets[m * loadsPerThread * numRepK + k * loadsPerThread + loadId];
-          Value loadAddress = gep(smemPtrTy, smemElemTy, smemBase, loadOffset);
-          Value vectorValue = load(loadVecTy, loadAddress);
-          if (numOfElems > 1) {
-            for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
-              Value elemVal =
-                  extract_element(aElemTy, vectorValue, i32_val(elemId));
-              elemVal = bitcast(elemVal, resElemTy);
-              valVec = insert_element(vecTy, valVec, elemVal,
-                                      i32_val(loadId * elemsPerLoad + elemId));
-            }
-          } else {
-            valVec = extract_element(aElemTy, vectorValue, i32_val(0));
-            valVec = bitcast(valVec, resElemTy);
-          }
-        }
-        if (aElemTy == i8_ty && numOfElems == 4)
-          valVec = bitcast(valVec, i32_ty);
-        if (aElemTy == i8_ty && numOfElems == 8)
-          valVec = bitcast(valVec, i64_ty);
-        ha.push_back(valVec);
-      }
-    }
-  } else { // normal path
-    SmallVector<Value> offsets = computeOffsetsAType(
-        rewriter, loc, aElemsPerInstr, waveM, lane, warpsPerGroupM, numOfElems,
-        numReps, smemObj, sharedLayout, nonKDim);
-
-    Value smemBase = computeBasePtr(rewriter, loc, smemObj);
-    Type resElemTy = typeConverter->convertType(aElemTy);
-
-
-    int loadsPerThread = offsets.size() / (numReps[0] * numReps[1]);
-    int elemsPerLoad = numOfElems / loadsPerThread;
-
-    for (int m = 0; m < numRepM; ++m) {
-      for (int k = 0; k < numRepK; ++k) {
-        auto vecTy = vec_ty(resElemTy, numOfElems);
-        Value valVec = undef(vecTy);
-        for (unsigned loadId = 0; loadId < loadsPerThread; ++loadId) {
-          auto loadVecTy = vec_ty(aElemTy, elemsPerLoad);
-          Value loadOffset = offsets[m * loadsPerThread * numRepK +
-                                     k * loadsPerThread + loadId];
-          Value loadAddress = gep(smemPtrTy, smemElemTy, smemBase, loadOffset);
-          Value vectorValue = load(loadVecTy, loadAddress);
-          if (numOfElems > 1) {
-            for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
-              Value elemVal =
-                  extract_element(aElemTy, vectorValue, i32_val(elemId));
-              elemVal = bitcast(elemVal, resElemTy);
-              valVec = insert_element(vecTy, valVec, elemVal,
-                                      i32_val(loadId * elemsPerLoad + elemId));
-            }
-          } else {
-            valVec = extract_element(aElemTy, vectorValue, i32_val(0));
-            valVec = bitcast(valVec, resElemTy);
-          }
-        }
-        if (aElemTy == i8_ty && numOfElems == 4)
-          valVec = bitcast(valVec, i32_ty);
-        if (aElemTy == i8_ty && numOfElems == 8)
-          valVec = bitcast(valVec, i64_ty);
-        ha.push_back(valVec);
-      }
-    }
-  }
-
-  MLIRContext *ctx = mfmaLayout.getContext();
-  Type structTy = LLVM::LLVMStructType::getLiteral(
-      ctx, SmallVector<Type>(ha.size(), ha[0].getType()));
-  auto result = typeConverter->packLLElements(loc, ha, rewriter, structTy);
-  return result;
-}
-
-Value loadB(ConversionPatternRewriter &rewriter, Location loc, Value thread,
-            DotOperandEncodingAttr encoding,
-            TritonGPUToLLVMTypeConverter *typeConverter, Value tensor,
-            const SharedMemoryObject &smemObj) {
-  auto mfmaLayout = encoding.getParent().cast<AMDMfmaEncodingAttr>();
-  auto nonKDim = mfmaLayout.getMDim();
-  assert(nonKDim == 32 || nonKDim == 16 || nonKDim == 4);
-  auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
-
-  auto bTensorTy = tensor.getType().cast<RankedTensorType>();
-  ArrayRef<int64_t> shape = bTensorTy.getShape();
-  auto sharedLayout = bTensorTy.getEncoding().cast<SharedEncodingAttr>();
-  auto order = sharedLayout.getOrder();
-
-  auto bElemTy = bTensorTy.getElementType();
-  int kWidth = encoding.getKWidth();
-  auto bElemsPerInstr = mfmaLayout.getMFMAElemsPerInstrForOperands(kWidth, 1);
-  auto mfmaInstrK = bElemsPerInstr[0];
-  auto mfmaInstrN = bElemsPerInstr[1];
-
-  auto numReps = mfmaLayout.getMFMARepForOperands(shape, bElemTy, kWidth, 1);
-  auto numRepK = numReps[0];
-  auto numRepN = numReps[1];
-
-  unsigned iWaveSize = triton::gpu::getWarpSize(mfmaLayout);
-  assert(iWaveSize == 64);
-  Value waveSize = i32_val(iWaveSize);
-  Value wave = udiv(thread, waveSize);
-  Value lane = urem(thread, waveSize);
-
-  Value waveN =
-      getWaveN(rewriter, loc, wave, warpsPerCTA, mfmaInstrN, shape[1]);
-  int numOfElems = mfmaInstrK * mfmaInstrN / iWaveSize;
-  assert(numOfElems >= 1);
-
-  unsigned int maxNumWarps = shape[1] / mfmaInstrN;
-  int warpsPerGroupN = std::min(warpsPerCTA[1], maxNumWarps);
-  bElemTy = typeConverter->convertType(bElemTy);
-  Type smemPtrTy = ptr_ty(rewriter.getContext(), 3);
-  Type smemElemTy = bElemTy;
-
-  SmallVector<Value> hb;
-  if (fastPathAvailable(smemObj, sharedLayout, mfmaLayout)) {
-    Value cSwizzleOffset = smemObj.getCSwizzleOffset(order[0]);
-
-    llvm::SmallVector<Value> offsets;
-    unsigned int maxNumWarps = shape[1] / mfmaInstrN;
-    int warpsPerGroupN = std::min(warpsPerCTA[1], maxNumWarps);
-    if (isTransposed(order)) {
-      SmallVector<int64_t> elemsPerInstr{mfmaInstrN, mfmaInstrK};
-      SmallVector<int64_t> reps{numReps[1], numReps[0]};
-      offsets = fastPathComputeOffsetsTy1(rewriter, loc, elemsPerInstr, waveN,
-                                          lane, warpsPerGroupN, numOfElems,
-                                          reps, cSwizzleOffset);
-    } else {
-      offsets = fastPathComputeOffsetsTy2(rewriter, loc, bElemsPerInstr, waveN,
-                                          lane, warpsPerGroupN, numOfElems,
-                                          numReps, cSwizzleOffset);
-    }
-
-    Value smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
-
-    Type resElemTy = typeConverter->convertType(bElemTy);
-
-    const int loadsPerThread = offsets.size() / (numRepN * numRepK);
-    const int elemsPerLoad = numOfElems / loadsPerThread;
-    assert(numOfElems % loadsPerThread == 0);
-
-    for (int n = 0; n < numRepN; ++n) {
-      for (int k = 0; k < numRepK; ++k) {
-        auto vecTy = vec_ty(resElemTy, numOfElems);
-        Value valVec = undef(vecTy);
-        for (unsigned loadId = 0; loadId < loadsPerThread; ++loadId) {
-          auto loadVecTy = vec_ty(bElemTy, elemsPerLoad);
-          Value loadOffset =
-              offsets[n * loadsPerThread * numRepK + k * loadsPerThread + loadId];
-          Value loadAddress = gep(smemPtrTy, smemElemTy, smemBase, loadOffset);
-          Value vectorValue = load(loadVecTy, loadAddress);
-          if (numOfElems > 1) {
-            for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
-              Value elemVal =
-                  extract_element(bElemTy, vectorValue, i32_val(elemId));
-              elemVal = bitcast(elemVal, resElemTy);
-              valVec = insert_element(vecTy, valVec, elemVal,
-                                      i32_val(loadId * elemsPerLoad + elemId));
-            }
-          } else {
-            valVec = extract_element(bElemTy, vectorValue, i32_val(0));
-            valVec = bitcast(valVec, resElemTy);
-          }
-        }
-        if (bElemTy == i8_ty && numOfElems == 4)
-          valVec = bitcast(valVec, i32_ty);
-        if (bElemTy == i8_ty && numOfElems == 8)
-          valVec = bitcast(valVec, i64_ty);
-        hb.push_back(valVec);
-      }
-    }
-  } else { // normal path
-    llvm::SmallVector<Value> offsets = computeOffsetsBType(
-        rewriter, loc, bElemsPerInstr, waveN, lane, warpsPerGroupN, numOfElems,
-        numReps, smemObj, sharedLayout, nonKDim);
-
-    Value smemBase = computeBasePtr(rewriter, loc, smemObj);
-    Type resElemTy = typeConverter->convertType(bElemTy);
-
-    int loadsPerThread = offsets.size() / (numReps[0] * numReps[1]);
-    int elemsPerLoad = numOfElems / loadsPerThread;
-    for (int n = 0; n < numRepN; ++n) {
-      for (int k = 0; k < numRepK; ++k) {
-        auto vecTy = vec_ty(resElemTy, numOfElems);
-        Value valVec = undef(vecTy);
-        for (unsigned loadId = 0; loadId < loadsPerThread; ++loadId) {
-          auto loadVecTy = vec_ty(bElemTy, elemsPerLoad);
-          Value loadOffset = offsets[n * loadsPerThread * numRepK +
-                                     k * loadsPerThread + loadId];
-          Value loadAddress = gep(smemPtrTy, smemElemTy, smemBase, loadOffset);
-          Value vectorValue = load(loadVecTy, loadAddress);
-          if (numOfElems > 1) {
-            for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
-              Value elemVal =
-                  extract_element(bElemTy, vectorValue, i32_val(elemId));
-              elemVal = bitcast(elemVal, resElemTy);
-              valVec = insert_element(vecTy, valVec, elemVal,
-                                      i32_val(loadId * elemsPerLoad + elemId));
-            }
-          } else {
-            valVec = extract_element(bElemTy, vectorValue, i32_val(0));
-            valVec = bitcast(valVec, resElemTy);
-          }
-        }
-        if (bElemTy == i8_ty && numOfElems == 4)
-          valVec = bitcast(valVec, i32_ty);
-        if (bElemTy == i8_ty && numOfElems == 8)
-          valVec = bitcast(valVec, i64_ty);
-        hb.push_back(valVec);
-      }
-    }
-  }
-
-  MLIRContext *ctx = mfmaLayout.getContext();
-  Type structTy = LLVM::LLVMStructType::getLiteral(
-      ctx, SmallVector<Type>(hb.size(), hb[0].getType()));
-  auto result = typeConverter->packLLElements(loc, hb, rewriter, structTy);
-  return result;
+bool isKMajor(::llvm::ArrayRef<unsigned> order, int opIdx) {
+  if (order[0] + opIdx == 1)
+    return true;
+  else
+    return false;
 }
 
 Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
                     Location loc, Value tensor, DotOperandEncodingAttr encoding,
                     const SharedMemoryObject &smemObj,
                     TritonGPUToLLVMTypeConverter *typeConverter, Value thread) {
-  switch (opIdx) {
-  case 0:
-    // operand $a
-    return loadA(rewriter, loc, thread, encoding, typeConverter, tensor,
-                 smemObj);
-  case 1:
-    // operand $b
-    return loadB(rewriter, loc, thread, encoding, typeConverter, tensor,
-                 smemObj);
-  default:
-    assert(false && "unexpected operand idx");
-    return Value();
+  assert((opIdx == 0 || opIdx == 1) && "unexpected operand idx");
+
+  int kDimIdx = opIdx == 0 ? 1 : 0;
+  int nonKDimIdx = opIdx == 0 ? 0 : 1;
+
+  auto mfmaLayout = encoding.getParent().cast<AMDMfmaEncodingAttr>();
+  auto mDim = mfmaLayout.getMDim();
+  auto nDim = mfmaLayout.getNDim();
+  assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
+         (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
+  auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
+
+  auto aTensorTy = tensor.getType().cast<RankedTensorType>();
+  ArrayRef<int64_t> shape = aTensorTy.getShape();
+  auto sharedLayout = aTensorTy.getEncoding().cast<SharedEncodingAttr>();
+  auto order = sharedLayout.getOrder();
+
+  auto elemTy = aTensorTy.getElementType();
+  auto kWidth = encoding.getKWidth();
+  auto elemsPerInstr = mfmaLayout.getMFMAInstrShapeForOperands(kWidth, opIdx);
+  auto mfmaInstrNonK = elemsPerInstr[nonKDimIdx];
+  auto mfmaInstrK = elemsPerInstr[kDimIdx];
+
+  auto numReps = mfmaLayout.getMFMARepForOperands(shape, kWidth, opIdx);
+  auto numRepNonK = numReps[nonKDimIdx];
+  auto numRepK = numReps[kDimIdx];
+
+  unsigned iWaveSize = triton::gpu::getWarpSize(mfmaLayout);
+  assert(iWaveSize == 64);
+  Value waveSize = i32_val(iWaveSize);
+  Value linearWaveId = udiv(thread, waveSize);
+  Value lane = urem(thread, waveSize);
+
+  Value spatialWaveId =
+      getWaveIdInBlock(rewriter, loc, linearWaveId, warpsPerCTA, mfmaInstrNonK,
+                       shape[nonKDimIdx], nonKDimIdx);
+  // number of duplicates of elements in wave
+  // In case of 64x4 x 4x4 multiplication, 4x4 B operand is duplicated 16 times
+  int numSubBlocks = 1;
+  if ((mfmaInstrK == 4 || mfmaInstrK == 1) && mfmaInstrNonK == 4)
+    numSubBlocks = 16;
+  int numOfElems = mfmaInstrNonK * mfmaInstrK * numSubBlocks / iWaveSize;
+  assert(numOfElems >= 1);
+
+  unsigned int maxNumWarps = shape[nonKDimIdx] / mfmaInstrNonK;
+  int warpsPerGroupNonK = std::min(warpsPerCTA[nonKDimIdx], maxNumWarps);
+  elemTy = typeConverter->convertType(elemTy);
+
+  SmallVector<Value> loadedValues;
+  SmallVector<Value> offsets;
+  Value smemBase;
+  bool isFastPath = !isKMajor(order, opIdx) && !hasSwizzleEnabled(sharedLayout);
+  if (isFastPath) {
+    // fast path handles tensors that are not k-major and have swizzling
+    // disabled, in which case offsets computation can be simplified
+    // TODO (zhanglx): later when we enable vector access to LDS for non k-major
+    // tensors, we'll refactor the scope of fast and normal path
+    Value cSwizzleOffset = smemObj.getCSwizzleOffset(order[0]);
+    if (opIdx == 0) {
+      if (isColMajor(order)) {
+        SmallVector<int64_t> elemsPerInstr{mfmaInstrK, mfmaInstrNonK};
+        SmallVector<int64_t> reps{numReps[1], numReps[0]};
+        offsets = fastPathComputeOffsets(rewriter, loc, elemsPerInstr,
+                                         spatialWaveId, lane, warpsPerGroupNonK,
+                                         numOfElems, reps, cSwizzleOffset);
+      } else {
+        llvm_unreachable(
+            "row major operand A should be handled in the normal path");
+      }
+    } else {
+      if (isColMajor(order)) {
+        llvm_unreachable(
+            "col major operand B should be handled in the normal path");
+      } else {
+        offsets = fastPathComputeOffsets(rewriter, loc, elemsPerInstr,
+                                         spatialWaveId, lane, warpsPerGroupNonK,
+                                         numOfElems, numReps, cSwizzleOffset);
+      }
+    }
+    smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
+  } else { // normal path
+    // Normal path handles tensors that fall into either of the following three
+    // cases:
+    //   1. k-major + swizzling is enabled <-- this should be the most
+    //   performant case
+    //   2. k-major + swizzling is disabled <-- for testing purpose only
+    //   3. non k-major + swizzling is enabled <-- for testing purpose only
+    //
+    // In this path, it requires a 2-step method to compute the offsets.
+    if (opIdx == 0) {
+      offsets = computeOffsetsAType(
+          rewriter, loc, elemsPerInstr, spatialWaveId, lane, warpsPerGroupNonK,
+          numOfElems, numReps, smemObj, sharedLayout, mDim, mfmaInstrK);
+    } else {
+      assert(opIdx == 1);
+      offsets = computeOffsetsBType(
+          rewriter, loc, elemsPerInstr, spatialWaveId, lane, warpsPerGroupNonK,
+          numOfElems, numReps, smemObj, sharedLayout, nDim, mfmaInstrK);
+    }
+    smemBase = computeBasePtr(rewriter, loc, smemObj);
   }
+
+  Type resElemTy = typeConverter->convertType(elemTy);
+  Type smemPtrTy = ptr_ty(rewriter.getContext(), 3);
+
+  int loadsPerThread = offsets.size() / numRepK / (isFastPath ? numRepNonK : 1);
+  int elemsPerLoad = numOfElems / loadsPerThread;
+  assert(numOfElems % loadsPerThread == 0);
+
+  for (int nonK = 0; nonK < numRepNonK; ++nonK) {
+    int blockNonKOffset = nonK * mfmaInstrNonK * warpsPerGroupNonK;
+    Value offAdjust = i32_val(blockNonKOffset * shape[order[0]]);
+    for (int k = 0; k < numRepK; ++k) {
+      auto vecTy = vec_ty(resElemTy, numOfElems);
+      Value valVec = undef(vecTy);
+      for (unsigned loadId = 0; loadId < loadsPerThread; ++loadId) {
+        auto loadVecTy = vec_ty(elemTy, elemsPerLoad);
+        Value loadOffset;
+        if (isFastPath)
+          loadOffset = offsets[nonK * loadsPerThread * numRepK +
+                               k * loadsPerThread + loadId];
+        else
+          // In the normal path, we only computed the offsets of elements
+          // in the first wave-block. Therefore, we update the offsets
+          // of elements in later wave-blocks by adding a constant stride
+          loadOffset = add(offAdjust, offsets[k * loadsPerThread + loadId]);
+        Value loadAddress = gep(smemPtrTy, elemTy, smemBase, loadOffset);
+        Value loadedValue = load(loadVecTy, loadAddress);
+        if (loadsPerThread > 1) {
+          for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
+            Value elemVal =
+                extract_element(elemTy, loadedValue, i32_val(elemId));
+            elemVal = bitcast(elemVal, resElemTy);
+            valVec = insert_element(vecTy, valVec, elemVal,
+                                    i32_val(loadId * elemsPerLoad + elemId));
+          }
+        } else {
+          valVec = loadedValue;
+        }
+      }
+      loadedValues.push_back(valVec);
+    }
+  }
+
+  MLIRContext *ctx = mfmaLayout.getContext();
+  Type structTy = LLVM::LLVMStructType::getLiteral(
+      ctx, SmallVector<Type>(loadedValues.size(), loadedValues[0].getType()));
+  auto result =
+      typeConverter->packLLElements(loc, loadedValues, rewriter, structTy);
+  return result;
 }
 
 } // namespace SharedToDotOperandMFMA

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -192,10 +192,10 @@ struct DotOpMFMAConversionHelper {
     auto bEncoding = bTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
     int kWidth = aEncoding.getKWidth();
 
-    auto repA = mfmaLayout.getMFMARepForOperands(aTensorTy.getShape(), elemTyA,
-                                                 kWidth, 0);
-    auto repB = mfmaLayout.getMFMARepForOperands(bTensorTy.getShape(), elemTyB,
-                                                 kWidth, 1);
+    auto repA =
+        mfmaLayout.getMFMARepForOperands(aTensorTy.getShape(), kWidth, 0);
+    auto repB =
+        mfmaLayout.getMFMARepForOperands(bTensorTy.getShape(), kWidth, 1);
 
     assert(repA[1] == repB[0]);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TypeConverter.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TypeConverter.cpp
@@ -128,16 +128,7 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
     return elemTy;
 #ifdef USE_ROCM
   if (auto mfmaParent = dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
-    if (elemTy.isF32())
-      return elemTy;
-    if (elemTy.isInteger(16)) // aka BF16
-      return vec_ty(elemTy, dotOpLayout.getKWidth());
-    if (elemTy.isF16())
-      return vec_ty(elemTy, 4);
-    if (elemTy.isInteger(8) && dotOpLayout.getKWidth() == 4)
-      return IntegerType::get(ctx, 32);
-    if (elemTy.isInteger(8) && dotOpLayout.getKWidth() == 8)
-      return IntegerType::get(ctx, 64);
+    return vec_ty(elemTy, dotOpLayout.getKWidth());
   }
 #endif
   auto mmaParent = dotOpLayout.getParent().dyn_cast<NvidiaMmaEncodingAttr>();


### PR DESCRIPTION
This PR updates SharedToDotOperandMFMA.cpp and MFMA.cpp.
- SharedToDotOperandMFMA.cpp is up to date with triton-mlir as of today, which includes changes until https://github.com/ROCm/triton/pull/482
  - Fixed issue with opaque pointers
  - Fixed API for `getMFMAElemsPerInstrForOperands` and `getMFMARepForOperands`
- MFMA.cpp is synced with triton-mlir@6bb04d, which includes changes until https://github.com/ROCm/triton/pull/469

Note to @binarman: changes in other files from https://github.com/ROCm/triton/pull/469 are not included in this PR. We can bring up the support for mfma 64x4 and 4x64 later.