### PR TITLE
[FRONTEND] Fix arg name conflict bug

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -36,7 +36,7 @@ class DependenciesFinder(ast.NodeVisitor):
         return self.hasher.hexdigest()
 
     def visit_Name(self, node):
-        if node.id in self.local_name:
+        if node.id in self.local_names:
             # The global name is hidden by the local name.
             return None
         return self.globals.get(node.id, None)
@@ -84,6 +84,15 @@ class DependenciesFinder(ast.NodeVisitor):
         # Save the local name which may hide the global name.
         self.local_names = [arg.arg for arg in node.args.args]
         self.generic_visit(node)
+
+    def visit_Assign(self, node):
+        _names = []
+        for target in node.targets:
+          _names += [target.id]
+        if len(_names) == 1:
+          self.local_names += _names
+        else:
+          raise TypeError(f"Simultaneous multiple assignment is not supported.")
 
 # -----------------------------------------------------------------------------
 # JITFunction

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -88,11 +88,12 @@ class DependenciesFinder(ast.NodeVisitor):
     def visit_Assign(self, node):
         _names = []
         for target in node.targets:
-          _names += [target.id]
+            _names += [target.id]
         if len(_names) == 1:
-          self.local_names += _names
+            self.local_names += _names
         else:
-          raise TypeError("Simultaneous multiple assignment is not supported.")
+            raise TypeError("Simultaneous multiple assignment is not supported.")
+
 
 # -----------------------------------------------------------------------------
 # JITFunction

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -92,7 +92,7 @@ class DependenciesFinder(ast.NodeVisitor):
         if len(_names) == 1:
           self.local_names += _names
         else:
-          raise TypeError(f"Simultaneous multiple assignment is not supported.")
+          raise TypeError("Simultaneous multiple assignment is not supported.")
 
 # -----------------------------------------------------------------------------
 # JITFunction

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -36,6 +36,9 @@ class DependenciesFinder(ast.NodeVisitor):
         return self.hasher.hexdigest()
 
     def visit_Name(self, node):
+        if node.id in self.local_name:
+            # The global name is hidedden by the local name.
+            return None
         return self.globals.get(node.id, None)
 
     def visit_Attribute(self, node):
@@ -77,6 +80,10 @@ class DependenciesFinder(ast.NodeVisitor):
             key = func_cache_key + noinline
             self.hasher.update(key.encode("utf-8"))
 
+    def visit_FunctionDef(self, node):
+        # Save the local name which may hide the global name.
+        self.local_name = [arg.arg for arg in node.args.args]
+        self.generic_visit(node)
 
 # -----------------------------------------------------------------------------
 # JITFunction

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -88,7 +88,7 @@ class DependenciesFinder(ast.NodeVisitor):
     def visit_Assign(self, node):
         _names = []
         for target in node.targets:
-            _names += [target.id]
+            _names += [self.visit(target)]
         if len(_names) == 1:
             self.local_names += _names
         else:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -37,7 +37,7 @@ class DependenciesFinder(ast.NodeVisitor):
 
     def visit_Name(self, node):
         if node.id in self.local_name:
-            # The global name is hidedden by the local name.
+            # The global name is hidden by the local name.
             return None
         return self.globals.get(node.id, None)
 
@@ -82,7 +82,7 @@ class DependenciesFinder(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node):
         # Save the local name which may hide the global name.
-        self.local_name = [arg.arg for arg in node.args.args]
+        self.local_names = [arg.arg for arg in node.args.args]
         self.generic_visit(node)
 
 # -----------------------------------------------------------------------------

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -93,6 +93,7 @@ class DependenciesFinder(ast.NodeVisitor):
             self.local_names += _names
         else:
             raise TypeError("Simultaneous multiple assignment is not supported.")
+        self.generic_visit(node)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
There is a bug introduced in latest triton code where AttributeError is getting thrown if kernel function args has same name as global variable. See the below example for more clarity

```
import torch
import triton
import triton.language as tl

@triton.jit
def kernel(
      out, adj, num_rows,
      WG_SIZE : tl.constexpr
  ):
    zero_indices = tl.zeros((WG_SIZE,), dtype=adj.dtype.element_ty)


if __name__ == '__main__':
    device = torch.device('cuda')

    num_rows, num_indices, heads = 16, 16, 16, 4
    adj = torch.zeros(num_rows + 1, dtype=torch.int32, device=device)
    out = torch.empty((num_indices,heads), dtype=e_src.dtype, device=e_src.device)
    # invoke triton kernel
    launch_grid = (num_rows * heads // 256,)
    kernel[launch_grid](out, adj, num_rows, 256) 
```
Error it throws something like below
`    return getattr(lhs, node.attr)
           ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'torch.dtype' object has no attribute 'element_ty'`

With the proposed change I see test is passing. I have verified it on Nvidia and Intel platforms.
