### PR TITLE
[Backend] Allow dot operand pipelining in more circumstances.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -146,7 +146,7 @@ createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
 }
 
 // If all the transitive uses of the given value have are used by a convert to
-// the same dot operand encoding, return true and set the shared encoding that
+// the same dot operand encoding, return true and get the shared encoding that
 // needs to be used to be compatible with users' layouts.
 static std::optional<ttg::SharedEncodingAttr>
 getSharedEncIfAllUsersAreDotEnc(Value val) {
@@ -159,8 +159,7 @@ getSharedEncIfAllUsersAreDotEnc(Value val) {
             user->getResult(0).getType().dyn_cast<triton::MemDescType>()) {
       // First time we find a shared encoding in the chain, save it and try to
       // use it if it is compatible with the other users.
-      if (!tempAttr)
-        tempAttr = memDesc.getEncoding().cast<ttg::SharedEncodingAttr>();
+      tempAttr = memDesc.getEncoding().cast<ttg::SharedEncodingAttr>();
       if (!getSharedEncIfAllUsersAreDotEnc(user->getResult(0)).has_value())
         return std::nullopt;
     } else {
@@ -392,7 +391,7 @@ collectOpsToPipeline(scf::ForOp forOp,
   // loads.
   for (auto &[loadOp, distAndUse] : loadOpToDistAndUse) {
     PipelinedOpInfo loadInfo;
-    if (isa<tt::DotOp>(distAndUse.second)) {
+    if (auto dot = dyn_cast<tt::DotOp>(distAndUse.second)) {
       if (loadIsMMAv3(loadOp)) {
         loadInfo.loadIsMMAV3 = true;
         loadInfo.sharedEncoding =
@@ -401,12 +400,40 @@ collectOpsToPipeline(scf::ForOp forOp,
         loadInfo.sharedEncoding =
             getSharedEncIfAllUsersAreDotEnc(loadOp.getResult())
                 .value_or(nullptr);
+
+        // HACK: Triton LLVM codegen has a bug where local_loads from #shared to
+        // #mma layout can lead to invalid code if the loaded shape is smaller
+        // than the mma tile (e.g. loading a 128x1 tensor for an MMAv2 dot with
+        // tile {16,8} is bad because 1 < 8).  To work around this, don't
+        // pipeline such loads.
+        //
+        // The codegen bug is caught by an assertion, so if you think you've
+        // fixed it, feel free to delete this code and see if the assert still
+        // fails.  :)
+        if (!loadInfo.sharedEncoding) {
+          if (auto dotEnc = dot.getResult()
+                                .getType()
+                                .getEncoding()
+                                .dyn_cast<ttg::NvidiaMmaEncodingAttr>()) {
+            auto loadTy = loadOp.getType().cast<RankedTensorType>();
+            auto mmaInstrShape = dotEnc.getInstrShape();
+            if (loadTy.getRank() < mmaInstrShape.size())
+              continue;
+            bool ok = true;
+            for (int i = 0; i < mmaInstrShape.size(); i++) {
+              if (loadTy.getShape()[loadTy.getRank() - mmaInstrShape.size() +
+                                    i] < mmaInstrShape[i]) {
+                ok = false;
+                break;
+              }
+            }
+            // If this load might trigger the bug, don't do the fallback logic
+            // below, which might allow the load to be pipelined.
+            if (!ok)
+              continue;
+          }
+        }
       }
-      // TODO(jlebar): Remove this if statement, which effectively rolls back
-      // back https://github.com/openai/triton/pull/3415, once internal bugs are
-      // fixed.
-      if (!loadInfo.sharedEncoding)
-        continue;
     } else if (isa<tt::LoadOp>(distAndUse.second)) {
       // The use of this loadOp is another loadOp. If the use is not in the
       // loadInfo already, it means that the use is not valid for pipelining

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -1267,3 +1267,44 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
     tt.return
   }
 }
+
+// -----
+
+// CHECK-LABEL: @dont_pipeline_128x1
+// CHECK-NOT: local_load{{.*}}128x1
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @dont_pipeline_128x1(%arg6: !tt.ptr<i32, 1> {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x64xf32, #mma>
+    %c128_i32 = arith.constant 128 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %cst_4 = arith.constant dense<-1.000000e+30> : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+
+    %99:1 = scf.for %arg25 = %c0_i32 to %c128_i32 step %c64_i32 iter_args(%arg31 = %cst_4) -> (tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>)  : i32 {
+      %94 = tt.splat %arg6 : !tt.ptr<i32, 1> -> tensor<128x1x!tt.ptr<i32, 1>, #blocked>
+      %151 = tt.load %94 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<128x1xi32, #blocked>
+      %161 = triton_gpu.convert_layout %151 : tensor<128x1xi32, #blocked> -> tensor<128x1xi32, #mma>
+      %162 = tt.broadcast %161 : tensor<128x1xi32, #mma> -> tensor<128x64xi32, #mma>
+      %170 = arith.sitofp %162 : tensor<128x64xi32, #mma> to tensor<128x64xf32, #mma>
+
+      %173 = "tt.reduce"(%170) <{axis = 1 : i32}> ({
+      ^bb0(%arg33: f32, %arg34: f32):
+        %207 = arith.maxnumf %arg33, %arg34 : f32
+        tt.reduce.return %207 : f32
+      }) : (tensor<128x64xf32, #mma>) -> tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+      %175 = arith.maxnumf %arg31, %173 : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+
+      %201 = arith.truncf %170 : tensor<128x64xf32, #mma> to tensor<128x64xf16, #mma>
+      %202 = triton_gpu.convert_layout %201 : tensor<128x64xf16, #mma> -> tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>>
+
+      %192 = arith.constant dense<0.> : tensor<128x64xf32, #mma>
+      %203 = arith.constant dense<0.> : tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+      %204 = tt.dot %202, %203, %192 {inputPrecision = 0 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma, kWidth = 2}>> * tensor<64x64xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>> -> tensor<128x64xf32, #mma>
+
+      scf.yield %175 : tensor<128xf32, #triton_gpu.slice<{dim = 1, parent = #mma}>>
+    }
+    tt.return
+  }
+}


### PR DESCRIPTION
<git-pr-chain>


[Backend] Allow dot operand pipelining in more circumstances.

PR #3472 partially rolled back PR #3415 due to internal test failures.  This PR
rolls forward the change as much as we currently can, allowing *most* but not
all relevant loads to be pipelined.

There is still a TritonGPU -> LLVM codegen bug in Triton that we have not been
able to fix, but now we catch it with asserts, PR #3549.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3561 👈 **YOU ARE HERE**


</git-pr-chain>


