### PR TITLE
Use ttgir line number instead of source line number to help matching from ttgir to llir/ptx

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ $ ninja -C build && ( cd build ; lit test )
   `LLVM_IR_ENABLE_DUMP=1`, extract the IR before the LLVM pass of interest, and
   then run LLVM's `opt` standalone, perhaps passing `-debug-only=foo` on the
   command line.
+- `USE_TTGIR_LOC` reparses the ttgir such that the location information will
+  be the line number of the ttgir instead of line number of the python file.
+  This can provide a direct mapping from ttgir to llir/ptx. When used with
+  performance tools, it can provide a breakdown on ttgir instructions.
 
 # Changelog
 

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -42,7 +42,6 @@ inline const std::set<std::string> ENV_VARS = {
     "TRITON_DISABLE_RESHAPE_ENCODING_INFERENCE",
     "MLIR_ENABLE_DIAGNOSTICS",
     "TRITON_ENABLE_LLVM_DEBUG",
-    "DISABLE_LOC_DUMP",
     "USE_TTGIR_LOC",
 };
 

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -42,6 +42,8 @@ inline const std::set<std::string> ENV_VARS = {
     "TRITON_DISABLE_RESHAPE_ENCODING_INFERENCE",
     "MLIR_ENABLE_DIAGNOSTICS",
     "TRITON_ENABLE_LLVM_DEBUG",
+    "DISABLE_LOC_DUMP",
+    "USE_TTGIR_LOC",
 };
 
 namespace tools {

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -379,7 +379,8 @@ void init_triton_ir(py::module &&m) {
              llvm::raw_string_ostream os(str);
              auto printingFlags = OpPrintingFlags();
              bool dumpLoc = !::triton::tools::getBoolEnv("DISABLE_LOC_DUMP");
-             if (dumpLoc) printingFlags.enableDebugInfo();
+             if (dumpLoc)
+               printingFlags.enableDebugInfo();
              self->print(os, printingFlags);
              return str;
            })
@@ -445,7 +446,8 @@ void init_triton_ir(py::module &&m) {
              llvm::raw_string_ostream os(str);
              auto printingFlags = OpPrintingFlags();
              bool dumpLoc = !::triton::tools::getBoolEnv("DISABLE_LOC_DUMP");
-             if (dumpLoc) printingFlags.enableDebugInfo();
+             if (dumpLoc)
+               printingFlags.enableDebugInfo();
              self.print(os, printingFlags);
              return str;
            })

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -494,10 +494,10 @@ void init_triton_ir(py::module &&m) {
         if (!module)
           throw std::runtime_error("Parse MLIR file failed.");
         // locations are incompatible with ptx < 7.5 !
-        module->walk([](Operation *op) {
-          if (!::triton::tools::getBoolEnv("USE_TTGIR_LOC"))
+        if (!::triton::tools::getBoolEnv("USE_TTGIR_LOC"))
+          module->walk([](Operation *op) {
             op->setLoc(UnknownLoc::get(op->getContext()));
-        });
+          });
 
         return module->clone();
       },

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -378,7 +378,8 @@ void init_triton_ir(py::module &&m) {
              std::string str;
              llvm::raw_string_ostream os(str);
              auto printingFlags = OpPrintingFlags();
-             printingFlags.enableDebugInfo();
+             bool dumpLoc = !::triton::tools::getBoolEnv("DISABLE_LOC_DUMP");
+             if (dumpLoc) printingFlags.enableDebugInfo();
              self->print(os, printingFlags);
              return str;
            })
@@ -443,7 +444,8 @@ void init_triton_ir(py::module &&m) {
              std::string str;
              llvm::raw_string_ostream os(str);
              auto printingFlags = OpPrintingFlags();
-             printingFlags.enableDebugInfo();
+             bool dumpLoc = !::triton::tools::getBoolEnv("DISABLE_LOC_DUMP");
+             if (dumpLoc) printingFlags.enableDebugInfo();
              self.print(os, printingFlags);
              return str;
            })
@@ -491,7 +493,8 @@ void init_triton_ir(py::module &&m) {
           throw std::runtime_error("Parse MLIR file failed.");
         // locations are incompatible with ptx < 7.5 !
         module->walk([](Operation *op) {
-          op->setLoc(UnknownLoc::get(op->getContext()));
+          if (!::triton::tools::getBoolEnv("USE_TTGIR_LOC"))
+            op->setLoc(UnknownLoc::get(op->getContext()));
         });
 
         return module->clone();

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -378,7 +378,7 @@ void init_triton_ir(py::module &&m) {
              std::string str;
              llvm::raw_string_ostream os(str);
              auto printingFlags = OpPrintingFlags();
-             bool dumpLoc = !::triton::tools::getBoolEnv("DISABLE_LOC_DUMP");
+             bool dumpLoc = !::triton::tools::getBoolEnv("USE_TTGIR_LOC");
              if (dumpLoc)
                printingFlags.enableDebugInfo();
              self->print(os, printingFlags);
@@ -445,7 +445,7 @@ void init_triton_ir(py::module &&m) {
              std::string str;
              llvm::raw_string_ostream os(str);
              auto printingFlags = OpPrintingFlags();
-             bool dumpLoc = !::triton::tools::getBoolEnv("DISABLE_LOC_DUMP");
+             bool dumpLoc = !::triton::tools::getBoolEnv("USE_TTGIR_LOC");
              if (dumpLoc)
                printingFlags.enableDebugInfo();
              self.print(os, printingFlags);

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -279,6 +279,12 @@ def compile(src, target=None, options=None):
             print(f"\nOverriding kernel with file {ir_filename}")
             full_name = fn_override_manager.get_file(ir_filename)
             next_module = parse(full_name, ext, context)
+        # use an env variable to parse ttgir from file
+        use_ttgir_loc = os.environ.get("USE_TTGIR_LOC", "0") == "1"
+        if use_ttgir_loc and ext == "ttgir":
+            ttgir_full_name = fn_cache_manager.get_file(ir_filename)
+            next_module = parse(ttgir_full_name, ext, context)
+            print(f"re-parse ttgir with {ttgir_full_name}")
         module = next_module
     # write-back metadata
     metadata_group[metadata_filename] = fn_cache_manager.put(json.dumps(metadata, default=vars), metadata_filename,

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -269,6 +269,7 @@ def compile(src, target=None, options=None):
     except Exception as e:
         filter_traceback(e)
         raise
+    use_ttgir_loc = os.environ.get("USE_TTGIR_LOC", "0") == "1"
     for ext, compile_ir in list(stages.items())[first_stage:]:
         next_module = compile_ir(module, metadata)
         ir_filename = f"{src.name}.{ext}"
@@ -280,7 +281,6 @@ def compile(src, target=None, options=None):
             full_name = fn_override_manager.get_file(ir_filename)
             next_module = parse(full_name, ext, context)
         # use an env variable to parse ttgir from file
-        use_ttgir_loc = os.environ.get("USE_TTGIR_LOC", "0") == "1"
         if use_ttgir_loc and ext == "ttgir":
             ttgir_full_name = fn_cache_manager.get_file(ir_filename)
             next_module = parse(ttgir_full_name, ext, context)


### PR DESCRIPTION
This can help us analyzing the mapping from ttgir to llir/ptx. When used with performance tools, it can provide a breakdown on ttgir instructions.
Added one env variable:
    "USE_TTGIR_LOC": will not emit location information in the dumped ttgir, will re-parse the ttgir file and use ttgir line numbers as debug info
When running on vector-add with USE_TTGIR_LOC=1:
    ttgir: #loc = loc("/cache-path/add_kernel.ttgir":2:1)
    llir: !3 = !DIFile(filename: "add_kernel.ttgir", directory: "/cache-path")