### PR TITLE
[cmake] Find pybind11 if building from CMake directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,10 +47,6 @@ endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17")
 
-# Third-party
-include_directories(${PYBIND11_INCLUDE_DIR})
-
-
 
 # #########
 # LLVM
@@ -138,10 +134,17 @@ if(TRITON_BUILD_PYTHON_MODULE)
   include_directories(${PYTHON_SRC_PATH})
 
   if(PYTHON_INCLUDE_DIRS)
+    # We have PYTHON_INCLUDE_DIRS set--this is what we expect when building
+    # using pip install.
     include_directories(${PYTHON_INCLUDE_DIRS})
+    include_directories(${PYBIND11_INCLUDE_DIR})
   else()
+    # Otherwise, we might be building from top CMakeLists.txt directly.
+    # Try to find Python and pybind11 packages.
     find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
+    find_package(pybind11 CONFIG REQUIRED HINTS "${Python3_SITELIB}")
     include_directories(${Python3_INCLUDE_DIRS})
+    include_directories(${pybind11_INCLUDE_DIR})
     link_directories(${Python3_LIBRARY_DIRS})
     link_libraries(${Python3_LIBRARIES})
     add_link_options(${Python3_LINK_OPTIONS})


### PR DESCRIPTION
If we are building with `TRITON_BUILD_PYTHON_MODULE` on, we need to find pybind11. This commit adds logic to search Python3 site packages for pybind11 and use it. With it, the following works:

```
cmake -GNinja -S . -B build-debug -DCMAKE_BUILD_TYPE=Debug \
  -DTRITON_BUILD_PYTHON_MODULE=ON \
  -DTRITON_CODEGEN_BACKENDS="amd;nvidia" \
  -DLLVM_INCLUDE_DIRS=/data/llvm/build-mlir/include \
  -DLLVM_LIBRARY_DIR=/data/llvm/build-mlir/lib \
  -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
  -DCMAKE_LINKER=lld \
  -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld \
  -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld \
  -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld \
  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
```