### PR TITLE
[backend][amd] Switch back to code object v4 and be consistent

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -122,14 +122,14 @@ void init_triton_llvm(py::module &&m) {
   // for details.
   py::class_<llvm::Module::ModFlagBehavior>(m, "module_flag_behavior",
                                             py::module_local());
-  m.attr("MODULE_FLAG_BEHAVIOR_ERROR") = (llvm::Module::Error);
-  m.attr("MODULE_FLAG_BEHAVIOR_WARNING") = (llvm::Module::Warning);
-  m.attr("MODULE_FLAG_BEHAVIOR_REQUIRE") = (llvm::Module::Require);
-  m.attr("MODULE_FLAG_BEHAVIOR_OVERRIDE") = (llvm::Module::Override);
-  m.attr("MODULE_FLAG_BEHAVIOR_APPEND") = (llvm::Module::Append);
-  m.attr("MODULE_FLAG_BEHAVIOR_APPEND_UNIQUE") = (llvm::Module::AppendUnique);
-  m.attr("MODULE_FLAG_BEHAVIOR_MAX") = (llvm::Module::Max);
-  m.attr("MODULE_FLAG_BEHAVIOR_MIN") = (llvm::Module::Min);
+  m.attr("MODULE_FLAG_BEHAVIOR_ERROR") = llvm::Module::Error;
+  m.attr("MODULE_FLAG_BEHAVIOR_WARNING") = llvm::Module::Warning;
+  m.attr("MODULE_FLAG_BEHAVIOR_REQUIRE") = llvm::Module::Require;
+  m.attr("MODULE_FLAG_BEHAVIOR_OVERRIDE") = llvm::Module::Override;
+  m.attr("MODULE_FLAG_BEHAVIOR_APPEND") = llvm::Module::Append;
+  m.attr("MODULE_FLAG_BEHAVIOR_APPEND_UNIQUE") = llvm::Module::AppendUnique;
+  m.attr("MODULE_FLAG_BEHAVIOR_MAX") = llvm::Module::Max;
+  m.attr("MODULE_FLAG_BEHAVIOR_MIN") = llvm::Module::Min;
 
   py::class_<llvm::Module>(m, "module", py::module_local())
       .def(
@@ -166,12 +166,12 @@ void init_triton_llvm(py::module &&m) {
   // optimization levels
   py::class_<llvm::OptimizationLevel>(m, "optimization_level",
                                       py::module_local());
-  m.attr("OPTIMIZE_O0") = (llvm::OptimizationLevel::O0);
-  m.attr("OPTIMIZE_O1") = (llvm::OptimizationLevel::O1);
-  m.attr("OPTIMIZE_O2") = (llvm::OptimizationLevel::O2);
-  m.attr("OPTIMIZE_O3") = (llvm::OptimizationLevel::O3);
-  m.attr("OPTIMIZE_Os") = (llvm::OptimizationLevel::Os);
-  m.attr("OPTIMIZE_Oz") = (llvm::OptimizationLevel::Oz);
+  m.attr("OPTIMIZE_O0") = llvm::OptimizationLevel::O0;
+  m.attr("OPTIMIZE_O1") = llvm::OptimizationLevel::O1;
+  m.attr("OPTIMIZE_O2") = llvm::OptimizationLevel::O2;
+  m.attr("OPTIMIZE_O3") = llvm::OptimizationLevel::O3;
+  m.attr("OPTIMIZE_Os") = llvm::OptimizationLevel::Os;
+  m.attr("OPTIMIZE_Oz") = llvm::OptimizationLevel::Oz;
 
   m.def(
       "to_module",

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -117,6 +117,20 @@ void init_triton_llvm(py::module &&m) {
           },
           py::keep_alive<0, 1>());
 
+  // Module Flag behavior. See
+  // https://llvm.org/doxygen/classllvm_1_1Module.html#a0a5c55e12c97b80021330fe82b642293
+  // for details.
+  py::class_<llvm::Module::ModFlagBehavior>(m, "module_flag_behavior",
+                                            py::module_local());
+  m.attr("MODULE_FLAG_BEHAVIOR_ERROR") = (llvm::Module::Error);
+  m.attr("MODULE_FLAG_BEHAVIOR_WARNING") = (llvm::Module::Warning);
+  m.attr("MODULE_FLAG_BEHAVIOR_REQUIRE") = (llvm::Module::Require);
+  m.attr("MODULE_FLAG_BEHAVIOR_OVERRIDE") = (llvm::Module::Override);
+  m.attr("MODULE_FLAG_BEHAVIOR_APPEND") = (llvm::Module::Append);
+  m.attr("MODULE_FLAG_BEHAVIOR_APPEND_UNIQUE") = (llvm::Module::AppendUnique);
+  m.attr("MODULE_FLAG_BEHAVIOR_MAX") = (llvm::Module::Max);
+  m.attr("MODULE_FLAG_BEHAVIOR_MIN") = (llvm::Module::Min);
+
   py::class_<llvm::Module>(m, "module", py::module_local())
       .def(
           "__str__",
@@ -132,7 +146,12 @@ void init_triton_llvm(py::module &&m) {
           [](llvm::Module *mod) -> llvm::Module::FunctionListType & {
             return mod->getFunctionList();
           },
-          ret::reference_internal);
+          ret::reference_internal)
+      .def("add_flag",
+           [](llvm::Module *mod, llvm::Module::ModFlagBehavior behavior,
+              std::string &key, uint32_t value) {
+             return mod->addModuleFlag(behavior, key, value);
+           });
 
   py::class_<llvm::Function>(m, "function", py::module_local())
       .def("set_calling_conv", &llvm::Function::setCallingConv)


### PR DESCRIPTION
https://github.com/openai/triton/pull/3493 moved the AMD backend to use code object v5. But that reveals some issues that we still need to investigate and resolve. For now switch back to v4.

Though we need to be consistent by attaching the LLVM module attribute `amdhsa_code_object_version`, given that's what the AMDGPU LLVM backend is trying to query:
https://github.com/llvm/llvm-project/blob/6f44bb77/llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp#L166-L173 If missing it will fallback to use v5, which was happening before https://github.com/openai/triton/pull/3493.

And FWIW, the magic string used to be `amdgpu_code_object_version`: https://github.com/llvm/llvm-project/pull/79905. The last LLVM bump https://github.com/openai/triton/pull/3463 picked up the renaming patch.