### PR TITLE
[AMD] Make target a list instead of a tuple for HIP backend

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2793,6 +2793,8 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, allow_tf32, in_dtype, o
             pytest.skip("Only test out_dtype=float16 on devices with sm >=80")
     if capability[0] < 9 and in_dtype == 'float8e4nv':
         pytest.skip("float8e4nv not supported on sm <= 80")
+    if is_hip() and (in_dtype == 'float8e4nv' or in_dtype == 'float8e5'):
+        pytest.skip("float8e4nv and float8e5 not supported on HIP")
     if is_interpreter() and in_dtype == 'int8':
         pytest.skip(
             "numpy.dot with int8 inputs will overflow while tl.dot doesn't because MMA instruction's accumulator is 32-bit"

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -82,12 +82,12 @@ class HIPOptions:
 class HIPBackend(BaseBackend):
 
     @staticmethod
-    def supports_target(target: tuple):
+    def supports_target(target: list):
         return target[0] == 'hip'
 
-    def __init__(self, target: tuple) -> None:
+    def __init__(self, target: list) -> None:
         super().__init__(target)
-        assert isinstance(target, tuple) and len(target) == 3
+        assert isinstance(target, list) and len(target) == 3
         assert isinstance(target[1], str)
         self.binary_ext = "hsaco"
 

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -272,4 +272,4 @@ class HIPDriver(GPUDriver):
         device_properties = self.utils.get_device_properties(device)
         arch = device_properties['arch']
         warpSize = device_properties['warpSize']
-        return ("hip", arch.split(':')[0], warpSize)
+        return ["hip", arch.split(':')[0], warpSize]


### PR DESCRIPTION
Fix AMD backend failure caused by https://github.com/openai/triton/pull/3362 and https://github.com/openai/triton/pull/3370