### PR TITLE
[AMD] Enable Flash Attention Tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -299,7 +299,8 @@ jobs:
               ./test/unit/language/test_subprocess.py \
               ./test/unit/language/test_standard.py \
               ./test/unit/language/test_compile_errors.py \
-              ./test/unit/language/test_block_pointer.py
+              ./test/unit/language/test_block_pointer.py \
+              ./test/unit/operators/test_flash_attention.py
 
       - name: Run C++ unittests
         run: |

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -579,11 +579,10 @@ bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
   // improved. In addition, we can enable this shortcut for regular MFMA
   // layout when opIdx == 1.
   return mfmaLayout.getWarpsPerCTA()[1] == 1 &&
-         dotOperandLayout.getOpIdx() == 0 &&
-         dotOperandLayout.getKWidth() == 4 &&
+         dotOperandLayout.getOpIdx() == 0 && mfmaLayout.getIsTransposed() &&
+         dotOperandLayout.getKWidth() == getContigPerThread(mfmaLayout)[1] &&
          dotOperandLayout.getParent() == mfmaLayout &&
          (mfmaLayout.getMDim() == 32 || mfmaLayout.getMDim() == 16) &&
-         mfmaLayout.getIsTransposed() &&
          (srcTy.getElementType().isF16() || srcTy.getElementType().isBF16());
 }
 

--- a/python/triton/ops/flash_attention.py
+++ b/python/triton/ops/flash_attention.py
@@ -375,11 +375,6 @@ class _attention(torch.autograd.Function):
             raise RuntimeError("Flash attention currently only supported for compute capability >= 80")
         BLOCK_M = 128
         BLOCK_N = 64
-
-        if is_hip():
-            # Some accuracy issues observed on hip with BLOCK_M = 128.
-            BLOCK_M = 64
-
         # shape constraints
         Lq, Lk, Lv = q.shape[-1], k.shape[-1], v.shape[-1]
         assert Lq == Lk and Lk == Lv

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -151,11 +151,6 @@ private:
       //
       // For cases where these two values are equal MFMA and MFMA operand
       // layouts are the same.
-      auto dstLayout = dstTy.getEncoding();
-      auto dotOperandLayout = dstLayout.cast<DotOperandEncodingAttr>();
-      assert(dotOperandLayout.getOpIdx() == 0 &&
-             dotOperandLayout.getKWidth() == 4);
-      // get source values
       auto vals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
       Value view =
           packLLElements(loc, getTypeConverter(), vals, rewriter, dstTy);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -141,37 +141,24 @@ private:
     RankedTensorType srcTy = op.getSrc().getType();
     RankedTensorType dstTy = op.getType();
     if (isMfmaToDotShortcut(srcTy, dstTy)) {
+      // vecSize is an number of sequential elements stored by one thread
+      // - For MFMA encoding (encoding of the result tensor of dot
+      // operation) it is 4
+      // - For MFMA operand encoding it is
+      // dotOperandEncoding::kWidth,
+      //   which is 4 in certain cases (e.g. fp16 and bfloat16 dtypes with kpack
+      //   = 1)
+      //
+      // For cases where these two values are equal MFMA and MFMA operand
+      // layouts are the same.
+      auto dstLayout = dstTy.getEncoding();
+      auto dotOperandLayout = dstLayout.cast<DotOperandEncodingAttr>();
+      assert(dotOperandLayout.getOpIdx() == 0 &&
+             dotOperandLayout.getKWidth() == 4);
       // get source values
       auto vals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-      unsigned elems = getTotalElemsPerThread(srcTy);
-      Type elemTy =
-          this->getTypeConverter()->convertType(srcTy.getElementType());
-      // for the destination type, we need to pack values together
-      // so they can be consumed by tensor core operations
-      SmallVector<Value> vecVals;
-      SmallVector<Type> types;
-      auto elemSize = elemTy.getIntOrFloatBitWidth();
-      // TODO: Support types other than float16 and
-      // bf16 (represented as int16 in llvm ir).
-      assert((type::isFloat(elemTy) || type::isInt(elemTy)) && elemSize == 16);
-      // vecSize is an number of sequential elements stored by one thread
-      // - For MFMA (nonKDim == 32) encoding it is 4
-      // - For MFMA (nonKDim == 32) operand encoding it is
-      // dotOperandEndocing::kWidth,
-      //   which is 4 for fp16 and bfloat16 dtypes
-      //
-      // For mentioned types MFMA and MFMA operand layouts are the same
-      const unsigned vecSize = 4;
-      Type vecTy = vec_ty(elemTy, vecSize);
-      types = SmallVector<Type>(elems / vecSize, vecTy);
-      for (unsigned i = 0; i < elems; i += vecSize) {
-        Value packed = rewriter.create<LLVM::UndefOp>(loc, vecTy);
-        for (unsigned j = 0; j < vecSize; j++)
-          packed = insert_element(vecTy, packed, vals[i + j], i32_val(j));
-        vecVals.push_back(packed);
-      }
       Value view =
-          packLLElements(loc, getTypeConverter(), vecVals, rewriter, dstTy);
+          packLLElements(loc, getTypeConverter(), vals, rewriter, dstTy);
       rewriter.replaceOp(op, view);
       return success();
     }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
@@ -204,10 +204,12 @@ static bool hasConvertToAmdMmaTransisitiveUse(Operation *op,
     getForwardSlice(currentValue, &forwardSlice);
     for (Operation *op : forwardSlice) {
       if (auto convertOp = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
-        if (convertOp.getResult()
-                .getType()
-                .cast<RankedTensorType>()
-                .getEncoding() == encoding)
+        Attribute dstEncoding = convertOp.getResult()
+                                    .getType()
+                                    .cast<RankedTensorType>()
+                                    .getEncoding();
+        if (dstEncoding.isa<triton::gpu::AMDMfmaEncodingAttr,
+                            triton::gpu::AMDWmmaEncodingAttr>())
           return true;
       }
       auto yield = dyn_cast<scf::YieldOp>(op);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/RemoveLayoutConversions.cpp
@@ -189,7 +189,6 @@ static bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
   return false;
 }
 
-#ifdef USE_ROCM
 // Look ahead to at the transitive uses and see if there is a convert to mfma or
 // wmma operations.
 // TODO: unify with hasConvertToMMATransisitiveUse?
@@ -228,7 +227,6 @@ static bool hasConvertToAmdMmaTransisitiveUse(Operation *op,
   }
   return false;
 }
-#endif
 
 // Return true if the op is an op with a layout we don't want to change. We will
 // propagate the layout starting from anchor ops.


### PR DESCRIPTION
This commit fixes the lowerMfmaToDotOperand function by removing the packing of vecSize elements into LLVM structs. This was previously done because dot lowering required operands of the dot operation to be packed in this way, which was later changed. This commit also adds FA tests to AMD CI.