### PR TITLE
[BACKEND][AMDGPU] Use full-vectorized load instructions for load vectorization

### DIFF
--- a/test/Conversion/amd/load_store.mlir
+++ b/test/Conversion/amd/load_store.mlir
@@ -1,0 +1,29 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm | FileCheck %s
+
+#blocked0 = #triton_gpu.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {
+  // CHECK-LABEL: global_load_store_vec8
+    tt.func @global_load_store_vec8(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg2: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %arg3: i32) {
+    %c256_i32 = arith.constant 256 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = arith.muli %0, %c256_i32 : i32
+    %2 = tt.make_range {end = 256 : i32, start = 0 : i32} : tensor<256xi32, #blocked0>
+    %3 = tt.splat %1 : i32 -> tensor<256xi32, #blocked0>
+    %4 = arith.addi %3, %2 : tensor<256xi32, #blocked0>
+    %5 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked0>
+    %6 = tt.addptr %5, %4 : tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xi32, #blocked0>
+    %7 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked0>
+    %8 = tt.addptr %7, %4 : tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xi32, #blocked0>
+    // Load 8 elements from A with two vectorized load instruction
+    // CHECK-COUNT-2: llvm.load {{.*}} : !llvm.ptr -> vector<4xf32>
+    %9 = tt.load %6 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x!tt.ptr<f32>, #blocked0>
+    // Load 8 elements from B with two vectorized load instruction
+    // CHECK-COUNT-2: llvm.load {{.*}} : !llvm.ptr -> vector<4xf32>
+    %10 = tt.load %8 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<256x!tt.ptr<f32>, #blocked0>
+    %11 = arith.addf %9, %10 : tensor<256xf32, #blocked0>
+    %12 = tt.splat %arg2 : !tt.ptr<f32> -> tensor<256x!tt.ptr<f32>, #blocked0>
+    %13 = tt.addptr %12, %4 : tensor<256x!tt.ptr<f32>, #blocked0>, tensor<256xi32, #blocked0>
+    tt.store %13, %11 : tensor<256x!tt.ptr<f32>, #blocked0>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -202,44 +202,41 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
       assert(wordNElems * nWords * numVecs == numElems);
 
       Value pred = mask ? maskElems[vecStart] : int_val(1, 1);
-      for (size_t wordIdx = 0; wordIdx < nWords; ++wordIdx) {
-        size_t elemOffset = vecStart + wordIdx * wordNElems;
-        Type int_ty = IntegerType::get(getContext(), width);
-        Value ptr = addrspacecast(ptr_ty(getContext()), ptrElems[elemOffset]);
-        auto loaded = rewriter.create<scf::IfOp>(
-            loc, pred,
-            [&](OpBuilder &builder, Location loc) {
-              auto loadVal = builder.create<LLVM::LoadOp>(loc, int_ty, ptr);
-              builder.create<mlir::scf::YieldOp>(loc, ValueRange({loadVal}));
-            },
-            [&](OpBuilder &builder, Location loc) {
-              Value zeroVal = int_val(width, 0);
-              Value otherVal;
-              if (other) {
-                auto vecTy = LLVM::getFixedVectorType(valueElemTy, wordNElems);
-                Value v = undef(vecTy);
-                for (size_t s = 0; s < wordNElems; ++s) {
-                  Value falseVal = otherElems[elemOffset + s];
-                  Value sVal = createIndexAttrConstant(
-                      rewriter, loc, this->getTypeConverter()->getIndexType(),
-                      s);
-                  v = insert_element(vecTy, v, falseVal, sVal);
-                }
-                otherVal = bitcast(v, IntegerType::get(getContext(), width));
+      auto vecTy = LLVM::getFixedVectorType(valueElemTy, vec);
+      auto loaded = rewriter.create<scf::IfOp>(
+          loc, pred,
+          [&](OpBuilder &builder, Location loc) {
+            Value ptr = addrspacecast(ptr_ty(getContext()), ptrElems[vecStart]);
+            auto loadVal = rewriter.create<LLVM::LoadOp>(loc, vecTy, ptr);
+            builder.create<mlir::scf::YieldOp>(loc, ValueRange({loadVal}));
+          },
+          [&](OpBuilder &builder, Location loc) {
+            mlir::Attribute zero = builder.getZeroAttr(valueElemTy);
+            auto denseValue =
+                DenseElementsAttr::get(vecTy.cast<mlir::ShapedType>(), zero);
+            Value zeroVal =
+                rewriter.create<LLVM::ConstantOp>(loc, vecTy, denseValue);
+            Value otherVal;
+            if (other) {
+              Value v = undef(vecTy);
+              for (size_t s = 0; s < vec; ++s) {
+                Value falseVal = otherElems[vecStart + s];
+                Value sVal = createIndexAttrConstant(
+                    rewriter, loc, this->getTypeConverter()->getIndexType(), s);
+                v = insert_element(vecTy, v, falseVal, sVal);
               }
-              Value falseVal = other ? otherVal : zeroVal;
-              builder.create<mlir::scf::YieldOp>(loc, ValueRange({falseVal}));
-            });
-        Value loadVal =
-            bitcast(loaded->getResult(0),
-                    LLVM::getFixedVectorType(valueElemTy, wordNElems));
-        for (size_t ii = 0; ii < wordNElems; ++ii) {
-          Value vecIdx = createIndexAttrConstant(
-              rewriter, loc, this->getTypeConverter()->getIndexType(),
-              ii % wordNElems);
-          Value loaded = extract_element(valueElemTy, loadVal, vecIdx);
-          loadedVals.push_back(loaded);
-        }
+              otherVal = v;
+            }
+            Value falseVal = other ? otherVal : zeroVal;
+            builder.create<mlir::scf::YieldOp>(loc, ValueRange({falseVal}));
+          });
+
+      Value loadVal = bitcast(loaded->getResult(0), vecTy);
+      for (size_t ii = 0; ii < vec; ++ii) {
+        Value vecIdx = createIndexAttrConstant(
+            rewriter, loc, this->getTypeConverter()->getIndexType(), ii % vec);
+        Value loaded = extract_element(valueElemTy, loadVal, vecIdx);
+        loadedVals.push_back(loaded);
       }
     } // end vec
 


### PR DESCRIPTION
Current implementation for load vectorization uses segmented short-vectorized loads instead of a full 128-bit load. Using multiple copies of shorter load creates a dependency on the LLVM backend (esp. the load and store vectorizer) for full vectorization. This could be fragile as I saw in some cases the vector combine pass and the jump threading pass screwed it up and resulted in non-ideal vectorization

This is a backport of https://github.com/ROCm/triton/pull/445/