### PR TITLE
[FRONTEND] Fix assertion containing incorrect function call in min/max

### DIFF
--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -179,7 +179,7 @@ def max(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
             if core.constexpr(input.dtype.is_floating()):
                 input = input.to(core.float32)
             else:
-                assert input.dtype.is_integer_type()
+                assert input.dtype.is_int(), "Expecting input to be integer type"
                 input = input.to(core.int32)
         return core.reduce(input, axis, _elementwise_max, keep_dims=keep_dims)
 
@@ -238,7 +238,7 @@ def min(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
             if core.constexpr(input.dtype.is_floating()):
                 input = input.to(core.float32)
             else:
-                assert input.dtype.is_integer_type()
+                assert input.dtype.is_int(), "Expecting input to be integer type"
                 input = input.to(core.int32)
         return core.reduce(input, axis, _elementwise_min, keep_dims=keep_dims)
 


### PR DESCRIPTION
When running with assertions (`TRITON_DEBUG=1`), there was a compilation issue in the min and max functions in standard.py. Previously,  to check whether the datatype was an integer, a function call to `input.dtype.is_integer_type()` was made, but this function call does not exist as a part of dtype. This has now been replaced with the appropriate function call `input.dtype.is_int()`. 