### PR TITLE
Make compile-only work on non-gpu hosts

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -89,6 +89,7 @@ class HIPBackend(BaseBackend):
         super().__init__(target)
         assert isinstance(target, tuple) and len(target) == 3
         assert isinstance(target[1], str)
+        self.binary_ext = "hsaco"
 
     def parse_options(self, opts) -> Any:
         args = {'arch': self.target[1]}

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -260,7 +260,6 @@ class HIPDriver(GPUDriver):
     def __init__(self):
         super().__init__()
         self.utils = HIPUtils()
-        self.binary_ext = "hsaco"
         self.launcher_cls = HIPLauncher
 
     @staticmethod

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -98,6 +98,7 @@ class CUDABackend(BaseBackend):
         super().__init__(target)
         self.capability = target[1]
         assert isinstance(self.capability, int)
+        self.binary_ext = "cubin"
 
     def parse_options(self, opts) -> Any:
         args = {k: opts[k] for k in CUDAOptions.__dataclass_fields__.keys() if k in opts}

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -348,7 +348,6 @@ class CudaDriver(GPUDriver):
 
     def __init__(self):
         self.utils = CudaUtils()  # TODO: make static
-        self.binary_ext = "cubin"
         self.launcher_cls = CudaLauncher
         super().__init__()
 


### PR DESCRIPTION
Previously, we could compile Triton kernels on non-gpu hosts. However, it started to fail recently once we switch to the latest version of Triton.

In our workload, we have a way to compile all relevant Triton kernels beforehand (AOT), and then launch/run these kernels on gpu hosts, so kind of build and run are two separate processes.

This PR is trying to make Triton compile work again on non-gpu hosts.