### PR TITLE
[backend][amd] Add step to cleanup version metadata in bitcode

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -205,8 +205,8 @@ class HIPBackend(BaseBackend):
         # Get some metadata
         metadata["shared"] = src.get_int_attr("triton_gpu.shared")
 
-        ret = str(llvm_mod)
-        return ret
+        amd.cleanup_bitcode_metadata(llvm_mod)
+        return str(llvm_mod)
 
     @staticmethod
     def make_hsaco(src, metadata, options):

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -106,4 +106,14 @@ void init_triton_amd(py::module &&m) {
     module->addModuleFlag(llvm::Module::Error, "amdhsa_code_object_version",
                           version);
   });
+
+  m.def("cleanup_bitcode_metadata", [](llvm::Module *module) {
+    // We can have Clang version metadata from device libraries linked in. We
+    // don't care about them so drop them.
+    if (auto *ident = module->getNamedMetadata("llvm.ident"))
+      module->eraseNamedMetadata(ident);
+    // Also various OpenCL version details.
+    if (auto *openclVersion = module->getNamedMetadata("opencl.ocl.version"))
+      module->eraseNamedMetadata(openclVersion);
+  });
 }


### PR DESCRIPTION
We don't care about these Clang and OpenCL version details..