### PR TITLE
Ignore build-*/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Triton builds
 build/
+build-*/
 
 # Triton Python module builds
 python/build/


### PR DESCRIPTION
It's common to use different suffixes to the build
directory when directly compilng from C++.