### PR TITLE
[FRONTEND] Revert use of `|` operator for unioning types

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -4,7 +4,7 @@ from warnings import warn
 from contextlib import contextmanager
 from enum import Enum
 from functools import partial, wraps
-from typing import Union, Callable, List, Sequence, TypeVar, cast
+from typing import Union, Callable, List, Sequence, TypeVar, cast, Optional
 import builtins
 from ..runtime.jit import jit
 import inspect
@@ -926,7 +926,7 @@ class tensor:
         assert False, "Transposition must be created by the AST Visitor"
 
     @builtin
-    def to(self, dtype: dtype, fp_downcast_rounding: str | None = None, bitcast: bool = False, _builder=None):
+    def to(self, dtype: dtype, fp_downcast_rounding: Optional[str] = None, bitcast: bool = False, _builder=None):
         """
         Casts the tensor to the given :code:`dtype`.
 

--- a/python/triton/runtime/errors.py
+++ b/python/triton/runtime/errors.py
@@ -1,9 +1,10 @@
 from ..errors import TritonError
+from typing import Optional
 
 
 class InterpreterError(TritonError):
 
-    def __init__(self, error_message: str | None = None):
+    def __init__(self, error_message: Optional[str] = None):
         self.error_message = error_message
 
     def __str__(self) -> str:


### PR DESCRIPTION
We still want to support Python 3.9. `Allow writing union types as X | Y` is only introduced in python 3.10. https://peps.python.org/pep-0604/