### PR TITLE
[BACKEND] Add -o for triton-llvm-opt

### DIFF
--- a/bin/triton-llvm-opt.cpp
+++ b/bin/triton-llvm-opt.cpp
@@ -26,6 +26,10 @@ static cl::opt<std::string> InputFilename(cl::Positional,
                                           cl::init("-"),
                                           cl::value_desc("filename"));
 
+static cl::opt<std::string> OutputFilename("o",
+                                           cl::desc("Override output filename"),
+                                           cl::value_desc("filename"));
+
 static cl::opt<std::string> ClDataLayout("data-layout",
                                          cl::desc("data layout string to use"),
                                          cl::value_desc("layout-string"),
@@ -101,7 +105,9 @@ int main(int argc, char **argv) {
 
   // Write to standard output.
   std::unique_ptr<ToolOutputFile> Out;
-  std::string OutputFilename = "-";
+  // Default to standard output.
+  if (OutputFilename.empty())
+    OutputFilename = "-";
   std::error_code EC;
   sys::fs::OpenFlags Flags = sys::fs::OF_TextWithCRLF;
   Out.reset(new ToolOutputFile(OutputFilename, EC, Flags));
@@ -110,5 +116,6 @@ int main(int argc, char **argv) {
     return 1;
   }
   Out->os() << *M << "\n";
+  Out->keep();
   return 0;
 }


### PR DESCRIPTION
Add an `-o` option to allow specifying output file name. This is useful for separating IR output from pass printings which will be added later.