### PR TITLE
[backend][amd] NFC: nest AMD namespace inside mlir::triton

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -1,9 +1,8 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "Utility.h"
-#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
-
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
 using ::mlir::triton::gpu::AMDMfmaEncodingAttr;
@@ -181,7 +180,7 @@ private:
 };
 } // namespace
 
-namespace AMD {
+namespace mlir::triton::AMD {
 void populateConvertLayoutOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, const TargetInfo &targetInfo,
     RewritePatternSet &patterns, int numWarps,
@@ -191,4 +190,4 @@ void populateConvertLayoutOpToLLVMPatterns(
   mlir::triton::populateConvertLayoutOpToLLVMPatterns(typeConverter, targetInfo,
                                                       patterns, benefit);
 }
-} // namespace AMD
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
@@ -1,6 +1,8 @@
 #include "SharedToDotOperandHelper.h"
 
-namespace AMD {
+using ::mlir::triton::gpu::SharedEncodingAttr;
+
+namespace mlir::triton::AMD {
 
 // Get warpId inside block of warps.
 Value getWarpIdInBlock(ConversionPatternRewriter &rewriter, Location loc,
@@ -149,4 +151,4 @@ llvm::SmallVector<Value> computeOffsetsBType(
   return bOffsets;
 }
 
-} // namespace AMD
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
@@ -3,18 +3,14 @@
 
 #include "Utility.h"
 
-using ::mlir::triton::gpu::DotOperandEncodingAttr;
-using ::mlir::triton::gpu::getOrder;
-using ::mlir::triton::gpu::SharedEncodingAttr;
-
-namespace AMD {
+namespace mlir::triton::AMD {
 
 // Get warpId inside block of warps.
 Value getWarpIdInBlock(ConversionPatternRewriter &rewriter, Location loc,
                        Value warpId, const ArrayRef<unsigned int> &wpt,
                        int elemPerInstrNonK, int tensorSizeNonK, int nonKIdx);
 
-bool isSwizzled(SharedEncodingAttr layout);
+bool isSwizzled(gpu::SharedEncodingAttr layout);
 
 /**
  * @brief swizzling tensor element indexes according pattern encoded in
@@ -30,11 +26,12 @@ bool isSwizzled(SharedEncodingAttr layout);
  */
 std::pair<mlir::Value, mlir::Value>
 swizzleIndexes(ConversionPatternRewriter &rewriter, Location loc, Value row,
-               Value col, SharedMemoryObject smemObj, SharedEncodingAttr attr);
+               Value col, SharedMemoryObject smemObj,
+               gpu::SharedEncodingAttr attr);
 
 Value computeOffset(ConversionPatternRewriter &rewriter, Location loc,
                     Value row, Value col, SharedMemoryObject smemObj,
-                    SharedEncodingAttr srcLayout);
+                    gpu::SharedEncodingAttr srcLayout);
 
 Value computeBasePtr(ConversionPatternRewriter &rewriter, Location loc,
                      const SharedMemoryObject &smemObj);
@@ -50,15 +47,15 @@ llvm::SmallVector<Value> computeOffsetsAType(
     computeTensorElemMappingInBlockT fn, const ArrayRef<int64_t> &elemsPerInstr,
     Value warpId, Value laneId, int warpsPerBlock, int numOfElems,
     ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-    SharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
+    gpu::SharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
 
 llvm::SmallVector<Value> computeOffsetsBType(
     ConversionPatternRewriter &rewriter, Location loc,
     computeTensorElemMappingInBlockT fn, const ArrayRef<int64_t> &elemsPerInstr,
     Value warpId, Value laneId, int warpsPerBlock, int numOfElems,
     ArrayRef<int64_t> reps, SharedMemoryObject smemObj,
-    SharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
+    gpu::SharedEncodingAttr srcLayout, unsigned nonKDim, unsigned kDim);
 
-} // namespace AMD
+} // namespace mlir::triton::AMD
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
@@ -1,16 +1,12 @@
 #include "Utility.h"
-
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+
 using namespace mlir;
-using namespace mlir::triton;
 
-using ::mlir::LLVM::getSharedMemoryObjectFromStruct;
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
-using ::mlir::triton::gpu::DotOperandEncodingAttr;
 using ::mlir::triton::gpu::getShapePerCTA;
-using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 
-namespace AMD {
+namespace mlir::triton::AMD {
 LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter);
@@ -18,7 +14,7 @@ LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
 LogicalResult convertWMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter);
-} // namespace AMD
+} // namespace mlir::triton::AMD
 
 namespace {
 struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
@@ -60,11 +56,11 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
 };
 } // namespace
 
-namespace AMD {
+namespace mlir::triton::AMD {
 void populateDotOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                  RewritePatternSet &patterns, int numWarps,
                                  ModuleAxisInfoAnalysis &axisInfoAnalysis,
                                  PatternBenefit benefit) {
   patterns.add<DotOpConversion>(typeConverter, benefit);
 }
-} // namespace AMD
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -293,7 +293,7 @@ struct DotOpMFMAConversionHelper {
 
 } // namespace
 
-namespace AMD {
+namespace mlir::triton::AMD {
 LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter) {
@@ -325,6 +325,6 @@ LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
 
   return helper.convertDot(op, adaptor);
 }
-} // namespace AMD
+} // namespace mlir::triton::AMD
 
 #endif // ifdef USE_ROCM

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -23,18 +23,13 @@
 
 #include "../PatternTritonGPUOpToLLVM.h"
 #include "Utility.h"
-
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 
-using namespace mlir;
-using namespace mlir::triton;
-
-namespace AMD {
+namespace mlir::triton::AMD {
 namespace {
 
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
-using ::mlir::triton::gpu::SharedEncodingAttr;
 
 enum class WMMAInstrType : uint8_t {
   // D = AB + C;
@@ -253,4 +248,4 @@ LogicalResult convertWMMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
 
   return convertDot(op, adaptor, rewriter, typeConverter);
 }
-} // namespace AMD
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1401,7 +1401,7 @@ struct ExpOpConversionApprox
 
 } // namespace
 
-namespace AMD {
+namespace mlir::triton::AMD {
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns, int numWarps,
     ModuleAxisInfoAnalysis &axisInfoAnalysis, ModuleAllocation &allocation,
@@ -1445,4 +1445,4 @@ void populateElementwiseOpToLLVMPatterns(
   mlir::triton::populateClampFOpToLLVMPattern(
       typeConverter, patterns, axisInfoAnalysis, targetInfo, benefit);
 }
-} // namespace AMD
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -9,10 +9,9 @@
 #include <numeric>
 
 using namespace mlir;
-using namespace mlir::triton;
 
 using ::mlir::LLVM::delinearize;
-using mlir::LLVM::getSharedMemoryBase;
+using ::mlir::LLVM::getSharedMemoryBase;
 using ::mlir::triton::gpu::getTotalElemsPerThread;
 
 namespace {
@@ -652,7 +651,7 @@ struct AtomicRMWOpConversion
 };
 } // namespace
 
-namespace AMD {
+namespace mlir::triton::AMD {
 void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        RewritePatternSet &patterns,
                                        int numWarps,
@@ -663,4 +662,4 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
   patterns.add<AtomicCASOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<AtomicRMWOpConversion>(typeConverter, axisInfoAnalysis, benefit);
 }
-} // namespace AMD
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -6,9 +6,7 @@
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/AxisInfo.h"
 
-using namespace mlir;
-using namespace mlir::triton;
-namespace AMD {
+namespace mlir::triton::AMD {
 void populateConvertLayoutOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, const TargetInfo &targetInfo,
     RewritePatternSet &patterns, int numWarps,
@@ -33,6 +31,6 @@ void populateSPMDOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                  RewritePatternSet &patterns,
                                  PatternBenefit benefit);
 
-} // namespace AMD
+} // namespace mlir::triton::AMD
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SPMDOpToLLVM.cpp
@@ -1,10 +1,9 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "Utility.h"
 
-namespace {
-
 using namespace mlir;
-using namespace mlir::triton;
+
+namespace {
 
 struct GetNumProgramsOpConversion
     : public ConvertOpToLLVMPattern<triton::GetNumProgramsOp> {
@@ -28,8 +27,8 @@ struct GetNumProgramsOpConversion
 
 } // namespace
 
-void AMD::populateSPMDOpToLLVMPattern(LLVMTypeConverter &typeConverter,
-                                      RewritePatternSet &patterns,
-                                      PatternBenefit benefit) {
+void mlir::triton::AMD::populateSPMDOpToLLVMPattern(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    PatternBenefit benefit) {
   patterns.add<GetNumProgramsOpConversion>(typeConverter, benefit);
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -4,8 +4,7 @@
 #include "mlir/Dialect/LLVMIR/NVVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
-using namespace mlir;
-namespace AMD {
+namespace mlir::triton::AMD {
 
 bool TargetInfo::supportMaximumMinimum() const { return false; }
 Value TargetInfo::ballot(ConversionPatternRewriter &rewriter, Location loc,
@@ -68,7 +67,7 @@ Value TargetInfo::shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
 }
 
 Value TargetInfo::programId(Location loc, ConversionPatternRewriter &rewriter,
-                           ModuleOp moduleOp, int axis) const {
+                            ModuleOp moduleOp, int axis) const {
   return LLVM::AMD::llGetPid(loc, rewriter, moduleOp, axis);
 }
 
@@ -86,4 +85,4 @@ bool TargetInfo::processReplicaUsingStMatrix(
   return false;
 }
 
-} // namespace AMD
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -2,10 +2,10 @@
 #define TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOAMD_H
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include <string>
-namespace AMD {
+namespace mlir::triton::AMD {
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
-  TargetInfo(std::string arch) : arch(arch) {}
+  TargetInfo(std::string arch) : arch(std::move(arch)) {}
   bool supportMaximumMinimum() const override;
   Value ballot(ConversionPatternRewriter &rewriter, Location loc, Type type,
                Value cmp) const override;
@@ -35,5 +35,5 @@ public:
 private:
   std::string arch;
 };
-} // namespace AMD
+} // namespace mlir::triton::AMD
 #endif // TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOAMD_H

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -1,5 +1,6 @@
 #include "TritonAMDGPUToLLVM/Passes.h"
 
+#include "PatternTritonGPUOpToLLVM.h"
 #include "TargetInfo.h"
 #include "Utility.h"
 #include "mlir/Analysis/DataFlowFramework.h"
@@ -10,6 +11,7 @@
 #include "mlir/Conversion/LLVMCommon/VectorPattern.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
+#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/Index/IR/IndexOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -20,18 +22,13 @@
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Analysis/Membar.h"
+#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
+#include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
 #include "triton/Dialect/NVGPU/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/Sys/GetPlatform.hpp"
-
-#include "PatternTritonGPUOpToLLVM.h"
-#include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
-
-#include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
-
-#include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 
 namespace mlir {
 namespace triton {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -14,12 +14,7 @@ enum class ShflKind : uint32_t {
 };
 }
 
-namespace mlir {
-
-namespace LLVM {
-using namespace mlir::triton;
-
-namespace AMD {
+namespace mlir::LLVM::AMD {
 static Value shuffleCommon(Location loc, ConversionPatternRewriter &rewriter,
                            Value val, Value i, int strideInt, ShflKind mode,
                            Value clamp) {
@@ -142,7 +137,4 @@ Value llGetPid(Location loc, ConversionPatternRewriter &rewriter,
   return rewriter.create<arith::IndexCastOp>(loc, i32_ty, blockId);
 }
 
-} // namespace AMD
-
-} // namespace LLVM
-} // namespace mlir
+} // namespace mlir::LLVM::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -8,10 +8,7 @@
 #include "triton/Analysis/Utility.h"
 #include "triton/Conversion/MLIRTypes.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
-namespace mlir {
-namespace LLVM {
-using namespace mlir::triton;
-namespace AMD {
+namespace mlir::LLVM::AMD {
 
 Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
                  int i);
@@ -22,11 +19,8 @@ Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
 Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
                  Value i);
 
-Value llGetPid(Location loc, ConversionPatternRewriter &rewriter, 
+Value llGetPid(Location loc, ConversionPatternRewriter &rewriter,
                ModuleOp moduleOp, int axis);
-} // namespace AMD
-
-} // namespace LLVM
-} // namespace mlir
+} // namespace mlir::LLVM::AMD
 
 #endif


### PR DESCRIPTION
This is following better practice to avoid polluting and potential symbol collison. Along the way, also dropped various `using` clauses that are in header files or unused in cpp files.