### PR TITLE
[FRONTEND] Keep pointer_type name and its __str__ in-sync.

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -401,13 +401,13 @@ class pointer_type(dtype):
         self.element_ty = element_ty
         self.address_space = address_space
 
-        self.name = self.__str__()
+        self.name = f'pointer<{element_ty}>'
 
     def to_ir(self, builder: ir.builder) -> ir.pointer_type:
         return builder.get_ptr_ty(self.element_ty.to_ir(builder), 1)
 
     def __str__(self):
-        return f'pointer<{self.element_ty}>'
+        return self.name
 
     def __repr__(self):
         return self.__str__()

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -466,13 +466,13 @@ class block_type(dtype):
         if self.numel > TRITON_MAX_TENSOR_NUMEL:
             raise ValueError(f"numel ({self.numel}) exceeds triton maximum tensor numel ({TRITON_MAX_TENSOR_NUMEL})")
 
-        self.name = self.__str__()
+        self.name = f'<{self.shape}, {self.element_ty}>'
 
     def to_ir(self, builder: ir.builder) -> ir.block_type:
         return builder.get_block_ty(self.element_ty.to_ir(builder), self.shape)
 
     def __str__(self):
-        return f'<{self.shape}, {self.element_ty}>'
+        return self.name
 
     def __repr__(self):
         return self.__str__()


### PR DESCRIPTION
This change ensures that `name` cannot get out of sync with `__str__` and `__repr__`, since all of the fields are technically mutable and can be changed at any time. This also comes with a potential performance benefit of computing this f-string only once instead of computing it on each `__str__`/`__repr__` invocation.

It would be even better to also to make this class immutable, but it's a separate story.