### PR TITLE
[Easy][FRONTEND] Expose `RedisRemoteCacheBackend` in `__init__.py`

### DIFF
--- a/python/triton/runtime/__init__.py
+++ b/python/triton/runtime/__init__.py
@@ -1,4 +1,5 @@
 from .autotuner import (Autotuner, Config, Heuristics, OutOfResources, autotune, heuristics)
+from .cache import RedisRemoteCacheBackend, RemoteCacheBackend
 from .driver import driver
 from .jit import JITFunction, KernelInterface, MockTensor, TensorWrapper, reinterpret
 
@@ -10,7 +11,9 @@ __all__ = [
     "heuristics",
     "JITFunction",
     "KernelInterface",
+    "RedisRemoteCacheBackend",
     "reinterpret",
+    "RemoteCacheBackend",
     "TensorWrapper",
     "OutOfResources",
     "MockTensor",


### PR DESCRIPTION
https://github.com/openai/triton/pull/2934 added `RedisRemoteCacheBackend` but did not add the symbol to `__init__.py`. Let's also add there so that we can refer to it via full path instead of having to `from ... import RedisRemoteCacheBackend`.