### PR TITLE
[AUTOTUNER] adding simple report flag for autotuner runs

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -12,8 +12,18 @@ from .errors import OutOfResources
 
 class Autotuner(KernelInterface):
 
-    def __init__(self, fn, arg_names, configs, key, reset_to_zero, restore_value, prune_configs_by: Dict = None,
-                 warmup=25, rep=100):
+    def __init__(
+        self,
+        fn,
+        arg_names,
+        configs,
+        key,
+        reset_to_zero,
+        restore_value,
+        prune_configs_by: Dict = None,
+        warmup=25,
+        rep=100,
+    ):
         """
         :param prune_configs_by: a dict of functions that are used to prune configs, fields:
             'perf_model': performance model used to predicate running time with different configs, returns running time
@@ -68,9 +78,6 @@ class Autotuner(KernelInterface):
         self.fn = fn
         self.num_warmups = warmup
         self.num_reps = rep
-        self.print_autotune_stats = False
-        if os.getenv("TRITON_PRINT_AUTOTUNING", "0") == "1":
-            self.print_autotune_stats = True
 
     def _bench(self, *args, config, **meta):
         # check for conflicts, i.e. meta-parameters both provided
@@ -130,10 +137,9 @@ class Autotuner(KernelInterface):
         else:
             config = self.configs[0]
         self.best_config = config
-        if self.print_autotune_stats and not used_cached_result:
-            print(
-                f"Autotuner for function {self.fn} finished after {self.bench_time:.2f}s; best config selected: {self.best_config};"
-            )
+        if os.getenv("TRITON_PRINT_AUTOTUNING", None) == "1" and not used_cached_result:
+            print(f"Triton autotuning for function {self.fn} finished after "
+                  f"{self.bench_time:.2f}s; best config selected: {self.best_config};")
         full_nargs = {**self.nargs, **kwargs, **self.best_config.kwargs}
         if config.pre_hook is not None:
             config.pre_hook(full_nargs)


### PR DESCRIPTION
For our application, we wanted to investigate when, how often, and for how long the triton autotuner is triggered (to asses the impact on the latency of the application).  
Therefore, we implemented a simple report flag to the autotuner decorator:

```python
@triton.autotune(
    configs=[...],  
    key=[...],
    report=True,  # new, optional
)
@triton.jit
def fused_add_rmsnorm_triton(...
```

If this flag is set to true, the autotuner will print the following statement, every time a new autotune run is triggered:

```
Autotuner for function JITFunction(__main__:fused_add_rmsnorm_triton) finished after 4.15s; best config selected: BLOCK_N_SIZE: 512, num_warps: 8, num_ctas: 1, num_stages: 3;
```
There are no prints if a cached configuration is used. 

(We thought this could be also a helpful feature for others, therefore we created this PR directly and we can make/discuss requested changes here. However, if you think this should be discussed instead in an issue, let us know and sorry). 