### PR TITLE
Revert "[FRONTEND] Emit NegFOp for unary minus operator (#3394)"

### DIFF
--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -96,10 +96,9 @@ void populateArithPatternsAndLegality(TritonGPUTypeConverter &typeConverter,
       GenericOpPattern<arith::RemSIOp>, GenericOpPattern<arith::AndIOp>,
       GenericOpPattern<arith::OrIOp>, GenericOpPattern<arith::XOrIOp>,
       GenericOpPattern<arith::ShLIOp>, GenericOpPattern<arith::ShRUIOp>,
-      GenericOpPattern<arith::ShRSIOp>,
+      GenericOpPattern<arith::ShRSIOp>, // NegFOp
       // Floating point
       GenericOpPattern<arith::AddFOp>, GenericOpPattern<arith::SubFOp>,
-      GenericOpPattern<arith::NegFOp>,
       // MaxMin
       GenericOpPattern<arith::MaximumFOp>, GenericOpPattern<arith::MaxNumFOp>,
       GenericOpPattern<arith::MaxSIOp>, GenericOpPattern<arith::MaxUIOp>,

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1419,10 +1419,6 @@ void init_triton_ir(py::module &&m) {
            [](TritonOpBuilder &self, Value &val) -> Value {
              return self.create<math::AbsIOp>(val);
            })
-      .def("create_fneg",
-           [](TritonOpBuilder &self, Value &val) -> Value {
-             return self.create<arith::NegFOp>(val);
-           })
       .def("create_reduce",
            [](TritonOpBuilder &self, std::vector<Value> operands, int axis)
                -> OpState { return self.create<ReduceOp>(operands, axis); })

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -854,40 +854,6 @@ def test_unary_op(dtype_x, expr, num_ctas, device):
     _test_unary(dtype_x, expr, device=device, num_ctas=num_ctas)
 
 
-@pytest.mark.interpreter
-@pytest.mark.parametrize("dtype", dtypes_with_bfloat16)
-@pytest.mark.parametrize("num_ctas", num_ctas_list)
-def test_minus_zero(dtype, num_ctas, device):
-    # Test that -0 is handled correctly for all dtypes
-
-    check_type_supported(dtype, device)  # early return if dtype_x is not supported
-    SIZE = 128
-    # define the kernel / launch-grid
-
-    @triton.jit
-    def kernel(Z, X, SIZE: tl.constexpr):
-        off = tl.arange(0, SIZE)
-        x = tl.load(X + off)
-        z = -x
-        tl.store(Z + off, z)
-
-    # inputs
-    mask = numpy_random(SIZE, dtype_str="bool")
-    np_dtype = np.float64 if "float" in dtype else np.int64
-    np_zero = np.zeros(SIZE, np_dtype)
-    x = np.where(mask, np_zero, -np_zero)
-    # reference result
-    z_ref = -x
-    # triton result
-    x_tri = to_triton(x, device=device, dst_type=dtype)
-    z_tri = to_triton(np.empty_like(x), device=device, dst_type=dtype)
-    kernel[(1, )](z_tri, x_tri, SIZE=SIZE, num_warps=4, num_ctas=num_ctas)
-    # compare
-    z_np = to_numpy(z_tri)
-    np.testing.assert_array_equal(z_np, 0.0)
-    np.testing.assert_array_equal(np.signbit(z_np), np.signbit(z_ref))
-
-
 # ----------------
 # test math ops
 # ----------------

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -387,10 +387,8 @@ def minus(input: tl.tensor, builder: ir.builder) -> tl.tensor:
     input_sca_ty = input.type.scalar
     if input_sca_ty.is_ptr():
         raise ValueError("wrong type argument to unary minus (" + input_sca_ty.__repr__() + ")")
-    if input_sca_ty.is_int():
-        _0 = tl.tensor(builder.get_null_value(input_sca_ty.to_ir(builder)), input_sca_ty)
-        return sub(_0, input, builder)
-    return tl.tensor(builder.create_fneg(input.handle), input.type)
+    _0 = tl.tensor(builder.get_null_value(input_sca_ty.to_ir(builder)), input_sca_ty)
+    return sub(_0, input, builder)
 
 
 def invert(input: tl.tensor, builder: tl.tensor) -> tl.tensor:

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -335,7 +335,6 @@ class Builder:
     create_sqrt = lambda self, arg: self.unary_op(arg, np.sqrt)
     create_fabs = lambda self, arg: self.unary_op(arg, np.abs)
     create_iabs = lambda self, arg: self.unary_op(arg, np.abs)
-    create_fneg = lambda self, arg: self.unary_op(arg, np.negative)
 
     # tensor operators
     create_reshape = lambda self, arg, shape, allow_reorder: TensorHandle(arg.data.reshape(shape), arg.dtype)

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -765,30 +765,6 @@ struct FSubOpConversion
   }
 };
 
-struct FNegOpConversion
-    : ElementwiseOpConversionBase<arith::NegFOp, FNegOpConversion> {
-  using Base = ElementwiseOpConversionBase<arith::NegFOp, FNegOpConversion>;
-  using Base::Base;
-  using Adaptor = typename Base::OpAdaptor;
-
-  SmallVector<Value> createDestOps(arith::NegFOp op, OpAdaptor adaptor,
-                                   ConversionPatternRewriter &rewriter,
-                                   Type elemTy, MultipleOperandsRange operands,
-                                   Location loc) const {
-    auto operandTy = getElementType(op.getOperand());
-    if (operandTy.isBF16()) {
-      PTXBuilder builder;
-      auto &neg = builder.create<PTXInstr>("neg")->o("bf16");
-      auto res = builder.newOperand("=h");
-      auto val = builder.newOperand(operands[0][0], "h");
-      neg(res, val);
-      return {builder.launch(rewriter, loc, i16_ty, false)};
-    } else {
-      return {rewriter.create<LLVM::FNegOp>(loc, elemTy, operands[0][0])};
-    }
-  }
-};
-
 // Uses inline ptx to convert s8/u8 to bf16, since the
 struct SIToFPOpConversion
     : ElementwiseOpConversionBase<arith::SIToFPOp, SIToFPOpConversion> {
@@ -1151,7 +1127,6 @@ void mlir::triton::NVIDIA::populateElementwiseOpToLLVMPatterns(
   patterns.add<FSubOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<FAddOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<FMulOpConversion>(typeConverter, axisInfoAnalysis, benefit);
-  patterns.add<FNegOpConversion>(typeConverter, axisInfoAnalysis, benefit);
 
   patterns.add<ExtFOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<TruncFOpConversion>(typeConverter, axisInfoAnalysis, benefit);


### PR DESCRIPTION
This reverts commit 235d5d86bdcc3031000bd51daff18f5b9f34c98d.

This causes a failure in one of our internal test (it seems like this change the numeric precision even though I don't think it should). It will be investigated next week as OAI is on a break this week. 

Sorry for the inconvenience.