### PR TITLE
[TESTS] Rewrite test_conversions to only use portable code

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -112,18 +112,15 @@ def arbitrary_fp32_downcast(x, rounding : tl.constexpr, exponent_bits : tl.const
     exponent = tl.where(exponent > -1, exponent, exponent + 1)
 
     if rounding == 'rtne':
-        #         mantissa = tl.inline_asm_elementwise("""{
-        #         cvt.rni.s32.f32 $0, $1;
-        # }""", "=r,r", [mantissa,], dtype=tl.int32, is_pure=True, pack=1).to(tl.uint32)
+        # Bring the value to the range [2 ** 23, 2 ** 24]
+        # where the representable floats map exactly to integers.
+        # Addition has RTNE semantics.
         mantissa += 0x800000
+        # Bring the value back to the original range.
         mantissa -= 0x800000
         mantissa = mantissa.to(tl.int32)
     elif rounding == 'rtz':
         mantissa = mantissa.to(tl.int32)
-
-#         mantissa = tl.inline_asm_elementwise("""{
-#         cvt.rzi.s32.f32 $0, $1;
-# }""", "=r,r", [mantissa,], dtype=tl.int32, is_pure=True, pack=1).to(tl.uint32)
     else:
         raise ValueError('unrecognized rounding mode')
 

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -112,13 +112,18 @@ def arbitrary_fp32_downcast(x, rounding : tl.constexpr, exponent_bits : tl.const
     exponent = tl.where(exponent > -1, exponent, exponent + 1)
 
     if rounding == 'rtne':
-        mantissa = tl.inline_asm_elementwise("""{
-        cvt.rni.s32.f32 $0, $1;
-}""", "=r,r", [mantissa,], dtype=tl.int32, is_pure=True, pack=1).to(tl.uint32)
+        #         mantissa = tl.inline_asm_elementwise("""{
+        #         cvt.rni.s32.f32 $0, $1;
+        # }""", "=r,r", [mantissa,], dtype=tl.int32, is_pure=True, pack=1).to(tl.uint32)
+        mantissa += 0x800000
+        mantissa -= 0x800000
+        mantissa = mantissa.to(tl.int32)
     elif rounding == 'rtz':
-        mantissa = tl.inline_asm_elementwise("""{
-        cvt.rzi.s32.f32 $0, $1;
-}""", "=r,r", [mantissa,], dtype=tl.int32, is_pure=True, pack=1).to(tl.uint32)
+        mantissa = mantissa.to(tl.int32)
+
+#         mantissa = tl.inline_asm_elementwise("""{
+#         cvt.rzi.s32.f32 $0, $1;
+# }""", "=r,r", [mantissa,], dtype=tl.int32, is_pure=True, pack=1).to(tl.uint32)
     else:
         raise ValueError('unrecognized rounding mode')
 


### PR DESCRIPTION
Removing ptx inline assembly from test_conversions.py. Using method proposed by Adam Goucher to perform the RTNE rounding instead:
Add the 0x800000 (8388608) to bring the value to the range [2 ** 23, 2 ** 24], where floats correspond with integers. Also, this utilizes the default RTNE rounding of addition. Then subtract 0x800000 to bring the value to the original range, already rounded to integer. Finally, do a simple fp to int cast.