### PR TITLE
[backend][amd] Use code object v5

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -52,7 +52,7 @@ class HIPOptions:
         oclc_wavefrontsize_lib = "oclc_wavefrontsize64_on" if self.warp_size == 64 else "oclc_wavefrontsize64_off"
         libs = [
             "cuda2gcn", "opencl", "ocml", "ockl", "oclc_finite_only_off", "oclc_daz_opt_off",
-            "oclc_correctly_rounded_sqrt_on", "oclc_unsafe_math_off", oclc_wavefrontsize_lib, "oclc_abi_version_400"
+            "oclc_correctly_rounded_sqrt_on", "oclc_unsafe_math_off", oclc_wavefrontsize_lib, "oclc_abi_version_500"
         ]
         libs += ['oclc_isa_version_' + self.arch.replace('gfx', '')]
         for lib in libs:


### PR DESCRIPTION
Code object v4 will be deprecated:
https://rocm.docs.amd.com/en/docs-5.0.2/CHANGELOG.html#warning-compiler-generated-code-object-version-4-deprecation

Code object v5 is the default version in the LLVM pinned by Triton:
https://github.com/llvm/llvm-project/blob/4017f04e/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp#L36

Making it consistent redues the risk of running into version mismatch issues.