### PR TITLE
[FRONTEND] Consider python backend driver files when computing triton…

### DIFF
--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -156,7 +156,12 @@ def triton_key():
     for lib in pkgutil.iter_modules([compiler_path, backends_path]):
         with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
             contents += [hashlib.sha256(f.read()).hexdigest()]
-    # backend
+    # Python backend
+    tp_backends_path = os.path.join(TRITON_PATH, 'backends')
+    for lib in pkgutil.iter_modules([tp_backends_path]):
+        with open(lib.module_finder.find_spec(lib.name).origin, "rb") as f:
+            contents += [hashlib.sha256(f.read()).hexdigest()]
+    # C++ backend
     libtriton_hash = hashlib.sha256()
     with open(os.path.join(TRITON_PATH, "_C/libtriton.so"), "rb") as f:
         while True:

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -143,6 +143,9 @@ class IRSource:
         return dict()
 
 
+# This is an alternative implementation of pkgutil.walk_packages which isn't very reliable
+# in that it does not handle same-named but different-pathed files well unless using module
+# prefixes explicitly. Using prefixes is not bullet-proof to future path structure changes.
 def iter_modules_recursively(paths):
     for path in paths:
         for lib in pkgutil.iter_modules([path]):


### PR DESCRIPTION
Previously third-party driver files such as `third_party/nvidia/backend/compiler.py` was not considered as a part of `triton_key`. This led to an issue where change optimization pass order didn't trigger recompilation. 


With this patch, the following files are now considered. Note that the last four are new:

python/triton/compiler/code_generator.py
python/triton/compiler/compiler.py
python/triton/compiler/errors.py
python/triton/compiler/make_launcher.py
**python/triton/backends/compiler.py
python/triton/backends/driver.py
python/triton/backends/nvidia/compiler.py
python/triton/backends/nvidia/driver.py**
