### PR TITLE
Revert "fix: correctly fallback to setuptools (#3219)"

### DIFF
--- a/python/test/backend/test_device_backend.py
+++ b/python/test/backend/test_device_backend.py
@@ -43,7 +43,7 @@ def build_for_backend(name, src, srcdir):
         scheme = 'posix_prefix'
     py_include_dir = sysconfig.get_paths(scheme=scheme)["include"]
 
-    ret = subprocess.run([cc, src, f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", "-o", so])
+    ret = subprocess.check_call([cc, src, f"-I{py_include_dir}", f"-I{srcdir}", "-shared", "-fPIC", "-o", so])
     if ret == 0:
         return so
     # fallback on setuptools

--- a/python/triton/runtime/build.py
+++ b/python/triton/runtime/build.py
@@ -45,7 +45,7 @@ def _build(name, src, srcdir, library_dirs, include_dirs, libraries):
     cc_cmd += [f'-l{lib}' for lib in libraries]
     cc_cmd += [f"-L{dir}" for dir in library_dirs]
     cc_cmd += [f"-I{dir}" for dir in include_dirs]
-    ret = subprocess.run(cc_cmd)
+    ret = subprocess.check_call(cc_cmd)
     if ret == 0:
         return so
     # fallback on setuptools


### PR DESCRIPTION
This reverts commit 375fee087e408d645a9c30bb1424f16fd148d97c.

Reverting this PR as it causes error in our internal tests. It reaches this error in `python3.11/site-packages/setuptools/_distutils/core.py `
```
def run_commands(dist):
    """Given a Distribution object run all the commands,
    raising ``SystemExit`` errors in the case of failure.

    This function assumes that either ``sys.argv`` or ``dist.script_args``
    is already set accordingly.
    """
    try:
        dist.run_commands()
    except KeyboardInterrupt:
        raise SystemExit("interrupted")
    except OSError as exc:
        if DEBUG: 
            sys.stderr.write("error: {}\n".format(exc))
            raise 
        else:
            raise SystemExit("error: {}".format(exc))
   
    except (DistutilsError, CCompilerError) as msg:
        if DEBUG:
            raise
        else:
            raise SystemExit("error: " + str(msg))

    return dist
```