### PR TITLE
Allow pipelining loads that don't feed directly into tl.dot.

### DIFF
--- a/include/triton/Dialect/Triton/IR/Utility.h
+++ b/include/triton/Dialect/Triton/IR/Utility.h
@@ -184,6 +184,27 @@ template <typename VecT> bool isConsecutive(const VecT &vec) {
   return isConsecutive(ArrayRef(vec));
 }
 
+// LLVM's STLExtras.h provides a bunch of functions that work over ranges, but
+// it's missing min/max_element until
+// https://github.com/llvm/llvm-project/commit/fab2bb8b makes it into Triton.
+// TODO(jlebar): Remove this once we have the LLVM helpers.
+template <typename R> auto min_element(R &&Range) {
+  return std::min_element(llvm::adl_begin(Range), llvm::adl_end(Range));
+}
+template <typename R, typename Compare>
+auto min_element(R &&Range, Compare &&C) {
+  return std::min_element(llvm::adl_begin(Range), llvm::adl_end(Range),
+                          std::forward<Compare>(C));
+}
+template <typename R> auto max_element(R &&Range) {
+  return std::max_element(llvm::adl_begin(Range), llvm::adl_end(Range));
+}
+template <typename R, typename T, typename Compare>
+auto max_element(R &&Range, Compare &&C) {
+  return std::max_element(llvm::adl_begin(Range), llvm::adl_end(Range),
+                          std::forward<Compare>(C));
+}
+
 } // namespace triton
 } // namespace mlir
 

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -6,6 +6,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
@@ -15,6 +16,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/Support/Debug.h"
 
@@ -46,6 +48,14 @@ struct PipelinedOpInfo {
 };
 
 } // namespace
+
+static bool isMMAv3Dot(Operation *op) {
+  auto dot = dyn_cast<tt::DotOp>(op);
+  if (!dot)
+    return false;
+  auto enc = dot.getType().getEncoding().dyn_cast<ttg::NvidiaMmaEncodingAttr>();
+  return enc && enc.isHopper();
+}
 
 // Replace the ForOp's yield with a new one with the given operands appended.
 static void appendToYield(scf::ForOp forOp, ArrayRef<Value> newOperands) {
@@ -132,23 +142,11 @@ createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
   loadOp.erase();
 }
 
-/// Create an async load equivalent to the given load.
-static void
-createAsyncLoad(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
-                Value insertIdx, Value extractIdx, Value phase,
-                llvm::MapVector<Operation *, PipelinedOpInfo> &opToInfo) {
-  createAsyncCopy(forOp, loadOp, alloc, insertIdx, extractIdx, opToInfo);
-}
-
 // If all the transitive uses of the given value have are used by a convert to
 // the same dot operand encoding, return true and set the shared encoding that
 // needs to be used to be compatible with users' layouts.
-//
-// TODO: Rename, because the name only tells us half the story: We check for all
-// users having a dot encoding, but then we return a shared encoding, which is
-// surprising given the name.
 static std::optional<ttg::SharedEncodingAttr>
-allTransitiveUsesHaveDotEncoding(Value val) {
+getSharedEncIfAllUsersAreDotEnc(Value val) {
   ttg::SharedEncodingAttr attr;
   for (Operation *user : val.getUsers()) {
     ttg::SharedEncodingAttr tempAttr;
@@ -160,7 +158,7 @@ allTransitiveUsesHaveDotEncoding(Value val) {
       // use it if it is compatible with the other users.
       if (!tempAttr)
         tempAttr = memDesc.getEncoding().cast<ttg::SharedEncodingAttr>();
-      if (!allTransitiveUsesHaveDotEncoding(user->getResult(0)).has_value())
+      if (!getSharedEncIfAllUsersAreDotEnc(user->getResult(0)).has_value())
         return std::nullopt;
     } else {
       if (!isa<ttg::LocalLoadOp, ttg::ConvertLayoutOp>(user))
@@ -190,42 +188,6 @@ allTransitiveUsesHaveDotEncoding(Value val) {
   return attr;
 }
 
-// TODO: This returns true and *sometimes* sets enc?
-bool loadDotOperand(tt::LoadOp loadOp, bool &hasMMAV3,
-                    ttg::SharedEncodingAttr &enc) {
-  if (loadOp.getResult().hasOneUse()) {
-    Operation *use = *loadOp.getResult().getUsers().begin();
-    if (auto alloc = llvm::dyn_cast<ttg::LocalAllocOp>(use)) {
-      auto sharedEnc =
-          alloc.getType().getEncoding().cast<ttg::SharedEncodingAttr>();
-      if (sharedEnc.getHasLeadingOffset()) {
-        // MMA V3 case.
-        auto newOrder = sharedEnc.getOrder();
-        auto ty = loadOp.getType().cast<RankedTensorType>();
-        auto oldOrder = ttg::getOrder(ty.getEncoding());
-        if (newOrder[0] == oldOrder[0] || newOrder[1] == oldOrder[1]) {
-          // The operand of MMAv3 is in SharedEncoding and it's order should
-          // not be changed after FuseTranspositions Pass. So we only pipeline
-          // the load if the order of the loaded BlockedEncoding is the same
-          // as the order of the SharedEncoding it is converted to.
-          // TODO: remove this constraint once the LoadOp supports transpose
-          // fusion
-          hasMMAV3 = true;
-          return true;
-        }
-      }
-    }
-  }
-
-  std::optional<ttg::SharedEncodingAttr> sharedEnc =
-      allTransitiveUsesHaveDotEncoding(loadOp.getResult());
-  if (!sharedEnc.has_value()) {
-    return false;
-  }
-  enc = *sharedEnc;
-  return true;
-}
-
 static ttg::BlockedEncodingAttr
 getBlockedEncoding(tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfo) {
   Value src = loadOp.getPtr();
@@ -245,9 +207,8 @@ getBlockedEncoding(tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfo) {
                                        threadsPerWarp, ctaLayout);
 }
 
-static ttg::SharedEncodingAttr getSharedEncoding(tt::LoadOp loadOp,
-                                                 Operation *use, bool isMMAV3) {
-
+static std::optional<ttg::SharedEncodingAttr>
+getSharedEncoding(tt::LoadOp loadOp, bool isMMAV3) {
   auto ty = loadOp.getType().cast<RankedTensorType>();
   auto ctaLayout = ttg::getCTALayout(ty.getEncoding());
   auto blockedOrder = ttg::getOrder(ty.getEncoding());
@@ -262,19 +223,36 @@ static ttg::SharedEncodingAttr getSharedEncoding(tt::LoadOp loadOp,
   } else {
     order = blockedOrder;
   }
-  if (isa<tt::DotOp>(use)) {
-    assert(isMMAV3 &&
-           "Load used by dot op should be either MMAv3 or have a "
-           "shared encoding already picked based on users' layouts.");
+  if (isMMAV3) {
     return ttg::SharedEncodingAttr::get(ty.getContext(), ty.getShape(), order,
                                         ctaLayout, ty.getElementType());
-  } else {
-    assert(!isMMAV3 && "Load used by non-dot op should not be MMAv3.");
-    // Use non-swizzled layout for loads that do not feed into dot ops.
-    // TODO: This won't be optimal for 2D tensors.
-    return ttg::SharedEncodingAttr::get(ty.getContext(), 1, 1, 1, order,
-                                        ctaLayout);
   }
+
+  // If the load is used by a LocalAllocOp, use the same encoding as the allocs.
+  // If the allocs don't all have the same encoding, bail.
+  if (llvm::any_of(loadOp->getUsers(), [&](Operation *user) {
+        return isa<ttg::LocalAllocOp>(user);
+      })) {
+    ttg::SharedEncodingAttr localAllocEnc;
+    for (auto user : loadOp->getUsers()) {
+      auto localAlloc = dyn_cast<ttg::LocalAllocOp>(user);
+      if (!localAlloc)
+        continue;
+      auto enc =
+          localAlloc.getType().getEncoding().cast<ttg::SharedEncodingAttr>();
+      if (!localAllocEnc) {
+        localAllocEnc = enc;
+      }
+      if (enc != localAllocEnc)
+        return std::nullopt;
+    }
+    return localAllocEnc;
+  }
+
+  // Use non-swizzled layout for loads that do not feed into dot ops.
+  // TODO: This won't be optimal for 2D tensors.
+  return ttg::SharedEncodingAttr::get(ty.getContext(), 1, 1, 1, order,
+                                      ctaLayout);
 }
 
 // Create a map from load ops to their distance to the nearest dot op and the
@@ -350,11 +328,34 @@ loadOpsToDistanceAndUse(scf::ForOp forOp) {
   return loadOpToDistAndUse;
 }
 
-/// Collect loads to pipeline. Returns true if loads are found to pipeline.
+static bool loadIsMMAv3(tt::LoadOp loadOp) {
+  if (!loadOp->hasOneUse())
+    return false;
+  auto alloc = dyn_cast<ttg::LocalAllocOp>(*loadOp->getUsers().begin());
+  if (!alloc)
+    return false;
+  auto sharedEnc =
+      alloc.getType().getEncoding().cast<ttg::SharedEncodingAttr>();
+  if (!sharedEnc.getHasLeadingOffset())
+    return false;
+
+  // MMA V3 case.
+  auto newOrder = sharedEnc.getOrder();
+  auto ty = loadOp.getType().cast<RankedTensorType>();
+  auto oldOrder = ttg::getOrder(ty.getEncoding());
+
+  // The operand of MMAv3 is in SharedEncoding and its order should not
+  // be changed after FuseTranspositions Pass. So we only pipeline the
+  // load if the order of the loaded BlockedEncoding is the same as the
+  // order of the SharedEncoding it is converted to.
+  return oldOrder == newOrder;
+}
+
+/// Collect ops to pipeline. Returns true if any ops are found to pipeline.
 static bool
 collectOpsToPipeline(scf::ForOp forOp,
                      llvm::MapVector<Operation *, PipelinedOpInfo> &opInfo,
-                     int numStages, bool &hasMMAV3) {
+                     int numStages) {
   ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
   tt::ModuleAxisInfoAnalysis axisInfoAnalysis(moduleOp);
 
@@ -362,51 +363,55 @@ collectOpsToPipeline(scf::ForOp forOp,
   llvm::MapVector<tt::LoadOp, std::pair<int, Operation *>> loadOpToDistAndUse =
       loadOpsToDistanceAndUse(forOp);
   LLVM_DEBUG({
-    DBGS() << "Found " << loadOpToDistAndUse.size() << " loads to pipeline:\n";
+    LDBG("Found " << loadOpToDistAndUse.size() << " loads to pipeline:");
     for (const auto &[k, v] : loadOpToDistAndUse) {
-      DBGS() << "  " << *k << " distance=" << v.first << " use=" << *v.second
-             << "\n";
+      LDBG("  - distance: " << v.first);
+      LDBG("    op to pipeline: " << *k);
+      LDBG("    use: " << *v.second);
     }
   });
   if (loadOpToDistAndUse.empty())
     return false;
 
-  int maxDistance = -1;
-  for (auto &[op, distAndUse] : loadOpToDistAndUse) {
-    if (distAndUse.first > maxDistance) {
-      maxDistance = distAndUse.first;
-    }
-  }
-  assert(maxDistance >= 0);
-
   // Start by initializing PipelinedOpInfo for users of the loads.
   for (auto &[loadOp, distAndUse] : loadOpToDistAndUse)
     opInfo[distAndUse.second] = PipelinedOpInfo();
 
+  int maxDistance = *triton::max_element(
+      llvm::make_first_range(llvm::make_second_range(loadOpToDistAndUse)));
   unsigned stagesBetweenLoads = ceil<unsigned>(numStages - 2, maxDistance + 1);
 
   // Then consider the load ops that feed into the dot ops or are used by other
   // loads.
   for (auto &[loadOp, distAndUse] : loadOpToDistAndUse) {
     PipelinedOpInfo loadInfo;
-    bool loadIsMMAV3 = false;
     if (isa<tt::DotOp>(distAndUse.second)) {
-      ttg::SharedEncodingAttr sharedEnc;
-      bool isLoadDotOperand = loadDotOperand(loadOp, loadIsMMAV3, sharedEnc);
-      hasMMAV3 |= loadIsMMAV3;
-      if (!isLoadDotOperand)
-        continue;
-      loadInfo.sharedEncoding = sharedEnc;
-    } else {
+      if (loadIsMMAv3(loadOp)) {
+        loadInfo.loadIsMMAV3 = true;
+        loadInfo.sharedEncoding =
+            getSharedEncoding(loadOp, /*loadIsMMAv3=*/true).value_or(nullptr);
+      } else {
+        loadInfo.sharedEncoding =
+            getSharedEncIfAllUsersAreDotEnc(loadOp.getResult())
+                .value_or(nullptr);
+      }
+    }
+
+    // If we still don't have a shared encoding, try a "generic" shared
+    // encoding.
+    if (!loadInfo.sharedEncoding && !isMMAv3Dot(distAndUse.second)) {
+      loadInfo.sharedEncoding =
+          getSharedEncoding(loadOp, /*isMMAV3=*/loadInfo.loadIsMMAV3)
+              .value_or(nullptr);
       loadInfo.blockedEncoding = getBlockedEncoding(loadOp, axisInfoAnalysis);
     }
-    // If we haven't already assigned a layout do it now.
-    if (!loadInfo.sharedEncoding)
-      loadInfo.sharedEncoding =
-          getSharedEncoding(loadOp, distAndUse.second, loadIsMMAV3);
-    loadInfo.loadIsMMAV3 = loadIsMMAV3;
-    int stage = (maxDistance - distAndUse.first) * stagesBetweenLoads;
-    loadInfo.stage = stage;
+
+    // If that still didn't work, bail on pipelining this load.
+    if (!loadInfo.sharedEncoding) {
+      continue;
+    }
+
+    loadInfo.stage = (maxDistance - distAndUse.first) * stagesBetweenLoads;
     loadInfo.use = distAndUse.second;
     opInfo[loadOp] = loadInfo;
   }
@@ -444,9 +449,9 @@ static Value createAlloc(scf::ForOp &forOp, tt::LoadOp loadOp,
 // Convert load ops into their asyn version and apply multi-buffering based on
 // the required number of buffers.
 static SmallVector<Value>
-createAsynOps(scf::ForOp &forOp,
-              llvm::MapVector<Operation *, PipelinedOpInfo> &opToInfo,
-              int numBuffers, bool hasMMAV3) {
+createAsyncOps(scf::ForOp &forOp,
+               llvm::MapVector<Operation *, PipelinedOpInfo> &opToInfo,
+               int numBuffers, bool hasMMAV3) {
   struct AsyncLoad {
     AsyncLoad(tt::LoadOp loadOp, Value alloc) : loadOp(loadOp), alloc(alloc) {}
     tt::LoadOp loadOp;
@@ -503,8 +508,8 @@ createAsynOps(scf::ForOp &forOp,
   extractIdx = builder.create<arith::SelectOp>(loc, cndExt, extractIdx, zero);
 
   for (AsyncLoad &asyncLoad : asyncLoads) {
-    createAsyncLoad(forOp, asyncLoad.loadOp, asyncLoad.alloc, insertIdx,
-                    extractIdx, phase, opToInfo);
+    createAsyncCopy(forOp, asyncLoad.loadOp, asyncLoad.alloc, insertIdx,
+                    extractIdx, opToInfo);
   }
   SmallVector<Value> newYieldOperands = {insertIdx, extractIdx};
   // Patch the yield with the updated counters.
@@ -711,9 +716,11 @@ bool mlir::triton::preProcessLoopAndGetSchedule(
   // 1. First collect "interesting" operations with a stage where to schedule
   // them. This gives a coarse scheduling for the loop.
   llvm::MapVector<Operation *, PipelinedOpInfo> opToInfo;
-  bool hasMMAV3 = false;
-  if (!collectOpsToPipeline(forOp, opToInfo, numStages, hasMMAV3))
+  if (!collectOpsToPipeline(forOp, opToInfo, numStages))
     return false;
+
+  bool hasMMAV3 =
+      llvm::any_of(opToInfo, [](auto &kv) { return kv.second.loadIsMMAV3; });
 
   // Calculate the number of buffers needed for each load.
   // TODO pawel: we could do more fine-grained allocation here and
@@ -742,7 +749,7 @@ bool mlir::triton::preProcessLoopAndGetSchedule(
 
   // 2. Convert the loads into async loads and create the allocs.
   SmallVector<Value> allocs =
-      createAsynOps(forOp, opToInfo, maxNumBuffers, hasMMAV3);
+      createAsyncOps(forOp, opToInfo, maxNumBuffers, hasMMAV3);
 
   // 3. Create the final schedule for the kernel loop. This will dictate the
   // stages and order of operations to the pipeline expander.
@@ -1157,9 +1164,7 @@ void triton::asyncLaunchDots(scf::ForOp forOp) {
   // "properly async", or sometimes just "async".
   IRRewriter builder(forOp.getContext());
   for (auto dotOp : llvm::to_vector(forOp.getBody()->getOps<tt::DotOp>())) {
-    auto resEnc =
-        dotOp.getType().getEncoding().dyn_cast<ttg::NvidiaMmaEncodingAttr>();
-    if (resEnc && resEnc.isHopper()) {
+    if (isMMAv3Dot(dotOp)) {
       builder.setInsertionPoint(dotOp);
       builder.replaceOpWithNewOp<ttng::DotAsyncOp>(
           dotOp, dotOp.getA(), dotOp.getB(), dotOp.getC(), dotOp.getAllowTF32(),

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3253,7 +3253,7 @@ def test_max_num_imprecise_acc(device):
 
 
 @pytest.mark.parametrize('in_dtype', ['float32'])
-def test_dot_mulbroadcastred(in_dtype, device):
+def test_dot_mulbroadcasted(in_dtype, device):
     if is_cuda():
         capability = torch.cuda.get_device_capability()
         if capability[0] < 8:
@@ -3297,10 +3297,9 @@ def test_dot_mulbroadcastred(in_dtype, device):
     if not is_cuda():
         return
     assert "tt.dot" in h.asm['ttir']
-    # when using MMAv3, we will not pipeline the load op for Y
-    # as the loaded value is in rowmajor. But MMAv3 requires it's second
-    # operand is in colmajor because transpose is not supported for MMAv3
-    # with float32 input.
+    # When using MMAv3, we will not pipeline the load op for Y, as the loaded
+    # value is in rowmajor. But MMAv3 requires its second operand is in colmajor
+    # because transpose is not supported for MMAv3 with float32 input.
     if capability[0] >= 9:
         assert re.search(r"triton_gpu.async_wait %.* {num = 1 : i32}", h.asm["ttgir"]) is not None
     else:

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -722,7 +722,7 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
 #mma = #triton_gpu.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [2, 2], instrShape = [16, 8]}>
 module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
-  tt.func public @nested_loops(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32} loc(unknown), %arg1: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32} loc(unknown), %arg2: !tt.ptr<i32, 1> {tt.divisibility = 16 : i32} loc(unknown), %arg3: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32} loc(unknown)) attributes {noinline = false} {
+  tt.func public @nested_loops(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<i32, 1> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
     %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #mma>
     %cst_0 = arith.constant dense<320> : tensor<32x1xi32, #blocked>
     %c0_i32 = arith.constant 0 : i32
@@ -784,7 +784,7 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
 #shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1], hasLeadingOffset = false}>
 #shared1 = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [1, 0], hasLeadingOffset = false}>
 module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
-  tt.func public @_jagged_hstu_attn_fwd_0d1d2d3d4d5de(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32} loc(unknown), %arg1: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32} loc(unknown), %arg2: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32} loc(unknown), %arg3: !tt.ptr<i64, 1> {tt.divisibility = 16 : i32} loc(unknown), %arg4: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32} loc(unknown), %arg5: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32} loc(unknown)) attributes {noinline = false} {
+  tt.func public @_jagged_hstu_attn_fwd_0d1d2d3d4d5de(%arg0: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<i64, 1> {tt.divisibility = 16 : i32}, %arg4: !tt.ptr<f32, 1> {tt.divisibility = 16 : i32}, %arg5: i32 {tt.divisibility = 16 : i32, tt.max_divisibility = 8 : i32}) attributes {noinline = false} {
     %cst = arith.constant dense<0.000000e+00> : tensor<64x32xf32, #mma>
     %c64_i32 = arith.constant 64 : i32
     %c0_i32 = arith.constant 0 : i32
@@ -1096,5 +1096,75 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
       }
     }
     tt.return
+  }
+}
+
+// -----
+
+  // CHECK-LABEL: @int4_matmul_ampere
+#blocked = #triton_gpu.blocked<{sizePerThread = [16, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 8], order = [0, 1]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [2, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked2 = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked3 = #triton_gpu.blocked<{sizePerThread = [16, 1, 2], threadsPerWarp = [4, 8, 1], warpsPerCTA = [1, 8, 1], order = [2, 0, 1]}>
+#blocked4 = #triton_gpu.blocked<{sizePerThread = [16, 2, 1], threadsPerWarp = [4, 1, 8], warpsPerCTA = [1, 1, 8], order = [1, 0, 2]}>
+#blocked5 = #triton_gpu.blocked<{sizePerThread = [32, 1], threadsPerWarp = [4, 8], warpsPerCTA = [1, 8], order = [0, 1]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [1, 8], instrShape = [16, 8]}>
+module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @int4_matmul_ampere(
+    %arg0: !tt.ptr<f16, 1> {tt.divisibility = 16 : i32},
+    %arg1: !tt.ptr<i8, 1> {tt.divisibility = 16 : i32}
+  ) -> tensor<16x256xf32, #mma> attributes {noinline = false} {
+    %cst = arith.constant dense<64> : tensor<64x256xi32, #blocked>
+    %cst_0 = arith.constant dense<128> : tensor<16x128xi32, #blocked1>
+    %c256_i32 = arith.constant 256 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c128_i32 = arith.constant 128 : i32
+    %cst_1 = arith.constant dense<0.000000e+00> : tensor<16x128xf16, #blocked1>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c255_i32 = arith.constant 255 : i32
+    %c15_i32 = arith.constant 15 : i32
+    %cst_2 = arith.constant dense<4> : tensor<64x256xi8, #blocked>
+    %cst_3 = arith.constant dense<0.000000e+00> : tensor<16x256xf32, #mma>
+
+    %35 = tt.make_range {end = 128 : i32, start = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>>
+    %36 = tt.expand_dims %35 {axis = 0 : i32} : tensor<128xi32, #triton_gpu.slice<{dim = 0, parent = #blocked1}>> -> tensor<1x128xi32, #blocked1>
+    %38 = tt.broadcast %36 : tensor<1x128xi32, #blocked1> -> tensor<16x128xi32, #blocked1>
+    %40 = tt.splat %arg0 : !tt.ptr<f16, 1> -> tensor<16x128x!tt.ptr<f16, 1>, #blocked1>
+    %41 = tt.addptr %40, %38 : tensor<16x128x!tt.ptr<f16, 1>, #blocked1>, tensor<16x128xi32, #blocked1>
+
+    %42 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>>
+    %43 = tt.expand_dims %42 {axis = 1 : i32} : tensor<64xi32, #triton_gpu.slice<{dim = 1, parent = #blocked}>> -> tensor<64x1xi32, #blocked>
+    %47 = tt.broadcast %43 : tensor<64x1xi32, #blocked> -> tensor<64x256xi32, #blocked>
+    %50 = tt.splat %arg1 : !tt.ptr<i8, 1> -> tensor<64x256x!tt.ptr<i8, 1>, #blocked>
+    %51 = tt.addptr %50, %47 : tensor<64x256x!tt.ptr<i8, 1>, #blocked>, tensor<64x256xi32, #blocked>
+
+    // Check that both loads in the loop are pipelined.
+    // CHECK: scf.for
+    // CHECK-NOT: tt.load
+    // CHECK: triton_gpu.async_copy_global_to_local
+    // CHECK-NOT: tt.load
+    // CHECK: triton_gpu.async_copy_global_to_local
+    // CHECK-NOT: tt.load
+    // CHECK: scf.yield
+    %54:3 = scf.for %arg9 = %c0_i32 to %c16_i32 step %c1_i32 iter_args(%arg10 = %cst_3, %arg11 = %41, %arg12 = %51) -> (tensor<16x256xf32, #mma>, tensor<16x128x!tt.ptr<f16, 1>, #blocked1>, tensor<64x256x!tt.ptr<i8, 1>, #blocked>)  : i32 {
+      %78 = tt.load %arg11 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<16x128xf16, #blocked1>
+      %79 = tt.load %arg12 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<64x256xi8, #blocked>
+      %80 = arith.shli %79, %cst_2 : tensor<64x256xi8, #blocked>
+      %81 = arith.shrsi %80, %cst_2 : tensor<64x256xi8, #blocked>
+      %82 = arith.shrsi %79, %cst_2 : tensor<64x256xi8, #blocked>
+      %83 = arith.sitofp %81 : tensor<64x256xi8, #blocked> to tensor<64x256xf16, #blocked>
+      %84 = arith.sitofp %82 : tensor<64x256xi8, #blocked> to tensor<64x256xf16, #blocked>
+      %85 = tt.join %83, %84 : tensor<64x256xf16, #blocked> -> tensor<64x256x2xf16, #blocked3>
+      %86 = tt.trans %85 {order = array<i32: 0, 2, 1>} : tensor<64x256x2xf16, #blocked3> -> tensor<64x2x256xf16, #blocked4>
+      %87 = tt.reshape %86 {allow_reorder = false} : tensor<64x2x256xf16, #blocked4> -> tensor<128x256xf16, #blocked5>
+      %88 = triton_gpu.convert_layout %78 : tensor<16x128xf16, #blocked1> -> tensor<16x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+      %89 = triton_gpu.convert_layout %87 : tensor<128x256xf16, #blocked5> -> tensor<128x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %90 = tt.dot %88, %89, %arg10 {allowTF32 = true, maxNumImpreciseAcc = 0 : i32} : tensor<16x128xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<128x256xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<16x256xf32, #mma>
+      %91 = tt.addptr %arg11, %cst_0 : tensor<16x128x!tt.ptr<f16, 1>, #blocked1>, tensor<16x128xi32, #blocked1>
+      %92 = tt.addptr %arg12, %cst : tensor<64x256x!tt.ptr<i8, 1>, #blocked>, tensor<64x256xi32, #blocked>
+      scf.yield %90, %91, %92 : tensor<16x256xf32, #mma>, tensor<16x128x!tt.ptr<f16, 1>, #blocked1>, tensor<64x256x!tt.ptr<i8, 1>, #blocked>
+    }
+    tt.return %54#0 : tensor<16x256xf32, #mma>
   }
 }


### PR DESCRIPTION
<git-pr-chain>


Allow pipelining more loads indirectly used by a dot.

Previously if a load was used indirectly by a dot but there were non-unary
operations between the load and the dot, we couldn't pipeline it.

Also clean up some TODOs.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3415 👈 **YOU ARE HERE**


</git-pr-chain>







