### PR TITLE
[FRONTEND][BACKEND] Cleanup and re-enable optimization with fp8e4b15

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -163,6 +163,11 @@ Value linearize(OpBuilder &b, Location loc, ArrayRef<Value> multiDim,
 
 Value linearize(OpBuilder &b, Location loc, ArrayRef<Value> multiDim,
                 ArrayRef<unsigned> shape);
+
+// Return true if the op is a pure elementwise_inline_asm op with a single
+// operand and single result.
+bool isUnaryLikeInlineAsm(Operation *op);
+
 } // namespace mlir
 
 #endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_UTILITY_H_

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -150,7 +150,8 @@ SmallVector<Value> packI32(const SmallVector<Value> &inValues, Type srcTy,
   return outValues;
 }
 
-int getNumElmenetPerThreads(Type type, const LLVMTypeConverter *typeConverter) {
+int getNumElementsPerThreads(Type type,
+                             const LLVMTypeConverter *typeConverter) {
   int numElemsPerThread = 1;
   auto tensorTy = type.dyn_cast<RankedTensorType>();
   if (!tensorTy)
@@ -467,8 +468,8 @@ struct ElementwiseInlineAsmOpConversion
           unpackI32(subOperands, argTy, rewriter, loc, getTypeConverter()));
     }
 
-    int numElemsPerThread =
-        getNumElmenetPerThreads(op->getResult(0).getType(), getTypeConverter());
+    int numElemsPerThread = getNumElementsPerThreads(op->getResult(0).getType(),
+                                                     getTypeConverter());
 
     // These are checked by the verifier, so we don't need to raise a nice
     // error.
@@ -476,8 +477,8 @@ struct ElementwiseInlineAsmOpConversion
       return operands.size() == numElemsPerThread;
     }));
     if (numElemsPerThread % op.getPackedElement() != 0) {
-      // Pad with the first value of the operand for each operand to have a
-      // multiple of op.getPackedElement() elements.
+      // Pad with the undef for each operand to have a multiple of
+      // op.getPackedElement() elements.
       int numPaddedValue =
           op.getPackedElement() - numElemsPerThread % op.getPackedElement();
       for (auto &operands : unpackedOperands) {

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -133,6 +133,7 @@ class BlockedToMMA : public mlir::RewritePattern {
   static bool bwdFilter(Operation *op) {
     return op->getNumOperands() == 1 &&
            (isa<tt::FpToFpOp, tt::BitcastOp, ttg::ConvertLayoutOp>(op) ||
+            isUnaryLikeInlineAsm(op) ||
             op->getDialect()->getTypeID() ==
                 mlir::TypeID::get<arith::ArithDialect>());
   }

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -128,7 +128,7 @@ public:
 
     // Only consider custom conversions or arith ops.
     // TODO(jlebar): Is this too restrictive?
-    if (!isa<FpToFpOp, BitcastOp>(src) &&
+    if (!isa<FpToFpOp, BitcastOp>(src) && !isUnaryLikeInlineAsm(src) &&
         src->getDialect()->getTypeID() != TypeID::get<arith::ArithDialect>())
       return failure();
 
@@ -168,6 +168,7 @@ public:
         // Bail out if there exists an op after Load that is not FpToFp,
         // Bitcast, or Arith.
         if (!isa<FpToFpOp, BitcastOp>(currOp) &&
+            !isUnaryLikeInlineAsm(currOp) &&
             currOp->getDialect()->getTypeID() !=
                 TypeID::get<arith::ArithDialect>())
           return failure();

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -803,6 +803,14 @@ Value linearize(OpBuilder &b, Location loc, ArrayRef<Value> multiDim,
   return linear;
 }
 
+bool isUnaryLikeInlineAsm(Operation *op) {
+  auto inlineAsmOp = dyn_cast<ElementwiseInlineAsmOp>(op);
+  if (!inlineAsmOp)
+    return false;
+  return op->getNumOperands() == 1 && op->getNumResults() == 1 &&
+         inlineAsmOp.getPure();
+}
+
 namespace {
 
 /// Detect dead arguments in scf.for op by assuming all the values are dead and

--- a/python/triton/language/extra/cuda/__init__.py
+++ b/python/triton/language/extra/cuda/__init__.py
@@ -1,8 +1,5 @@
 from . import libdevice
 
-from .utils import (globaltimer, num_threads, num_warps, smid, convert_custom_float8_sm80, convert_custom_float8_sm90)
+from .utils import (globaltimer, num_threads, num_warps, smid, convert_custom_float8)
 
-__all__ = [
-    "libdevice", "globaltimer", "num_threads", "num_warps", "smid", "convert_custom_float8_sm80",
-    "convert_custom_float8_sm90"
-]
+__all__ = ["libdevice", "globaltimer", "num_threads", "num_warps", "smid", "convert_custom_float8"]

--- a/python/triton/language/extra/cuda/utils.py
+++ b/python/triton/language/extra/cuda/utils.py
@@ -48,7 +48,7 @@ def convert_fp8e4b15_to_float16(arg, _builder=None):
 
 
 @core.builtin
-def convert_float16_to_fp8e4b15(arg, has_minx2, _builder=None):
+def convert_float16_to_fp8e4b15(arg, _builder=None):
     asm = """{
             .reg .pred p<4>;
             .reg .b32 a<2>, b<2>;
@@ -58,33 +58,21 @@ def convert_float16_to_fp8e4b15(arg, has_minx2, _builder=None):
             mov.b16 max_val_f16,   0x3F00;
             mov.b32 max_val_f16x2, 0x3F003F00;
             and.b32 a0, $1, 0x7fff7fff;
-            and.b32 a1, $2, 0x7fff7fff;"""
-    if has_minx2:
-        asm += """min.f16x2 a0, a0, max_val_f16x2;
-                  min.f16x2 a1, a1, max_val_f16x2;"""
-    else:
-        asm += """setp.lt.f16x2  p0|p1, a0, max_val_f16x2;
-                  setp.lt.f16x2  p2|p3, a1, max_val_f16x2;
-                  mov.b32 {c0, c1}, a0;
-                  mov.b32 {c2, c3}, a1;
-                  selp.b16  c0, c0, max_val_f16, p0;
-                  selp.b16  c1, c1, max_val_f16, p1;
-                  selp.b16  c2, c2, max_val_f16, p2;
-                  selp.b16  c3, c3, max_val_f16, p3;
-                  mov.b32 a0, {c0, c1};
-                  mov.b32 a1, {c2, c3};"""
-    asm += """mad.lo.u32 a0, a0, 2, 0x00800080;
-              mad.lo.u32 a1, a1, 2, 0x00800080;
-              lop3.b32 b0, $1, 0x80008000, a0, 0xea;
-              lop3.b32 b1, $2, 0x80008000, a1, 0xea;
-              prmt.b32 $0, b0, b1, 0x7531;
-              }"""
+            and.b32 a1, $2, 0x7fff7fff;
+            min.f16x2 a0, a0, max_val_f16x2;
+            min.f16x2 a1, a1, max_val_f16x2;
+            mad.lo.u32 a0, a0, 2, 0x00800080;
+            mad.lo.u32 a1, a1, 2, 0x00800080;
+            lop3.b32 b0, $1, 0x80008000, a0, 0xea;
+            lop3.b32 b1, $2, 0x80008000, a1, 0xea;
+            prmt.b32 $0, b0, b1, 0x7531;
+            }"""
     return core.inline_asm_elementwise(asm, "=r,r,r", [arg], dtype=core.float8e4b15, is_pure=True, pack=4,
                                        _builder=_builder)
 
 
 @core.builtin
-def convert_custom_float8(arg, dst_ty, fp_downcast_rounding, has_minx2, _builder=None):
+def convert_custom_float8(arg, dst_ty, fp_downcast_rounding, _builder=None):
     if arg.type.scalar.is_fp8e4b15():
         upcast_val = convert_fp8e4b15_to_float16(arg, _builder=_builder)
         if dst_ty.scalar.is_fp32():
@@ -94,16 +82,6 @@ def convert_custom_float8(arg, dst_ty, fp_downcast_rounding, has_minx2, _builder
     assert arg.type.scalar.is_fp16() or arg.type.scalar.is_fp32()
     downcast_val = arg
     if arg.type.scalar.is_fp32():
-        downcast_val = downcast_val.to(core.float16, _builder=_builder)
-    downcast_val = convert_float16_to_fp8e4b15(downcast_val, has_minx2=has_minx2, _builder=_builder)
+        downcast_val = downcast_val.to(core.float16, fp_downcast_rounding="rtz", _builder=_builder)
+    downcast_val = convert_float16_to_fp8e4b15(downcast_val, _builder=_builder)
     return downcast_val
-
-
-@core.builtin
-def convert_custom_float8_sm90(arg, dst_ty, fp_downcast_rounding=None, _builder=None):
-    return convert_custom_float8(arg, dst_ty, fp_downcast_rounding, has_minx2=True, _builder=_builder)
-
-
-@core.builtin
-def convert_custom_float8_sm80(arg, dst_ty, fp_downcast_rounding=None, _builder=None):
-    return convert_custom_float8(arg, dst_ty, fp_downcast_rounding, has_minx2=False, _builder=_builder)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -111,8 +111,7 @@ class CUDABackend(BaseBackend):
     def get_codegen_implementation(self):
         import triton.language.extra.cuda as cuda
         codegen_fns = dict()
-        codegen_fns[
-            "convert_custom_types"] = cuda.convert_custom_float8_sm90 if self.capability >= 90 else cuda.convert_custom_float8_sm80
+        codegen_fns["convert_custom_types"] = cuda.convert_custom_float8
         return codegen_fns
 
     def load_dialects(self, ctx):


### PR DESCRIPTION
Multiple fixes to allow pipelining to happen when generating a matmul with fp8e4b15 inputs. Also clean useless code in the frontend.