### PR TITLE
[AMD] Enable test_matmul on CI and fix test_subproc on MI300

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -309,8 +309,7 @@ jobs:
       - name: Run partial tests on HIP
         run: |
           cd python/test/unit
-          python3 -m pytest -vvv -n 8 operators --ignore=operators/test_matmul.py \
-                                                --ignore=operators/test_blocksparse.py
+          python3 -m pytest -vvv -n 8 operators --ignore=operators/test_blocksparse.py
 
       - name: Run C++ unittests
         run: |

--- a/python/test/unit/operators/test_matmul.py
+++ b/python/test/unit/operators/test_matmul.py
@@ -177,7 +177,7 @@ def test_op(BLOCK_M, BLOCK_N, BLOCK_K, SPLIT_K, NWARP, NSTAGE, M, N, K, AT, BT, 
 
     if is_hip():
         if INPUT_PRECISION == 'tf32x3' or is_fp8(ADTYPE) or is_fp8(BDTYPE):
-            pytest.skip("Skip fp8 inputs and tf32x3 precison on hip")
+            pytest.skip("fp8 inputs or tf32x3 precison does not have native support on hip")
     # allocate/transpose inputs
     a = init_input(M, K, ADTYPE, ACC_DTYPE)
     b = init_input(K, N, BDTYPE, ACC_DTYPE)

--- a/python/test/unit/runtime/test_subproc.py
+++ b/python/test/unit/runtime/test_subproc.py
@@ -10,6 +10,8 @@ from triton.compiler import ASTSource
 
 tmpdir = ".tmp"
 
+target = triton.runtime.driver.active.get_current_target()
+
 
 def reset_tmp_dir():
     os.environ["TRITON_CACHE_DIR"] = tmpdir
@@ -30,7 +32,7 @@ def compile_fn(attrs, capability):
         signature={0: "*fp32", 1: "*fp32", 2: "*fp32"},
         attrs=attrs,
     )
-    triton.compile(src=src, target=("cuda", capability))
+    triton.compile(src=src, target=target)
 
 
 def test_compile_in_subproc() -> None:
@@ -55,7 +57,7 @@ def compile_fn_dot(attrs, capability):
         tl.store(Z + offs, z)
 
     src = ASTSource(fn=kernel_dot, signature={0: "*fp32"}, attrs=attrs, constants=dict())
-    triton.compile(src=src, target=("cuda", capability))
+    triton.compile(src=src, target=target)
 
 
 def test_compile_in_forked_subproc() -> None:


### PR DESCRIPTION
This PR 
- enables test_matmul by skipping fp8 input and tf32x3.
- fixes test_subproc on MI300.