### PR TITLE
Added/edited LLVM utilities

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -45,8 +45,8 @@ using namespace mlir::triton;
 #define or_(...) rewriter.create<LLVM::OrOp>(loc, __VA_ARGS__)
 #define bitcast(val__, type__)                                                 \
   rewriter.create<LLVM::BitcastOp>(loc, type__, val__)
-#define addrspacecast(val__, type__)                                           \
-  rewriter.create<LLVM::AddrSpaceCastOp>(loc, type__, val__)
+#define addrspacecast(...)                                                     \
+  rewriter.create<LLVM::AddrSpaceCastOp>(loc, __VA_ARGS__)
 #define gep(...) rewriter.create<LLVM::GEPOp>(loc, __VA_ARGS__)
 #define ptr_ty(...) LLVM::LLVMPointerType::get(__VA_ARGS__)
 #define insert_val(...) rewriter.create<LLVM::InsertValueOp>(loc, __VA_ARGS__)
@@ -56,7 +56,7 @@ using namespace mlir::triton;
 #define extract_element(...)                                                   \
   rewriter.create<LLVM::ExtractElementOp>(loc, __VA_ARGS__)
 #define load(...) rewriter.create<LLVM::LoadOp>(loc, __VA_ARGS__)
-#define store(val, ptr) rewriter.create<LLVM::StoreOp>(loc, val, ptr)
+#define store(...) rewriter.create<LLVM::StoreOp>(loc, __VA_ARGS__)
 #define load_dsmem(...) LLVM::createLoadDSmem(loc, rewriter, __VA_ARGS__)
 #define store_dsmem(...) LLVM::createStoreDSmem(loc, rewriter, __VA_ARGS__)
 #define fcmp_ogt(lhs, rhs)                                                     \
@@ -115,9 +115,11 @@ using namespace mlir::triton;
 #define array_ty(elemTy, count) LLVM::LLVMArrayType::get(elemTy, count)
 
 // Constants
+#define f16_val(...) LLVM::createConstantF16(loc, rewriter, __VA_ARGS__)
 #define f32_val(...) LLVM::createConstantF32(loc, rewriter, __VA_ARGS__)
 #define f64_val(...) LLVM::createConstantF64(loc, rewriter, __VA_ARGS__)
 #define i32_val(...) LLVM::createConstantI32(loc, rewriter, __VA_ARGS__)
+#define i64_val(...) LLVM::createConstantI64(loc, rewriter, __VA_ARGS__)
 #define int_val(width, val)                                                    \
   LLVM::createLLVMIntegerConstant(rewriter, loc, width, val)
 #define tid_val() getThreadId(rewriter, loc)

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -120,6 +120,18 @@ Value createConstantI32(Location loc, OpBuilder &rewriter, int32_t v) {
                                            IntegerAttr::get(i32ty, v));
 }
 
+Value createConstantI64(Location loc, OpBuilder &rewriter, int64_t v) {
+  auto i64ty = rewriter.getIntegerType(64);
+  return rewriter.create<LLVM::ConstantOp>(loc, i64ty,
+                                           IntegerAttr::get(i64ty, v));
+}
+
+Value createConstantF16(Location loc, OpBuilder &rewriter, float v) {
+  auto type = type::f16Ty(rewriter.getContext());
+  return rewriter.create<LLVM::ConstantOp>(loc, type,
+                                           rewriter.getF16FloatAttr(v));
+}
+
 Value createConstantF32(Location loc, OpBuilder &rewriter, float v) {
   auto type = type::f32Ty(rewriter.getContext());
   return rewriter.create<LLVM::ConstantOp>(loc, type,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -205,7 +205,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
         size_t elemOffset = vecStart + wordIdx * wordNElems;
         Type int_ty = IntegerType::get(getContext(), width);
-        Value ptr = addrspacecast(ptrElems[elemOffset], ptr_ty(getContext()));
+        Value ptr = addrspacecast(ptr_ty(getContext()), ptrElems[elemOffset]);
         auto loaded = rewriter.create<scf::IfOp>(
             loc, pred,
             [&](OpBuilder &builder, Location loc) {


### PR DESCRIPTION
Add more backend independent utilities, also edit 2 existing macros to use variable arguments

Previously, the addrspacecast macro would swap the parameters ->
#define addrspacecast(**val__, type__**)                                           \
  rewriter.create<LLVM::AddrSpaceCastOp>(loc, **type__, val__**)

Once I changed the macro to use variable arguments, third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp would break because it expected the arguments to be in the opposite order, which is why that file had to be edited for this change to work.