### PR TITLE
[Backend] Remove extra call to emitIndices.

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -354,11 +354,11 @@ SmallVector<Value> getWrappedMultiDimOffset(
     ArrayRef<Value> multiDimOffset, ArrayRef<unsigned> shape,
     SmallVector<unsigned> shapePerCTATile, SmallVector<int64_t> shapePerCTA);
 
-static bool isKernel(FunctionOpInterface funcOp) {
+inline bool isKernel(FunctionOpInterface funcOp) {
   return funcOp.getVisibility() == SymbolTable::Visibility::Public;
 }
 
-static Value getStackPointer(PatternRewriter &rewriter,
+inline Value getStackPointer(PatternRewriter &rewriter,
                              FunctionOpInterface funcOp) {
   auto mod = funcOp->getParentOfType<ModuleOp>();
   LLVM::GlobalOp globalBase = nullptr;
@@ -373,7 +373,7 @@ static Value getStackPointer(PatternRewriter &rewriter,
     return funcOp.getArgument(funcOp.getNumArguments() - 1);
 }
 
-static Value getSharedMemoryBase(Location loc,
+inline Value getSharedMemoryBase(Location loc,
                                  ConversionPatternRewriter &rewriter,
                                  Operation *op) {
   auto ptrTy = LLVM::LLVMPointerType::get(rewriter.getContext(), 3);
@@ -392,20 +392,20 @@ static Value getSharedMemoryBase(Location loc,
 
 /* ------------------------------------ */
 // Returns CTA level thread idx
-static Value getThreadIdInCTA(RewriterBase &rewriter, Location loc) {
+inline Value getThreadIdInCTA(RewriterBase &rewriter, Location loc) {
   Value tid =
       rewriter.create<::mlir::gpu::ThreadIdOp>(loc, ::mlir::gpu::Dimension::x);
   return rewriter.create<arith::IndexCastOp>(loc, i32_ty, tid);
 }
 
 // Returns CTA level thread idx.
-static Value getThreadId(RewriterBase &rewriter, Location loc) {
+inline Value getThreadId(RewriterBase &rewriter, Location loc) {
   Value tid = getThreadIdInCTA(rewriter, loc);
   auto mod = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   return tid;
 }
 
-static Value getClusterCTAId(RewriterBase &rewriter, Location loc) {
+inline Value getClusterCTAId(RewriterBase &rewriter, Location loc) {
   return rewriter.create<triton::nvgpu::ClusterCTAIdOp>(loc,
                                                         rewriter.getI32Type());
 }
@@ -425,7 +425,7 @@ using ::mlir::triton::gpu::DotOperandEncodingAttr;
 using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 using ::mlir::triton::gpu::SliceEncodingAttr;
 
-static Value dot(RewriterBase &rewriter, Location loc, ArrayRef<Value> offsets,
+inline Value dot(RewriterBase &rewriter, Location loc, ArrayRef<Value> offsets,
                  ArrayRef<Value> strides) {
   assert(offsets.size() == strides.size());
   Value ret = i32_val(0);
@@ -440,7 +440,7 @@ static Value dot(RewriterBase &rewriter, Location loc, ArrayRef<Value> offsets,
 // -----------------------------------------------------------------------
 
 // Get an index-base for each dimension for a \param blockedLayout.
-static SmallVector<Value>
+inline SmallVector<Value>
 emitBaseIndexWithinCTAForBlockedLayout(Location loc, RewriterBase &rewriter,
                                        const BlockedEncodingAttr &blockedLayout,
                                        RankedTensorType type) {
@@ -483,7 +483,7 @@ emitBaseIndexWithinCTAForBlockedLayout(Location loc, RewriterBase &rewriter,
   return multiDimBase;
 }
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForBlockedLayout(const BlockedEncodingAttr &blockedLayout,
                            RankedTensorType type) {
   auto shape = type.getShape();
@@ -524,7 +524,7 @@ emitOffsetForBlockedLayout(const BlockedEncodingAttr &blockedLayout,
 // Mma layout indices
 // -----------------------------------------------------------------------
 
-static SmallVector<Value>
+inline SmallVector<Value>
 emitBaseIndexWithinCTAForMmaLayoutV1(Location loc, RewriterBase &rewriter,
                                      const NvidiaMmaEncodingAttr &mmaLayout,
                                      RankedTensorType type) {
@@ -593,7 +593,7 @@ emitBaseIndexWithinCTAForMmaLayoutV1(Location loc, RewriterBase &rewriter,
   return {offsetCM, offsetCN};
 }
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForMmaLayoutV1(const NvidiaMmaEncodingAttr &mmaLayout,
                          RankedTensorType type) {
   auto shape = type.getShape();
@@ -640,7 +640,7 @@ emitOffsetForMmaLayoutV1(const NvidiaMmaEncodingAttr &mmaLayout,
   return ret;
 }
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForMmaLayoutV2(const NvidiaMmaEncodingAttr &mmaLayout,
                          RankedTensorType type) {
   auto shape = type.getShape();
@@ -668,7 +668,7 @@ emitOffsetForMmaLayoutV2(const NvidiaMmaEncodingAttr &mmaLayout,
   return ret;
 }
 
-static SmallVector<Value>
+inline SmallVector<Value>
 emitBaseIndexWithinCTAForMmaLayoutV2V3(Location loc, RewriterBase &rewriter,
                                        const NvidiaMmaEncodingAttr &mmaLayout,
                                        RankedTensorType type) {
@@ -734,7 +734,7 @@ emitBaseIndexWithinCTAForMmaLayoutV2V3(Location loc, RewriterBase &rewriter,
   return multiDimBase;
 }
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForMmaLayoutV3(const NvidiaMmaEncodingAttr &mmaLayout,
                          RankedTensorType type) {
   auto shape = type.getShape();
@@ -757,7 +757,7 @@ emitOffsetForMmaLayoutV3(const NvidiaMmaEncodingAttr &mmaLayout,
   return ret;
 }
 
-static SmallVector<Value>
+inline SmallVector<Value>
 emitBaseIndexForMfmaLayout(Location loc, RewriterBase &rewriter,
                            const AMDMfmaEncodingAttr &mfmaLayout,
                            RankedTensorType type) {
@@ -806,7 +806,7 @@ emitBaseIndexForMfmaLayout(Location loc, RewriterBase &rewriter,
   return multiDimBase;
 }
 
-static void emitMfmaOffsetForCTA(const AMDMfmaEncodingAttr &mfmaLayout,
+inline void emitMfmaOffsetForCTA(const AMDMfmaEncodingAttr &mfmaLayout,
                                  SmallVector<SmallVector<unsigned>> &offsets,
                                  unsigned ctaOffsetX, unsigned ctaOffsetY) {
   auto nonKDim = mfmaLayout.getMDim();
@@ -833,7 +833,7 @@ static void emitMfmaOffsetForCTA(const AMDMfmaEncodingAttr &mfmaLayout,
   }
 }
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForMfmaLayout(const AMDMfmaEncodingAttr &mfmaLayout,
                         RankedTensorType type) {
   auto tensorShape = type.getShape();
@@ -856,7 +856,7 @@ emitOffsetForMfmaLayout(const AMDMfmaEncodingAttr &mfmaLayout,
   return offsets;
 }
 
-static void emitWmmaOffsetForCTA(const AMDWmmaEncodingAttr &wmmaLayout,
+inline void emitWmmaOffsetForCTA(const AMDWmmaEncodingAttr &wmmaLayout,
                                  SmallVector<SmallVector<unsigned>> &offsets,
                                  unsigned ctaOffsetX, unsigned ctaOffsetY) {
   const unsigned elemsPerThreadPerGroup = 8;
@@ -869,7 +869,7 @@ static void emitWmmaOffsetForCTA(const AMDWmmaEncodingAttr &wmmaLayout,
   }
 }
 
-static SmallVector<Value>
+inline SmallVector<Value>
 emitBaseIndexForWmmaLayout(Location loc, RewriterBase &rewriter,
                            const AMDWmmaEncodingAttr &wmmaLayout,
                            RankedTensorType type) {
@@ -897,7 +897,7 @@ emitBaseIndexForWmmaLayout(Location loc, RewriterBase &rewriter,
           add(laneId, offWarp1)};
 }
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForWmmaLayout(const AMDWmmaEncodingAttr &wmmaLayout,
                         RankedTensorType type) {
   auto tensorShape = type.getShape();
@@ -921,10 +921,10 @@ emitOffsetForWmmaLayout(const AMDWmmaEncodingAttr &wmmaLayout,
   return offsets;
 }
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForLayout(Attribute layout, RankedTensorType type);
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForSliceLayout(const SliceEncodingAttr &sliceLayout,
                          RankedTensorType type) {
   auto parentEncoding = sliceLayout.getParent();
@@ -955,7 +955,7 @@ emitOffsetForSliceLayout(const SliceEncodingAttr &sliceLayout,
 // Get offsets / indices for any layout
 // -----------------------------------------------------------------------
 
-static SmallVector<Value> emitCTAOffsetForLayout(Location loc,
+inline SmallVector<Value> emitCTAOffsetForLayout(Location loc,
                                                  RewriterBase &rewriter,
                                                  Attribute layout,
                                                  ArrayRef<int64_t> shape) {
@@ -985,7 +985,7 @@ static SmallVector<Value> emitCTAOffsetForLayout(Location loc,
   return CTAOffset;
 }
 
-static SmallVector<Value>
+inline SmallVector<Value>
 emitBaseIndexForLayout(Location loc, RewriterBase &rewriter, Attribute layout,
                        RankedTensorType type, bool withCTAOffset) {
   auto shape = type.getShape();
@@ -1029,7 +1029,7 @@ emitBaseIndexForLayout(Location loc, RewriterBase &rewriter, Attribute layout,
   return result;
 }
 
-static SmallVector<SmallVector<unsigned>>
+inline SmallVector<SmallVector<unsigned>>
 emitOffsetForLayout(Attribute layout, RankedTensorType type) {
   if (auto blockedLayout = layout.dyn_cast<BlockedEncodingAttr>())
     return emitOffsetForBlockedLayout(blockedLayout, type);
@@ -1054,7 +1054,7 @@ emitOffsetForLayout(Attribute layout, RankedTensorType type) {
 
 // Emit indices calculation within each ConversionPattern, and returns a
 // [elemsPerThread X rank] index matrix.
-static SmallVector<SmallVector<Value>>
+inline SmallVector<SmallVector<Value>>
 emitIndices(Location loc, RewriterBase &rewriter, Attribute layout,
             RankedTensorType type, bool withCTAOffset) {
   // step 1, delinearize threadId to get the base index
@@ -1078,7 +1078,7 @@ emitIndices(Location loc, RewriterBase &rewriter, Attribute layout,
 
 /* ---------------- */
 /* ---------------- */
-DenseMap<unsigned, Value> static getSwizzledSharedPtrs(
+inline DenseMap<unsigned, Value> getSwizzledSharedPtrs(
     Location loc, unsigned inVec, RankedTensorType srcTy,
     triton::gpu::SharedEncodingAttr resSharedLayout, Type resElemTy,
     SharedMemoryObject smemObj, RewriterBase &rewriter,
@@ -1240,10 +1240,10 @@ DenseMap<unsigned, Value> static getSwizzledSharedPtrs(
   return ret;
 }
 
-static SmallVector<Value>
-loadSharedToDistributed(Value dst, ArrayRef<SmallVector<Value>> dstIndices,
-                        Value src, SharedMemoryObject smemObj, Type elemTy,
-                        Location loc, ConversionPatternRewriter &rewriter) {
+inline SmallVector<Value>
+loadSharedToDistributed(Value dst, Value src, SharedMemoryObject smemObj,
+                        Type elemTy, Location loc,
+                        ConversionPatternRewriter &rewriter) {
   auto dstTy = dst.getType().cast<RankedTensorType>();
   auto dstShape = dstTy.getShape();
   assert(dstShape.size() <= 2 && "Unexpected rank of loadSharedToDistributed");
@@ -1275,7 +1275,6 @@ loadSharedToDistributed(Value dst, ArrayRef<SmallVector<Value>> dstIndices,
   unsigned minVec = std::min(outVec, inVec);
   unsigned outElems = triton::gpu::getTotalElemsPerThread(dstTy);
   SmallVector<Value> offsetVals = {smemObj.strides.size(), i32_val(0)};
-  assert(outElems == dstIndices.size());
 
   DenseMap<unsigned, Value> sharedPtrs =
       getSwizzledSharedPtrs(loc, outVec, dstTy, srcSharedLayout, elemTy,
@@ -1297,11 +1296,9 @@ loadSharedToDistributed(Value dst, ArrayRef<SmallVector<Value>> dstIndices,
   return outVals;
 }
 
-static void storeDistributedToShared(Value src, ArrayRef<Value> inVals,
-                                     ArrayRef<Value> dstStrides,
-                                     ArrayRef<SmallVector<Value>> srcIndices,
-                                     Value dst, Value smemBase, Type elemTy,
-                                     Location loc,
+inline void storeDistributedToShared(Value src, ArrayRef<Value> inVals,
+                                     ArrayRef<Value> dstStrides, Value dst,
+                                     Value smemBase, Type elemTy, Location loc,
                                      ConversionPatternRewriter &rewriter) {
   auto srcTy = src.getType().cast<RankedTensorType>();
   auto srcShape = srcTy.getShape();
@@ -1331,7 +1328,6 @@ static void storeDistributedToShared(Value src, ArrayRef<Value> inVals,
                         : dstSharedLayout.getVec();
   unsigned minVec = std::min(outVec, inVec);
   unsigned numElems = triton::gpu::getTotalElemsPerThread(srcTy);
-  assert(numElems == srcIndices.size());
   auto wordTy = vec_ty(elemTy, minVec);
   Value word;
 
@@ -1357,7 +1353,7 @@ static void storeDistributedToShared(Value src, ArrayRef<Value> inVals,
   }
 }
 
-static Value
+inline Value
 getStructFromSharedMemoryObject(Location loc, const SharedMemoryObject &smemObj,
                                 ConversionPatternRewriter &rewriter) {
   auto elems = smemObj.getElems();
@@ -1373,7 +1369,7 @@ getStructFromSharedMemoryObject(Location loc, const SharedMemoryObject &smemObj,
   return llvmStruct;
 }
 
-static SmallVector<Value>
+inline SmallVector<Value>
 unpackLLElements(Location loc, Value llvmStruct,
                  ConversionPatternRewriter &rewriter) {
   assert(bool(llvmStruct) && "can not unpack null values");
@@ -1391,7 +1387,7 @@ unpackLLElements(Location loc, Value llvmStruct,
   return results;
 }
 
-static Value packLLElements(Location loc,
+inline Value packLLElements(Location loc,
                             const LLVMTypeConverter *typeConverter,
                             ValueRange resultVals,
                             ConversionPatternRewriter &rewriter, Type type) {
@@ -1427,7 +1423,7 @@ static Value packLLElements(Location loc,
   return llvmStruct;
 }
 
-static bool isLayoutMmaV1(Attribute layout) {
+inline bool isLayoutMmaV1(Attribute layout) {
   bool isMmaV1 = false;
   if (auto mmaLayout = layout.dyn_cast<NvidiaMmaEncodingAttr>()) {
     isMmaV1 = mmaLayout.isVolta();

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -92,11 +92,9 @@ private:
 
     auto srcStrides =
         getStridesFromShapeAndOrder(srcTy.getShape(), inOrd, loc, rewriter);
-    auto dstIndices = emitIndices(loc, rewriter, dstLayout, dstTy, true);
 
-    SmallVector<Value> outVals =
-        loadSharedToDistributed(op.getResult(), dstIndices, op.getSrc(),
-                                smemObj, elemTy, loc, rewriter);
+    SmallVector<Value> outVals = loadSharedToDistributed(
+        op.getResult(), op.getSrc(), smemObj, elemTy, loc, rewriter);
 
     Value result = packLLElements(loc, typeConverter, outVals, rewriter, dstTy);
     rewriter.replaceOp(op, result);

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -29,10 +29,9 @@ void lowerDistributedToShared(LocalAllocOp op, LocalAllocOpAdaptor adaptor,
   unsigned numElems = triton::gpu::getTotalElemsPerThread(srcTy);
   auto dstStrides =
       LLVM::getStridesFromShapeAndOrder(dstShapePerCTA, outOrd, loc, rewriter);
-  auto srcIndices = emitIndices(loc, rewriter, srcLayout, srcTy, false);
   auto inVals = unpackLLElements(loc, adaptor.getInit(), rewriter);
-  storeDistributedToShared(op.getInit(), inVals, dstStrides, srcIndices,
-                           op.getResult(), smemBase, elemTy, loc, rewriter);
+  storeDistributedToShared(op.getInit(), inVals, dstStrides, op.getResult(),
+                           smemBase, elemTy, loc, rewriter);
 }
 
 struct LocalAllocOpConversion


### PR DESCRIPTION
<git-pr-chain>


[Backend] Remove extra call to emitIndices.

storeDistributedToShared and loadSharedToDistributed both accepted a list of
indices and then didn't use them.  (Instead, they create the indices
themselves, lower in the callstack.)

Remove these, which removes a bunch of unneded IR.

While we're here, we also fix incorrect use of `static` in Utility.h.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3529 👈 **YOU ARE HERE**


</git-pr-chain>
