### PR TITLE
[Tests] Add test for local_load to #mma layout.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -4660,7 +4660,7 @@ def compute_rep_shape(layout):
         rep_shape = np.multiply(warp_shape, layout.warps_per_cta)
         return rep_shape
     else:
-        assert "TODO: support compute_rep_shape for layout " + str(type(layout))
+        assert False, "TODO: support compute_rep_shape for layout " + str(type(layout))
 
 
 # This function gives a lower bound approximation of scratch buffer shape for convert_layout operation
@@ -4685,7 +4685,10 @@ def test_convert2d(M, N, src_layout, interm_layout, dst_layout, dtype, device):
     if str(src_layout) == str(dst_layout):
         pytest.skip()
     if is_hip():
-        scratch_shape = compute_scratch_buffer_shape(src_layout, dst_layout, (M, N))
+        try:
+            scratch_shape = compute_scratch_buffer_shape(src_layout, dst_layout, (M, N))
+        except AssertionError:
+            pytest.skip("Can't compute scratch buffer size")
         lds_size = 65536
         # consider int32 dtype in scratch buffer size,
         # because it is the largest dtype used in convert_layout in this test

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -56,7 +56,7 @@ prototype_pattern = {
     "ptx": ptx_prototype_pattern,
 }
 
-mlir_arg_type_pattern = r'%\w+: ((?:[^,\s<]+|<[^>]+>)+),?'
+mlir_arg_type_pattern = r'%\w+: ((?:[^,\s<)]+|<[^>]+>)+),?'
 ptx_arg_type_pattern = r"\.param\s+\.(\w+)"
 arg_type_pattern = {
     "ttir": mlir_arg_type_pattern,


### PR DESCRIPTION
This is a TTGIR test for the bug worked around in PR https://github.com/openai/triton/pull/3561.

While we're here, we also do a minor cleanup in test_core.py.

A previous version of this patch needed us to fix the regex for parsing an MLIR
file to find the individual arguments.  Previously it would include the
function's closing paren in the argument type.  We keep this because it's a
reasonable fix.

I am extremely frightened by this test; if you comment out the skip() at the
beginning, many tests fail due to OOB memory accesses or wrong results, in
addition to the asserts added in PR https://github.com/openai/triton/pull/3561.  Who knows if we hit this today?