### PR TITLE
[CI] Update Github actions to node.js 20

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,14 +13,14 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.CI_PAT }}
           fetch-depth: 0
 
       - name: Clear docs
         run: |
-          rm -r /tmp/triton-docs
+          rm -rf /tmp/triton-docs
         continue-on-error: true
 
       - name: Install dependent packages
@@ -45,7 +45,7 @@ jobs:
           sudo cp -r CNAME /tmp/triton-docs/
           sudo cp -r index.html /tmp/triton-docs/
           sudo cp -r .nojekyll /tmp/triton-docs/
-          sudo rm -r *
+          sudo rm -rf *
           sudo cp -r /tmp/triton-docs/* .
           sudo git add .
           sudo git config --global user.email "N/A"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: "true"
       - name: Set CUDA ENV
@@ -156,7 +156,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install gh CLI
         run: |

--- a/.github/workflows/test-backends.yml
+++ b/.github/workflows/test-backends.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set XPU ENV
         if: ${{(matrix.runner[0] == 'self-hosted') && (matrix.runner[1] == 'arc770')}}

--- a/.github/workflows/torch-inductor-tests.yml
+++ b/.github/workflows/torch-inductor-tests.yml
@@ -27,7 +27,7 @@ jobs:
         runner: ${{fromJson(needs.Runner-Preparation.outputs.matrix)}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Packages
         run: |
           ./.github/workflows/torch-inductor/scripts/install_torchinductor.sh torchbench


### PR DESCRIPTION
1. Resolve GH actions warnings due using deprecated versions of checkout, v2 (node.js 12; EOL) and v3 (node.js 16; EOL), by upgrading to checkout v4 (node.js 20).

2. add -f (force) flag to rm cmds bc it always completes successfully (return 0) even if file/folder is not found. Without the force flag, "file not found" error causes the cmd to return 1 (fail) when the objective was technically met.