### PR TITLE
[SETUP] Set max timeout when downloading nvidia dependencies

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -160,8 +160,8 @@ def open_url(url):
         'User-Agent': user_agent,
     }
     request = urllib.request.Request(url, None, headers)
-    # Set timeout to 120 seconds to prevent the request from hanging forver
-    return urllib.request.urlopen(request, timeout=120)
+    # Set timeout to 300 seconds to prevent the request from hanging forver
+    return urllib.request.urlopen(request, timeout=300)
 
 
 # ---- package data ---

--- a/python/setup.py
+++ b/python/setup.py
@@ -160,7 +160,8 @@ def open_url(url):
         'User-Agent': user_agent,
     }
     request = urllib.request.Request(url, None, headers)
-    return urllib.request.urlopen(request)
+    # Set timeout to 120 seconds to prevent the request from hanging forver
+    return urllib.request.urlopen(request, timeout=120)
 
 
 # ---- package data ---


### PR DESCRIPTION
We have experienced intermittent forever hangs during triton installation, specifically when downloading the nvidia dependencies. This developer has found that `request.urlopen` not having a set timeout can potentially lead to this issue: https://github.com/mesonbuild/meson/issues/4087
I have set the timeout to 5 minutes which should be enough to download each individual dependency while also preventing the forever hang.