### PR TITLE
[PIPELINER] Schedule verifier improvements

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
@@ -215,8 +215,7 @@ bool LoopPipelinerInternal::initializeLoopInfo(
   return true;
 }
 
-/// Find Values that are defined by the block containing the `op` and used by
-/// it or any nested operation - set of operands of anything within the `op`.
+/// Find operands of all the nested operations within `op`.
 static SetVector<Value> getNestedOperands(Operation *op) {
   SetVector<Value> operands;
   op->walk([&](Operation *nestedOp) {

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
@@ -217,12 +217,11 @@ bool LoopPipelinerInternal::initializeLoopInfo(
 
 /// Find Values that are defined by the block containing the `op` and used by
 /// it or any nested operation - set of operands of anything within the `op`.
-static SmallVector<Value> getNestedOperands(Operation *op) {
-  SmallVector<Value> operands;
+static SetVector<Value> getNestedOperands(Operation *op) {
+  SetVector<Value> operands;
   op->walk([&](Operation *nestedOp) {
     for (Value operand : nestedOp->getOperands()) {
-      if (operand.getParentBlock()->getParentOp()->isAncestor(nestedOp))
-        operands.push_back(operand);
+      operands.insert(operand);
     }
   });
   return operands;


### PR DESCRIPTION
Verifier was not catching the cases where the improperly scheduled op was nested in another op - so far we were looking only at the top level operations.
I have checked the perf tests to make sure we are not preventing any currently pipelined kernels from pipelining. Everything looks green.