### PR TITLE
[tests] Move --device argument up a level

### DIFF
--- a/python/test/unit/conftest.py
+++ b/python/test/unit/conftest.py
@@ -1,0 +1,12 @@
+# content of conftest.py
+
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--device", action="store", default='cuda')
+
+
+@pytest.fixture
+def device(request):
+    return request.config.getoption("--device")

--- a/python/test/unit/language/conftest.py
+++ b/python/test/unit/language/conftest.py
@@ -1,16 +1,5 @@
 # content of conftest.py
 
-import pytest
-
-
-def pytest_addoption(parser):
-    parser.addoption("--device", action="store", default='cuda')
-
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "interpreter: indicate whether interpreter supports the test")
-
-
-@pytest.fixture
-def device(request):
-    return request.config.getoption("--device")

--- a/python/test/unit/operators/conftest.py
+++ b/python/test/unit/operators/conftest.py
@@ -1,16 +1,5 @@
 # content of conftest.py
 
-import pytest
-
-
-def pytest_addoption(parser):
-    parser.addoption("--device", action="store", default='cuda')
-
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "interpreter: indicate whether interpreter supports the test")
-
-
-@pytest.fixture
-def device(request):
-    return request.config.getoption("--device")


### PR DESCRIPTION
When trying to run the unit tests from the top level directory, was getting:
```
ValueError: option names {'--device'} already added
```
since this was defined in both `operators` and `language` tests.