### PR TITLE
Handle file paths with spaces (#3305)

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -21,14 +21,13 @@ def _path_to_binary(binary: str):
         os.path.join(os.path.dirname(__file__), "bin", binary),
     ]
 
-    for p in paths:
-        bin = p.split(" ")[0]
+    for bin in paths:
         if os.path.exists(bin) and os.path.isfile(bin):
             result = subprocess.check_output([bin, "--version"], stderr=subprocess.STDOUT)
             if result is not None:
                 version = re.search(r".*release (\d+\.\d+).*", result.decode("utf-8"), flags=re.MULTILINE)
                 if version is not None:
-                    return p, version.group(1)
+                    return bin, version.group(1)
     raise RuntimeError(f"Cannot find {binary}")
 
 


### PR DESCRIPTION
A call to split() on a file path string results in a truncated path if the latter has spaces in it, then the target binary is not found. It was an unnecessary step.