### PR TITLE
Add a parameter reorder to existing tl.reshape

### DIFF
--- a/python/test/unit/hopper/test_gemm_fusion.py
+++ b/python/test/unit/hopper/test_gemm_fusion.py
@@ -127,22 +127,22 @@ def batched_gemm_fusion(Q, K, V, Out,  #
     )
 
     q = tl.load(q_tile_ptr, boundary_check=(0, 1, 2, 3))
-    q = tl.reshape(q, (BLOCK_M, BLOCK_DMODEL), reorder=True)
+    q = tl.reshape(q, (BLOCK_M, BLOCK_DMODEL), can_reorder=True)
     for i in range(0, N_CTX, BLOCK_N):
         k = tl.load(k_tile_ptr, boundary_check=(0, 1, 2, 3))
-        k = tl.reshape(k, (BLOCK_N, BLOCK_DMODEL), reorder=True)
+        k = tl.reshape(k, (BLOCK_N, BLOCK_DMODEL), can_reorder=True)
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
         qk += tl.dot(q, tl.trans(k))
 
         p = qk.to(tl.float16)
         v = tl.load(v_tile_ptr, boundary_check=(0, 1, 2, 3))
-        v = tl.reshape(v, (BLOCK_N, BLOCK_DMODEL), reorder=True)
+        v = tl.reshape(v, (BLOCK_N, BLOCK_DMODEL), can_reorder=True)
         acc += tl.dot(p, v)
 
         k_tile_ptr = tl.advance(k_tile_ptr, [0, 0, BLOCK_N, 0])
         v_tile_ptr = tl.advance(v_tile_ptr, [0, 0, BLOCK_N, 0])
 
-    acc = tl.reshape(acc, (1, 1, BLOCK_M, BLOCK_DMODEL), reorder=True)
+    acc = tl.reshape(acc, (1, 1, BLOCK_M, BLOCK_DMODEL), can_reorder=True)
     acc = acc.to(tl.float16)
     tl.store(o_tile_ptr, acc)
 

--- a/python/test/unit/hopper/test_gemm_fusion.py
+++ b/python/test/unit/hopper/test_gemm_fusion.py
@@ -127,22 +127,22 @@ def batched_gemm_fusion(Q, K, V, Out,  #
     )
 
     q = tl.load(q_tile_ptr, boundary_check=(0, 1, 2, 3))
-    q = tl.view(q, (BLOCK_M, BLOCK_DMODEL))
+    q = tl.reshape(q, (BLOCK_M, BLOCK_DMODEL), reorder=True)
     for i in range(0, N_CTX, BLOCK_N):
         k = tl.load(k_tile_ptr, boundary_check=(0, 1, 2, 3))
-        k = tl.view(k, (BLOCK_N, BLOCK_DMODEL))
+        k = tl.reshape(k, (BLOCK_N, BLOCK_DMODEL), reorder=True)
         qk = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
         qk += tl.dot(q, tl.trans(k))
 
         p = qk.to(tl.float16)
         v = tl.load(v_tile_ptr, boundary_check=(0, 1, 2, 3))
-        v = tl.view(v, (BLOCK_N, BLOCK_DMODEL))
+        v = tl.reshape(v, (BLOCK_N, BLOCK_DMODEL), reorder=True)
         acc += tl.dot(p, v)
 
         k_tile_ptr = tl.advance(k_tile_ptr, [0, 0, BLOCK_N, 0])
         v_tile_ptr = tl.advance(v_tile_ptr, [0, 0, BLOCK_N, 0])
 
-    acc = tl.view(acc, (1, 1, BLOCK_M, BLOCK_DMODEL))
+    acc = tl.reshape(acc, (1, 1, BLOCK_M, BLOCK_DMODEL), reorder=True)
     acc = acc.to(tl.float16)
     tl.store(o_tile_ptr, acc)
 

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1429,7 +1429,7 @@ def view(input, *shape, _builder=None):
     """
     warn("view is deprecated, please use reshape with can_reorder being true.")
     shape = _shape_check_impl(_unwrap_iterable(shape))
-    return semantic.view(input, shape, _builder)
+    return semantic.reshape(input, shape, can_reorder=True, builder=_builder)
 
 
 @_tensor_member_fn

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1427,14 +1427,14 @@ def view(input, *shape, _builder=None):
         view(x, (32, 32))
         view(x, 32, 32)
     """
-    warn("view is deprecated, please use reshape with reorder being true.")
+    warn("view is deprecated, please use reshape with can_reorder being true.")
     shape = _shape_check_impl(_unwrap_iterable(shape))
     return semantic.view(input, shape, _builder)
 
 
 @_tensor_member_fn
 @builtin
-def reshape(input, *shape, reorder=False, _builder=None):
+def reshape(input, *shape, can_reorder=False, _builder=None):
     """
     Returns a tensor with the same number of elements as input but with the
     provided shape.
@@ -1450,7 +1450,7 @@ def reshape(input, *shape, reorder=False, _builder=None):
         reshape(x, 32, 32)
     """
     shape = _shape_check_impl(_unwrap_iterable(shape))
-    return semantic.reshape(input, shape, reorder, _builder)
+    return semantic.reshape(input, shape, can_reorder, _builder)
 
 
 def _wrap_axis(axis, ndim):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1427,13 +1427,16 @@ def view(input, *shape, _builder=None):
         view(x, (32, 32))
         view(x, 32, 32)
     """
+    warn(
+        f"view is deprecated, please use reshape with reorder being true."
+    )
     shape = _shape_check_impl(_unwrap_iterable(shape))
     return semantic.view(input, shape, _builder)
 
 
 @_tensor_member_fn
 @builtin
-def reshape(input, *shape, _builder=None):
+def reshape(input, *shape, reorder=False, _builder=None):
     """
     Returns a tensor with the same number of elements as input but with the
     provided shape.
@@ -1449,7 +1452,7 @@ def reshape(input, *shape, _builder=None):
         reshape(x, 32, 32)
     """
     shape = _shape_check_impl(_unwrap_iterable(shape))
-    return semantic.reshape(input, shape, _builder)
+    return semantic.reshape(input, shape, reorder, _builder)
 
 
 def _wrap_axis(axis, ndim):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1427,9 +1427,7 @@ def view(input, *shape, _builder=None):
         view(x, (32, 32))
         view(x, 32, 32)
     """
-    warn(
-        f"view is deprecated, please use reshape with reorder being true."
-    )
+    warn("view is deprecated, please use reshape with reorder being true.")
     shape = _shape_check_impl(_unwrap_iterable(shape))
     return semantic.view(input, shape, _builder)
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -554,14 +554,14 @@ def view(input: tl.tensor, dst_shape: List[int], builder: ir.builder) -> tl.tens
     return tl.tensor(builder.create_reshape(input.handle, dst_shape, True), ret_ty)
 
 
-def reshape(input: tl.tensor, dst_shape: List[int], builder: ir.builder) -> tl.tensor:
+def reshape(input: tl.tensor, dst_shape: List[int], reorder: bool, builder: ir.builder) -> tl.tensor:
     numel = 1
     for s in dst_shape:
         numel *= s
     if input.type.numel != numel:
         raise ValueError("reshape() cannot change total number of elements in tensor")
     ret_ty = tl.block_type(input.type.scalar, dst_shape)
-    return tl.tensor(builder.create_reshape(input.handle, dst_shape, False), ret_ty)
+    return tl.tensor(builder.create_reshape(input.handle, dst_shape, reorder), ret_ty)
 
 
 def expand_dims(input: tl.tensor, axis: int, builder: ir.builder) -> tl.tensor:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -554,14 +554,14 @@ def view(input: tl.tensor, dst_shape: List[int], builder: ir.builder) -> tl.tens
     return tl.tensor(builder.create_reshape(input.handle, dst_shape, True), ret_ty)
 
 
-def reshape(input: tl.tensor, dst_shape: List[int], reorder: bool, builder: ir.builder) -> tl.tensor:
+def reshape(input: tl.tensor, dst_shape: List[int], can_reorder: bool, builder: ir.builder) -> tl.tensor:
     numel = 1
     for s in dst_shape:
         numel *= s
     if input.type.numel != numel:
         raise ValueError("reshape() cannot change total number of elements in tensor")
     ret_ty = tl.block_type(input.type.scalar, dst_shape)
-    return tl.tensor(builder.create_reshape(input.handle, dst_shape, reorder), ret_ty)
+    return tl.tensor(builder.create_reshape(input.handle, dst_shape, can_reorder), ret_ty)
 
 
 def expand_dims(input: tl.tensor, axis: int, builder: ir.builder) -> tl.tensor:
@@ -602,7 +602,7 @@ def join(a: tl.tensor, b: tl.tensor, builder: ir.builder) -> tl.tensor:
     ret = tl.tensor(builder.create_join(a.handle, b.handle), ret_type)
 
     if was_rank_1:
-        ret = reshape(ret, [2], reorder=False, builder=builder)
+        ret = reshape(ret, [2], can_reorder=False, builder=builder)
 
     return ret
 
@@ -1406,7 +1406,7 @@ def wrap_tensor(x, scalar_ty, ret_shape):
 
 def reduction(inputs: Sequence[tl.tensor], axis: int, region_builder_fn, builder: ir.builder) -> Tuple[tl.tensor, ...]:
     if axis is None:
-        inputs = tuple(view(t, [t.numel.value], builder) for t in inputs)
+        inputs = tuple(reshape(t, [t.numel.value], can_reorder=True, builder=builder) for t in inputs)
         axis = 0
     # get result shape
     shape = inputs[0].type.shape

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -602,7 +602,7 @@ def join(a: tl.tensor, b: tl.tensor, builder: ir.builder) -> tl.tensor:
     ret = tl.tensor(builder.create_join(a.handle, b.handle), ret_type)
 
     if was_rank_1:
-        ret = reshape(ret, [2], builder)
+        ret = reshape(ret, [2], reorder=False, builder=builder)
 
     return ret
 

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -544,16 +544,6 @@ def splat(value: tl.tensor, shape: List[int], builder: ir.builder) -> tl.tensor:
     return tl.tensor(builder.create_splat(value.handle, shape), ret_ty)
 
 
-def view(input: tl.tensor, dst_shape: List[int], builder: ir.builder) -> tl.tensor:
-    numel = 1
-    for s in dst_shape:
-        numel *= s
-    if input.type.numel != numel:
-        raise ValueError("view() cannot change total number of elements in tensor")
-    ret_ty = tl.block_type(input.type.scalar, dst_shape)
-    return tl.tensor(builder.create_reshape(input.handle, dst_shape, True), ret_ty)
-
-
 def reshape(input: tl.tensor, dst_shape: List[int], can_reorder: bool, builder: ir.builder) -> tl.tensor:
     numel = 1
     for s in dst_shape:

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -70,7 +70,7 @@ def ravel(x):
     :param x: the input tensor
     :type x: Block
     """
-    return core.view(x, [x.numel])
+    return core.reshape(x, [x.numel], can_reorder=True)
 
 
 @jit


### PR DESCRIPTION
Emit a deprecation message for tl.view.
As stated in https://github.com/openai/triton/issues/2829, the reorder bit in tl.view is confusing, make it explicit in tl.reshape.