### PR TITLE
[ci] Clean up condition and environment variable usage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -264,7 +264,7 @@ jobs:
 
       - name: Update PATH
         run: |
-          echo "/opt/rocm/llvm/bin:$PATH" >> $GITHUB_PATH
+          echo "/opt/rocm/llvm/bin" >> $GITHUB_PATH
 
       - name: Install Triton on ROCM
         run: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -149,6 +149,10 @@ jobs:
           mkdir -p ~/.triton
           ls -alh ~/.triton
 
+      - name: Update PATH
+        run: |
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Install apt dependencies
         run: |
           sudo apt-get update -y

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -165,6 +165,7 @@ jobs:
 
       - name: Install Triton
         run: |
+          echo "PATH is '$PATH'"
           cd python
           TRITON_BUILD_WITH_CCACHE=true python3 -m pip install --no-build-isolation -vvv '.[tests]'
 
@@ -246,9 +247,9 @@ jobs:
 
       - name: Clear triton cache directory
         run: |
+          rm -rf ~/.triton
           mkdir -p ~/.triton
           ls -alh ~/.triton
-          rm -rf ~/.triton
 
       - name: Cache build dependency
         uses: actions/cache@v4
@@ -270,14 +271,14 @@ jobs:
         run: |
           echo "/opt/rocm/llvm/bin" >> $GITHUB_PATH
 
-      - name: Install Triton on ROCM
+      - name: Install Triton on HIP
         run: |
+          echo "PATH is '$PATH'"
           pip uninstall -y triton
-          export PATH="/opt/rocm/llvm/bin:$PATH"
           cd python
           pip install -v -e .
 
-      - name: Run python tests on ROCM
+      - name: Run python tests on HIP
         run: |
           cd python
           pytest --capture=tee-sys -rfs -vvv -n 32 ./test/unit/language/test_core.py \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,9 @@ concurrency:
 permissions: read-all
 
 env:
+  TRITON_BUILD_WITH_CLANG_LLD: "TRUE"
   TRITON_USE_ASSERT_ENABLED_LLVM: "TRUE"
+  TRITON_DISABLE_LINE_INFO: 1
 
 jobs:
   Runner-Preparation:
@@ -147,20 +149,10 @@ jobs:
           mkdir -p ~/.triton
           ls -alh ~/.triton
 
-      - name: Update PATH
-        run: |
-          echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
-
       - name: Install apt dependencies
         run: |
           sudo apt-get update -y
           sudo apt-get install -y ccache clang lld
-
-      - name: Set CUDA ENV
-        if: ${{(matrix.runner[0] == 'self-hosted') && (matrix.runner[1] == 'V100' || matrix.runner[1] == 'A100' || matrix.runner[1] == 'H100')}}
-        run: |
-          echo "BACKEND=CUDA" >> "${GITHUB_ENV}"
-          echo "TRITON_DISABLE_LINE_INFO=1" >> "${GITHUB_ENV}"
 
       - name: Install pip dependencies
         run: |
@@ -168,13 +160,11 @@ jobs:
           python3 -m pip install wheel cmake==3.24 ninja pytest-xdist lit
 
       - name: Install Triton
-        if: ${{ env.BACKEND == 'CUDA'}}
         run: |
           cd python
-          TRITON_BUILD_WITH_CLANG_LLD=true TRITON_BUILD_WITH_CCACHE=true python3 -m pip install --no-build-isolation -vvv '.[tests]'
+          TRITON_BUILD_WITH_CCACHE=true python3 -m pip install --no-build-isolation -vvv '.[tests]'
 
       - name: Run lit tests
-        if: ${{ env.BACKEND == 'CUDA'}}
         run: |
           cd python
           LIT_TEST_DIR="build/$(ls build | grep -i cmake)/test"
@@ -184,7 +174,6 @@ jobs:
           lit -v "${LIT_TEST_DIR}"
 
       - name: Run python tests on CUDA
-        if: ${{ env.BACKEND == 'CUDA' }}
         run: |
           cd python/test/unit
           python3 -m pytest -vvv -n 8 --ignore=hopper/test_flashattention.py --ignore=runtime --ignore=operators --ignore=language/test_line_info.py --ignore=language/test_subprocess.py
@@ -206,13 +195,11 @@ jobs:
            language/test_random.py operators/test_flash_attention.py::test_op --device cpu
 
       - name: Run partial tests on CUDA
-        if: ${{ env.BACKEND == 'CUDA' }}
         run: |
           cd python/test/unit
           python3 -m pytest -vvv -n 8 operators
 
       - name: Run CXX unittests
-        if: ${{ env.BACKEND == 'CUDA'}}
         run: |
           cd python
           cd "build/$(ls build | grep -i cmake)"
@@ -275,21 +262,17 @@ jobs:
           mkdir -p ~/.triton
           ls -alh ~/.triton
 
-      - name: Set ROCM ENV
-        run: |
-          echo "BACKEND=ROCM" >> "${GITHUB_ENV}"
-
       - name: Update PATH
         run: |
-          echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
+          echo "/opt/rocm/llvm/bin:$PATH" >> $GITHUB_PATH
 
       - name: Install Triton on ROCM
         run: |
           pip uninstall -y triton
           export PATH="/opt/rocm/llvm/bin:$PATH"
-          export TRITON_BUILD_WITH_CLANG_LLD=true
           cd python
           pip install -v -e .
+
       - name: Run python tests on ROCM
         run: |
           cd python


### PR DESCRIPTION
We have separate paths for AMD and NVIDIA backends in the integration tests so the if conditions for the NVIDIA part is just dead code.

Also unified environment variables into global scope when possible; and updated `$PATH` handling.