### PR TITLE
Recommit [OPTIMIZATION] Fix addptr combine pattern (#3148)

### DIFF
--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -49,6 +49,47 @@ DenseElementsAttr getConstantValue(Builder &builder, Attribute value,
   return res;
 }
 
+bool isAddPtrOffsetCombinable(Value first, Value second) {
+  auto GetConstantIntValue = [](Value val) -> std::optional<llvm::APInt> {
+    DenseElementsAttr constAttr;
+    auto defOp = val.getDefiningOp();
+    if (defOp) {
+      if (auto splatOp = llvm::dyn_cast<SplatOp>(defOp))
+        val = splatOp.getSrc();
+      else if (matchPattern(defOp, m_Constant(&constAttr)) &&
+               constAttr.isSplat()) {
+        auto attr = constAttr.getSplatValue<Attribute>();
+        // Check IntegerAttr
+        if (auto intAttr = dyn_cast_or_null<IntegerAttr>(attr))
+          return intAttr.getValue();
+      }
+    }
+
+    // Check constant value.
+    llvm::APInt intVal;
+    if (matchPattern(val, m_ConstantInt(&intVal)))
+      return intVal;
+
+    return std::nullopt;
+  };
+
+  if (first.getType() == second.getType()) {
+    // Whether bitwidth of element type is equal to pointer
+    if (getElementTypeOrSelf(first.getType()).getIntOrFloatBitWidth() == 64)
+      return true;
+
+    // first + second does not overflow
+    auto firstVal = GetConstantIntValue(first);
+    auto secondVal = GetConstantIntValue(second);
+    if (firstVal && secondVal) {
+      bool overflow = false;
+      auto resVal = firstVal->sadd_ov(*secondVal, overflow);
+      return !overflow;
+    }
+  }
+  return false;
+}
+
 // TODO(csigg): remove after next LLVM integrate.
 using FastMathFlags = arith::FastMathFlags;
 
@@ -195,7 +236,7 @@ public:
     patterns.add<CombineDotAddFRevPattern>(context);
     // %}
     patterns.add<CombineSelectMaskedLoadPattern>(context);
-    // patterns.add<CombineAddPtrPattern>(context);
+    patterns.add<CombineAddPtrPattern>(context);
     patterns.add<CombineBroadcastConstantPattern>(context);
     patterns.add<CombineBroadcastMulReducePattern>(context);
 

--- a/lib/Dialect/Triton/Transforms/Combine.td
+++ b/lib/Dialect/Triton/Transforms/Combine.td
@@ -35,14 +35,14 @@ def CombineDotAddFRevPattern : Pat<
          (Constraint<CPred<"::llvm::cast<::mlir::IntegerAttr>($0).getInt() == 0">> $maxNumImpreciseAcc),
          (Constraint<CPred<"res->hasOneUse()">, "dot result has a single use">)]>;
 
-// TODO: this fails for addptr(addptr(ptr, i32), i64)
-// Commented out until fixed
 // addptr(addptr(%ptr, %idx0), %idx1) => addptr(%ptr, AddI(%idx0, %idx1))
 //   Note: leave (sub %c0, %c0) canceling to ArithDialect
 //         (ref: ArithCanonicalization.td)
-// def CombineAddPtrPattern : Pat<
-//         (TT_AddPtrOp (TT_AddPtrOp $ptr, $idx0), $idx1),
-//         (TT_AddPtrOp $ptr, (Arith_AddIOp $idx0, $idx1))>;
+defvar DefOverflow = ConstantEnumCase<Arith_IntegerOverflowAttr, "none">;
+def CombineAddPtrPattern : Pat<
+        (TT_AddPtrOp (TT_AddPtrOp $ptr, $idx0), $idx1),
+        (TT_AddPtrOp $ptr, (Arith_AddIOp $idx0, $idx1, DefOverflow)),
+        [(Constraint<CPred<"isAddPtrOffsetCombinable($0, $1)">> $idx0, $idx1)]>;
 
 // broadcast(cst) => cst
 def getConstantValue : NativeCodeCall<"getConstantValue($_builder, $0, $1)">;

--- a/test/Triton/combine.mlir
+++ b/test/Triton/combine.mlir
@@ -63,28 +63,111 @@ tt.func @test_combine_dot_add_rev_pattern() -> (tensor<128x128xf32>) {
 }
 
 
-// COM: CHECK-LABEL: @test_combine_addptr_pattern
+// CHECK-LABEL: @test_combine_addptr_pattern
 tt.func @test_combine_addptr_pattern(%base: !tt.ptr<f32>) -> tensor<8x!tt.ptr<f32>> {
     %off0 = arith.constant 10 : i32
     %off1 = arith.constant 15 : i32
 
-    // 10 + 15 = 25
-    // COM: CHECK-NEXT: %[[cst:.*]] = arith.constant dense<25> : tensor<8xi32>
+    // CHECK-NEXT: %[[cst:.*]] = arith.constant dense<25> : tensor<8xi32>
 
     %base_ = tt.splat %base : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
 
-    // COM: CHECK-NEXT: %[[tmp0:.*]] = tt.splat %{{.*}} : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    // CHECK-NEXT: %[[tmp0:.*]] = tt.splat %{{.*}} : !tt.ptr<f32, 1> -> tensor<8x!tt.ptr<f32, 1>>
 
     %idx0 = tt.splat %off0 : i32 -> tensor<8xi32>
     %idx1 = tt.splat %off1 : i32 -> tensor<8xi32>
 
-    // COM: CHECK-NEXT: %1 = tt.addptr %[[tmp0]], %[[cst]] : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    // CHECK-NEXT: %1 = tt.addptr %[[tmp0]], %[[cst]] : tensor<8x!tt.ptr<f32, 1>>, tensor<8xi32>
     %ptr0 = tt.addptr %base_, %idx0 : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    %ptr1 = tt.addptr %ptr0, %idx1 : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+
+    tt.return %ptr1 : tensor<8x!tt.ptr<f32, 1>>
+}
+
+// CHECK-LABEL: @test_combine_addptr_pattern_i64
+tt.func @test_combine_addptr_pattern_i64(%base: !tt.ptr<f32>) -> tensor<8x!tt.ptr<f32>> {
+    %off0 = arith.constant 10 : i64
+    %off1 = arith.constant dense<15> : tensor<8xi64>
+
+    // CHECK-NEXT: %[[cst:.*]] = arith.constant dense<25> : tensor<8xi64>
+
+    %base_ = tt.splat %base : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+
+    // CHECK-NEXT: %[[tmp0:.*]] = tt.splat %{{.*}} : !tt.ptr<f32, 1> -> tensor<8x!tt.ptr<f32, 1>>
+
+    %idx0 = tt.splat %off0 : i64 -> tensor<8xi64>
+
+    // CHECK-NEXT: %1 = tt.addptr %[[tmp0]], %[[cst]] : tensor<8x!tt.ptr<f32, 1>>, tensor<8xi64>
+    %ptr0 = tt.addptr %base_, %idx0 : tensor<8x!tt.ptr<f32>>, tensor<8xi64>
+    %ptr1 = tt.addptr %ptr0, %off1 : tensor<8x!tt.ptr<f32>>, tensor<8xi64>
+
+    tt.return %ptr1 : tensor<8x!tt.ptr<f32, 1>>
+}
+
+// CHECK-LABEL: @test_combine_addptr_pattern_scalar
+tt.func @test_combine_addptr_pattern_scalar(%base: !tt.ptr<f32>) -> !tt.ptr<f32> {
+    %off0 = arith.constant 10 : i32
+    %off1 = arith.constant 15 : i32
+
+    // CHECK-NEXT: %[[cst:.*]] = arith.constant 25 : i32
+    // CHECK-NEXT: %0 = tt.addptr %{{.*}}, %[[cst]] : !tt.ptr<f32, 1>, i32
+    %ptr0 = tt.addptr %base, %off0 : !tt.ptr<f32>, i32
+    %ptr1 = tt.addptr %ptr0, %off1 : !tt.ptr<f32>, i32
+
+    tt.return %ptr1 : !tt.ptr<f32, 1>
+}
+
+// CHECK-LABEL: @test_not_combine_addptr_pattern_1
+tt.func @test_not_combine_addptr_pattern_1(%base: !tt.ptr<f32>, %idx0: tensor<8xi32>) -> tensor<8x!tt.ptr<f32>> {
+    %off1 = arith.constant 15 : i32
+
+    %base_ = tt.splat %base : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+    %idx1 = tt.splat %off1 : i32 -> tensor<8xi32>
+
+    // CHECK: tt.addptr
+    // CHECK-NEXT: tt.addptr
+    %ptr0 = tt.addptr %base_, %idx0 : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    %ptr1 = tt.addptr %ptr0, %idx1 : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
+    tt.return %ptr1 : tensor<8x!tt.ptr<f32>>
+}
+
+// CHECK-LABEL: @test_not_combine_addptr_pattern
+tt.func @test_not_combine_addptr_pattern(%base: !tt.ptr<f32>) -> tensor<8x!tt.ptr<f32>> {
+    %off0 = arith.constant 10 : i16
+    %off1 = arith.constant 15 : i32
+
+    // CHECK-DAG: %[[cst:.*]] = arith.constant dense<10> : tensor<8xi16>
+    // CHECK-DAG: %[[cst1:.*]] = arith.constant dense<15> : tensor<8xi32>
+
+    %base_ = tt.splat %base : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+
+    %idx0 = tt.splat %off0 : i16 -> tensor<8xi16>
+    %idx1 = tt.splat %off1 : i32 -> tensor<8xi32>
+
+    %ptr0 = tt.addptr %base_, %idx0 : tensor<8x!tt.ptr<f32>>, tensor<8xi16>
     %ptr1 = tt.addptr %ptr0, %idx1 : tensor<8x!tt.ptr<f32>>, tensor<8xi32>
 
     tt.return %ptr1 : tensor<8x!tt.ptr<f32>>
 }
 
+// CHECK-LABEL: @test_not_combine_addptr_pattern_overflow
+tt.func @test_not_combine_addptr_pattern_overflow(%base: !tt.ptr<f32>) -> tensor<8x!tt.ptr<f32>> {
+    %off0 = arith.constant 127 : i8
+    %off1 = arith.constant 1 : i8
+
+    // CHECK-DAG: %[[cst:.*]] = arith.constant dense<127> : tensor<8xi8>
+    // CHECK-DAG: %[[cst1:.*]] = arith.constant dense<1> : tensor<8xi8>
+
+    %base_ = tt.splat %base : !tt.ptr<f32> -> tensor<8x!tt.ptr<f32>>
+
+    %idx0 = tt.splat %off0 : i8 -> tensor<8xi8>
+    %idx1 = tt.splat %off1 : i8 -> tensor<8xi8>
+
+    %ptr0 = tt.addptr %base_, %idx0 : tensor<8x!tt.ptr<f32>>, tensor<8xi8>
+    %ptr1 = tt.addptr %ptr0, %idx1 : tensor<8x!tt.ptr<f32>>, tensor<8xi8>
+
+    tt.return %ptr1 : tensor<8x!tt.ptr<f32>>
+}
 
 // CHECK-LABEL: @test_combine_select_masked_load_pattern
 tt.func @test_combine_select_masked_load_pattern(%ptr: tensor<8x!tt.ptr<f32>>, %cond: i1) -> (tensor<8xf32>, tensor<8xf32>) {


### PR DESCRIPTION
Add addptr(addptr(%ptr, %idx0), %idx1) pattern again with constraint which makes sure that both element type of offset should be same.