### PR TITLE
[Backend] Clean up MMAv3 part of MatmulLoopPipeline.

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -105,8 +105,11 @@ def TTNG_DotWaitOp : TTNG_Op<"dot_wait", [DeclareOpInterfaceMethods<InferTypeOpI
   let arguments = (ins Variadic<TT_FpIntTensor>:$inputs, I32Attr:$pendings);
   let results = (outs Variadic<TT_FpIntTensor>:$outputs);
   let description = [{
-    This operation defining the waiting action for a async dot, MMAv3 .e.g.
-    The subsequent operations should not execute until this operation completes waiting.
+    Waits until there are $pendings or fewer outstanding async dot operations.
+
+    $inputs must be the tensors corresponding to the async dot ops that we're
+    waiting on.  For example, if there are N pending async dot ops and we call
+    `dot_wait 1`, then $inputs must be the result of the first dot op.
   }];
 
   let assemblyFormat = "$inputs attr-dict `:` type($inputs)";

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -82,9 +82,8 @@ public:
   bool match(Operation *op) final { return isa<OpTy>(op); }
 
   virtual AxisInfo
-  getAxisInfo(OpTy op, ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) {
-    llvm_unreachable("Unimplemented getAxisInfo");
-  }
+  getAxisInfo(OpTy op,
+              ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) = 0;
 };
 
 // Binary operations
@@ -1008,7 +1007,7 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
                   CastOpAxisInfoVisitor<mlir::UnrealizedConversionCastOp>,
                   CastOpAxisInfoVisitor<triton::BitcastOp>>();
   // TODO: Remove rules for LLVM::ConstantOp, LLVM::AddOp
-  // when scf.for supports integers induction variable
+  // when scf.for supports integer induction variables
   visitors.append<MakeRangeOpAxisInfoVisitor>();
   visitors.append<ConstantOpAxisInfoVisitor<arith::ConstantOp>,
                   ConstantOpAxisInfoVisitor<LLVM::ConstantOp>>();

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -20,8 +20,7 @@ using ttg::DotOperandEncodingAttr;
 using ttg::NvidiaMmaEncodingAttr;
 using ttg::SliceEncodingAttr;
 
-// higher mma version is preferred, will fallback to lower version if not
-// supported
+// Get the highest version supported for the hardware and the dot.
 static int getMMAVersionSafe(int computeCapability, tt::DotOp op) {
   int baseVersion = 0;
   if (computeCapability < 75) {
@@ -397,7 +396,7 @@ public:
     if (applyPatternsAndFoldGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();
     }
-    // now that we pick the mma type decompose dot that are not natively
+    // Now that we have picked the mma type, decompose dot that are not natively
     // supported.
     decomposeMixedModeDotOp(m);
   }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -8,9 +8,11 @@
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Attributes.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
@@ -31,7 +33,7 @@ namespace ttng = mlir::triton::nvidia_gpu;
 
 namespace {
 
-struct PipelineOpInfo {
+struct PipelinedOpInfo {
   int stage = -1;
   Operation *use = nullptr;
 
@@ -42,15 +44,15 @@ struct PipelineOpInfo {
   bool loadIsMMAV3 = false;
 };
 
-}; // namespace
+} // namespace
 
-/// Replace the yield with a new one with the given operands appended.
+// Replace the ForOp's yield with a new one with the given operands appended.
 static void appendToYield(scf::ForOp forOp, ArrayRef<Value> newOperands) {
   // Fix up the yield op.
   Operation *yieldOp = forOp.getBody()->getTerminator();
-  SmallVector<Value> operands(yieldOp->getOperands().begin(),
-                              yieldOp->getOperands().end());
+  SmallVector<Value> operands(yieldOp->getOperands());
   operands.append(newOperands.begin(), newOperands.end());
+
   OpBuilder builder(yieldOp);
   builder.create<scf::YieldOp>(yieldOp->getLoc(), operands);
   yieldOp->erase();
@@ -59,7 +61,7 @@ static void appendToYield(scf::ForOp forOp, ArrayRef<Value> newOperands) {
 static void
 createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
                 Value insertIdx, Value extractIdx,
-                llvm::MapVector<Operation *, PipelineOpInfo> &opToInfo) {
+                llvm::MapVector<Operation *, PipelinedOpInfo> &opToInfo) {
   OpBuilder builder(forOp);
   Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
   // Replace the load with insert/extract slice.
@@ -129,61 +131,61 @@ createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
 static void
 createAsyncLoad(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
                 Value insertIdx, Value extractIdx, Value phase,
-                llvm::MapVector<Operation *, PipelineOpInfo> &opToInfo) {
+                llvm::MapVector<Operation *, PipelinedOpInfo> &opToInfo) {
   createAsyncCopy(forOp, loadOp, alloc, insertIdx, extractIdx, opToInfo);
 }
 
 // If all the transitive uses of the given value have are used by a convert to
 // the same dot operand encoding, return true and set the shared encoding that
 // needs to be used to be compatible with users' layouts.
-static bool
-allTransitiveUsesHaveDotEncoding(Value val,
-                                 ttg::SharedEncodingAttr &sharedEnc) {
+//
+// TODO: Rename, because the name only tells us half the story: We check for all
+// users having a dot encoding, but then we return a shared encoding, which is
+// surprising given the name.
+static std::optional<ttg::SharedEncodingAttr>
+allTransitiveUsesHaveDotEncoding(Value val) {
   ttg::SharedEncodingAttr attr;
   for (Operation *user : val.getUsers()) {
     ttg::SharedEncodingAttr tempAttr;
     if (user->getNumResults() != 1)
-      return false;
+      return std::nullopt;
     if (auto memDesc =
             user->getResult(0).getType().dyn_cast<triton::MemDescType>()) {
       // First time we find a shared encoding in the chain, save it and try to
       // use it if it is compatible with the other users.
       if (!tempAttr)
         tempAttr = memDesc.getEncoding().cast<ttg::SharedEncodingAttr>();
-      ttg::SharedEncodingAttr nextEncoding;
-      bool hasDotEncodingUse =
-          allTransitiveUsesHaveDotEncoding(user->getResult(0), nextEncoding);
-      if (!hasDotEncodingUse)
-        return false;
+      if (!allTransitiveUsesHaveDotEncoding(user->getResult(0)).has_value())
+        return std::nullopt;
     } else {
       if (!isa<ttg::LocalLoadOp, ttg::ConvertLayoutOp>(user))
-        return false;
+        return std::nullopt;
       auto dotOpEnc = user->getResult(0)
                           .getType()
                           .cast<TensorOrMemDesc>()
                           .getEncoding()
                           .dyn_cast<ttg::DotOperandEncodingAttr>();
       if (!dotOpEnc)
-        return false;
-      auto srcTensorType = val.getType().cast<TensorOrMemDesc>();
-      auto CTALayout = ttg::getCTALayout(srcTensorType.getEncoding());
-      auto order = ttg::getOrder(srcTensorType.getEncoding());
-      unsigned bitWidth =
-          srcTensorType.getElementType().getIntOrFloatBitWidth();
+        return std::nullopt;
+      auto srcTy = val.getType().cast<TensorOrMemDesc>();
+      auto CTALayout = ttg::getCTALayout(srcTy.getEncoding());
+      auto order = ttg::getOrder(srcTy.getEncoding());
+      unsigned bitWidth = srcTy.getElementType().getIntOrFloatBitWidth();
       tempAttr = ttg::SharedEncodingAttr::get(
-          val.getContext(), dotOpEnc, srcTensorType.getShape(), order,
-          CTALayout, bitWidth, /*needTrans=*/false);
+          val.getContext(), dotOpEnc, srcTy.getShape(),
+          ttg::getOrder(srcTy.getEncoding()),
+          ttg::getCTALayout(srcTy.getEncoding()),
+          srcTy.getElementType().getIntOrFloatBitWidth(), /*needTrans=*/false);
     }
-    // We need to check that the shared encoding needed by the users are
-    // compatible.
+    // Check that the shared encodings needed by the users are compatible.
     if (!tempAttr || (attr != nullptr && attr != tempAttr))
-      return false;
+      return std::nullopt;
     attr = tempAttr;
   }
-  sharedEnc = attr;
-  return true;
+  return attr;
 }
 
+// TODO: This returns true and *sometimes* sets enc?
 bool loadDotOperand(tt::LoadOp loadOp, bool &hasMMAV3,
                     ttg::SharedEncodingAttr &enc) {
   if (loadOp.getResult().hasOneUse()) {
@@ -209,10 +211,15 @@ bool loadDotOperand(tt::LoadOp loadOp, bool &hasMMAV3,
       }
     }
   }
-  if (allTransitiveUsesHaveDotEncoding(loadOp.getResult(), enc))
-    return true;
-  return false;
-};
+
+  std::optional<ttg::SharedEncodingAttr> sharedEnc =
+      allTransitiveUsesHaveDotEncoding(loadOp.getResult());
+  if (!sharedEnc.has_value()) {
+    return false;
+  }
+  enc = *sharedEnc;
+  return true;
+}
 
 static ttg::BlockedEncodingAttr
 getBlockedEncoding(tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfo) {
@@ -227,17 +234,17 @@ getBlockedEncoding(tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfo) {
   unsigned currPerThread = getNumElementsPerThread(loadOp, order, axisInfo);
   SmallVector<unsigned> sizePerThread(order.size(), 1);
   sizePerThread[order[0]] = currPerThread;
-  ttg::CTALayoutAttr CTALayout = ttg::getCTALayout(ty.getEncoding());
+  ttg::CTALayoutAttr ctaLayout = ttg::getCTALayout(ty.getEncoding());
   return ttg::BlockedEncodingAttr::get(loadOp->getContext(), ty.getShape(),
                                        sizePerThread, order, numWarps,
-                                       threadsPerWarp, CTALayout);
+                                       threadsPerWarp, ctaLayout);
 }
 
 static ttg::SharedEncodingAttr getSharedEncoding(tt::LoadOp loadOp,
                                                  Operation *use, bool isMMAV3) {
 
   auto ty = loadOp.getType().cast<RankedTensorType>();
-  auto CTALayout = ttg::getCTALayout(ty.getEncoding());
+  auto ctaLayout = ttg::getCTALayout(ty.getEncoding());
   auto blockedOrder = ttg::getOrder(ty.getEncoding());
   SmallVector<unsigned> order;
   if (blockedOrder.size() == 3) {
@@ -251,16 +258,17 @@ static ttg::SharedEncodingAttr getSharedEncoding(tt::LoadOp loadOp,
     order = blockedOrder;
   }
   if (isa<tt::DotOp>(use)) {
-    assert(isMMAV3 && "Load used by dot op should be either MMAv3 or have a "
-                      "shared encoding already picked based on users layouts.");
+    assert(isMMAV3 &&
+           "Load used by dot op should be either MMAv3 or have a "
+           "shared encoding already picked based on users' layouts.");
     return ttg::SharedEncodingAttr::get(ty.getContext(), ty.getShape(), order,
-                                        CTALayout, ty.getElementType());
+                                        ctaLayout, ty.getElementType());
   } else {
     assert(!isMMAV3 && "Load used by non-dot op should not be MMAv3.");
     // Use non-swizzled layout for loads that do not feed into dot ops.
     // TODO: This won't be optimal for 2D tensors.
     return ttg::SharedEncodingAttr::get(ty.getContext(), 1, 1, 1, order,
-                                        CTALayout);
+                                        ctaLayout);
   }
 }
 
@@ -288,12 +296,14 @@ loadOpsToDistanceAndUse(scf::ForOp forOp) {
     auto ty =
         tensorTy.getElementType().cast<tt::PointerType>().getPointeeType();
     unsigned width = vec * ty.getIntOrFloatBitWidth();
+
     // We do not pipeline all loads for the following reasons:
-    // 1. On nvidia GPUs, cp.async's cp-size can only be 4, 8 and 16.
+    // 1. On nvidia GPUs, cp.async's cp-size can only be 4, 8, or 16.
     // 2. It's likely that pipling small loads won't offer much performance
     //    improvement and may even hurt performance by increasing register
     //    pressure.
-    return (width >= 32);
+    LDBG("Load " << *loadOp << " has width " << width);
+    return width >= 32;
   };
 
   std::function<void(Operation * op, int, Operation *)> dfs =
@@ -303,6 +313,7 @@ loadOpsToDistanceAndUse(scf::ForOp forOp) {
         if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
           if (!isCandidate(loadOp))
             return;
+          // TODO: What if there are multiple uses at different distances?
           loadOpToDistAndUse[loadOp] = std::make_pair(distance, use);
           use = op;
           distance++;
@@ -337,7 +348,7 @@ loadOpsToDistanceAndUse(scf::ForOp forOp) {
 /// Collect loads to pipeline. Returns true if loads are found to pipeline.
 static bool
 collectOpsToPipeline(scf::ForOp forOp,
-                     llvm::MapVector<Operation *, PipelineOpInfo> &opInfo,
+                     llvm::MapVector<Operation *, PipelinedOpInfo> &opInfo,
                      int numStages, bool &hasMMAV3) {
   ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
   tt::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
@@ -345,6 +356,13 @@ collectOpsToPipeline(scf::ForOp forOp,
   // Loads ordered by their dependency distance to the nearest dot op.
   llvm::MapVector<tt::LoadOp, std::pair<int, Operation *>> loadOpToDistAndUse =
       loadOpsToDistanceAndUse(forOp);
+  LLVM_DEBUG({
+    DBGS() << "Found " << loadOpToDistAndUse.size() << " loads to pipeline:\n";
+    for (const auto &[k, v] : loadOpToDistAndUse) {
+      DBGS() << "  " << *k << " distance=" << v.first << " use=" << *v.second
+             << "\n";
+    }
+  });
   if (loadOpToDistAndUse.empty())
     return false;
 
@@ -356,16 +374,16 @@ collectOpsToPipeline(scf::ForOp forOp,
   }
   assert(maxDistance >= 0);
 
-  // Start by initializing PipelineOpInfo for users of the loads.
+  // Start by initializing PipelinedOpInfo for users of the loads.
   for (auto &[loadOp, distAndUse] : loadOpToDistAndUse)
-    opInfo[distAndUse.second] = PipelineOpInfo();
+    opInfo[distAndUse.second] = PipelinedOpInfo();
 
   unsigned stagesBetweenLoads = ceil<unsigned>(numStages - 2, maxDistance + 1);
 
   // Then consider the load ops that feed into the dot ops or are used by other
   // loads.
   for (auto &[loadOp, distAndUse] : loadOpToDistAndUse) {
-    PipelineOpInfo loadInfo;
+    PipelinedOpInfo loadInfo;
     bool loadIsMMAV3 = false;
     if (isa<tt::DotOp>(distAndUse.second)) {
       ttg::SharedEncodingAttr sharedEnc;
@@ -386,19 +404,18 @@ collectOpsToPipeline(scf::ForOp forOp,
     loadInfo.stage = stage;
     loadInfo.use = distAndUse.second;
     opInfo[loadOp] = loadInfo;
-  };
+  }
 
-  // Last, find load users and assigning a stage for them.
+  // Last, find root load users (i.e. users that aren't used by another stage of
+  // the pipeline) and assign them to the last stage.
+  //
   // We cannot use forOp.walk(...) here because we only want to visit the
   // operations in the loop body block. Nested blocks are handled separately.
   for (Operation &op : forOp) {
     auto iter = opInfo.find(&op);
     if (iter != opInfo.end() && iter->second.stage == -1) {
       assert(!isa<tt::LoadOp>(iter->first));
-      PipelineOpInfo useOpInfo{
-          .stage = numStages - 1,
-      };
-      iter->second = useOpInfo;
+      iter->second.stage = numStages - 1;
     }
   }
 
@@ -423,7 +440,7 @@ static Value createAlloc(scf::ForOp &forOp, tt::LoadOp loadOp,
 // the required number of buffers.
 static SmallVector<Value>
 createAsynOps(scf::ForOp &forOp,
-              llvm::MapVector<Operation *, PipelineOpInfo> &opToInfo,
+              llvm::MapVector<Operation *, PipelinedOpInfo> &opToInfo,
               int numBuffers, bool hasMMAV3) {
   struct AsyncLoad {
     AsyncLoad(tt::LoadOp loadOp, Value alloc) : loadOp(loadOp), alloc(alloc) {}
@@ -496,7 +513,7 @@ printSchedule(std::vector<std::pair<Operation *, unsigned>> &schedule,
               int numStages) {
   LDBG("Schedule:");
   for (int i = 0; i < numStages; i++) {
-    LDBG("\nStage " << i);
+    LDBG("- Stage " << i);
     for (auto &pair : schedule) {
       if (pair.second == i) {
         pair.first->dump();
@@ -520,11 +537,11 @@ isScheduleValid(scf::ForOp forOp,
   return true;
 }
 
-// create the schedule for a matmul loop. This is ad hoc based on how we know
+// Create the schedule for a matmul loop. This is ad hoc based on how we know
 // matmul loops should be pipelined and is not a generic scheduler.
 static std::vector<std::pair<Operation *, unsigned>>
 createSchedule(scf::ForOp forOp, int numStages,
-               llvm::MapVector<Operation *, PipelineOpInfo> &opToInfo,
+               llvm::MapVector<Operation *, PipelinedOpInfo> &opToInfo,
                bool prefetchExtract) {
   LLVM_DEBUG({
     LDBG("For loop:");
@@ -532,7 +549,7 @@ createSchedule(scf::ForOp forOp, int numStages,
 
     LDBG("Initial schedule:");
     for (int i = 0; i < numStages; i++) {
-      LDBG("\nOps in stage " << i);
+      LDBG("- Ops in stage " << i);
       for (auto &[op, info] : opToInfo) {
         if (i == info.stage) {
           op->dump();
@@ -576,7 +593,7 @@ createSchedule(scf::ForOp forOp, int numStages,
 
   LLVM_DEBUG({
     for (int stage = 0; stage < numStages; stage++) {
-      LDBG("\ninsertAndDeps " << stage);
+      LDBG("- insertAndDeps " << stage);
       printDenseSet(insertAndDeps[stage]);
     }
   });
@@ -601,7 +618,7 @@ createSchedule(scf::ForOp forOp, int numStages,
       }
     }
     LLVM_DEBUG({
-      LDBG("\ndistanceOneUsers " << stage);
+      LDBG("- distanceOneUsers " << stage);
       printDenseSet(distanceOneUsers[stage]);
     });
   }
@@ -629,7 +646,7 @@ createSchedule(scf::ForOp forOp, int numStages,
         tt::addDep(op, stage1deps[i + 1], true, &allInsertAndDeps);
     }
     LLVM_DEBUG({
-      LDBG("\nstage1deps " << i);
+      LDBG("- stage1deps " << i);
       printDenseSet(stage1deps[i]);
     });
   }
@@ -644,7 +661,7 @@ createSchedule(scf::ForOp forOp, int numStages,
     tt::addDep(op, extractAndDeps, true, &allInsertAndDeps);
   }
   LLVM_DEBUG({
-    LDBG("\nextractAndDeps:");
+    LDBG("- extractAndDeps:");
     printDenseSet(extractAndDeps);
   });
 
@@ -688,7 +705,7 @@ bool mlir::triton::preProcessLoopAndGetSchedule(
     scf::ForOp &forOp, int numStages, mlir::triton::PipeliningOption &options) {
   // 1. First collect "interesting" operations with a stage where to schedule
   // them. This gives a coarse scheduling for the loop.
-  llvm::MapVector<Operation *, PipelineOpInfo> opToInfo;
+  llvm::MapVector<Operation *, PipelinedOpInfo> opToInfo;
   bool hasMMAV3 = false;
   if (!collectOpsToPipeline(forOp, opToInfo, numStages, hasMMAV3))
     return false;
@@ -856,199 +873,240 @@ void mlir::triton::updateWaits(ModuleOp module) {
   combineRedundantWaitOps(waitOps);
 }
 
-/// MMA V3 post-processing.
-static bool selfDepend(tt::DotOp dotOp, scf::ForOp forOp,
-                       Operation **firstUse) {
-  std::function<bool(Value, int, scf::ForOp)> dependOn =
-      [&dependOn](Value v, int argId, scf::ForOp forOp) {
-        auto op = v.getDefiningOp();
-        if (isa<BlockArgument>(v)) {
-          auto iterArgs = forOp.getRegionIterArgs();
-          auto iter = std::find(iterArgs.begin(), iterArgs.end(), v);
-          if (iter != iterArgs.end())
-            return std::distance(iterArgs.begin(), iter) == argId;
-        } else {
-          if (!op)
-            return false;
-          for (auto operand : op->getOperands()) {
-            if (dependOn(operand, argId, forOp))
-              return true;
-          }
-        }
-        return false;
-      };
-  auto result = dotOp.getResult();
-  auto yieldOp = forOp.getBody()->getTerminator();
-  int argIdx = -1;
-  auto iter = std::find(yieldOp->getOperands().begin(),
-                        yieldOp->getOperands().end(), result);
-  if (iter != yieldOp->getOperands().end())
-    argIdx = std::distance(yieldOp->getOperands().begin(), iter);
-  if (argIdx == -1)
-    return false;
-  for (auto operand : dotOp.getOperands()) {
-    if (dependOn(operand, argIdx, forOp)) {
-      auto iterArgs = forOp.getRegionIterArgs();
-      *firstUse = iterArgs[argIdx].use_begin().getUser();
+// Tries to cast op to a tt::DotOp, if it's an MMAv3 (i.e. wgmma / hopper) dot.
+//
+// Note that this returns nullptr for ttng::DotAsyncOps, but we can't call this
+// "dynCastMMAv3SyncDot", because this is sometimes used before we've converted
+// eligible tt::DotOps to ttng::DotAsyncOp.
+tt::DotOp dynCastMMAv3Dot(Operation *op) {
+  if (auto dotOp = dyn_cast<tt::DotOp>(op)) {
+    auto resEnc =
+        dotOp.getType().getEncoding().dyn_cast<ttg::NvidiaMmaEncodingAttr>();
+    if (resEnc && resEnc.isHopper()) {
+      return dotOp;
+    }
+  }
+  return nullptr;
+}
+
+// Determines whether a tt.dot op can be transformed into ttng.dot.async.  The
+// dot can be made async if all of the following are true.
+//
+//  0. The operation is an MMAv3 dot.
+//
+//  1. All operands that touch shared memory are multi-buffered, i.e. can't read
+//     an incomplete value while it's being written asynchronously by a load.
+//
+//  2. During iteration i, nothing other than the loop's `yield` reads the
+//     result of the dot.
+//
+//  3. During iteration i, the result of the dot from iteration i-1 is consumed
+//     only by other MMAv3 dots (either sync or async) as the `c` operand.
+//
+//     This is safe because the following pseudo-PTX is valid:
+//
+//        %accum = dot_async %a1, %b1, %c1
+//        %accum = dot_async %a2, %b2, %accum
+//
+//     That is, the second async dot can use the result of the first one without
+//     an intervening wait.  However, the only operation that can legally read
+//     %accum before the wait is another dot.async, and this only works for the
+//     `c` operand, not `a` or `b`.  See
+//     https://docs.nvidia.com/cuda/parallel-thread-execution/#asynchronous-warpgroup-level-matrix-instructions-wgmma-fence
+//     (ttng::DotAsyncOp corresponds to wgmma.fence followed by one or more
+//     wgmma.async ops, so our reading is that the two ttng::DotAsyncOps don't
+//     have to correspond to wgmma.async ops with the same shapes as specified
+//     in the docs, because there's an intervening fence.)
+//
+//     A synchronous MMAv3 dot will be codegen'ed as `dot.async; wait 0`, so it
+//     works just as well as an async dot for these purposes.
+//
+// On success, this function returns the index of the dot in the loop's
+// iter_args.  (Rule (2) above ensures this is well-defined.)
+static std::optional<int> dotCanBeMadeAsync(Operation *op, scf::ForOp forOp) {
+  // Rule 0: The operation is an MMAv3 dot.
+  tt::DotOp dotOp = dynCastMMAv3Dot(op);
+  if (!dotOp)
+    return std::nullopt;
+
+  // Rule 1: All shmem operands are multi-buffered.
+  auto checkOperand = [&](Value operand) {
+    if (!isa<ttg::SharedEncodingAttr>(
+            operand.getType().cast<TensorOrMemDesc>().getEncoding())) {
       return true;
     }
-  }
-  return false;
-}
 
-static void removeExtraWait(tt::nvidia_gpu::DotWaitOp dotWaitOp,
-                            bool hasDotWait0) {
-  if (hasDotWait0) {
-    dotWaitOp->erase();
-  }
-}
-
-void mlir::triton::asyncLaunchDots(scf::ForOp forOp) {
-  Block *loop = forOp.getBody();
-  auto getBlockNumInFor = [](Operation *op, scf::ForOp forOp) {
-    if (!op)
-      return -1l;
-    auto lastOp = op;
-    while (op->getBlock()->getParentOp() != forOp) {
-      lastOp = op;
-      op = op->getBlock()->getParentOp();
+    // If it's a shmem operand, it must either be defined outside the loop, or
+    // come from an MemDescSubview op.  Only ConvertLayout and Trans ops are
+    // allowed in between.
+    Value transitiveOperand = operand;
+    while (isa_and_nonnull<ttg::ConvertLayoutOp, tt::TransOp>(
+        transitiveOperand.getDefiningOp())) {
+      transitiveOperand = transitiveOperand.getDefiningOp()->getOperand(0);
     }
-    return std::distance(lastOp->getBlock()->getParent()->begin(),
-                         lastOp->getBlock()->getIterator());
+    return forOp.isDefinedOutsideOfLoop(transitiveOperand) ||
+           isa<ttg::MemDescSubviewOp>(transitiveOperand.getDefiningOp());
   };
-  /// XXX(Keren): Clean up the following duplicate code with checkDotOp
-  /// dots to be pipelined
-  bool hasSyncDot = false;
-  bool hasDotWait0 = false;
-  SmallVector<tt::DotOp> allDots;
-  SmallVector<tt::DotOp> dots;
-  SmallVector<unsigned> resultNeedSync;
-  for (Operation &op : *loop) {
-    if (auto dotWaitOp = dyn_cast<tt::nvidia_gpu::DotWaitOp>(&op)) {
-      auto attr = dotWaitOp->getAttrOfType<IntegerAttr>("pendings");
-      auto pendingCount = attr.getInt();
-      if (pendingCount == 0)
-        hasDotWait0 = true;
-    }
-    if (auto dotOp = dyn_cast<tt::DotOp>(&op)) {
-      allDots.push_back(dotOp);
-    }
+
+  // We don't have to call checkOperand on getC() because it's always in
+  // registers, never in shmem.
+  assert(isa<ttg::NvidiaMmaEncodingAttr>(dotOp.getC().getType().getEncoding()));
+  if (!checkOperand(dotOp.getA()) || !checkOperand(dotOp.getB()))
+    return std::nullopt;
+
+  // Rule 2: The dot should only be used by the for loop's `yield`.
+  if (!dotOp->hasOneUse() ||
+      *dotOp->getUsers().begin() != forOp.getBody()->getTerminator())
+    return std::nullopt;
+
+  // The result of the dot becomes this loop carry value.
+  auto iterArgIdx = dotOp->getUses().begin()->getOperandNumber();
+
+  // Rule 3: The only users of the dot's result from iteration i-1 are other
+  // MMAv3 dots (synchronous or async) as the `c` operand.
+  if (!llvm::all_of(forOp.getRegionIterArg(iterArgIdx).getUses(),
+                    [&](OpOperand &use) {
+                      return dynCastMMAv3Dot(use.getOwner()) &&
+                             use.getOperandNumber() == 2;
+                    })) {
+    return std::nullopt;
   }
-  for (Operation &op : *loop) {
-    if (auto dotOp = dyn_cast<tt::DotOp>(&op)) {
-      RankedTensorType resTy = dotOp.getType();
-      if (auto resEnc =
-              resTy.getEncoding().dyn_cast<ttg::NvidiaMmaEncodingAttr>()) {
-        if (resEnc && resEnc.isHopper()) {
-          auto dot = dotOp.getResult();
-          bool valid = true;
 
-          // all users of dot should be scf.yield
-          if (!dot.hasOneUse())
-            valid = false;
-          if (!isa<scf::YieldOp>(*dot.getUsers().begin()))
-            valid = false;
+  return iterArgIdx;
+}
 
-          Operation *firstUse = nullptr;
-          auto depend = selfDepend(dotOp, forOp, &firstUse);
-          bool selfDirectDepend = (dotOp == firstUse);
-          for (auto tempInAll : allDots) {
-            auto iter = std::find(dots.begin(), dots.end(), tempInAll);
-            if (iter != dots.end())
-              continue;
-            auto db = getBlockNumInFor(tempInAll, forOp);
-            auto fb = getBlockNumInFor(firstUse, forOp);
-            if (db < fb ||
-                (db == fb && db >= 0 && tempInAll->isBeforeInBlock(firstUse)))
-              hasSyncDot = true;
-          }
-          auto CArg = dotOp.getOperand(2);
-          if (!(selfDirectDepend ||
-                (depend && !selfDirectDepend && hasSyncDot)) ||
-              !CArg.hasOneUse())
-            valid = false;
-
-          // Both operands needs to have been multi-buffered if they come from
-          // shared memory otherwise we will have a race condition as the shared
-          // memory will be overriden before the wgmma wait.
-          // Note that we relay on the assumption that `createAsynOps` will have
-          // allocated enough buffers to pipeline dot operation with 2 stages.
-          for (Value operand : {dotOp.getOperand(0), dotOp.getOperand(1)}) {
-            auto operandEncoding =
-                operand.getType().cast<TensorOrMemDesc>().getEncoding();
-            if (!operandEncoding.isa<ttg::SharedEncodingAttr>())
-              continue;
-            Value transitiveOperand = operand;
-            while (isa_and_nonnull<ttg::ConvertLayoutOp, tt::TransOp>(
-                transitiveOperand.getDefiningOp()))
-              transitiveOperand =
-                  transitiveOperand.getDefiningOp()->getOperand(0);
-            if (forOp.isDefinedOutsideOfLoop(transitiveOperand))
-              continue;
-            if (transitiveOperand.getDefiningOp<ttg::MemDescSubviewOp>() ==
-                nullptr)
-              valid = false;
-          }
-
-          if (valid) {
-            dots.push_back(dotOp);
-            resultNeedSync.push_back(
-                dotOp->getUses().begin()->getOperandNumber());
-          }
-        }
+// If necessary, insert a dot-wait inside the loop, waiting for the results of
+// the async dots from iteration i-1 to complete.  (We pipeline to depth 2, so
+// there are at most 2 dots in flight at any point in time.)
+//
+// We can skip inserting the wait if we have a synchronous MMAv3 dot that
+// appears either (a) before any uses of async dots' values from iteration i-1,
+// or (b) after all uses of the async dots in iteration this iteration.
+//
+// By contract, the only users of the async dots' results from iteration i-1 are
+// other MMAv3 dots, and the only user of the async dots in the current
+// iteration is the loop's `yield` op.  So it's sufficient to check whether a
+// sync dot appears first or last in the list of all sync+async dots.
+//
+// If such a sync dot exists, we convert it to async+wait so that we can thread
+// the dependencies through the wait op.  This keeps other passes from
+// reordering the dots.
+//
+// TODO(jlebar): It's possible that the sync dot might appear in the wrong place
+// but could be hoisted/sunk to the right place.  Right now we don't handle
+// this.
+static void insertAsyncDotWaitInLoop(
+    scf::ForOp forOp,
+    MutableArrayRef<std::pair<Operation *, int /*iterArgIdx*/>> asyncDots) {
+  // If a synchronous dot appears before an async dot in this range, return it.
+  auto findSynchronizingDot = [](auto &&range) -> tt::DotOp {
+    for (Operation &op : range) {
+      if (isa<ttng::DotAsyncOp>(op)) {
+        break;
+      }
+      if (tt::DotOp dot = dynCastMMAv3Dot(&op)) {
+        return dot;
       }
     }
+    return nullptr;
+  };
+
+  tt::DotOp synchronizingDot;
+  bool syncAtBeginning = false;
+  if (auto dot = findSynchronizingDot(*forOp.getBody())) {
+    synchronizingDot = dot;
+    syncAtBeginning = true;
+  } else if (auto dot = findSynchronizingDot(llvm::reverse(*forOp.getBody()))) {
+    synchronizingDot = dot;
   }
 
-  // Early stop: no need to continue if there is no valid dot in the loop.
-  if (dots.empty())
-    return;
-
-  OpBuilder builder(forOp);
-  // 0. insert dot_wait after the last dot in the loop as we implicitly pipeline
-  // wgmma ops by one stage.
-  // This is needed to prevent shared memory inputs to be overridden before the
-  // operation is completed.
-  // TODO: merge this with the rest of the pipelining transformation and look at
-  // a better representation for async dots.
-  tt::DotOp lastDot = dots.back();
-  auto loc = lastDot.getLoc();
-  builder.setInsertionPointAfter(lastDot);
-  auto dotWait = builder.create<tt::nvidia_gpu::DotWaitOp>(
-      lastDot.getLoc(), lastDot.getResult(), dots.size());
-
-  // 1. replace Dot with DotAsync
-  for (size_t idx = 0; idx < dots.size(); ++idx) {
-    tt::DotOp dotOp = dots[idx];
-    builder.setInsertionPoint(dotOp);
-    auto dotAsync = builder.create<tt::nvidia_gpu::DotAsyncOp>(
-        dotOp.getLoc(), dotOp.getA(), dotOp.getB(), dotOp.getC(),
-        dotOp.getAllowTF32(), dotOp.getMaxNumImpreciseAcc());
-    dotOp.replaceAllUsesWith(dotAsync.getResult());
-    dotOp->erase();
+  // If we have a synchyronizing dot, convert it to async and insert a wait
+  // right after it.  Otherwise, we'll insert the wait right after the last
+  // async dot.  (You might want to put the wait at the end of the loop, but
+  // there might be a load into shmem between the last async dot and the end of
+  // the loop, and that could clobber memory being used by a dot.)
+  IRRewriter builder(forOp.getContext());
+  if (synchronizingDot) {
+    builder.setInsertionPointAfter(synchronizingDot);
+    builder.replaceOpWithNewOp<ttng::DotAsyncOp>(
+        synchronizingDot.getOperation(), synchronizingDot.getA(),
+        synchronizingDot.getB(), synchronizingDot.getC(),
+        synchronizingDot.getAllowTF32(),
+        synchronizingDot.getMaxNumImpreciseAcc());
+  } else {
+    builder.setInsertionPointAfter(asyncDots.back().first);
   }
 
-  hasDotWait0 = hasDotWait0 || hasSyncDot;
-
-  // 2. If there's any outstanding DotAsyncOps, we need to wait for them.
-  builder.setInsertionPointAfter(forOp);
   SmallVector<Value> waitOperands;
-  for (int i = 0; i < resultNeedSync.size(); ++i) {
-    Value result = forOp->getResult(resultNeedSync[i]);
-    if (result.use_empty())
-      continue;
-    waitOperands.push_back(result);
+  for (auto [asyncDot, iterArgIdx] : asyncDots) {
+    waitOperands.push_back(syncAtBeginning
+                               ? cast<Value>(forOp.getRegionIterArg(iterArgIdx))
+                               : cast<Value>(asyncDot->getResult(0)));
   }
-  if (!waitOperands.empty()) {
-    auto dotWait = builder.create<tt::nvidia_gpu::DotWaitOp>(forOp.getLoc(),
-                                                             waitOperands, 0);
-    for (int i = 0; i < resultNeedSync.size(); ++i) {
-      Value result = forOp->getResult(resultNeedSync[i]);
-      result.replaceAllUsesExcept(dotWait.getResult(i), dotWait);
+
+  // If this wait belongs to a synchronous dot, we need to wait for *all* async
+  // dots to complete, so we pass 0 for `pendings`.  OTOH if there are no sync
+  // dots, we wait for all async dots from the i-1'th iteration to complete, IOW
+  // we wait until there are at most `asyncDots.size()` dots in flight.
+  auto dotWait = builder.create<ttng::DotWaitOp>(
+      asyncDots.back().first->getLoc(), waitOperands,
+      /*pendings=*/synchronizingDot ? 0 : asyncDots.size());
+  for (int i = 0; i < waitOperands.size(); ++i) {
+    waitOperands[i].replaceAllUsesExcept(dotWait.getResult(i), dotWait);
+  }
+}
+
+// Convert tt::DotOps into ttng::DotAsyncOps and insert waits as necessary.
+//
+// We assume we have space for each dot to be pipelined to depth 2, i.e. each
+// dot op in the loop can have at most 2 wgmma ops in flight at once.
+void triton::asyncLaunchDots(scf::ForOp forOp) {
+  LDBG("Original loop:\n" << *forOp);
+
+  // Dots that can be made async.  Each dot's only use is in the loop's `yield`
+  // statement; the `int` is its index in that op.
+  SmallVector<std::pair<Operation *, int /*iterArgIdx*/>> asyncDots;
+  for (Operation &op : *forOp.getBody()) {
+    if (auto iterArgsIdx = dotCanBeMadeAsync(&op, forOp)) {
+      LDBG("Will convert into an async dot: " << op);
+      asyncDots.push_back({&op, iterArgsIdx.value()});
     }
   }
 
-  // 3. potentially remove redundant dot_wait after dot_async if having multiple
-  // DotOp in the loop
-  removeExtraWait(dotWait, hasDotWait0);
+  if (asyncDots.empty()) {
+    LDBG("No dots to make async.");
+    return;
+  }
+
+  IRRewriter builder(forOp.getContext());
+
+  // First, make each eligible dot asynchronous.
+  for (auto &[op, iterArgIdx] : asyncDots) {
+    auto dotOp = cast<tt::DotOp>(op);
+    builder.setInsertionPoint(op);
+    op = builder.replaceOpWithNewOp<ttng::DotAsyncOp>(
+        dotOp, dotOp.getA(), dotOp.getB(), dotOp.getC(), dotOp.getAllowTF32(),
+        dotOp.getMaxNumImpreciseAcc());
+  }
+
+  // Next, insert a wait inside the loop.  We pipeline to depth 2, so the third
+  // iteration's set of asynchronous dots (and their corresponding async copies
+  // from global to shmem) can't start until the first iteration's set has
+  // completed.
+  insertAsyncDotWaitInLoop(forOp, asyncDots);
+
+  // Finally, insert a wait after the loop, waiting for dots from the final
+  // iteration of the loop.
+  SmallVector<Value> waitOperands;
+  for (auto [asyncDot, iterArgIdx] : asyncDots) {
+    waitOperands.push_back(forOp.getResult(iterArgIdx));
+  }
+  // Wait until there are 0 outstanding async dot ops.
+  builder.setInsertionPointAfter(forOp);
+  auto dotWaitAfterLoop =
+      builder.create<ttng::DotWaitOp>(forOp.getLoc(), waitOperands, 0);
+  for (int i = 0; i < waitOperands.size(); ++i) {
+    waitOperands[i].replaceAllUsesExcept(dotWaitAfterLoop.getResult(i),
+                                         dotWaitAfterLoop);
+  }
 }

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -99,7 +99,6 @@ unsigned getElementBitWidth(RankedTensorType type) {
 unsigned getNumElementsPerThread(Operation *op, SmallVector<unsigned> order,
                                  ModuleAxisInfoAnalysis &axisInfoAnalysis) {
   Value val = getMemAccessPtr(op);
-  assert(val.getType().isa<RankedTensorType>());
   auto ty = val.getType().cast<RankedTensorType>();
   auto shapePerCTA = triton::gpu::getShapePerCTA(ty);
   AxisInfo &valInfo = *axisInfoAnalysis.getAxisInfo(val);

--- a/test/TritonGPU/pipeline-hopper-remove-wait.mlir
+++ b/test/TritonGPU/pipeline-hopper-remove-wait.mlir
@@ -114,6 +114,10 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
       %116 = arith.truncf %115 : tensor<128x64xf32, #mma> to tensor<128x64xf16, #mma>
       %117 = triton_gpu.local_alloc %112 : (tensor<64x128xf16, #blocked>) -> !tt.memdesc<64x128xf16, #shared>
       %118 = triton_gpu.convert_layout %116 : tensor<128x64xf16, #mma> -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma}>>
+      // The first dot gets converted to dot-async + wait.  The second one
+      // doesn't have a wait because the first wait is sufficient.
+      // CHECK: triton_nvidia_gpu.dot_async
+      // CHECK: triton_nvidia_gpu.dot_wait {{.*}} {pendings = 0 : i32}
       // CHECK: triton_nvidia_gpu.dot_async
       // CHECK-NOT: triton_nvidia_gpu.dot_wait
       // CHECK: scf.yield


### PR DESCRIPTION
<git-pr-chain>


[Backend] Clean up MMAv3 part of MatmulLoopPipeline.

The MMAv3 pipelining code needed some love and comments.

There are some minor functional changes in here.  For example, the old
code relied on a particular order of op.users(), and I'm not convinced
it was correct.

Once you unravel the code, what it needs to do is a lot less complicated
than what it was doing.  Indeed, despite the fact that I added a ton of
comments, it's roughly the same length as before.

The changes to the test are cosmetic.  Previously we emitted tt.dot and
assumed it would eventually becdome ttng.dot_async in a later pass (or
at least during codegen).  Now we explicitly convert some tt.dot's to
ttng.dot_async so we can have an explicit wait and thread the results
through.

There's more cleanup that can be done here (see the TODOs added in this
PR), but I needed to stop somewhere.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3301 👈 **YOU ARE HERE**


</git-pr-chain>








