### PR TITLE
[Backend] Allow dot operand pipelining in more circumstances.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -146,7 +146,7 @@ createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
 }
 
 // If all the transitive uses of the given value have are used by a convert to
-// the same dot operand encoding, return true and set the shared encoding that
+// the same dot operand encoding, return true and get the shared encoding that
 // needs to be used to be compatible with users' layouts.
 static std::optional<ttg::SharedEncodingAttr>
 getSharedEncIfAllUsersAreDotEnc(Value val) {
@@ -159,8 +159,7 @@ getSharedEncIfAllUsersAreDotEnc(Value val) {
             user->getResult(0).getType().dyn_cast<triton::MemDescType>()) {
       // First time we find a shared encoding in the chain, save it and try to
       // use it if it is compatible with the other users.
-      if (!tempAttr)
-        tempAttr = memDesc.getEncoding().cast<ttg::SharedEncodingAttr>();
+      tempAttr = memDesc.getEncoding().cast<ttg::SharedEncodingAttr>();
       if (!getSharedEncIfAllUsersAreDotEnc(user->getResult(0)).has_value())
         return std::nullopt;
     } else {
@@ -392,7 +391,7 @@ collectOpsToPipeline(scf::ForOp forOp,
   // loads.
   for (auto &[loadOp, distAndUse] : loadOpToDistAndUse) {
     PipelinedOpInfo loadInfo;
-    if (isa<tt::DotOp>(distAndUse.second)) {
+    if (auto dot = dyn_cast<tt::DotOp>(distAndUse.second)) {
       if (loadIsMMAv3(loadOp)) {
         loadInfo.loadIsMMAV3 = true;
         loadInfo.sharedEncoding =
@@ -401,12 +400,40 @@ collectOpsToPipeline(scf::ForOp forOp,
         loadInfo.sharedEncoding =
             getSharedEncIfAllUsersAreDotEnc(loadOp.getResult())
                 .value_or(nullptr);
+
+        // HACK: Triton LLVM codegen has a bug where local_loads from #shared to
+        // #mma layout can lead to invalid code if the loaded shape is smaller
+        // than the mma tile (e.g. loading a 128x1 tensor for an MMAv2 dot with
+        // tile {16,8} is bad because 1 < 8).  To work around this, don't
+        // pipeline such loads.
+        //
+        // The codegen bug is caught by an assertion, so if you think you've
+        // fixed it, feel free to delete this code and see if the assert still
+        // fails.  :)
+        if (!loadInfo.sharedEncoding) {
+          if (auto dotEnc = dot.getResult()
+                                .getType()
+                                .getEncoding()
+                                .dyn_cast<ttg::NvidiaMmaEncodingAttr>()) {
+            auto loadTy = loadOp.getType().cast<RankedTensorType>();
+            auto mmaInstrShape = dotEnc.getInstrShape();
+            if (loadTy.getRank() < mmaInstrShape.size())
+              continue;
+            bool ok = true;
+            for (int i = 0; i < mmaInstrShape.size(); i++) {
+              if (loadTy.getShape()[loadTy.getRank() - mmaInstrShape.size() +
+                                    i] != mmaInstrShape[i]) {
+                ok = false;
+                break;
+              }
+            }
+            // If this load might trigger the bug, don't do the fallback logic
+            // below, which might allow the load to be pipelined.
+            if (!ok)
+              continue;
+          }
+        }
       }
-      // TODO(jlebar): Remove this if statement, which effectively rolls back
-      // back https://github.com/openai/triton/pull/3415, once internal bugs are
-      // fixed.
-      if (!loadInfo.sharedEncoding)
-        continue;
     } else if (isa<tt::LoadOp>(distAndUse.second)) {
       // The use of this loadOp is another loadOp. If the use is not in the
       // loadInfo already, it means that the use is not valid for pipelining


### PR DESCRIPTION
<git-pr-chain>


[Backend] Allow dot operand pipelining in more circumstances.

PR #3472 partially rolled back PR #3415 due to internal test failures.  This PR
rolls forward the change as much as we currently can, allowing *most* but not
all relevant loads to be pipelined.

There is still a TritonGPU -> LLVM codegen bug in Triton that we have not been
able to fix, but now we catch it with asserts, PR #3549.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3560 👈 **YOU ARE HERE**


</git-pr-chain>
