### PR TITLE
[INTERPRETER] Use acc's dtype as computation dtype in `tl.dot`

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -2955,10 +2955,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
         pytest.skip("float8e4nv not supported on sm <= 80")
     if is_hip() and (in_dtype == 'float8e4nv' or in_dtype == 'float8e5'):
         pytest.skip("float8e4nv and float8e5 not supported on HIP")
-    if is_interpreter() and in_dtype == 'int8':
-        pytest.skip(
-            "numpy.dot with int8 inputs will overflow while tl.dot doesn't because MMA instruction's accumulator is 32-bit"
-        )
     if is_hip() and (input_precision != "ieee"):
         pytest.skip(f"{input_precision} not supported on HIP")
 
@@ -3146,8 +3142,6 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
 def test_dot3d(B, num_warps, M, N, K, in_dtype_str, out_dtype_str, device):
     if is_hip():
         pytest.skip('TODO test_dot3d not supported on HIP.')
-    if in_dtype_str == 'int8' and is_interpreter():
-        pytest.skip('numpy.dot with int8 inputs will overflow')
 
     @triton.jit
     def kernel(

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -411,7 +411,7 @@ class InterpreterBuilder:
         return TensorHandle(np.transpose(arg.data, perm), arg.dtype)
 
     def create_dot(self, a, b, d, input_precision, max_num_imprecise_acc):
-        return TensorHandle(np.matmul(a.data, b.data) + d.data, d.dtype)
+        return TensorHandle(np.matmul(a.data, b.data, dtype=d.data.dtype) + d.data, d.dtype)
 
     def create_make_range(self, start, stop):
         return TensorHandle(np.arange(start, stop, dtype=np.int32), tl.int32)


### PR DESCRIPTION
I found with `TRITON_INTERPRET=1`, `tl.dot` almost always gives wrong result for INT8 input, due to `np.matmul` use inputs' dtype as result dtype by default:

```
>>> a = np.array([[10, 20]], np.int8)
>>> np.matmul(a, a.transpose())
array([[-12]], dtype=int8)
>>> np.matmul(a, a.transpose(), dtype=np.int32)
array([[500]])
```
