### PR TITLE
[BACKEND] Fix compiling time core dump in AccelerateMatmul (#3382)

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -58,10 +58,12 @@ warpsPerTileV2(tt::DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps) {
   for (Operation *op : slices) {
     if (isa<tt::DotOp>(op) && (op != dotOp)) {
       auto chainedDot = cast<tt::DotOp>(op);
-      if (auto mmaEncoding = chainedDot.getResult()
-                                 .getType()
-                                 .getEncoding()
-                                 .dyn_cast<NvidiaMmaEncodingAttr>()) {
+      auto resTy = chainedDot.getResult().getType();
+      if (resTy.getRank() != rank) {
+        continue;
+      }
+      if (auto mmaEncoding =
+              resTy.getEncoding().dyn_cast<NvidiaMmaEncodingAttr>()) {
         return ttg::getWarpsPerCTA(mmaEncoding);
       }
       hasChainedDot = true;


### PR DESCRIPTION
    - The core dump is caused by mixing layout of different ranks when determining mma layout by looking at def-use slice. I simply filter out mma layouts of different rank in the slice.
