### PR TITLE
[AMD] Map PreciseSqrtOp and PreciseDivFOp to LLVM instructions

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3859,8 +3859,6 @@ def test_num_warps_pow2(device):
                           ('tl.math.div_rn(x,y)', '(x.to(tl.float64) / y.to(tl.float64)).to(tl.float32)')])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_precise_math(expr_prec, expr_ref, num_ctas, device):
-    if is_hip():
-        pytest.skip("TODO test_precise_math (added by https://github.com/openai/triton/pull/3172) does not work on HIP")
 
     @triton.jit
     def kernel(X, Y, OUT, OUT_REF, BLOCK: tl.constexpr):

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1539,6 +1539,7 @@ void populateElementwiseOpToLLVMPatterns(
   POPULATE_BINARY_OP(arith::MaxSIOp, LLVM::SMaxOp) // smax
   POPULATE_BINARY_OP(arith::MinUIOp, LLVM::UMinOp) // umin
   POPULATE_BINARY_OP(arith::MaxUIOp, LLVM::UMaxOp) // umax
+  POPULATE_BINARY_OP(triton::PreciseDivFOp, LLVM::FDivOp)
 #undef POPULATE_BINARY_OP
 
 #define POPULATE_UNARY_OP(SRC_OP, DST_OP)                                      \
@@ -1561,6 +1562,7 @@ void populateElementwiseOpToLLVMPatterns(
   POPULATE_UNARY_OP(triton::BitcastOp, LLVM::BitcastOp)
   POPULATE_UNARY_OP(triton::IntToPtrOp, LLVM::IntToPtrOp)
   POPULATE_UNARY_OP(triton::PtrToIntOp, LLVM::PtrToIntOp)
+  POPULATE_UNARY_OP(triton::PreciseSqrtOp, LLVM::SqrtOp)
 #undef POPULATE_UNARY_OP
 
   patterns.add<ElementwiseOpConversion<math::FmaOp, LLVM::FMAOp>>(


### PR DESCRIPTION
Here we map PreciseSqrtOp and PreciseDivOp to LLVM instructions for the AMD backend.

These "Precise" ops are currently defined as round-to-nearest-even which is the default rounding mode in the LLVM instructions for the AMD backend. 
Alternatively we could call into the AMD `ocml.bc`. This works for sqrt but `__ocml_div_{rm}_f32` is currently unimplemented.
If further "Precise" math ops are added with different rounding modes or otherwise don't map to LLVM ops, we can revisit this.