### PR TITLE
[NVGPU] Allow async dots in an additional case.

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -192,6 +192,11 @@ def TTG_LocalDeallocOp : TTG_Op<"local_dealloc", [MemoryEffects<[MemFree<SharedM
     This operation is optional.  If you don't explicitly dealloc a buffer, the
     compiler assumes it's deallocated at the first point that post-dominates all
     uses of the alloc.
+
+    Because we assume a memdesc is dead at the first point that post-dominates
+    its uses, ops that wait for an async operation on a memdesc to complete
+    (such as triton_nvidia_gpu.dot_wait) should also take the memdesc as an
+    operand.
   }];
 
   let arguments = (ins TT_MemDescType:$ptr);

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -102,8 +102,8 @@ def TTNG_DotAsyncOp : TTNG_Op<"dot_async", [Pure,
 def TTNG_DotWaitOp : TTNG_Op<"dot_wait", [DeclareOpInterfaceMethods<InferTypeOpInterface>,
                                           AllTypesMatch<["inputs", "outputs"]>]> {
   let summary = "dot wait";
-  let arguments = (ins Variadic<TT_FpIntTensor>:$inputs, I32Attr:$pendings);
-  let results = (outs Variadic<TT_FpIntTensor>:$outputs);
+  let arguments = (ins Variadic<TT_TensorOrMemDesc>:$inputs, I32Attr:$pendings);
+  let results = (outs Variadic<TT_TensorOrMemDesc>:$outputs);
   let description = [{
     Waits until there are $pendings or fewer outstanding async dot operations.
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -873,26 +873,54 @@ void mlir::triton::updateWaits(ModuleOp module) {
   combineRedundantWaitOps(waitOps);
 }
 
-// Tries to cast op to a tt::DotOp, if it's an MMAv3 (i.e. wgmma / hopper) dot.
+// Add the given values as operands of the given wait, and replace all uses of
+// the values with the wait.
 //
-// Note that this returns nullptr for ttng::DotAsyncOps, but we can't call this
-// "dynCastMMAv3SyncDot", because this is sometimes used before we've converted
-// eligible tt::DotOps to ttng::DotAsyncOp.
-tt::DotOp dynCastMMAv3Dot(Operation *op) {
-  if (auto dotOp = dyn_cast<tt::DotOp>(op)) {
-    auto resEnc =
-        dotOp.getType().getEncoding().dyn_cast<ttg::NvidiaMmaEncodingAttr>();
-    if (resEnc && resEnc.isHopper()) {
-      return dotOp;
-    }
+// That is, threading %a through the wait transforms
+//
+//   %a = <...>
+//   (%x', %y') = ttng.async_wait %x, %y
+//   %b = fn(%a)
+//
+// into
+//
+//   %a = <...>
+//   (%x', %y', %a') = ttng.async_wait %x, %y, %a
+//   %b = fn(%a')
+//
+// The wait must dominate all uses of the elements of `values`.
+static void threadValuesThroughWait(ttng::DotWaitOp wait,
+                                    MutableArrayRef<Value> values) {
+  IRRewriter builder(wait.getContext());
+  builder.setInsertionPoint(wait);
+
+  SmallVector<Value> newOperands(wait->getOperands());
+  newOperands.insert(newOperands.end(), values.begin(), values.end());
+
+  // We can't use replaceWithNewOp because we're changing the number of return
+  // values in the operation.
+  auto newWait = builder.create<ttng::DotWaitOp>(wait.getLoc(), newOperands,
+                                                 wait.getPendings());
+  for (int i = 0; i < wait->getNumResults(); i++) {
+    wait.getResult(i).replaceAllUsesWith(newWait.getResult(i));
   }
-  return nullptr;
+  for (int i = 0; i < values.size(); i++) {
+    values[i].replaceAllUsesExcept(newWait.getResult(wait->getNumResults() + i),
+                                   newWait);
+  }
+  wait->erase();
 }
 
-// Determines whether a tt.dot op can be transformed into ttng.dot.async.  The
-// dot can be made async if all of the following are true.
+// Determines whether a given MMAv3 dot op, represented as ttng.dot_async, needs
+// a wait immediately after it.
 //
-//  0. The operation is an MMAv3 dot.
+// In PTX, MMAv3 exists only as an asynchronous op.  In Triton, we can represent
+// MMAv3 ops as either tt.dot (synchronous) or ttng.dot_async.  But even if we
+// use ttng.dot_async, the conservative thing is to make a dot "effectively
+// synchronous" by inserting a `ttng.dot_wait {pendings=0}` right after it.
+//
+// We can omit the wait and create a "properly async" dot if all of the
+// following are true.
 //
 //  1. All operands that touch shared memory are multi-buffered, i.e. can't read
 //     an incomplete value while it's being written asynchronously by a load.
@@ -900,8 +928,9 @@ tt::DotOp dynCastMMAv3Dot(Operation *op) {
 //  2. During iteration i, nothing other than the loop's `yield` reads the
 //     result of the dot.
 //
-//  3. During iteration i, the result of the dot from iteration i-1 is consumed
-//     only by other MMAv3 dots (either sync or async) as the `c` operand.
+//  3. During iteration i, between the start of the loop up until the first
+//     `ttng.dot_wait {pendings=0}` op, the result of the dot from iteration i-1
+//     is consumed only by other MMAv3 dots as the `c` operand.
 //
 //     This is safe because the following pseudo-PTX is valid:
 //
@@ -910,24 +939,20 @@ tt::DotOp dynCastMMAv3Dot(Operation *op) {
 //
 //     That is, the second async dot can use the result of the first one without
 //     an intervening wait.  However, the only operation that can legally read
-//     %accum before the wait is another dot.async, and this only works for the
+//     %accum before the wait is another dot_async, and this only works for the
 //     `c` operand, not `a` or `b`.  See
 //     https://docs.nvidia.com/cuda/parallel-thread-execution/#asynchronous-warpgroup-level-matrix-instructions-wgmma-fence
 //     (ttng::DotAsyncOp corresponds to wgmma.fence followed by one or more
-//     wgmma.async ops, so our reading is that the two ttng::DotAsyncOps don't
-//     have to correspond to wgmma.async ops with the same shapes as specified
-//     in the docs, because there's an intervening fence.)
+//     wgmma.async ops, so our understanding is that the two ttng::DotAsyncOps
+//     don't have to correspond to wgmma.async ops with the same shapes as
+//     specified in the docs, because there's an intervening fence.)
 //
-//     A synchronous MMAv3 dot will be codegen'ed as `dot.async; wait 0`, so it
-//     works just as well as an async dot for these purposes.
+// If the op can be properly async, this function returns the index of the dot
+// in the loop's iter_args.  (Rule (2) above ensures this is well-defined.)
 //
-// On success, this function returns the index of the dot in the loop's
-// iter_args.  (Rule (2) above ensures this is well-defined.)
-static std::optional<int> dotCanBeMadeAsync(Operation *op, scf::ForOp forOp) {
-  // Rule 0: The operation is an MMAv3 dot.
-  tt::DotOp dotOp = dynCastMMAv3Dot(op);
-  if (!dotOp)
-    return std::nullopt;
+static std::optional<int> dotCanBeProperlyAsync(ttng::DotAsyncOp dotOp,
+                                                scf::ForOp forOp) {
+  LDBG("Considering whether to make MMAv3 dot properly async: " << dotOp);
 
   // Rule 1: All shmem operands are multi-buffered.
   auto checkOperand = [&](Value operand) {
@@ -951,162 +976,209 @@ static std::optional<int> dotCanBeMadeAsync(Operation *op, scf::ForOp forOp) {
   // We don't have to call checkOperand on getC() because it's always in
   // registers, never in shmem.
   assert(isa<ttg::NvidiaMmaEncodingAttr>(dotOp.getC().getType().getEncoding()));
-  if (!checkOperand(dotOp.getA()) || !checkOperand(dotOp.getB()))
-    return std::nullopt;
-
-  // Rule 2: The dot should only be used by the for loop's `yield`.
-  if (!dotOp->hasOneUse() ||
-      *dotOp->getUsers().begin() != forOp.getBody()->getTerminator())
-    return std::nullopt;
-
-  // The result of the dot becomes this loop carry value.
-  auto iterArgIdx = dotOp->getUses().begin()->getOperandNumber();
-
-  // Rule 3: The only users of the dot's result from iteration i-1 are other
-  // MMAv3 dots (synchronous or async) as the `c` operand.
-  if (!llvm::all_of(forOp.getRegionIterArg(iterArgIdx).getUses(),
-                    [&](OpOperand &use) {
-                      return dynCastMMAv3Dot(use.getOwner()) &&
-                             use.getOperandNumber() == 2;
-                    })) {
+  if (!checkOperand(dotOp.getA()) || !checkOperand(dotOp.getB())) {
+    LDBG("Can't make dot async because shmem operands aren't multi-buffered");
     return std::nullopt;
   }
 
-  return iterArgIdx;
+  // Rule 2: The dot should only be used by the for loop's `yield`.
+  if (!dotOp->hasOneUse() ||
+      *dotOp->getUsers().begin() != forOp.getBody()->getTerminator()) {
+    LDBG("Can't make dot async because it is not used only by the loop's "
+         "`yield`.");
+    return std::nullopt;
+  }
+
+  // The result of the dot becomes this loop carry value.
+  auto iterArgIdx = dotOp->getUses().begin()->getOperandNumber();
+  auto iterArg = forOp.getRegionIterArg(iterArgIdx);
+
+  // Rule 3a: Are the only users of the dot's result from iteration i-1 other
+  // MMAv3 dots?  If so, we're done, this dot can be properly async.
+  if (llvm::all_of(iterArg.getUses(), [&](OpOperand &use) {
+        return isa<ttng::DotAsyncOp>(use.getOwner()) &&
+               use.getOperandNumber() == 2;
+      })) {
+    return iterArgIdx;
+  }
+
+  // Rule 3b: Are all users of the dot's result from iteration i-1 after the
+  // first `dot_wait {pendings=0}` op?  If so, the dot can be properly async,
+  // but we have to thread its result from iteration i-1 through the wait.
+  auto waitOps = forOp.getBody()->getOps<ttng::DotWaitOp>();
+  auto firstWaitOpIter = llvm::find_if(
+      waitOps, [&](auto waitOp) { return waitOp.getPendings() == 0; });
+  if (firstWaitOpIter != waitOps.end() &&
+      llvm::all_of(iterArg.getUsers(), [&](Operation *user) {
+        assert(forOp->isAncestor(user));
+        while (user->getParentOp() != forOp) {
+          user = user->getParentOp();
+        }
+        return (*firstWaitOpIter)->isBeforeInBlock(user);
+      })) {
+    LDBG("MMAv3 dot can be properly async because it follows a dot_wait "
+         "{pendings=0}.\n"
+         << "  wait: " << *firstWaitOpIter << "\n"
+         << "  dot: " << dotOp);
+    threadValuesThroughWait(*firstWaitOpIter, {iterArg});
+    return iterArgIdx;
+  }
+
+  LDBG("Can't make dot async because its result from i-1 is used by "
+       "something other than another MMAv3 dot as the `c` operand.");
+  return std::nullopt;
 }
 
 // If necessary, insert a dot-wait inside the loop, waiting for the results of
 // the async dots from iteration i-1 to complete.  (We pipeline to depth 2, so
-// there are at most 2 dots in flight at any point in time.)
+// there are at most 2 copies of each dot_async in flight at a time.)
 //
-// We can skip inserting the wait if we have a synchronous MMAv3 dot that
+// We can skip inserting the wait if we have a `dot_wait {pendings=0}` that
 // appears either (a) before any uses of async dots' values from iteration i-1,
 // or (b) after all uses of the async dots in iteration this iteration.
 //
-// By contract, the only users of the async dots' results from iteration i-1 are
-// other MMAv3 dots, and the only user of the async dots in the current
-// iteration is the loop's `yield` op.  So it's sufficient to check whether a
-// sync dot appears first or last in the list of all sync+async dots.
+// By contract, the only users of the properly-async dots' results from
+// iteration i-1 are other MMAv3 dots, and the only user of the properly-async
+// dots in the current iteration is the loop's `yield` op.  So it's sufficient
+// to check whether a wait appears before or after all properly-async dots.
 //
-// If such a sync dot exists, we convert it to async+wait so that we can thread
-// the dependencies through the wait op.  This keeps other passes from
-// reordering the dots.
+// If such a wait exists, we thread the results of the dots through it.  This
+// keeps other passes from reordering the dots.
 //
-// TODO(jlebar): It's possible that the sync dot might appear in the wrong place
-// but could be hoisted/sunk to the right place.  Right now we don't handle
-// this.
+// TODO(jlebar): It's possible that the wait might appear in the wrong place but
+// could be hoisted/sunk to the right place.  Right now we don't handle this.
 static void insertAsyncDotWaitInLoop(
     scf::ForOp forOp,
-    MutableArrayRef<std::pair<Operation *, int /*iterArgIdx*/>> asyncDots) {
-  // If a synchronous dot appears before an async dot in this range, return it.
-  auto findSynchronizingDot = [](auto &&range) -> tt::DotOp {
+    const llvm::MapVector<Operation *, int /*iterArgIdx*/> &properlyAsyncDots) {
+  if (properlyAsyncDots.empty()) {
+    return;
+  }
+
+  // If a dot_wait {pendings=0} appears before a properly-async dot in this
+  // range, return it.
+  auto findSynchronizingWait = [&](auto &&range) -> ttng::DotWaitOp {
     for (Operation &op : range) {
-      if (isa<ttng::DotAsyncOp>(op)) {
+      if (properlyAsyncDots.contains(&op)) {
         break;
       }
-      if (tt::DotOp dot = dynCastMMAv3Dot(&op)) {
-        return dot;
+      if (auto wait = dyn_cast<ttng::DotWaitOp>(op)) {
+        if (wait.getPendings() == 0) {
+          return wait;
+        }
       }
     }
     return nullptr;
   };
 
-  tt::DotOp synchronizingDot;
+  ttng::DotWaitOp wait;
   bool syncAtBeginning = false;
-  if (auto dot = findSynchronizingDot(*forOp.getBody())) {
-    synchronizingDot = dot;
+  if (auto w = findSynchronizingWait(*forOp.getBody())) {
+    wait = w;
     syncAtBeginning = true;
-  } else if (auto dot = findSynchronizingDot(llvm::reverse(*forOp.getBody()))) {
-    synchronizingDot = dot;
+  } else if (auto w = findSynchronizingWait(llvm::reverse(*forOp.getBody()))) {
+    wait = w;
   }
 
-  // If we have a synchyronizing dot, convert it to async and insert a wait
-  // right after it.  Otherwise, we'll insert the wait right after the last
-  // async dot.  (You might want to put the wait at the end of the loop, but
-  // there might be a load into shmem between the last async dot and the end of
-  // the loop, and that could clobber memory being used by a dot.)
+  // If we don't have a synchronizing wait, add one right after the last
+  // properly-async dot.  This one only needs to wait for all properly-async
+  // dots from the i-1'th iteration to complete, IOW we wait until there are
+  // most `asyncDots.size()` dots in flight.
+  //
+  // (You might want to put the wait at the end of the loop instead of right
+  // after the last dot, but there could be a load into shmem between the last
+  // async dot and the end of the loop, and that could clobber memory being used
+  // by a dot.)
   IRRewriter builder(forOp.getContext());
-  if (synchronizingDot) {
-    builder.setInsertionPointAfter(synchronizingDot);
-    builder.replaceOpWithNewOp<ttng::DotAsyncOp>(
-        synchronizingDot.getOperation(), synchronizingDot.getA(),
-        synchronizingDot.getB(), synchronizingDot.getC(),
-        synchronizingDot.getAllowTF32(),
-        synchronizingDot.getMaxNumImpreciseAcc());
-  } else {
-    builder.setInsertionPointAfter(asyncDots.back().first);
+  if (!wait) {
+    auto lastAsyncDot = properlyAsyncDots.back().first;
+    builder.setInsertionPointAfter(lastAsyncDot);
+    wait = builder.create<ttng::DotWaitOp>(lastAsyncDot->getLoc(),
+                                           /*inputs=*/ArrayRef<Value>{},
+                                           properlyAsyncDots.size());
   }
 
-  SmallVector<Value> waitOperands;
-  for (auto [asyncDot, iterArgIdx] : asyncDots) {
-    waitOperands.push_back(syncAtBeginning
-                               ? cast<Value>(forOp.getRegionIterArg(iterArgIdx))
-                               : cast<Value>(asyncDot->getResult(0)));
+  // Thread the results of the async dots through the wait, noting that some
+  // might already be in there.
+  DenseSet<Value> curWaitOperands(wait.getOperands().begin(),
+                                  wait.getOperands().end());
+  SmallVector<Value> addlWaitOperands;
+  for (auto [asyncDot, iterArgIdx] : properlyAsyncDots) {
+    Value waitOperand = syncAtBeginning
+                            ? cast<Value>(forOp.getRegionIterArg(iterArgIdx))
+                            : cast<Value>(asyncDot->getResult(0));
+    if (!curWaitOperands.contains(waitOperand)) {
+      addlWaitOperands.push_back(waitOperand);
+    }
   }
-
-  // If this wait belongs to a synchronous dot, we need to wait for *all* async
-  // dots to complete, so we pass 0 for `pendings`.  OTOH if there are no sync
-  // dots, we wait for all async dots from the i-1'th iteration to complete, IOW
-  // we wait until there are at most `asyncDots.size()` dots in flight.
-  auto dotWait = builder.create<ttng::DotWaitOp>(
-      asyncDots.back().first->getLoc(), waitOperands,
-      /*pendings=*/synchronizingDot ? 0 : asyncDots.size());
-  for (int i = 0; i < waitOperands.size(); ++i) {
-    waitOperands[i].replaceAllUsesExcept(dotWait.getResult(i), dotWait);
-  }
+  threadValuesThroughWait(wait, addlWaitOperands);
 }
 
-// Convert tt::DotOps into ttng::DotAsyncOps and insert waits as necessary.
+// Convert MMAv3 tt::DotOps (i.e. Hopper wgmma) into ttng::DotAsyncOps and
+// insert ttng::DotWaitOps as necessary.
 //
 // We assume we have space for each dot to be pipelined to depth 2, i.e. each
-// dot op in the loop can have at most 2 wgmma ops in flight at once.
+// dot op in the loop can have at most 2 dot_async ops in flight at once.  (Each
+// dot_async op usually corresponds to a series of wgmma.async ops.)
 void triton::asyncLaunchDots(scf::ForOp forOp) {
   LDBG("Original loop:\n" << *forOp);
 
-  // Dots that can be made async.  Each dot's only use is in the loop's `yield`
-  // statement; the `int` is its index in that op.
-  SmallVector<std::pair<Operation *, int /*iterArgIdx*/>> asyncDots;
-  for (Operation &op : *forOp.getBody()) {
-    if (auto iterArgsIdx = dotCanBeMadeAsync(&op, forOp)) {
-      LDBG("Will convert into an async dot: " << op);
-      asyncDots.push_back({&op, iterArgsIdx.value()});
+  // First, change every MMAv3 tt.dot into ttng.dot_async.  The rest of this
+  // function is concerned with inserting ttng.dot_wait ops in the appropriate
+  // places.
+  //
+  // It's not strictly necessary to convert every dot into dot_async:
+  // Synchronous MMAv3 dots can be represented equally well as `tt.dot` or
+  // `ttng.dot_async; wait 0`.  But this makes things easier elsewhere.
+  //
+  // We call those dots that don't need to be followed immediately by a `wait 0`
+  // "properly async", or sometimes just "async".
+  IRRewriter builder(forOp.getContext());
+  for (auto dotOp : llvm::to_vector(forOp.getBody()->getOps<tt::DotOp>())) {
+    auto resEnc =
+        dotOp.getType().getEncoding().dyn_cast<ttg::NvidiaMmaEncodingAttr>();
+    if (resEnc && resEnc.isHopper()) {
+      builder.setInsertionPoint(dotOp);
+      builder.replaceOpWithNewOp<ttng::DotAsyncOp>(
+          dotOp, dotOp.getA(), dotOp.getB(), dotOp.getC(), dotOp.getAllowTF32(),
+          dotOp.getMaxNumImpreciseAcc());
     }
   }
 
-  if (asyncDots.empty()) {
-    LDBG("No dots to make async.");
-    return;
+  // For each dot, determine whether it can be properly async, or if it needs a
+  // sync immediately after.  If it can be properly async, we know its only use
+  // is in the loop's `yield` statement; asyncDots maps the op to its index in
+  // the yield op.
+  llvm::MapVector<Operation *, int /*iterArgIdx*/> properlyAsyncDots;
+  for (auto dotOp : forOp.getBody()->getOps<ttng::DotAsyncOp>()) {
+    if (auto iterArgIdx = dotCanBeProperlyAsync(dotOp, forOp)) {
+      properlyAsyncDots[dotOp] = *iterArgIdx;
+    } else {
+      builder.setInsertionPointAfter(dotOp);
+      builder.create<ttng::DotWaitOp>(dotOp.getLoc(), dotOp.getResult(),
+                                      /*pendings=*/0);
+    }
   }
 
-  IRRewriter builder(forOp.getContext());
-
-  // First, make each eligible dot asynchronous.
-  for (auto &[op, iterArgIdx] : asyncDots) {
-    auto dotOp = cast<tt::DotOp>(op);
-    builder.setInsertionPoint(op);
-    op = builder.replaceOpWithNewOp<ttng::DotAsyncOp>(
-        dotOp, dotOp.getA(), dotOp.getB(), dotOp.getC(), dotOp.getAllowTF32(),
-        dotOp.getMaxNumImpreciseAcc());
+  if (properlyAsyncDots.empty()) {
+    LDBG("No properly async dots.");
+    return;
   }
 
   // Next, insert a wait inside the loop.  We pipeline to depth 2, so the third
   // iteration's set of asynchronous dots (and their corresponding async copies
   // from global to shmem) can't start until the first iteration's set has
   // completed.
-  insertAsyncDotWaitInLoop(forOp, asyncDots);
+  insertAsyncDotWaitInLoop(forOp, properlyAsyncDots);
 
   // Finally, insert a wait after the loop, waiting for dots from the final
   // iteration of the loop.
   SmallVector<Value> waitOperands;
-  for (auto [asyncDot, iterArgIdx] : asyncDots) {
+  for (auto [asyncDot, iterArgIdx] : properlyAsyncDots) {
     waitOperands.push_back(forOp.getResult(iterArgIdx));
   }
   // Wait until there are 0 outstanding async dot ops.
   builder.setInsertionPointAfter(forOp);
   auto dotWaitAfterLoop =
-      builder.create<ttng::DotWaitOp>(forOp.getLoc(), waitOperands, 0);
-  for (int i = 0; i < waitOperands.size(); ++i) {
-    waitOperands[i].replaceAllUsesExcept(dotWaitAfterLoop.getResult(i),
-                                         dotWaitAfterLoop);
-  }
+      builder.create<ttng::DotWaitOp>(forOp.getLoc(), ArrayRef<Value>{}, 0);
+  threadValuesThroughWait(dotWaitAfterLoop, waitOperands);
 }

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -725,8 +725,13 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
           ConvertLayoutOp, nvidia_gpu::DotWaitOp>(op)) {
     Operation *newOp = cloneElementwise(rewriter, op, encoding);
     for (auto [oldResult, newResult] :
-         llvm::zip(op->getResults(), newOp->getResults()))
+         llvm::zip(op->getResults(), newOp->getResults())) {
+      if (oldResult.getType() == newResult.getType()) {
+        oldResult.replaceAllUsesWith(newResult);
+        continue;
+      }
       map(oldResult, newResult);
+    }
     return newOp;
   }
   llvm::report_fatal_error("unexpected op in rewrite");

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -tritongpu-pipeline=compute-capability=90 -canonicalize | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritongpu-pipeline=compute-capability=90 -canonicalize | FileCheck --dump-input-context=50 %s
 
 // 4 warps
 // matmul: 128x32 @ 32x128 -> 128x128
@@ -448,10 +448,10 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
     %19 = triton_gpu.local_alloc %9 : (tensor<128x64xf16, #blocked1>) -> !tt.memdesc<128x64xf16, #shared>
     %20 = triton_gpu.local_alloc %18 : (tensor<64x16xf16, #blocked>) -> !tt.memdesc<64x16xf16, #shared1>
     // CHECK: %[[R:.+]]:{{.+}} = scf.for
-    // CHECK:   triton_nvidia_gpu.dot_async
+    // CHECK:   %[[DOT1:.+]] = triton_nvidia_gpu.dot_async
     // CHECK:   triton_gpu.async_wait {{.*}} {num = 1 : i32}
-    // CHECK:   triton_nvidia_gpu.dot_async
-    // CHECK:   triton_nvidia_gpu.dot_wait %{{.*}} {pendings = 2 : i32}
+    // CHECK:   %[[DOT2:.+]] = triton_nvidia_gpu.dot_async
+    // CHECK:   triton_nvidia_gpu.dot_wait %[[DOT1]], %[[DOT2]] {pendings = 2 : i32}
     // CHECK:   scf.yield
     // CHECK: %{{.*}}:2 = triton_nvidia_gpu.dot_wait %[[R]]#{{.+}}, %[[R]]#{{.+}} {pendings = 0 : i32} : tensor<128x16xf32, #{{.*}}>, tensor<128x64xf32, #{{.*}}>
     %17:3 = scf.for %arg3 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%arg4 = %cst_3, %arg5 = %16, %arg6 = %cst_2) -> (tensor<128x64xf32, #mma>, tensor<64x16x!tt.ptr<f16, 1>, #blocked>, tensor<128x16xf32, #mma1>)  : i32 {
@@ -521,8 +521,8 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
       %38 = triton_gpu.local_alloc %36 : (tensor<64x256xf8E5M2, #blocked1>) -> !tt.memdesc<64x256xf8E5M2, #shared1>
       // CHECK: triton_gpu.local_alloc
       // CHECK: scf.for
-      // CHECK:   tt.dot
-      // CHECK-NOT:  triton_nvidia_gpu.dot_async
+      // CHECK:   triton_nvidia_gpu.dot_async
+      // CHECK-NEXT: triton_nvidia_gpu.dot_wait
       %39 = tt.dot %37, %38, %arg4 {allowTF32 = true, maxNumImpreciseAcc = 1073741824 : i32} : !tt.memdesc<128x64xf8E5M2, #shared> * !tt.memdesc<64x256xf8E5M2, #shared1> -> tensor<128x256xf32, #mma>
       %40 = tt.addptr %arg5, %cst_6 : tensor<128x64x!tt.ptr<f8E5M2, 1>, #blocked>, tensor<128x64xi32, #blocked>
       %41 = tt.addptr %arg6, %cst_5 : tensor<64x256x!tt.ptr<f8E5M2, 1>, #blocked1>, tensor<64x256xi32, #blocked1>
@@ -542,5 +542,79 @@ module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-c
     %34 = triton_gpu.convert_layout %33 : tensor<128x256xf8E5M2, #mma> -> tensor<128x256xf8E5M2, #blocked1>
     tt.store %32, %34 {cache = 1 : i32, evict = 1 : i32} : tensor<128x256xf8E5M2, #blocked1>
     tt.return
+  }
+}
+
+// -----
+
+// A dot can be properly async if all its uses follow a synchronous MMAv3 dot.
+#blocked = #triton_gpu.blocked<{sizePerThread = [8, 1], threadsPerWarp = [8, 4], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 16]}>
+#mma1 = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 16, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+#shared1 = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [0, 1], hasLeadingOffset = true}>
+module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: async_following_sync
+  tt.func @async_following_sync(%arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32}) -> (tensor<128x64xf32, #mma>, tensor<128x16xf32, #mma1>) {
+    %cst = arith.constant dense<0> : tensor<64x16xi32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %cst_0 = arith.constant dense<0> : tensor<1x16xi32, #blocked>
+    %cst_1 = arith.constant dense<0> : tensor<128x1xi32, #blocked1>
+    %c0_i64 = arith.constant 0 : i64
+    %cst_2 = arith.constant dense<0.000000e+00> : tensor<128x16xf32, #mma1>
+    %cst_3 = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %cst_4 = arith.constant dense<1.000000e+00> : tensor<128x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1}>>
+    %c1_i32 = arith.constant 1 : i32
+    %c8_i32 = arith.constant 8 : i32
+    %0 = tt.addptr %arg0, %c0_i64 : !tt.ptr<f16, 1>, i64
+    %1 = tt.addptr %arg1, %c0_i64 : !tt.ptr<f16, 1>, i64
+    %2 = tt.splat %1 : !tt.ptr<f16, 1> -> tensor<128x1x!tt.ptr<f16, 1>, #blocked1>
+    %3 = tt.addptr %2, %cst_1 : tensor<128x1x!tt.ptr<f16, 1>, #blocked1>, tensor<128x1xi32, #blocked1>
+    %4 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %5 = tt.expand_dims %4 {axis = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x64xi32, #blocked1>
+    %6 = tt.broadcast %3 : tensor<128x1x!tt.ptr<f16, 1>, #blocked1> -> tensor<128x64x!tt.ptr<f16, 1>, #blocked1>
+    %7 = tt.broadcast %5 : tensor<1x64xi32, #blocked1> -> tensor<128x64xi32, #blocked1>
+    %8 = tt.addptr %6, %7 : tensor<128x64x!tt.ptr<f16, 1>, #blocked1>, tensor<128x64xi32, #blocked1>
+    %9 = tt.load %8 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x64xf16, #blocked1>
+    %10 = tt.splat %0 : !tt.ptr<f16, 1> -> tensor<1x16x!tt.ptr<f16, 1>, #blocked>
+    %11 = tt.addptr %10, %cst_0 : tensor<1x16x!tt.ptr<f16, 1>, #blocked>, tensor<1x16xi32, #blocked>
+    %12 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %13 = tt.expand_dims %12 {axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %14 = tt.broadcast %11 : tensor<1x16x!tt.ptr<f16, 1>, #blocked> -> tensor<64x16x!tt.ptr<f16, 1>, #blocked>
+    %15 = tt.broadcast %13 : tensor<64x1xi32, #blocked> -> tensor<64x16xi32, #blocked>
+    %16 = tt.addptr %14, %15 : tensor<64x16x!tt.ptr<f16, 1>, #blocked>, tensor<64x16xi32, #blocked>
+    %18 = tt.load %16 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x16xf16, #blocked>
+    %19 = triton_gpu.local_alloc %9 : (tensor<128x64xf16, #blocked1>) -> !tt.memdesc<128x64xf16, #shared>
+    %20 = triton_gpu.local_alloc %18 : (tensor<64x16xf16, #blocked>) -> !tt.memdesc<64x16xf16, #shared1>
+    // CHECK:          %[[LOOP:[^ :]+]]{{.*}} scf.for {{.*}} iter_args(%[[PREV_DOT2:[^ ]+]]
+    // CHECK:            %[[DOT0:.+]] = triton_nvidia_gpu.dot_async
+    // CHECK:            %[[DOT1:.+]] = triton_nvidia_gpu.dot_async
+    // CHECK-NEXT:       triton_nvidia_gpu.dot_wait
+    // CHECK-DAG-SAME:     %[[DOT0]]
+    // CHECK-DAG-SAME:     %[[DOT1]]
+    // CHECK-DAG-SAME:     %[[PREV_DOT2]]
+    // CHECK-SAME:         {pendings = 0 : i32}
+    // CHECK:            %[[DOT2:.+]] = triton_nvidia_gpu.dot_async
+    // CHECK:            %[[WAIT:[^ :]+]]:2 = triton_nvidia_gpu.dot_wait %[[DOT0]], %[[DOT2]] {pendings = 2 : i32}
+    // CHECK:          scf.yield %[[WAIT]]#1
+    // CHECK:          triton_nvidia_gpu.dot_wait %[[LOOP]]#3, %[[LOOP]]#0 {pendings = 0 : i32}
+    %17:4 = scf.for %arg3 = %c0_i32 to %c8_i32 step %c1_i32 iter_args(%prev_dot2 = %cst_3, %arg5 = %16, %prev_dot1 = %cst_2, %prev_dot0 = %cst_2) -> (tensor<128x64xf32, #mma>, tensor<64x16x!tt.ptr<f16, 1>, #blocked>, tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1>)  : i32 {
+      // This one can be async.
+      %dot0 = tt.dot %19, %20, %prev_dot1 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : !tt.memdesc<128x64xf16, #shared> * !tt.memdesc<64x16xf16, #shared1> -> tensor<128x16xf32, #mma1>
+      // This can't be async because its result is modified before it's yielded.
+      %dot1 = tt.dot %19, %20, %prev_dot1 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : !tt.memdesc<128x64xf16, #shared> * !tt.memdesc<64x16xf16, #shared1> -> tensor<128x16xf32, #mma1>
+      %dot1.1 = arith.addf %dot1, %dot1 : tensor<128x16xf32, #mma1>
+      %l = tt.load %arg5 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x16xf16, #blocked>
+      %c = triton_gpu.local_alloc %l : (tensor<64x16xf16, #blocked>) -> !tt.memdesc<64x16xf16, #shared1>
+      %23 = tt.trans %c {order=array<i32: 1,0>} : !tt.memdesc<64x16xf16, #shared1> -> !tt.memdesc<16x64xf16, #shared>
+      // This dot can be async even though %prev_dot2 is not used directly by an
+      // async dot, because that use follows the synchronous dot above.
+      %prev_dot2.1 = arith.addf %prev_dot2, %prev_dot2 : tensor<128x64xf32, #mma>
+      %dot2 = tt.dot %cst_4, %23, %prev_dot2.1 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<128x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1}>> * !tt.memdesc<16x64xf16, #shared> -> tensor<128x64xf32, #mma>
+      %26 = tt.addptr %arg5, %cst : tensor<64x16x!tt.ptr<f16, 1>, #blocked>, tensor<64x16xi32, #blocked>
+      scf.yield %dot2, %26, %dot1.1, %dot0 : tensor<128x64xf32, #mma>, tensor<64x16x!tt.ptr<f16, 1>, #blocked>, tensor<128x16xf32, #mma1>, tensor<128x16xf32, #mma1>
+    }
+    tt.return %17#0, %17#2 : tensor<128x64xf32, #mma>, tensor<128x16xf32, #mma1>
   }
 }


### PR DESCRIPTION
<git-pr-chain>

#### Commits in this PR
1. [NVGPU] Allow async dots in an additional case.
    
    Previously a dot could be async if the only use of its value from iteration i-1
    was an async or sync dot.
    
    We relax this to allow arbitrary uses of the value from iteration i-1 so long
    as those uses come after a synchronous dot.  This better matches the original
    code before I rewrote it in https://github.com/openai/triton/pull/3097.
    
    To make this easier to reason about, I convert all MMAv3 dots to dot_async.
    The synchronous dots just have a wait immediately after.
    
    While we're here, we also thread dependencies properly through dot_wait ops.
    Now that all MMAv3 dots are dot_async, this is a lot easier to do.
1. Add memdesc's as operands of the dot_wait instruction.
1. Fix crash that was happening in RemoveLayoutConversions.

#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3327 👈 **YOU ARE HERE**


</git-pr-chain>




