### PR TITLE
Fix mixed key constants breaking sorted_constants for hashing ASTSource

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -103,7 +103,7 @@ class ASTSource:
     def hash(self):
         sorted_sig = [v for k, v in sorted(self.signature.items())]
         # Note - we stringify the keys here to allow sorting to work for cases
-        # where constants have mixed int/str keys. 
+        # where constants have mixed int/str keys.
         sorted_constants = sorted((str(k), v) for k, v in self.constants.items())
         key = f"{self.fn.cache_key}-{self.attrs.hash()}-{sorted_sig}-{sorted_constants}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -102,6 +102,8 @@ class ASTSource:
 
     def hash(self):
         sorted_sig = [v for k, v in sorted(self.signature.items())]
+        # Note - we stringify the keys here to allow sorting to work for cases
+        # where constants have mixed int/str keys. 
         sorted_constants = sorted((str(k), v) for k, v in self.constants.items())
         key = f"{self.fn.cache_key}-{self.attrs.hash()}-{sorted_sig}-{sorted_constants}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -102,7 +102,7 @@ class ASTSource:
 
     def hash(self):
         sorted_sig = [v for k, v in sorted(self.signature.items())]
-        sorted_constants = [(k, v) for k, v in sorted(self.constants.items())]
+        sorted_constants = sorted((str(k), v) for k, v in self.constants.items())
         key = f"{self.fn.cache_key}-{self.attrs.hash()}-{sorted_sig}-{sorted_constants}"
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 


### PR DESCRIPTION
Fixes bug introduced in: https://github.com/openai/triton/commit/1ecbc27a8169cd47ef81e061789f05b913a740b1

Reproed via dynamo with a manually updated pin 
`test_functions.py` running test `test_triton_kernel_various_args` creates constants of ` {'RANDOM_SIZE': 0, 5: 128}` which breaks this hashing.

A simple step to first string the keys, and then sort works.

cc: @bertmaher @jlebar @ptillet 