### PR TITLE
Dynamic `ptas`, `cuobjdump` and `nvdisasm` version selector - build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ pip install -U --index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/
 git clone https://github.com/openai/triton.git;
 cd triton;
 
-pip install ninja cmake wheel; # build-time dependencies
+pip install ninja cmake wheel bs4; # build-time dependencies
 pip install -e python
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ cd triton;
 python -m venv .venv --prompt triton;
 source .venv/bin/activate;
 
-pip install ninja cmake wheel; # build-time dependencies
+pip install ninja cmake wheel bs4; # build-time dependencies
 pip install -e python
 ```
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -236,7 +236,10 @@ def get_cuda_version():
     try:
         output = subprocess.check_output(["nvcc", "--version"], text=True)
         version_line = next(line for line in output.split("\n") if "release" in line)
-        return version_line.split("release")[-1].strip().split(",")[0]
+        cuda_version = version_line.split("release")[-1].strip().split(",")[0]
+        if cuda_version.count(".") < 2:
+            cuda_version+=".0"
+        return cuda_version
     except Exception as e:
         raise RuntimeError("Failed to determine CUDA version") from e
 
@@ -427,14 +430,14 @@ download_and_copy(
 download_and_copy(
     src_path="bin/cuobjdump",
     variable="TRITON_CUOBJDUMP_PATH",
-    version=ptxas_version,
+    version=cuobjdump_version,
     url_func=lambda arch, version:
     f"https://anaconda.org/nvidia/cuda-cuobjdump/{version}/download/linux-{arch}/cuda-cuobjdump-{version}-0.tar.bz2",
 )
 download_and_copy(
     src_path="bin/nvdisasm",
     variable="TRITON_NVDISASM_PATH",
-    version=ptxas_version,
+    version=nvdisasm_version,
     url_func=lambda arch, version:
     f"https://anaconda.org/nvidia/cuda-nvdisasm/{version}/download/linux-{arch}/cuda-nvdisasm-{version}-0.tar.bz2",
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -533,10 +533,7 @@ setup(
     ],
     test_suite="tests",
     extras_require={
-        "build": [
-            "cmake>=3.20",
-            "lit",
-        ],
+        "build": ["cmake>=3.20", "lit", "bs4"],
         "tests": [
             "autopep8",
             "flake8",


### PR DESCRIPTION
# Title: 
Dynamic `ptas`, `cuobjdump` and `nvdisasm` version selector - build from source
# Summary:
As of commit [95d9b7f](https://github.com/openai/triton/commit/95d9b7f4ae21710dc899e1de6a579b2136ea4f3d), when building from source using `pip3 install -e .` the version numbers are hardcoded in `python/setup.py`. While this is alright if the CUDA version (`nvcc --version`) matches the hardcoded string, the build from source fails silently. 

It is not obvious to the user until they have ran the tutorials under `python/tutorials` that the CUDA version used to compile the code and the CUDA version installed are incompatible. An example of this can be seen in the thread of #3486.

The following summary addresses this issue by making the version number dynamic based on the user's system. This way, the user does not have to wait for `triton` to finish compiling and then realize the kernels are incompatible.

# Detailed design:
The main pain point of the current `python/setup.py` is the user needs to manually check the compatible versions for `ptas`, `cuobjdump` and `nvdisasm` on the website and then update the version number to create compatibility. In the following PR, I am proposing a simple web-scrapper like check prior to installing the above tools. The workflow is pretty straightforward and has been tested on a system which previously required modifications to the file.

It should be noted, the build command will now fail in case the web-scrapper is unable to fetch a compatible url for the given CUDA version, system architecture and tool.

# Examples and Use Cases:
When building from source
```
git clone https://github.com/openai/triton.git;
cd triton;

pip install ninja cmake wheel bs4; # build-time dependencies
pip install -e python
```

Or with a virtualenv:

```
git clone https://github.com/openai/triton.git;
cd triton;

python -m venv .venv --prompt triton;
source .venv/bin/activate;

pip install ninja cmake wheel bs4; # build-time dependencies
pip install -e python
```

# Performance Impact:
It would be nice to get rid of `bs4` as a dependency 

Let me know if this PR is acceptable

