### PR TITLE
[AMD backend] fix `test_dot_without_load`

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -85,10 +85,6 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
   auto dotOpLayout = layout.dyn_cast<DotOperandEncodingAttr>();
   if (!dotOpLayout)
     return elemTy;
-  if (auto mfmaParent =
-          dotOpLayout.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
-    return vec_ty(elemTy, dotOpLayout.getKWidth());
-  }
   auto mmaParent = dotOpLayout.getParent().dyn_cast<NvidiaMmaEncodingAttr>();
   if (!mmaParent || mmaParent.isHopper())
     return elemTy;
@@ -127,8 +123,6 @@ Type TritonGPUToLLVMTypeConverter::convertMemDescType(MemDescType type) {
   auto ctx = type.getContext();
   Attribute layout = type.getEncoding();
   SmallVector<int64_t> shape(type.getShape().begin(), type.getShape().end());
-  Type eltType = getElementTypeForStruct(cast<TensorOrMemDesc>(type));
-  auto shared_layout = layout.cast<SharedEncodingAttr>();
   SmallVector<Type, 4> types;
   // base ptr
   auto ptrType = LLVM::LLVMPointerType::get(ctx, 3);

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1505,7 +1505,7 @@ unsigned AMDMfmaEncodingAttr::getTotalElemsPerThreadForOperands(
   constexpr int waveSize = 64;
   auto tileSize = getMFMAInstrShapeForOperands(kWidth, opIdx);
   auto rep = getMFMARepForOperands(shape, kWidth, opIdx);
-  return rep[0] * rep[1];
+  return rep[0] * rep[1] * kWidth;
 }
 
 SmallVector<unsigned>

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3202,9 +3202,6 @@ def test_dot_without_load(dtype_str, device):
     else:
         allow_tf32 = True
 
-    if is_hip() and dtype_str == "float16":
-        pytest.skip("TODO test_dot_without_load[float16] not supported in HIP")
-
     @triton.jit
     def _kernel(out, ALLOW_TF32: tl.constexpr):
         a = GENERATE_TEST_HERE

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -525,19 +525,11 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
                              k * loadsPerThread + loadId];
         Value loadAddress = gep(smemPtrTy, elemTy, smemBase, loadOffset);
         Value loadedValue = load(loadVecTy, loadAddress);
-        if (loadsPerThread > 1) {
-          for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
-            Value elemVal =
-                extract_element(elemTy, loadedValue, i32_val(elemId));
-            elemVal = bitcast(elemVal, resElemTy);
-            valVec = insert_element(vecTy, valVec, elemVal,
-                                    i32_val(loadId * elemsPerLoad + elemId));
-          }
-        } else {
-          valVec = loadedValue;
+        for (int elemId = 0; elemId < elemsPerLoad; ++elemId) {
+          Value elemVal = extract_element(elemTy, loadedValue, i32_val(elemId));
+          loadedValues.push_back(elemVal);      
         }
       }
-      loadedValues.push_back(valVec);
     }
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -265,7 +265,13 @@ struct DotOpMFMAConversionHelper {
     ValueTable vals;
     for (int i = 0; i < n0; i++) {
       for (int j = 0; j < n1; j++) {
-        auto rawElems = elems[n1 * i + j];
+        Type elemTy = typeConverter->convertType(type);
+        Type ty = vec_ty(elemTy, kWidth);
+        Value rawElems = undef(ty);
+        for (int k = 0; k < kWidth; ++k) {
+          rawElems = insert_element(ty, rawElems, elems[kWidth * (n1 * i + j) + k], i32_val(k));
+        }
+
         Value convertedElems;
         if (type.isF32()) {
           convertedElems = extract_element(type, rawElems, i32_val(0));


### PR DESCRIPTION
This PR is actually fix the regression in the reverted PR: https://github.com/openai/triton/pull/3338, which caused a regression for the test `test_masked_load_shared_memory`. The reason is for type used in packing dot_op for bfloat16. We  should use the type `i16` for `bf16` when packing dot_op for mfma.  

This time I ran all the tests in `test_core.py` locally, and all work fine. 