### PR TITLE
[backend][amd] Enable line info test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -299,6 +299,8 @@ jobs:
                  --ignore=language/test_reproducer.py \
                  --ignore=language/test_conversions.py \
                  --ignore=language/test_line_info.py
+          # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
+          TRITON_DISABLE_LINE_INFO=0 python3 -m pytest -vvv -n 8 language/test_line_info.py
 
           # Run runtime tests serially to avoid race condition with cache handling
           python3 -m pytest -vvv runtime

--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -6,7 +6,6 @@ import torch
 
 import triton
 import triton.language as tl
-from triton.backends.nvidia.compiler import _path_to_binary
 
 
 @triton.jit
@@ -68,18 +67,43 @@ def kernel_dot_combine(x):
     tl.device_print("", d)
 
 
-def extract_file_lines(asm):
-    nvdisasm, _ = _path_to_binary("nvdisasm")
+def get_disassembler_command_and_debug_line_format():
+    """Gets backend specific disassembler information.
+
+    Returns a tuple: (object file kind, disassembler tool command,
+    debug line anchor, debug line file and line number separator).
+    """
+    backend = triton.runtime.driver.active.get_current_target()[0]
+
+    if backend == "cuda":
+        from triton.backends.nvidia.compiler import _path_to_binary
+        nvdisasm, _ = _path_to_binary("nvdisasm")
+        return ("cubin", [nvdisasm, "-g"], "## File", ",")
+
+    if backend == "hip":
+        import shutil
+        # Try to find llvm-objdump from the current PATH to disassmble hsaco.
+        tool = shutil.which("llvm-objdump")
+        if tool is not None:
+            return ("hsaco", [tool, "-D", "-l", "--arch=amdgcn"], ";", ":")
+        raise RuntimeError("llvm-objdump not found in PATH")
+
+    raise RuntimeError(f"unknown backend {backend}")
+
+
+def extract_file_lines(command, anchor, separator, asm):
     fd, path = tempfile.mkstemp()
     with open(fd, 'wb') as cubin:
         cubin.write(asm)
-    asm = subprocess.check_output([nvdisasm, "-g", path]).decode("utf-8")
+    asm = subprocess.check_output(command + [path]).decode("utf-8")
     file_lines = []
     lines = asm.splitlines()
     for line in lines:
-        if "## File" in line:
-            entries = line[line.index("## File"):].split(",")
-            file_lines.append((entries[0].strip(), entries[1].strip()))
+        # We are looking for an anchor string and a separator between the file name and line number.
+        if anchor in line and separator in line:
+            entries = line[line.index(anchor):].split(separator)
+            if len(entries) == 2 and all(len(e) != 0 for e in entries):
+                file_lines.append((entries[0].strip(), entries[1].strip()))
     return file_lines
 
 
@@ -108,9 +132,9 @@ func_types = ["single", "call", "call_noinline", "autotune", "dot_combine"]
 @pytest.mark.parametrize("func", func_types)
 def test_line_info(func: str):
     try:
-        _, _ = _path_to_binary("nvdisasm")
+        obj_kind, command, anchor, separator = get_disassembler_command_and_debug_line_format()
     except BaseException:
-        pytest.skip("nvdisasm is not available")
+        pytest.skip("disassembler is not available")
 
     shape = (128, )
     kernel_info = {}
@@ -125,24 +149,23 @@ def test_line_info(func: str):
     elif func == "dot_combine":
         kernel_info = kernel_dot_combine.warmup(20, grid=(1,))
 
-    file_lines = extract_file_lines(kernel_info.asm["cubin"])
+    file_lines = extract_file_lines(command, anchor, separator, kernel_info.asm[obj_kind])
     if func == "single":
+        assert (check_file_lines(file_lines, "test_line_info.py", 15))
         assert (check_file_lines(file_lines, "test_line_info.py", 16))
-        assert (check_file_lines(file_lines, "test_line_info.py", 17))
     elif func == "call":
-        assert (check_file_lines(file_lines, "test_line_info.py", 29))
-        assert (check_file_lines(file_lines, "test_line_info.py", 22))
-        assert (check_file_lines(file_lines, "test_line_info.py", 31))
+        assert (check_file_lines(file_lines, "test_line_info.py", 28))
+        assert (check_file_lines(file_lines, "test_line_info.py", 21))
+        assert (check_file_lines(file_lines, "test_line_info.py", 30))
     elif func == "call_noinline":
-        assert (check_file_lines(file_lines, "test_line_info.py", 43))
+        assert (check_file_lines(file_lines, "test_line_info.py", 42))
+        assert (check_file_lines(file_lines, "test_line_info.py", 35))
         assert (check_file_lines(file_lines, "test_line_info.py", 36))
         assert (check_file_lines(file_lines, "test_line_info.py", 37))
-        assert (check_file_lines(file_lines, "test_line_info.py", 38))
     elif func == "autotune":
         assert (check_file_lines(file_lines, "test_line_info.py", 53))
         assert (check_file_lines(file_lines, "test_line_info.py", 54))
         assert (check_file_lines(file_lines, "test_line_info.py", 55))
-        assert (check_file_lines(file_lines, "test_line_info.py", 56))
     elif func == "dot_combine":
-        assert (check_file_lines(file_lines, "test_line_info.py", 66))
-        assert (check_file_lines(file_lines, "test_line_info.py", 67, should_contain=False))
+        assert (check_file_lines(file_lines, "test_line_info.py", 65))
+        assert (check_file_lines(file_lines, "test_line_info.py", 66, should_contain=False))


### PR DESCRIPTION
This commit enables test_line_info.py. It's mostly about finding the proper disassembler for hsaco and disassemble it with the necessary command line options.