### PR TITLE
[AMD] Fix AMD dot tests

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2924,8 +2924,6 @@ def convert_fp8_to_fp32(x, device, dtype_str):
      for float8_type in ["float8e5", "float8e4nv"]])
 @pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dtype, out_dtype, num_ctas, device):
-    if is_hip():
-        pytest.skip("Skipping test until we fix bug in amd backend (to use layout order)")
     check_cuda_only(device)
 
     capability = torch.cuda.get_device_capability()

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.cpp
@@ -7,10 +7,12 @@ namespace mlir::triton::AMD {
 // Get warpId inside block of warps.
 Value getWarpIdInBlock(ConversionPatternRewriter &rewriter, Location loc,
                        Value warpId, const ArrayRef<unsigned int> &wpt,
-                       int elemPerInstrNonK, int tensorSizeNonK, int nonKIdx) {
-  if (nonKIdx == 1)
-    warpId = udiv(warpId, i32_val(wpt[0]));
-  return urem(urem(warpId, i32_val(wpt[nonKIdx])),
+                       int elemPerInstrNonK, int tensorSizeNonK, int nonKIdx,
+                       const ArrayRef<unsigned int> &order) {
+  SmallVector<Value> multiDimWarpId =
+      delinearize(rewriter, loc, warpId, wpt, order);
+
+  return urem(multiDimWarpId[nonKIdx],
               i32_val(tensorSizeNonK / elemPerInstrNonK));
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandHelper.h
@@ -8,7 +8,8 @@ namespace mlir::triton::AMD {
 // Get warpId inside block of warps.
 Value getWarpIdInBlock(ConversionPatternRewriter &rewriter, Location loc,
                        Value warpId, const ArrayRef<unsigned int> &wpt,
-                       int elemPerInstrNonK, int tensorSizeNonK, int nonKIdx);
+                       int elemPerInstrNonK, int tensorSizeNonK, int nonKIdx,
+                       const ArrayRef<unsigned int> &order);
 
 bool isSwizzled(gpu::SharedEncodingAttr layout);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -60,10 +60,10 @@ namespace SharedToDotOperandMFMA {
  * @param rewriter
  * @param loc
  * @param elemsPerInstr operand tile shape consumed by one MFMA instruction
- * @param waveId id component of 2d wave grid along nono-K axis
+ * @param waveId id component of 2d wave grid along non-K axis
  * @param laneId lane id in warp [0..63]
  * @param numOfElems number of elements accessed by thread per repetition
- * @param reps number of instructions repretition to fully cover dot operand
+ * @param reps number of instructions repetition to fully cover dot operand
  * @param smemStrides strides in LDS tensor
  * @param loadVecSize number of elements loaded by one operation
  * @param iNonKDim non-K dimension size of one MFMA instruction
@@ -271,9 +271,9 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   Value linearWaveId = udiv(thread, waveSize);
   Value lane = urem(thread, waveSize);
 
-  Value spatialWaveId =
-      AMD::getWarpIdInBlock(rewriter, loc, linearWaveId, warpsPerCTA,
-                            mfmaInstrNonK, shape[nonKDimIdx], nonKDimIdx);
+  Value spatialWaveId = AMD::getWarpIdInBlock(
+      rewriter, loc, linearWaveId, warpsPerCTA, mfmaInstrNonK,
+      shape[nonKDimIdx], nonKDimIdx, triton::gpu::getOrder(mfmaLayout));
   // number of duplicates of elements in wave
   // In case of 64x4 x 4x4 multiplication, 4x4 B operand is duplicated 16 times
   int numSubBlocks = 1;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
@@ -51,15 +51,15 @@ namespace SharedToDotOperandWMMA {
  * 4. Offset of one lane data in a tile
  * 5. Offset of particular element of tensor processed by one lane
  *
- * This function computes these offsets for axies independently
+ * This function computes these offsets for axes independently
  *
  * @param rewriter
  * @param loc
  * @param elemsPerInstr operand tile shape consumed by one WMMA instruction
- * @param warpId id component of 2d warp grid along nono-K axis
+ * @param warpId id component of 2d warp grid along non-K axis
  * @param laneId lane id in warp [0..63]
  * @param numOfElems number of elements accessed by thread per repetition
- * @param reps number of instructions repretition to fully cover dot operand
+ * @param reps number of instructions repetition to fully cover dot operand
  * @param smemStrides strides in LDS tensor
  * @param loadVecSize number of elements loaded by one operation
  * @param iNonKDim non-K dimension of dot operand
@@ -150,9 +150,9 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   SmallVector<Value> loadedValues;
   SmallVector<Value> offsets;
   Value smemBase;
-  Value spatialWarpId =
-      AMD::getWarpIdInBlock(rewriter, loc, linearWarpId, warpsPerCTA,
-                            elemsPerInstr[0], shape[nonKDimIdx], nonKDimIdx);
+  Value spatialWarpId = AMD::getWarpIdInBlock(
+      rewriter, loc, linearWarpId, warpsPerCTA, elemsPerInstr[0],
+      shape[nonKDimIdx], nonKDimIdx, triton::gpu::getOrder(wmmaLayout));
   if (opIdx == 0) {
     offsets = AMD::computeOffsetsAType(
         rewriter, loc, computeTensorElemMappingInBlock, elemsPerInstr,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -142,7 +142,7 @@ struct DotOpMFMAConversionHelper {
     return reducedAcc;
   }
 
-  /// @brief MFMA 4x4 is computes 16 matrix mupliplications, this functions adds
+  /// @brief MFMA 4x4 is computes 16 matrix multiplications, this functions adds
   /// these 16 matrices to get final 4x4 matrix
   /// @param numSubBlocks
   /// @param acc


### PR DESCRIPTION
This commit Changes wave layout within a CTA to follow 'order' property of MFMA layout.
Additionally, this commit fixes some typos found in AMD code.