### PR TITLE
[TUTORIAL] Improve fp8 performance in matmul tutorial

### DIFF
--- a/python/tutorials/03-matrix-multiplication.py
+++ b/python/tutorials/03-matrix-multiplication.py
@@ -385,6 +385,7 @@ def benchmark(M, N, K, provider, fp8_inputs):
         ms, min_ms, max_ms = triton.testing.do_bench(lambda: torch.matmul(a, b), quantiles=quantiles)
     if provider == 'triton':
         if TORCH_HAS_FP8 and fp8_inputs:
+            # TODO: run torch with fp8 when possible.
             a = a.to(torch.float8_e5m2)
             b = b.T
             b = b.to(torch.float8_e5m2)


### PR DESCRIPTION
Few small tweaks to get good perf out of fp8 matmul tutorial.
Make sure to use 3 source dot and pre-transpose b to get good performance. Also add more configs that work well for fp8.

Results on H100:
```
matmul-performance-fp8:
         M       N       K       Triton
0    256.0   256.0   256.0     0.483438
1    384.0   384.0   384.0     1.768588
2    512.0   512.0   512.0     4.390792
3    640.0   640.0   640.0     9.194164
4    768.0   768.0   768.0    15.353337
5    896.0   896.0   896.0    24.886629
6   1024.0  1024.0  1024.0    37.882509
7   1152.0  1152.0  1152.0    51.427067
8   1280.0  1280.0  1280.0    73.470854
9   1408.0  1408.0  1408.0    96.225503
10  1536.0  1536.0  1536.0   125.411082
11  1664.0  1664.0  1664.0   158.921188
12  1792.0  1792.0  1792.0   193.992213
13  1920.0  1920.0  1920.0   239.117838
14  2048.0  2048.0  2048.0   280.570111
15  2176.0  2176.0  2176.0   284.182140
16  2304.0  2304.0  2304.0   411.416537
17  2432.0  2432.0  2432.0   438.333906
18  2560.0  2560.0  2560.0   527.320119
19  2688.0  2688.0  2688.0   650.862087
20  2816.0  2816.0  2816.0   757.684372
21  2944.0  2944.0  2944.0   859.936907
22  3072.0  3072.0  3072.0   961.241005
23  3200.0  3200.0  3200.0  1040.650362
24  3328.0  3328.0  3328.0  1117.226653
25  3456.0  3456.0  3456.0  1204.430514
26  3584.0  3584.0  3584.0  1279.934470
27  3712.0  3712.0  3712.0  1076.335008
28  3840.0  3840.0  3840.0  1145.660082
29  3968.0  3968.0  3968.0  1226.371204
30  4096.0  4096.0  4096.0  1292.886034
```