### PR TITLE
Micro-optimizations to improve kernel launch latency

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations, division
 import ast
+import functools
 import hashlib
 import inspect
 import itertools
@@ -281,6 +282,7 @@ class JITFunction(KernelInterface[T]):
         # equal_to_1)
 
     @staticmethod
+    @functools.lru_cache(None)
     def _type_of(key, is_const=False):
         # `None` is nullptr.  Implicitly convert to *i8.
         if key is None:

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -416,7 +416,7 @@ class JITFunction(KernelInterface[T]):
         # compute cache key
         args = [KernelArg(arg_value, param) for (_, arg_value), param in zip(bound_args.arguments.items(), self.params)]
         signature = {arg.param.name: arg.mangled_type() for arg in args if not arg.param.is_constexpr}
-        sig_key = signature.values()
+        sig_key = tuple(signature.values())
         spec_key = tuple(arg.specialization_key() for arg in args if not arg.param.do_not_specialize)
         constexpr_key = tuple(arg.value for arg in args if arg.param.is_constexpr)
         key = (sig_key, constexpr_key, spec_key, options)

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -73,12 +73,12 @@ class CUDAOptions:
     max_num_imprecise_acc_default: bool = None
     extern_libs: dict = None
     debug: bool = False
+    default_libdevice_path: str = str(Path(__file__).parent / 'lib' / 'libdevice.10.bc')
 
     def __post_init__(self):
-        default_libdir = Path(__file__).parent / 'lib'
         extern_libs = dict() if self.extern_libs is None else dict(self.extern_libs)
         if not extern_libs.get('libdevice', None):
-            extern_libs['libdevice'] = os.getenv("TRITON_LIBDEVICE_PATH", str(default_libdir / 'libdevice.10.bc'))
+            extern_libs['libdevice'] = os.getenv("TRITON_LIBDEVICE_PATH", self.default_libdevice_path)
         object.__setattr__(self, 'extern_libs', tuple(extern_libs.items()))
         assert self.num_warps > 0 and (self.num_warps & (self.num_warps - 1)) == 0, \
                "num_warps must be a power of 2"


### PR DESCRIPTION
A few recent refactors & checks added some latency to the kernel launch path.  These are a few very simple fixes to claw back ~200us or so of latency (370->170).  Still not fantastic but more in line with what we had as of a few months ago.