### PR TITLE
[BUILD] Fix linker error in Membar.cpp

### DIFF
--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -3,9 +3,6 @@
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
-#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
-
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include <deque>


### PR DESCRIPTION
We found an issue when linking `TritonAnalysis` without first fully building triton.

```
In file included from ~/triton/lib/Analysis/Membar.cpp:6:
In file included from ~/triton/include/triton/Conversion/TritonGPUToLLVM/Utility.h:8:
~/triton/include/triton/Dialect/NVGPU/IR/Dialect.h:32:10: fatal error: 'triton/Dialect/NVGPU/IR/Dialect.h.inc' file not found
#include "triton/Dialect/NVGPU/IR/Dialect.h.inc"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning and 1 error generated.
ninja: build stopped: subcommand failed.
```

So `Membar.cpp` includes `Utility.h` from `TritonGPUToLLVM` which in turns needs `NVGPU` and its tablegen files. `TritonAnalysis`'s cmake doesn't list neither `TritonGPUToLLVM` nor `NVGPU` as dependencies, hence the linker error. Technically we should have `TritonAnalysis` depend on `TritonGPUToLLVM`, but `TritonGPUToLLVM` already depends on `TritonAnalysis`.

Fortunately, `Membar.cpp` doesn't use this `Utility.h` file, so we could simply delete this include to break both the linker error and the potential circular dependency. Also note that the error doesn't show up in the full build because the tablegen files from `NVGPU` are already generated by the time we link the all libs.