### PR TITLE
[AMD backend] Fix unit test `test_dot_without_load` 

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -87,9 +87,7 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
     return elemTy;
   if (auto mfmaParent =
           dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
-    llvm::outs() << "mfmaLayouts================\n";
     return elemTy;
-    // return vec_ty(elemTy, dotOpLayout.getKWidth());
   }
   auto mmaParent = dotOpLayout.getParent().dyn_cast<NvidiaMmaEncodingAttr>();
   if (!mmaParent || mmaParent.isHopper())
@@ -121,17 +119,7 @@ Type TritonGPUToLLVMTypeConverter::convertTritonTensorType(
   }
 
   unsigned numElementsPerThread = getTotalElemsPerThread(type);
-  llvm::outs() << "layout = " << type.getEncoding();
-  llvm::outs() << ", numElementsPerThread = " << numElementsPerThread << ", eltType = " << eltType << "\n";
-  unsigned num = 1;
-  auto dotOpLayout = type.getEncoding().dyn_cast<DotOperandEncodingAttr>();
-  if (dotOpLayout) {
-    if (auto mfmaParent = dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
-      num = dotOpLayout.getKWidth();
-    }
-  }
-  // SmallVector<Type, 4> types(numElementsPerThread, eltType);
-  SmallVector<Type> types(numElementsPerThread * num, eltType);
+  SmallVector<Type> types(numElementsPerThread, eltType);
   return LLVM::LLVMStructType::getLiteral(ctx, types);
 }
 

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -126,8 +126,6 @@ Type TritonGPUToLLVMTypeConverter::convertTritonTensorType(
 Type TritonGPUToLLVMTypeConverter::convertMemDescType(MemDescType type) {
   auto ctx = type.getContext();
   Attribute layout = type.getEncoding();
-  // SmallVector<int64_t> shape(type.getShape().begin(), type.getShape().end());
-  // Type eltType = getElementTypeForStruct(cast<TensorOrMemDesc>(type));
   auto shared_layout = layout.cast<SharedEncodingAttr>();
   SmallVector<Type, 4> types;
   // base ptr

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -87,7 +87,8 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
     return elemTy;
   if (auto mfmaParent =
           dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
-    return vec_ty(elemTy, dotOpLayout.getKWidth());
+    return elemTy;
+    // return vec_ty(elemTy, dotOpLayout.getKWidth());
   }
   auto mmaParent = dotOpLayout.getParent().dyn_cast<NvidiaMmaEncodingAttr>();
   if (!mmaParent || mmaParent.isHopper())
@@ -119,7 +120,8 @@ Type TritonGPUToLLVMTypeConverter::convertTritonTensorType(
   }
 
   unsigned numElementsPerThread = getTotalElemsPerThread(type);
-  SmallVector<Type, 4> types(numElementsPerThread, eltType);
+  // SmallVector<Type, 4> types(numElementsPerThread, eltType);
+  SmallVector<Type> types(numElementsPerThread, eltType);
   return LLVM::LLVMStructType::getLiteral(ctx, types);
 }
 
@@ -127,7 +129,7 @@ Type TritonGPUToLLVMTypeConverter::convertMemDescType(MemDescType type) {
   auto ctx = type.getContext();
   Attribute layout = type.getEncoding();
   SmallVector<int64_t> shape(type.getShape().begin(), type.getShape().end());
-  Type eltType = getElementTypeForStruct(cast<TensorOrMemDesc>(type));
+  // Type eltType = getElementTypeForStruct(cast<TensorOrMemDesc>(type));
   auto shared_layout = layout.cast<SharedEncodingAttr>();
   SmallVector<Type, 4> types;
   // base ptr

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -85,10 +85,6 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
   auto dotOpLayout = layout.dyn_cast<DotOperandEncodingAttr>();
   if (!dotOpLayout)
     return elemTy;
-  if (auto mfmaParent =
-          dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
-    return elemTy;
-  }
   auto mmaParent = dotOpLayout.getParent().dyn_cast<NvidiaMmaEncodingAttr>();
   if (!mmaParent || mmaParent.isHopper())
     return elemTy;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -47,7 +47,8 @@ unsigned getTotalElemsPerThread(Attribute layout, ArrayRef<int64_t> shape,
     unsigned vecSize = 1;
     auto dotOpLayout = layout.dyn_cast<DotOperandEncodingAttr>();
     if (dotOpLayout) {
-      if (auto mfmaParent = dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
+      if (auto mfmaParent =
+              dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
         vecSize = dotOpLayout.getKWidth();
       }
     }

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -43,16 +43,7 @@ namespace gpu {
 unsigned getTotalElemsPerThread(Attribute layout, ArrayRef<int64_t> shape,
                                 Type eltTy) {
   if (auto tritonGPUAttr = layout.dyn_cast<TritonGPU_AttrTrait>()) {
-    unsigned elemNum = tritonGPUAttr.getTotalElemsPerThread(shape, eltTy);
-    unsigned vecSize = 1;
-    auto dotOpLayout = layout.dyn_cast<DotOperandEncodingAttr>();
-    if (dotOpLayout) {
-      if (auto mfmaParent =
-              dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
-        vecSize = dotOpLayout.getKWidth();
-      }
-    }
-    return elemNum * vecSize;
+    return tritonGPUAttr.getTotalElemsPerThread(shape, eltTy);
   } else {
     llvm::report_fatal_error("getTotalElemsPerThread not implemented");
     return 0;
@@ -1514,7 +1505,7 @@ unsigned AMDMfmaEncodingAttr::getTotalElemsPerThreadForOperands(
   constexpr int waveSize = 64;
   auto tileSize = getMFMAInstrShapeForOperands(kWidth, opIdx);
   auto rep = getMFMARepForOperands(shape, kWidth, opIdx);
-  return rep[0] * rep[1];
+  return rep[0] * rep[1] * kWidth;
 }
 
 SmallVector<unsigned>

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3209,9 +3209,6 @@ def test_dot_without_load(dtype_str, device):
     else:
         allow_tf32 = True
 
-    if is_hip() and dtype_str == "float16":
-        pytest.skip("TODO test_dot_without_load[float16] not supported in HIP")
-
     @triton.jit
     def _kernel(out, ALLOW_TF32: tl.constexpr):
         a = GENERATE_TEST_HERE

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -500,7 +500,6 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   }
 
   Type resElemTy = typeConverter->convertType(elemTy);
-  llvm::outs() << "resElemTy = " << resElemTy << "\n";
   Type smemPtrTy = ptr_ty(rewriter.getContext(), 3);
 
   int loadsPerThread = offsets.size() / numRepK / (isFastPath ? numRepNonK : 1);
@@ -549,10 +548,8 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   MLIRContext *ctx = mfmaLayout.getContext();
   Type structTy = LLVM::LLVMStructType::getLiteral(
       ctx, SmallVector<Type>(loadedValues.size(), loadedValues[0].getType()));
-  llvm::outs() << "structTy = " << structTy << "\n";
   auto result =
       packLLElements(loc, typeConverter, loadedValues, rewriter, structTy);
-  llvm::outs() << "converted_result = " << result << "\n";
   return result;
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -552,6 +552,7 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   llvm::outs() << "structTy = " << structTy << "\n";
   auto result =
       packLLElements(loc, typeConverter, loadedValues, rewriter, structTy);
+  llvm::outs() << "converted_result = " << result << "\n";
   return result;
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -525,23 +525,11 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
           loadOffset = add(offAdjust, offsets[k * loadsPerThread + loadId]);
         Value loadAddress = gep(smemPtrTy, elemTy, smemBase, loadOffset);
         Value loadedValue = load(loadVecTy, loadAddress);
-        // if (loadsPerThread > 1) {
-        //   for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
-        //     Value elemVal =
-        //         extract_element(elemTy, loadedValue, i32_val(elemId));
-        //     elemVal = bitcast(elemVal, resElemTy);
-        //     valVec = insert_element(vecTy, valVec, elemVal,
-        //                             i32_val(loadId * elemsPerLoad + elemId));
-        //   }
-        // } else {
-        //   valVec = loadedValue;
-        // }
         for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
           Value elemVal = extract_element(elemTy, loadedValue, i32_val(elemId));
           loadedValues.push_back(elemVal);
         }
       }
-      // loadedValues.push_back(valVec);
     }
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -266,9 +266,18 @@ struct DotOpMFMAConversionHelper {
     llvm::outs() << "n0 = " << n0 << ", n1 = " << n1 << ", elems_size = " << elems.size() << ", kWidth = " << kWidth << "\n";
     for (int i = 0; i < n0; i++) {
       for (int j = 0; j < n1; j++) {
-        for (int k = 0; k < kWidth; ++k) {
+        Value rawElems;
+        if (kWidth == 1) {
+          rawElems = elems[n1 * i + j];
         }
-        auto rawElems = elems[n1 * i + j];
+        else {
+          Type ty = vec_ty(type, kWidth);
+          rawElems = undef(ty);
+          for (int k = 0; k < kWidth; ++k) {
+            rawElems = insert_element(ty, rawElems, elems[kWidth * (n1 * i + j) + k], i32_val(k));
+          }
+        }
+
         Value convertedElems;
         if (type.isF32()) {
           convertedElems = extract_element(type, rawElems, i32_val(0));

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -201,6 +201,7 @@ struct DotOpMFMAConversionHelper {
     assert(repA[1] == repB[0]);
 
     Value loadedA = adaptor.getA();
+    llvm::outs() << "loadedA = " << loadedA << "\n";
     Value loadedB = adaptor.getB();
     Value loadedC = adaptor.getC();
 
@@ -262,8 +263,11 @@ struct DotOpMFMAConversionHelper {
                                                  int kWidth, Type type) const {
     auto elems = unpackLLElements(loc, value, rewriter);
     ValueTable vals;
+    llvm::outs() << "n0 = " << n0 << ", n1 = " << n1 << ", elems_size = " << elems.size() << ", kWidth = " << kWidth << "\n";
     for (int i = 0; i < n0; i++) {
       for (int j = 0; j < n1; j++) {
+        for (int k = 0; k < kWidth; ++k) {
+        }
         auto rawElems = elems[n1 * i + j];
         Value convertedElems;
         if (type.isF32()) {
@@ -277,6 +281,7 @@ struct DotOpMFMAConversionHelper {
           assert(type.isBF16() || type.isF16());
           convertedElems = rawElems;
         }
+        llvm::outs() << "convertedElems_type = " << convertedElems.getType() << "\n";
         vals[{i, j}] = convertedElems;
       }
     }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -201,7 +201,6 @@ struct DotOpMFMAConversionHelper {
     assert(repA[1] == repB[0]);
 
     Value loadedA = adaptor.getA();
-    llvm::outs() << "loadedA = " << loadedA << "\n";
     Value loadedB = adaptor.getB();
     Value loadedC = adaptor.getC();
 
@@ -263,19 +262,12 @@ struct DotOpMFMAConversionHelper {
                                                  int kWidth, Type type) const {
     auto elems = unpackLLElements(loc, value, rewriter);
     ValueTable vals;
-    llvm::outs() << "n0 = " << n0 << ", n1 = " << n1 << ", elems_size = " << elems.size() << ", kWidth = " << kWidth << "\n";
     for (int i = 0; i < n0; i++) {
       for (int j = 0; j < n1; j++) {
-        Value rawElems;
-        if (kWidth == 1) {
-          rawElems = elems[n1 * i + j];
-        }
-        else {
-          Type ty = vec_ty(type, kWidth);
-          rawElems = undef(ty);
-          for (int k = 0; k < kWidth; ++k) {
-            rawElems = insert_element(ty, rawElems, elems[kWidth * (n1 * i + j) + k], i32_val(k));
-          }
+        Type ty = vec_ty(type, kWidth);
+        Value rawElems = undef(ty);
+        for (int k = 0; k < kWidth; ++k) {
+          rawElems = insert_element(ty, rawElems, elems[kWidth * (n1 * i + j) + k], i32_val(k));
         }
 
         Value convertedElems;
@@ -290,7 +282,6 @@ struct DotOpMFMAConversionHelper {
           assert(type.isBF16() || type.isF16());
           convertedElems = rawElems;
         }
-        llvm::outs() << "convertedElems_type = " << convertedElems.getType() << "\n";
         vals[{i, j}] = convertedElems;
       }
     }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -191,7 +191,6 @@ struct DotOpMFMAConversionHelper {
       mfmaInsnName = (*maybeMfmaInsn).getInsnName();
 
     auto aEncoding = aTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
-    auto bEncoding = bTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
     int kWidth = aEncoding.getKWidth();
 
     auto repA =


### PR DESCRIPTION
This PR is to fix the unit test `test_dot_without_load` by by changing dot op from `vector<vector<type>>` to `vector<type>`, so the constantOp can be converted to mfma `dot_op` with existing lowering code. 