### PR TITLE
[AMD backend] enable atomic memory ordering in lowering atomic ops

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1493,8 +1493,8 @@ def test_atomic_cas(sem, num_ctas, device):
 
     Lock = torch.zeros((1, ), device=device, dtype=torch.int32)
     data = torch.zeros((128, ), device=device, dtype=torch.float32)
-    ref = torch.full((128, ), 64.0)
-    h = serialized_add[(64, )](data, Lock, SEM=sem, num_ctas=num_ctas)
+    ref = torch.full((128, ), 2000.0)
+    h = serialized_add[(2000, )](data, Lock, SEM=sem, num_ctas=num_ctas)
     sem_str = "acq_rel" if sem is None else sem
     np.testing.assert_allclose(to_numpy(data), to_numpy(ref))
     if not is_cuda():

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -361,6 +361,21 @@ void createBarrier(ConversionPatternRewriter &rewriter, Location loc,
 }
 } // namespace
 
+static LLVM::AtomicOrdering llvmMemoryOrdering(MemSemantic memOrdering) {
+  const static std::map<MemSemantic, LLVM::AtomicOrdering> memOrderingMap = {
+    {MemSemantic::RELAXED, LLVM::AtomicOrdering::monotonic},
+    {MemSemantic::ACQUIRE, LLVM::AtomicOrdering::acquire},
+    {MemSemantic::RELEASE, LLVM::AtomicOrdering::release},
+    {MemSemantic::ACQUIRE_RELEASE, LLVM::AtomicOrdering::acq_rel}
+  };
+
+  if (memOrderingMap.count(memOrdering) > 0) {
+    return memOrderingMap.at(memOrdering);
+  }
+
+  return LLVM::AtomicOrdering::acq_rel;
+}
+
 struct AtomicCASOpConversion
     : public ConvertOpToLLVMPattern<triton::AtomicCASOp>,
       public LoadStoreConversionBase {
@@ -388,6 +403,9 @@ struct AtomicCASOpConversion
     auto ptrElements = unpackLLElements(loc, llPtr, rewriter);
     auto cmpElements = unpackLLElements(loc, llCmp, rewriter);
     auto valElements = unpackLLElements(loc, llVal, rewriter);
+
+    auto memOrdering = op.getSem();
+    auto atomicMemOrdering = llvmMemoryOrdering(memOrdering);
 
     // deal with tensor or scalar
     auto valueTy = op.getResult().getType();
@@ -426,7 +444,7 @@ struct AtomicCASOpConversion
       if (TensorTy) { // for tensor
         auto retType = vec == 1 ? valueElemTy : vecTy;
         // TODO: USE ATOMIC CAS OP on Tensor
-        auto successOrdering = LLVM::AtomicOrdering::acq_rel;
+        auto successOrdering = atomicMemOrdering;
         auto failureOrdering = LLVM::AtomicOrdering::monotonic;
         auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
             loc, casPtr, casCmp, casVal, successOrdering, failureOrdering,
@@ -575,6 +593,9 @@ struct AtomicRMWOpConversion
     mask = and_(mask,
                 icmp_slt(mul(tid, i32_val(elemsPerThread)), i32_val(numElems)));
 
+    auto memOrdering = op.getSem();
+    auto atomicMemOrdering = llvmMemoryOrdering(memOrdering);
+
     auto vecTy = vec_ty(valueElemTy, vec);
     auto retType = vec == 1 ? valueElemTy : vecTy;
     SmallVector<Value> resultVals(elemsPerThread);
@@ -604,7 +625,7 @@ struct AtomicRMWOpConversion
       Value atom = rewriter
                        .create<LLVM::AtomicRMWOp>(
                            loc, *maybeKind, rmwPtr, valElements[i],
-                           LLVM::AtomicOrdering::monotonic, StringRef("agent"))
+                           atomicMemOrdering, StringRef("agent"))
                        .getResult();
 
       // NV for the f16v2 case generates one packed instruction. We have to
@@ -615,7 +636,7 @@ struct AtomicRMWOpConversion
             rewriter
                 .create<LLVM::AtomicRMWOp>(
                     loc, *maybeKind, ptrElements[i + 1], valElements[i + 1],
-                    LLVM::AtomicOrdering::monotonic, StringRef("agent"))
+                    atomicMemOrdering, StringRef("agent"))
                 .getResult();
         auto tmp = insert_element(vecTy, undef(vecTy), atom, i32_val(0));
         atom = insert_element(vecTy, tmp, atom2, i32_val(1)).getResult();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -362,18 +362,18 @@ void createBarrier(ConversionPatternRewriter &rewriter, Location loc,
 } // namespace
 
 static LLVM::AtomicOrdering llvmMemoryOrdering(MemSemantic memOrdering) {
-  const static std::map<MemSemantic, LLVM::AtomicOrdering> memOrderingMap = {
-    {MemSemantic::RELAXED, LLVM::AtomicOrdering::monotonic},
-    {MemSemantic::ACQUIRE, LLVM::AtomicOrdering::acquire},
-    {MemSemantic::RELEASE, LLVM::AtomicOrdering::release},
-    {MemSemantic::ACQUIRE_RELEASE, LLVM::AtomicOrdering::acq_rel}
-  };
-
-  if (memOrderingMap.count(memOrdering) > 0) {
-    return memOrderingMap.at(memOrdering);
+  switch (memOrdering) {
+  case MemSemantic::RELAXED:
+    return LLVM::AtomicOrdering::monotonic;
+  case MemSemantic::ACQUIRE:
+    return LLVM::AtomicOrdering::acquire;
+  case MemSemantic::RELEASE:
+    return LLVM::AtomicOrdering::release;
+  case MemSemantic::ACQUIRE_RELEASE:
+    return LLVM::AtomicOrdering::acq_rel;
+  default:
+    return LLVM::AtomicOrdering::acq_rel;
   }
-
-  return LLVM::AtomicOrdering::acq_rel;
 }
 
 struct AtomicCASOpConversion

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -361,7 +361,7 @@ void createBarrier(ConversionPatternRewriter &rewriter, Location loc,
 }
 } // namespace
 
-static LLVM::AtomicOrdering llvmMemoryOrdering(MemSemantic memOrdering) {
+static LLVM::AtomicOrdering getMemoryOrdering(MemSemantic memOrdering) {
   switch (memOrdering) {
   case MemSemantic::RELAXED:
     return LLVM::AtomicOrdering::monotonic;
@@ -405,7 +405,7 @@ struct AtomicCASOpConversion
     auto valElements = unpackLLElements(loc, llVal, rewriter);
 
     auto memOrdering = op.getSem();
-    auto atomicMemOrdering = llvmMemoryOrdering(memOrdering);
+    auto atomicMemOrdering = getMemoryOrdering(memOrdering);
 
     // deal with tensor or scalar
     auto valueTy = op.getResult().getType();
@@ -594,7 +594,7 @@ struct AtomicRMWOpConversion
                 icmp_slt(mul(tid, i32_val(elemsPerThread)), i32_val(numElems)));
 
     auto memOrdering = op.getSem();
-    auto atomicMemOrdering = llvmMemoryOrdering(memOrdering);
+    auto atomicMemOrdering = getMemoryOrdering(memOrdering);
 
     auto vecTy = vec_ty(valueElemTy, vec);
     auto retType = vec == 1 ? valueElemTy : vecTy;


### PR DESCRIPTION
This PR is to turn on the memory ordering in lowering the atomic ops and fix the UT `test_core.py::test_atomic_cas`. Also increased the number blocks in the kernel of the test for more pressure.