### PR TITLE
[backend] NFC: Make TargetInfo methods consistent with parameters

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -3,43 +3,47 @@
 
 #include "triton/Conversion/MLIRTypes.h"
 
-using namespace mlir;
 namespace mlir::triton {
 class TargetInfoBase {
 public:
   virtual bool supportMaximumMinimum() const = 0;
+
   virtual Value ballot(ConversionPatternRewriter &rewriter, Location loc,
                        Type type, Value cmp) const = 0;
+
   virtual Value storeShared(ConversionPatternRewriter &rewriter, Location loc,
                             Value ptr, Value val, Value pred) const = 0;
   virtual Value loadShared(ConversionPatternRewriter &rewriter, Location loc,
                            Value ptr, Type elemTy, Value pred) const = 0;
-  virtual Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter,
+
+  virtual Value shuffleXor(ConversionPatternRewriter &rewriter, Location loc,
                            Value val, int i) const = 0;
-  virtual Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter,
+  virtual Value shuffleUp(ConversionPatternRewriter &rewriter, Location loc,
                           Value val, int i) const = 0;
-  virtual Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
+  virtual Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
                            Value val, int i) const = 0;
-  virtual Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
+  virtual Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
                            Value val, Value i) const = 0;
-  virtual Value programId(Location loc, ConversionPatternRewriter &rewriter,
+
+  virtual Value programId(ConversionPatternRewriter &rewriter, Location loc,
                           ModuleOp moduleOp, int axis) const = 0;
+
   virtual bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                           SmallVector<Value> &acc, triton::ReduceOp op,
                           unsigned numLaneToReduce) const = 0;
+
   virtual bool processReplicaUsingStMatrix(
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
       SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
       ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
       ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const = 0;
 
-  // Emit LLVM code with |rewriter| to print a message following the given
+  // Emits LLVM code with |rewriter| to print a message following the given
   // format from the device. |formatStrStart| is the pointer to the start of
   // the format string global variable; |args| are the arguments to fill
   // placeholders in the format string.
-  virtual void printf(Value formatStrStart, int formatStrByteCount,
-                      ValueRange args,
-                      ConversionPatternRewriter &rewriter) const = 0;
+  virtual void printf(ConversionPatternRewriter &rewriter, Value formatStrStart,
+                      int formatStrByteCount, ValueRange args) const = 0;
   // Emits LLVM code with |rewriter| to perform assertion failure with the given
   // |message| from the given |func| in |file|.
   virtual void assertFail(ConversionPatternRewriter &rewriter, Location loc,

--- a/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
@@ -27,7 +27,7 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
     auto loc = op->getLoc();
 
     auto getPid = [&](int axis) {
-      return targetInfo.programId(loc, rewriter,
+      return targetInfo.programId(rewriter, loc,
                                   op->getParentOfType<ModuleOp>(), axis);
     };
     std::array<Value, 3> pid = {getPid(0), getPid(1), getPid(2)};
@@ -162,8 +162,8 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
         formatStrValue =
             llPrintf(formatStr, printfOperands, rewriter, &formatStrByteCount);
       } else {
-        targetInfo.printf(formatStrValue, formatStrByteCount, printfOperands,
-                          rewriter);
+        targetInfo.printf(rewriter, formatStrValue, formatStrByteCount,
+                          printfOperands);
       }
     }
   }
@@ -228,7 +228,7 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
     Value msgValue =
         LLVM::addStringToModule(UnknownLoc::get(rewriter.getContext()),
                                 rewriter, "printfFormat_", msgNewline);
-    targetInfo.printf(msgValue, msgNewline.size_in_bytes(), args, rewriter);
+    targetInfo.printf(rewriter, msgValue, msgNewline.size_in_bytes(), args);
     if (formatStrByteCount)
       *formatStrByteCount = msgNewline.size_in_bytes();
     return msgValue;

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -172,7 +172,7 @@ private:
     for (unsigned N = numLaneToReduce / 2; N > 0; N >>= 1) {
       SmallVector<Value> shfl(acc.size());
       for (unsigned i = 0; i < acc.size(); ++i) {
-        shfl[i] = targetInfo.shuffleXor(loc, rewriter, acc[i], N * interleave);
+        shfl[i] = targetInfo.shuffleXor(rewriter, loc, acc[i], N * interleave);
       }
       accumulate(rewriter, op.getCombineOp(), acc, shfl, false);
     }

--- a/lib/Conversion/TritonGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/SPMDOpToLLVM.cpp
@@ -17,7 +17,7 @@ struct GetProgramIdOpConversion
   LogicalResult
   matchAndRewrite(triton::GetProgramIdOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value programId = targetInfo.programId(op->getLoc(), rewriter,
+    Value programId = targetInfo.programId(rewriter, op->getLoc(),
                                            op->getParentOfType<ModuleOp>(),
                                            op.getAxisAsInt());
     rewriter.replaceOp(op, programId);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -91,27 +91,27 @@ Value TargetInfo::loadShared(ConversionPatternRewriter &rewriter, Location loc,
   return loaded.getResult(0);
 }
 
-Value TargetInfo::shuffleXor(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::shuffleXor(ConversionPatternRewriter &rewriter, Location loc,
                              Value val, int i) const {
   return LLVM::AMD::shuffleXor(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleUp(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::shuffleUp(ConversionPatternRewriter &rewriter, Location loc,
                             Value val, int i) const {
   return LLVM::AMD::shuffleUp(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
                              Value val, int i) const {
   return LLVM::AMD::shuffleIdx(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
                              Value val, Value i) const {
   return LLVM::AMD::shuffleIdx(loc, rewriter, val, i);
 }
 
-Value TargetInfo::programId(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::programId(ConversionPatternRewriter &rewriter, Location loc,
                             ModuleOp moduleOp, int axis) const {
   return LLVM::AMD::llGetPid(loc, rewriter, moduleOp, axis);
 }
@@ -197,9 +197,9 @@ void TargetInfo::printfImpl(Value formatStrStart, int formatStrByteCount,
   }
 }
 
-void TargetInfo::printf(Value formatStrStart, int formatStrByteCount,
-                        ValueRange args,
-                        ConversionPatternRewriter &rewriter) const {
+void TargetInfo::printf(ConversionPatternRewriter &rewriter,
+                        Value formatStrStart, int formatStrByteCount,
+                        ValueRange args) const {
   return printfImpl(formatStrStart, formatStrByteCount, args, rewriter,
                     /*useStdError=*/false);
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -6,33 +6,41 @@ namespace mlir::triton::AMD {
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
   TargetInfo(std::string arch) : arch(std::move(arch)) {}
+
   bool supportMaximumMinimum() const override;
+
   Value ballot(ConversionPatternRewriter &rewriter, Location loc, Type type,
                Value cmp) const override;
+
   Value storeShared(ConversionPatternRewriter &rewriter, Location loc,
                     Value ptr, Value val, Value pred) const override;
   Value loadShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
                    Type elemTy, Value pred) const override;
-  Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
+
+  Value shuffleXor(ConversionPatternRewriter &rewriter, Location loc, Value val,
                    int i) const override;
-  Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter, Value val,
+  Value shuffleUp(ConversionPatternRewriter &rewriter, Location loc, Value val,
                   int i) const override;
-  Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
+  Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc, Value val,
                    int i) const override;
-  Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
+  Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc, Value val,
                    Value i) const override;
-  Value programId(Location loc, ConversionPatternRewriter &rewriter,
+
+  Value programId(ConversionPatternRewriter &rewriter, Location loc,
                   ModuleOp moduleOp, int axis) const override;
+
   bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                   SmallVector<Value> &acc, triton::ReduceOp op,
                   unsigned numLaneToReduce) const override;
+
   bool processReplicaUsingStMatrix(
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
       SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
       ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
       ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const override;
-  void printf(Value formatStrStart, int formatStrByteCount, ValueRange args,
-              ConversionPatternRewriter &rewriter) const override;
+
+  void printf(ConversionPatternRewriter &rewriter, Value formatStrStart,
+              int formatStrByteCount, ValueRange args) const override;
   void assertFail(ConversionPatternRewriter &rewriter, Location loc,
                   StringRef message, StringRef file, StringRef func,
                   int line) const override;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -254,27 +254,27 @@ Value TargetInfo::loadShared(ConversionPatternRewriter &rewriter, Location loc,
   return builder.launch(rewriter, loc, elemTy);
 }
 
-Value TargetInfo::shuffleXor(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::shuffleXor(ConversionPatternRewriter &rewriter, Location loc,
                              Value val, int i) const {
   return LLVM::NVIDIA::shuffleXor(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleUp(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::shuffleUp(ConversionPatternRewriter &rewriter, Location loc,
                             Value val, int i) const {
   return LLVM::NVIDIA::shuffleUp(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
                              Value val, int i) const {
   return LLVM::NVIDIA::shuffleIdx(loc, rewriter, val, i);
 }
 
-Value TargetInfo::shuffleIdx(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::shuffleIdx(ConversionPatternRewriter &rewriter, Location loc,
                              Value val, Value i) const {
   return LLVM::NVIDIA::shuffleIdx(loc, rewriter, val, i);
 }
 
-Value TargetInfo::programId(Location loc, ConversionPatternRewriter &rewriter,
+Value TargetInfo::programId(ConversionPatternRewriter &rewriter, Location loc,
                             ModuleOp moduleOp, int axis) const {
   return LLVM::NVIDIA::llGetPid(loc, rewriter, moduleOp, axis);
 }
@@ -332,9 +332,9 @@ bool TargetInfo::processReplicaUsingStMatrix(
   return false;
 }
 
-void TargetInfo::printf(Value formatStrStart, int /*formatStrByteCount*/,
-                        ValueRange args,
-                        ConversionPatternRewriter &rewriter) const {
+void TargetInfo::printf(ConversionPatternRewriter &rewriter,
+                        Value formatStrStart, int /*formatStrByteCount*/,
+                        ValueRange args) const {
   auto *ctx = rewriter.getContext();
   Type ptr = ptr_ty(ctx);
   auto moduleOp = rewriter.getBlock()->getParent()->getParentOfType<ModuleOp>();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -5,33 +5,41 @@ namespace mlir::triton::NVIDIA {
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
   TargetInfo(int computeCapability) : computeCapability(computeCapability) {}
+
   bool supportMaximumMinimum() const override;
+
   Value ballot(ConversionPatternRewriter &rewriter, Location loc, Type type,
                Value cmp) const override;
+
   Value storeShared(ConversionPatternRewriter &rewriter, Location loc,
                     Value ptr, Value val, Value pred) const override;
   Value loadShared(ConversionPatternRewriter &rewriter, Location loc, Value ptr,
                    Type elemTy, Value pred) const override;
-  Value shuffleXor(Location loc, ConversionPatternRewriter &rewriter, Value val,
+
+  Value shuffleXor(ConversionPatternRewriter &rewriter, Location loc, Value val,
                    int i) const override;
-  Value shuffleUp(Location loc, ConversionPatternRewriter &rewriter, Value val,
+  Value shuffleUp(ConversionPatternRewriter &rewriter, Location loc, Value val,
                   int i) const override;
-  Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
+  Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc, Value val,
                    int i) const override;
-  Value shuffleIdx(Location loc, ConversionPatternRewriter &rewriter, Value val,
+  Value shuffleIdx(ConversionPatternRewriter &rewriter, Location loc, Value val,
                    Value i) const override;
-  Value programId(Location loc, ConversionPatternRewriter &rewriter,
+
+  Value programId(ConversionPatternRewriter &rewriter, Location loc,
                   ModuleOp moduleOp, int axis) const override;
+
   bool warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                   SmallVector<Value> &acc, triton::ReduceOp op,
                   unsigned numLaneToReduce) const override;
+
   bool processReplicaUsingStMatrix(
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
       SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
       ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
       ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const override;
-  void printf(Value formatStrStart, int formatStrByteCount, ValueRange args,
-              ConversionPatternRewriter &rewriter) const override;
+
+  void printf(ConversionPatternRewriter &rewriter, Value formatStrStart,
+              int formatStrByteCount, ValueRange args) const override;
   void assertFail(ConversionPatternRewriter &rewriter, Location loc,
                   StringRef message, StringRef file, StringRef func,
                   int line) const override;


### PR DESCRIPTION
This commit updates various methods in `TargetInfo` to be consistent regarding `rewriter` and `loc`.