### PR TITLE
[Easy][FRONTEND] Add pre run hooks to JITFunction

### DIFF
--- a/python/test/unit/runtime/test_jit.py
+++ b/python/test/unit/runtime/test_jit.py
@@ -1,0 +1,42 @@
+import itertools
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+
+
+def test_pre_call_hooks():
+
+    @triton.jit
+    def add_kernel(
+        in_ptr0,
+        in_ptr1,
+        out_ptr,
+        n_elements,
+        BLOCK_SIZE: "tl.constexpr",
+    ):
+        pid = tl.program_id(axis=0)
+        block_start = pid * BLOCK_SIZE
+        offsets = block_start + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(in_ptr0 + offsets, mask=mask)
+        y = tl.load(in_ptr1 + offsets, mask=mask)
+        output = x + y
+        tl.store(out_ptr + offsets, output, mask=mask)
+
+    class MyTensor(torch.Tensor):
+        pass
+
+    def my_hook(*args, **kwargs):
+        for arg in itertools.chain(args, kwargs.values()):
+            if isinstance(arg, MyTensor):
+                raise Exception("MyTensor is not allowed")
+
+    add_kernel.add_pre_run_hook(my_hook)
+
+    x = torch.randn(4).cuda()
+    y = MyTensor(x)
+    out = torch.zeros_like(x)
+    with pytest.raises(Exception):
+        add_kernel[(4, )](x, y, out, 4, 4)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -339,6 +339,14 @@ class JITFunction(KernelInterface[T]):
             already_compiled=False,
         )
 
+    def add_pre_run_hook(self, hook):
+        '''
+        Add a hook that will be executed prior to the execution of run
+        function with args and kwargs passed into the kernel
+        '''
+        assert callable(hook)
+        self.pre_run_hooks.append(hook)
+
     def run(self, *args, grid, warmup, **kwargs):
         from ..compiler import CompiledKernel, compile, ASTSource, make_backend
         # deprecated arguments
@@ -352,6 +360,11 @@ class JITFunction(KernelInterface[T]):
         backend = make_backend(target)
         kwargs["debug"] = self.debug
         options = backend.parse_options(kwargs)
+
+        # Execute pre run hooks with args and kwargs
+        for hook in self.pre_run_hooks:
+            hook(*args, **kwargs)
+
         # bind non-reserved keyword args and set defaults
         kwargs = {k: v for k, v in kwargs.items() if not k in options.__dict__}
         bound_args = self.signature.bind(*args, **kwargs)
@@ -447,6 +460,9 @@ class JITFunction(KernelInterface[T]):
         # remove the fields here.
         self.arg_names = [p.name for p in self.params]
         self.constexprs = [p.num for p in self.params if p.is_constexpr]
+
+        # Hooks that will be called prior to executing "run"
+        self.pre_run_hooks = []
 
         # reuse docs of wrapped function
         self.__doc__ = fn.__doc__


### PR DESCRIPTION
This PR adds pre run hooks to JITFunction in order for user to do analysis/error detection or any other pre hook operation they would like to do prior to execution of the kernel.

For PyTorch, the specific use case we have is being able to provide better error messages when a FakeTensor (our tracing tensors) are passed into the a Triton Kernel.

In addition our use case, these pre run hooks should provide generic functionality to users.