### PR TITLE
[frontend] Cache _path_to_binary

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -14,6 +14,7 @@ import subprocess
 from pathlib import Path
 
 
+@functools.lru_cache()
 def _path_to_binary(binary: str):
     paths = [
         os.environ.get(f"TRITON_{binary.upper()}_PATH", ""),


### PR DESCRIPTION
Calling subprocess is slow sometimes (depends on python version, size of CUDA context, etc.) and _path_to_binary doesn't change.