### PR TITLE
[AMD] Treat version as string avoid string/bytes comparison

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -221,5 +221,5 @@ class HIPBackend(BaseBackend):
 
     @functools.lru_cache()
     def hash(self):
-        version = subprocess.check_output([HIPBackend.path_to_rocm_lld(), "--version"])
+        version = subprocess.check_output([HIPBackend.path_to_rocm_lld(), "--version"], encoding='utf-8')
         return f'{version}-{self.target}'


### PR DESCRIPTION
Resolves an error observed as part of inductor support bring-up for AMD when running unit test's via PyTorch's run_test.py due to the addition of `-bb` flag in pytest which forbids string/bytes comparisons.
```
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/_inductor/triton_heuristics.py", line 208, in precompile
    compiled_binary, launcher = self._precompile_config(
  File "/opt/conda/envs/py_3.8/lib/python3.8/site-packages/torch/_inductor/triton_heuristics.py", line 365, in _precompile_config
    binary = triton.compile(*compile_args, **compile_kwargs)
  File "/root/triton/python/triton/compiler/compiler.py", line 229, in compile
    key = f"{triton_key()}-{src.hash()}-{backend.hash()}-{options.hash()}-{str(sorted(get_env_vars().items()))}"
  File "/root/triton/python/triton/backends/amd/compiler.py", line 231, in hash
    return f'{version}-{self.target}'
BytesWarning: str() on a bytes instance
```
To resolve this I am proposing to read in the version as a string to avoid string to bytes comparisons