### PR TITLE
fix unit test `test_dot_without_load` with type `float16` and `bfloat16` for amd backend

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -39,7 +39,8 @@ struct SplatOpConversion : public ConvertOpToLLVMPattern<triton::SplatOp> {
       for (unsigned i = 0; i < ratio; ++i)
         vec = insert_element(vecType, vec, intCst, int_val(32, i));
       constVal = vec;
-    } else if (mlir::VectorType srcElemVecTy = srcType.dyn_cast<mlir::VectorType>()) {
+    } else if (mlir::VectorType srcElemVecTy =
+                   srcType.dyn_cast<mlir::VectorType>()) {
       // elem is a vector type
       unsigned size = srcElemVecTy.getNumElements();
       Type eType = srcElemVecTy.getElementType();

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -39,6 +39,14 @@ struct SplatOpConversion : public ConvertOpToLLVMPattern<triton::SplatOp> {
       for (unsigned i = 0; i < ratio; ++i)
         vec = insert_element(vecType, vec, intCst, int_val(32, i));
       constVal = vec;
+    } else if (mlir::VectorType srcElemTy = srcType.dyn_cast_or_null<mlir::VectorType>()) {
+      // elem is a vector type
+      unsigned size = srcElemTy.getNumElements();
+      Value vec = undef(srcElemTy);
+      for (unsigned i = 0; i < size; ++i) {
+        vec = insert_element(srcElemTy, vec, constVal, i32_val(i));
+      }
+      constVal = vec;
     }
     auto llSrc = bitcast(constVal, srcType);
     size_t elemsPerThread = getTotalElemsPerThread(tensorTy);

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -39,7 +39,7 @@ struct SplatOpConversion : public ConvertOpToLLVMPattern<triton::SplatOp> {
       for (unsigned i = 0; i < ratio; ++i)
         vec = insert_element(vecType, vec, intCst, int_val(32, i));
       constVal = vec;
-    } else if (mlir::VectorType srcElemVecTy = srcType.dyn_cast_or_null<mlir::VectorType>()) {
+    } else if (mlir::VectorType srcElemVecTy = srcType.dyn_cast<mlir::VectorType>()) {
       // elem is a vector type
       unsigned size = srcElemVecTy.getNumElements();
       Type eType = srcElemVecTy.getElementType();

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3196,9 +3196,6 @@ def test_dot_without_load(dtype_str, device):
     else:
         allow_tf32 = True
 
-    if is_hip() and dtype_str == "float16":
-        pytest.skip("TODO test_dot_without_load[float16] not supported in HIP")
-
     @triton.jit
     def _kernel(out, ALLOW_TF32: tl.constexpr):
         a = GENERATE_TEST_HERE

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3188,7 +3188,7 @@ def test_constexpr(literal, dtype_str, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("dtype_str", ['float32', 'float16', 'bfloat16'])
+@pytest.mark.parametrize("dtype_str", ['float32', 'float16'])
 def test_dot_without_load(dtype_str, device):
     if is_cuda():
         capability = torch.cuda.get_device_capability()

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3188,7 +3188,7 @@ def test_constexpr(literal, dtype_str, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("dtype_str", ['float32', 'float16'])
+@pytest.mark.parametrize("dtype_str", ['float32', 'float16', 'bfloat16'])
 def test_dot_without_load(dtype_str, device):
     if is_cuda():
         capability = torch.cuda.get_device_capability()


### PR DESCRIPTION
Current implementation failed for the data type `float16` in `test_dot_without_load`. The problem is with converting constant value to dot_op of amd mfma, which use the vector of vector type. Current implementation has no processing for that scenario. This change fixed that and added another data type `bfloat16` to the unit test. 