### PR TITLE
[backend] Use one linker to link all external libraries

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -22,6 +22,7 @@
 #include "llvm/Transforms/InstCombine/InstCombine.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <stdexcept>
 
 namespace py = pybind11;
 
@@ -272,15 +273,15 @@ void init_triton_llvm(py::module &&m) {
       llvm::SMDiagnostic err;
       std::unique_ptr<llvm::Module> libMod = llvm::parseIRFile(path, err, ctx);
       if (!libMod) {
-        llvm::errs() << "Failed to load " << path;
-        return;
+        std::string message = "Failed to parse library at " + path;
+        throw std::invalid_argument(message);
       }
       libMod->setTargetTriple(dstMod->getTargetTriple());
       libMod->setDataLayout(dstMod->getDataLayout());
       if (linker.linkInModule(std::move(libMod),
                               llvm::Linker::Flags::LinkOnlyNeeded)) {
-        llvm::errs() << "Failed to link " << path;
-        return;
+        std::string message = "Failed to link library at " + path;
+        throw std::invalid_argument(message);
       }
     }
   });

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -177,8 +177,8 @@ class HIPBackend(BaseBackend):
         context = llvm.context()
         llvm_mod = llvm.to_module(mod, context)
         if options.extern_libs:
-            for name, path in options.extern_libs:
-                llvm.link_extern_lib(llvm_mod, path)
+            paths = [path for (name, path) in options.extern_libs]
+            llvm.link_extern_libs(llvm_mod, paths)
         llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
         # Set kernel attributes
         kernels = [fn for fn in llvm_mod.get_functions() if not fn.is_declaration()]

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -202,8 +202,8 @@ class CUDABackend(BaseBackend):
         llvm_mod = llvm.to_module(mod, context)
         nvidia.set_nvvm_reflect_ftz(llvm_mod)
         if options.extern_libs:
-            for name, path in options.extern_libs:
-                llvm.link_extern_lib(llvm_mod, path)
+            paths = [path for (name, path) in options.extern_libs]
+            llvm.link_extern_libs(llvm_mod, paths)
         llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)
         # Set kernel attributes
         # kernels = [fn for fn in llvm_mod.get_functions() if fn.has_public_visibility() and not fn.is_declaration()]


### PR DESCRIPTION
This avoids creating a separate linker each time to link a device library to avoid the overhead of internal tracking.