### PR TITLE
[frontend] Improve function def parsing with stacked decorators.

### DIFF
--- a/python/test/unit/language/test_decorator.py
+++ b/python/test/unit/language/test_decorator.py
@@ -1,0 +1,25 @@
+import triton
+import pytest
+
+
+def test_decorator_with_def(device):
+
+    def triton_heuristics_pointwise(**kwargs):
+
+        def decorator(func):
+            return func
+
+        return decorator
+
+    # "def" might appear in a decorator call, e.g. a hash string argument.
+    # This test makes sure the compiler can find the right position of function
+    # definition.
+    @triton_heuristics_pointwise(inductor_meta={'backend_hash': 'def0aeffabe53b3f8'}, )
+    @triton.jit
+    def kernel():
+        pass
+
+    try:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
+    except Exception as e:
+        pytest.fail(f"triton compile failed with error: {e}")

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -4,6 +4,7 @@ import hashlib
 import inspect
 import itertools
 import os
+import re
 import textwrap
 from collections import defaultdict
 from functools import cached_property
@@ -478,7 +479,7 @@ class JITFunction(KernelInterface[T]):
 
         # function source code (without decorators)
         self.src = textwrap.dedent(inspect.getsource(fn))
-        self.src = self.src[self.src.find("def"):]
+        self.src = self.src[re.search(r"^def\s+\w+\s*\(", self.src, re.MULTILINE).start():]
         # cache of just-in-time compiled kernels
         self.cache = defaultdict(dict)
         self.hash = None


### PR DESCRIPTION
Under certain conditions where we apply another decorator on top of triton.jit, there is a small chance that in the decorator body there's a "def" substring in it. This is problematic when JITFunction parses function def using str.find('def'). This causes an issue compiling some pytorch model when we happened to decorate a jit function with a hash string argument which has "def" in it.

This diff tries a bit harder to locate the real "def" position using a more complex regex which should further reduce the chance to hit this error.