### PR TITLE
[BACKEND] Add support for bf16 in scan op

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
@@ -4,6 +4,10 @@
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
+#include "llvm/ADT/STLExtras.h"
+
+#include <iterator>
+
 using namespace mlir;
 using namespace mlir::triton;
 
@@ -37,7 +41,9 @@ static SmallVector<Value> accumulate(ConversionPatternRewriter &rewriter,
 
   rewriter.inlineBlockBefore(&newScan, &*rewriter.getInsertionPoint(),
                              combineArgs);
-  auto results = returnOp.getResult();
+  SmallVector<Value> results;
+  llvm::transform(returnOp.getResult(), std::back_inserter(results),
+                  [&](Value res) { return rewriter.getRemappedValue(res); });
   // Delete the terminator, which is no longer used
   rewriter.eraseOp(returnOp);
   return results;

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2004,7 +2004,7 @@ scan2d_shapes = [(8, 32), (16, 32), (32, 16), (2, 1024), (1024, 2), (32, 32), (1
 
 scan_configs = [(op, type, shape, axis, reverse, num_warps)
                 for num_warps in [4, 16]
-                for type in ['int32', 'float32']
+                for type in ['int32', 'float32', 'bfloat16']
                 for axis in [1, 0]
                 for reverse in [True, False]
                 for shape in scan2d_shapes
@@ -2038,6 +2038,12 @@ def roll(a1, b1_last, b1_cur, a2, b2_last, b2_cur):
 @pytest.mark.parametrize("op, dtype_str, shape, axis, reverse, num_warps", scan_configs + negative_config)
 def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
     check_type_supported(dtype_str, device)
+    if dtype_str == 'bfloat16':
+        if op == 'cummax':
+            pytest.skip("bfloat16 compare not suppoted before sm90")
+        if op == 'linear_recurrence':
+            pytest.skip("Skipping linear_recurrence scan on bfloat16 due to accuracy issues")
+    numpy_dtype_str = 'float32' if dtype_str == 'bfloat16' else dtype_str
 
     # triton kernel
     @triton.jit
@@ -2090,12 +2096,11 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
     if reverse:
         x_in = np.flip(x, axis)
     z = np.empty_like(x)
-    x_tri = to_triton(x, device=device)
-    y_tri = to_triton(y, device=device)
+    x_tri = to_triton(x, device=device, dst_type=dtype_str)
+    y_tri = to_triton(y, device=device, dst_type=dtype_str)
     if op == 'cumsum' or op == 'cumprod':
         numpy_op = {'cumsum': np.cumsum, 'cumprod': np.cumprod}[op]
-        z_dtype_str = dtype_str
-        z_ref = numpy_op(x_in, axis=axis).astype(getattr(np, z_dtype_str))
+        z_ref = numpy_op(x_in, axis=axis).astype(getattr(np, numpy_dtype_str))
         if reverse:
             z_ref = np.flip(z_ref, axis)
 
@@ -2152,12 +2157,13 @@ def test_scan2d(op, dtype_str, shape, axis, reverse, num_warps, device):
                 z_ref[:, 1:] = x[:, 0:1]
 
     # triton result
+    # we don't cast the `fp32 = bf16 op bf16` result to bfloat16 to alleviate accuracy issues
     z_tri = to_triton(z, device=device)
     kernel[(1, )](x_tri, y_tri, z_tri, BLOCK_M=shape[0], BLOCK_N=shape[1], AXIS=axis, num_warps=num_warps)
 
     z_tri = to_numpy(z_tri)
     # compare
-    if dtype_str == 'float32':
+    if dtype_str not in int_dtypes:
         if op == 'cumprod':
             np.testing.assert_allclose(z_ref, z_tri, rtol=0.01, atol=1e-3)
         else:


### PR DESCRIPTION
When inling scan-op's body bb, tt.yield's result could have an illegal type, so we should use the remapped value from ConversionPatternRewriter, rather than the value itself.