### PR TITLE
Allow using `do_bench_cudagraph` in autotuning

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -4,8 +4,10 @@ import builtins
 import time
 from typing import Dict
 
-from ..testing import do_bench
+from ..testing import do_bench, do_bench_cudagraph
 from .jit import KernelInterface
+
+import torch
 
 
 class OutOfResources(Exception):
@@ -36,6 +38,7 @@ class Autotuner(KernelInterface):
         prune_configs_by: Dict = None,
         warmup=25,
         rep=100,
+        use_cuda_graph=False,
     ):
         """
         :param prune_configs_by: a dict of functions that are used to prune configs, fields:
@@ -91,6 +94,8 @@ class Autotuner(KernelInterface):
         self.fn = fn
         self.num_warmups = warmup
         self.num_reps = rep
+        self.use_cuda_graph = use_cuda_graph and torch.cuda.is_available()
+        self.benchmarkig_stream = torch.cuda.Stream() if self.use_cuda_graph else None
 
     def _bench(self, *args, config, **meta):
         # check for conflicts, i.e. meta-parameters both provided
@@ -112,11 +117,16 @@ class Autotuner(KernelInterface):
                 num_warps=config.num_warps,
                 num_stages=config.num_stages,
                 num_ctas=config.num_ctas,
+                autotune=autotune,
                 **current,
             )
             self.post_hook(args)
 
         try:
+            if self.use_cuda_graph:
+                with torch.cuda.stream(self.benchmarkig_stream):
+                    bench_res = do_bench_cudagraph(kernel_call, rep=self.num_reps, return_mode="median")
+                return [bench_res]
             return do_bench(kernel_call, warmup=self.num_warmups, rep=self.num_reps, quantiles=(0.5, 0.2, 0.8))
         except OutOfResources:
             return [float("inf"), float("inf"), float("inf")]
@@ -238,7 +248,7 @@ class Config:
         return ", ".join(res)
 
 
-def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_value=None, warmup=25, rep=100):
+def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_value=None, warmup=25, rep=100, use_cuda_graph=False):
     """
     Decorator for auto-tuning a :code:`triton.jit`'d function.
 
@@ -278,7 +288,7 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     """
 
     def decorator(fn):
-        return Autotuner(fn, fn.arg_names, configs, key, reset_to_zero, restore_value, prune_configs_by, warmup, rep)
+        return Autotuner(fn, fn.arg_names, configs, key, reset_to_zero, restore_value, prune_configs_by, warmup, rep, use_cuda_graph=use_cuda_graph)
 
     return decorator
 

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -16,7 +16,8 @@ def nvsmi(attrs):
     return ret
 
 
-def do_bench_cudagraph(fn, rep=20, grad_to_none=None):
+def do_bench_cudagraph(fn, rep=20, grad_to_none=None, return_mode="mean"):
+    assert return_mode in ["min", "max", "mean", "median"]
     import torch
     """
     Benchmark the runtime of the provided function.
@@ -73,7 +74,8 @@ def do_bench_cudagraph(fn, rep=20, grad_to_none=None):
         end_event.record()
         torch.cuda.synchronize()
         ret += [start_event.elapsed_time(end_event) / n_repeat]
-    return torch.mean(torch.tensor(ret)).item()
+    times = torch.tensor(ret)
+    return getattr(torch, return_mode)(times).item()
 
 
 def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, fast_flush=True, return_mode="mean"):


### PR DESCRIPTION
Currently autotuner uses `torch.testing.do_bench`, including Triton launch overhead into runtime. In a scenario when you know that your kernel will run in CUDA graph mode, this creates a discrepancy between the runtime autotuner sees and the actual runtime in production. For smaller kernels Triton launch overhead can be relatively large, and we have seen autotuner select suboptimal configs because of that.

So, for kernels which are supposed to be CUDA graphed in prod, it makes more sense to also compare runtimes in the same mode. This PR adds an option to use `torch.testing.do_bench_cudagraph` in that case.