### PR TITLE
[BACKEND] Move TTG_AsyncToken type to TritonGPUTypes.td

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -24,22 +24,6 @@ class TTG_Op<string mnemonic, list<Trait> traits = []> :
        !listconcat(traits, [VerifyTensorLayoutsTrait])> {
 }
 
-class TTG_Type<string name, string typeMnemonic,
-        list<Trait> traits = []> : TypeDef<TritonGPU_Dialect, name, traits> {
-  let mnemonic = typeMnemonic;
-}
-
-def TTG_AsyncToken : TTG_Type<"AsyncToken",
-                                    "async.token", []> {
-  let summary = "async token type";
-  let description = [{
-    `ttg.async.token` is a type returned by an asynchronous operation.
-    It is used to establish an SSA-based link between async operations
-    and operations that group or synchronize the async operations.
-  }];
-}
-
-
 def TTG_ConvertLayoutOp : TTG_Op<"convert_layout",
                                  [SameOperandsAndResultShape,
                                   SameOperandsAndResultElementType,

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUTypes.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUTypes.td
@@ -23,4 +23,14 @@ def TTG_TokenType : TTG_TypeDef<"Token", "token"> {
   let skipDefaultBuilders = 1;
 }
 
+def TTG_AsyncToken : TTG_TypeDef<"AsyncToken",
+                                    "async.token", []> {
+  let summary = "async token type";
+  let description = [{
+    `ttg.async.token` is a type returned by an asynchronous operation.
+    It is used to establish an SSA-based link between async operations
+    and operations that group or synchronize the async operations.
+  }];
+}
+
 #endif


### PR DESCRIPTION
Small clean up to keep Ops and Types in separated .td files.

Also remove `TTG_Type` because there is an identical class  `TTG_TypeDef` in `TritonGPUTypes.td`. 