### PR TITLE
[backend][amd] Add support for device assert

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -346,4 +346,4 @@ jobs:
       - name: Run python tests on ROCM
         run: |
           cd python
-          pytest --capture=tee-sys -rfs -vvv -n 32 ./test/unit/language/test_core.py ./test/unit/language/test_subprocess.py -k "not test_assert"
+          pytest --capture=tee-sys -rfs -vvv -n 32 ./test/unit/language/test_core.py ./test/unit/language/test_subprocess.py

--- a/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -37,6 +37,7 @@ void populateMemoryOpToLLVMPattern(LLVMTypeConverter &typeConverter,
 
 void populateAssertOpToLLVMPattern(LLVMTypeConverter &typeConverter,
                                    RewritePatternSet &patterns,
+                                   const TargetInfoBase &targetInfo,
                                    PatternBenefit benefit);
 
 void populateMakeRangeOpToLLVMPattern(LLVMTypeConverter &typeConverter,

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -33,13 +33,18 @@ public:
       ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
       ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const = 0;
 
-  // Prints a message following the given format from the device.
-  // |formatStrStart| is the pointer to the start of the format string global
-  // variable; |args| are the arguments to fill placeholders in the format
-  // string.
+  // Emit LLVM code with |rewriter| to print a message following the given
+  // format from the device. |formatStrStart| is the pointer to the start of
+  // the format string global variable; |args| are the arguments to fill
+  // placeholders in the format string.
   virtual void printf(Value formatStrStart, int formatStrByteCount,
                       ValueRange args,
                       ConversionPatternRewriter &rewriter) const = 0;
+  // Emits LLVM code with |rewriter| to perform assertion failure with the given
+  // |message| from the given |func| in |file|.
+  virtual void assertFail(ConversionPatternRewriter &rewriter, Location loc,
+                          StringRef message, StringRef file, StringRef func,
+                          int line) const = 0;
 
   virtual ~TargetInfoBase() {}
 };

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -193,4 +193,8 @@ void TargetInfo::printf(Value formatStrStart, int formatStrByteCount,
   }
 }
 
+void TargetInfo::assertFail(ConversionPatternRewriter &rewriter, Location loc,
+                            StringRef message, StringRef file, StringRef func,
+                            int line) const {}
+
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -130,9 +130,10 @@ bool TargetInfo::processReplicaUsingStMatrix(
   return false;
 }
 
-void TargetInfo::printf(Value formatStrStart, int formatStrByteCount,
-                        ValueRange args,
-                        ConversionPatternRewriter &rewriter) const {
+void TargetInfo::printfImpl(Value formatStrStart, int formatStrByteCount,
+                            ValueRange args,
+                            ConversionPatternRewriter &rewriter,
+                            bool useStdErr) const {
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
   auto *ctx = rewriter.getContext();
   mlir::Location loc = UnknownLoc::get(ctx);
@@ -140,9 +141,11 @@ void TargetInfo::printf(Value formatStrStart, int formatStrByteCount,
   // See
   // https://github.com/ROCm/ROCm-Device-Libs/blob/rocm-6.0.x/ockl/src/services.cl#L263-L361
   // for details about the following HIP device print functions.
-  LLVM::LLVMFuncOp printBeginFn =
-      getOrInsertFunction(moduleOp, loc, rewriter, "__ockl_printf_begin",
-                          LLVM::LLVMFunctionType::get(i64_ty, {i64_ty}));
+  LLVM::LLVMFuncOp printBeginFn = getOrInsertFunction(
+      moduleOp, loc, rewriter,
+      useStdErr ? "__ockl_fprintf_stderr_begin" : "__ockl_printf_begin",
+      LLVM::LLVMFunctionType::get(i64_ty,
+                                  useStdErr ? ArrayRef<Type>() : i64_ty));
   LLVM::LLVMFuncOp printStrFn = getOrInsertFunction(
       moduleOp, loc, rewriter, "__ockl_printf_append_string_n",
       LLVM::LLVMFunctionType::get(
@@ -158,7 +161,8 @@ void TargetInfo::printf(Value formatStrStart, int formatStrByteCount,
 
   // Emit the intrinsic function call to begin the printf.
   Value zeroI64 = rewriter.create<LLVM::ConstantOp>(loc, i64_ty, 0);
-  Value message = call(printBeginFn, zeroI64).getResult();
+  Value message =
+      call(printBeginFn, useStdErr ? ValueRange() : zeroI64).getResult();
 
   // Emit the intrinsic function call to handle the printf format string.
   Value oneI32 = i32_val(1);
@@ -193,8 +197,28 @@ void TargetInfo::printf(Value formatStrStart, int formatStrByteCount,
   }
 }
 
+void TargetInfo::printf(Value formatStrStart, int formatStrByteCount,
+                        ValueRange args,
+                        ConversionPatternRewriter &rewriter) const {
+  return printfImpl(formatStrStart, formatStrByteCount, args, rewriter,
+                    /*useStdError=*/false);
+}
+
 void TargetInfo::assertFail(ConversionPatternRewriter &rewriter, Location loc,
                             StringRef message, StringRef file, StringRef func,
-                            int line) const {}
+                            int line) const {
+  // Compose and print an assert message.
+  llvm::SmallString<256> msgBuffer;
+  llvm::Twine("device assertion failed: '" + message + "', in " + func +
+              " at " + file + ":" + llvm::Twine(line) + "\n\0")
+      .toStringRef(msgBuffer);
+  Value msgValue =
+      LLVM::addStringToModule(loc, rewriter, "printfFormat_", msgBuffer);
+  printfImpl(msgValue, msgBuffer.size_in_bytes(), /*args=*/ValueRange(),
+             rewriter, /*useStdError=*/true);
+
+  // Perform the trap to abort the kernel.
+  rewriter.create<LLVM::Trap>(loc);
+}
 
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -38,6 +38,9 @@ public:
                   int line) const override;
 
 private:
+  void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,
+                  ConversionPatternRewriter &rewriter, bool useStdErr) const;
+
   std::string arch;
 };
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -33,6 +33,9 @@ public:
       ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const override;
   void printf(Value formatStrStart, int formatStrByteCount, ValueRange args,
               ConversionPatternRewriter &rewriter) const override;
+  void assertFail(ConversionPatternRewriter &rewriter, Location loc,
+                  StringRef message, StringRef file, StringRef func,
+                  int line) const override;
 
 private:
   std::string arch;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -211,7 +211,7 @@ struct ConvertTritonAMDGPUToLLVM
     mlir::triton::populateMakeRangeOpToLLVMPattern(typeConverter, patterns,
                                                    benefit);
     mlir::triton::populateAssertOpToLLVMPattern(typeConverter, patterns,
-                                                benefit);
+                                                targetInfo, benefit);
     mlir::triton::populateControlFlowOpToLLVMPattern(typeConverter, patterns,
                                                      benefit);
     mlir::triton::populateSPMDOpToLLVMPattern(typeConverter, patterns,

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -155,6 +155,24 @@ std::pair<Type, Value> printfPromoteValue(ConversionPatternRewriter &rewriter,
 
   return {newType, newOp};
 }
+
+LLVM::LLVMFuncOp getAssertfailDeclaration(ConversionPatternRewriter &rewriter) {
+  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+  StringRef funcName("__assertfail");
+  Operation *funcOp = moduleOp.lookupSymbol(funcName);
+  if (funcOp)
+    return cast<LLVM::LLVMFuncOp>(*funcOp);
+  // void __assert_fail(const char * assertion, const char * file, unsigned
+  // int line, const char * function);
+  auto *ctx = rewriter.getContext();
+  SmallVector<Type> argsType{ptr_ty(ctx), ptr_ty(ctx), i32_ty, ptr_ty(ctx),
+                             rewriter.getIntegerType(sizeof(size_t) * 8)};
+  auto funcType = LLVM::LLVMFunctionType::get(void_ty(ctx), argsType);
+  ConversionPatternRewriter::InsertionGuard guard(rewriter);
+  rewriter.setInsertionPointToStart(moduleOp.getBody());
+  return rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(ctx), funcName,
+                                           funcType);
+}
 } // namespace
 
 namespace mlir::triton::NVIDIA {
@@ -354,6 +372,24 @@ void TargetInfo::printf(Value formatStrStart, int /*formatStrByteCount*/,
   }
 
   SmallVector<Value> operands{formatStrStart, bufferPtr};
+  call(funcOp, operands);
+}
+
+void TargetInfo::assertFail(ConversionPatternRewriter &rewriter, Location loc,
+                            StringRef message, StringRef file, StringRef func,
+                            int line) const {
+  auto funcOp = getAssertfailDeclaration(rewriter);
+  auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();
+  Value messageString =
+      LLVM::addStringToModule(loc, rewriter, "assertMessage_", message);
+  Value fileString =
+      LLVM::addStringToModule(loc, rewriter, "assertFile_", file);
+  Value funcString =
+      LLVM::addStringToModule(loc, rewriter, "assertFunc_", func);
+  Value lineNumber = i32_val(line);
+  Value charSize = int_val(sizeof(size_t) * 8, sizeof(char));
+  SmallVector<Value> operands = {messageString, fileString, lineNumber,
+                                 funcString, charSize};
   call(funcOp, operands);
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -32,6 +32,9 @@ public:
       ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const override;
   void printf(Value formatStrStart, int formatStrByteCount, ValueRange args,
               ConversionPatternRewriter &rewriter) const override;
+  void assertFail(ConversionPatternRewriter &rewriter, Location loc,
+                  StringRef message, StringRef file, StringRef func,
+                  int line) const override;
 
 private:
   int computeCapability;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -168,7 +168,7 @@ struct ConvertTritonGPUToLLVM
     mlir::triton::populateViewOpToLLVMPatterns(typeConverter, patterns,
                                                benefit);
     mlir::triton::populateAssertOpToLLVMPattern(typeConverter, patterns,
-                                                benefit);
+                                                targetInfo, benefit);
     mlir::triton::populateMemoryOpToLLVMPattern(typeConverter, patterns,
                                                 benefit);
     mlir::triton::populateMakeRangeOpToLLVMPattern(typeConverter, patterns,


### PR DESCRIPTION
This commit adds support for device assert in the AMD
backend. This creates a new virtual method on `TargetInfo`
so that we can specialize for different backends, given
that on AMD side we don't have the same lowering flow:
right now `__assert_fail` is not supported in the AMDGPU
backend; it's in the runtime. 

https://github.com/ROCm/clr/commit/7137a296ddab93708a245955cd6a7357922975cc

Instead we need to layer it on top of print and do trap
afterwards.