### PR TITLE
[FRONTEND] Fix triton.language.dtype repr

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -345,6 +345,13 @@ def _mod_operation_ill_conditioned(dtype_x, dtype_y) -> bool:
     ]
 
 
+def test_dtype_codegen():
+    for dtype in dtypes_with_bfloat16:
+        full_name = f"triton.language.{dtype}"
+        assert repr(eval(full_name)) == full_name
+    assert repr(triton.language.float8e4b15x4) == "triton.language.float8e4b15x4"
+
+
 # ---------------
 # test binary ops
 # ---------------

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -360,13 +360,22 @@ class dtype:
     def __str__(self):
         return self.name
 
+    def codegen_name(self):
+        if self.name.startswith("fp"):
+            return "float" + self.name[2:]
+        elif self.name.startswith("bf"):
+            return "bfloat" + self.name[2:]
+        else:
+            return self.name
+
     @property
     def cache_key_part(self) -> str:
         """See cache_key_part() in triton.cc."""
         return self.name
 
     def __repr__(self):
-        return f'triton.language.{str(self)}'
+        """Output of repr needs to be an evaluatable expression"""
+        return f'triton.language.{self.codegen_name()}'
 
 
 # Some functions have a param named `dtype`, which shadows the `dtype` class.


### PR DESCRIPTION
While working on adding `triton.language.dtype` to PyTorch, I discovered that `triton.language.float32` emits `triton.language.fp32` which I assume is done in order to be consistent with numpy and torch; however, this results in an un-evaluable expression as `triton.language.fp32` does not correspond to anything.
I thought of adding aliases to float32 as fp32 but that meant duplicating bunch of dtypes. This solution seems cleaner.