### PR TITLE
[AUTOTUNER] Pass `kwargs` to `early_config_prune` callback

### DIFF
--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -474,7 +474,7 @@ private:
 
   /// Computes the shared memory offsets for all related values.
   /// Paper: Algorithms for Compile-Time Memory Optimization
-  /// (https://www.cs.utexas.edu/users/harrison/papers/compile-time.pdf)
+  /// (https://dl.acm.org/doi/pdf/10.5555/314500.315082)
   void computeOffsets() {
     SmallVector<BufferT *> buffers;
     for (auto bufferIter : bufferRange) {

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -53,7 +53,7 @@ def test_prune_configs(with_perf_model: bool):
         records['run_early_config_prune'] = True
         if "N" in kwargs and kwargs["N"] == 1024:
             records['capture_kwargs'] = True
-        if "dst" in named_args and "src" in named_args:
+        if "dst" in named_args and "src" in named_args and len(named_args) == 2:
             records['capture_named_args'] = True
         return [configs[0]]
 

--- a/python/test/unit/runtime/test_autotuner.py
+++ b/python/test/unit/runtime/test_autotuner.py
@@ -49,8 +49,12 @@ def test_prune_configs(with_perf_model: bool):
     dst = torch.empty(N, device='cuda')
     records = {}
 
-    def early_config_prune(configs, named_args):
+    def early_config_prune(configs, named_args, **kwargs):
         records['run_early_config_prune'] = True
+        if "N" in kwargs and kwargs["N"] == 1024:
+            records['capture_kwargs'] = True
+        if "dst" in named_args and "src" in named_args:
+            records['capture_named_args'] = True
         return [configs[0]]
 
     def perf_model(*args, **kwargs):
@@ -72,10 +76,13 @@ def test_prune_configs(with_perf_model: bool):
         tl.store(dst + offsets, x, mask=offsets < N)
 
     grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE']), )
-    _kernel[grid](dst, src, N)
+    _kernel[grid](dst, src, N=N)
     torch.testing.assert_close(src, dst)
-    assert len(records) == 1
     if with_perf_model:
+        assert len(records) == 1
         assert records['run_perf_model']
     else:
+        assert len(records) == 3
         assert records['run_early_config_prune']
+        assert records['capture_kwargs']
+        assert records['capture_named_args']

--- a/python/triton/ops/matmul_perf_model.py
+++ b/python/triton/ops/matmul_perf_model.py
@@ -97,7 +97,7 @@ def estimate_matmul_time(
     return total_time_ms
 
 
-def early_config_prune(configs, named_args):
+def early_config_prune(configs, named_args, **kwargs):
     device = torch.cuda.current_device()
     capability = torch.cuda.get_device_capability()
     # BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, num_warps, num_stages

--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -165,7 +165,7 @@ class Autotuner(KernelInterface):
     def prune_configs(self, kwargs):
         pruned_configs = self.configs
         if self.early_config_prune:
-            pruned_configs = self.early_config_prune(self.configs, self.nargs)
+            pruned_configs = self.early_config_prune(self.configs, self.nargs, **kwargs)
         if self.perf_model:
             top_k = self.configs_top_k
             if isinstance(top_k, float) and top_k <= 1.0:


### PR DESCRIPTION
Otherwise any variables passed with `<name>=<value>` are not visible in the `early_config_prune` callback