### PR TITLE
[DEBUG] Fix `LLVM_IR_ENABLE_DUMP` for LLVMIR optimization passes

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -175,14 +175,14 @@ void init_triton_llvm(py::module &&m) {
     StandardInstrumentations standardInstr(mod->getContext(),
                                            /*DebugLogging*/ true);
     if (mlir::triton::tools::getBoolEnv("LLVM_IR_ENABLE_DUMP")) {
-      standardInstr.registerCallbacks(passInstrCb, &mam);
-      instrCbPtr = &passInstrCb;
       auto optMap = llvm::cl::getRegisteredOptions();
       auto optIt = optMap.find("print-after-all");
       if (optIt != optMap.end()) {
         auto optPtr = static_cast<llvm::cl::opt<bool> *>(optIt->second);
         *optPtr = true;
       }
+      standardInstr.registerCallbacks(passInstrCb, &mam);
+      instrCbPtr = &passInstrCb;
     }
 
     PipelineTuningOptions tuningOptions;


### PR DESCRIPTION
`StandardInstrumentations::registerCallbacks` reads the llvm registered options, so in order for it to enable printing, the `print-after-all` needs to be already set when it is being invoked.
This fixes the lack of IR dumps for optimization passes.