### PR TITLE
[AMD] Hint the compiler to preload kernel arguments

### DIFF
--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -157,16 +157,6 @@ void init_triton_llvm(py::module &&m) {
       .def("set_calling_conv", &llvm::Function::setCallingConv)
       .def("add_fn_attr", [](llvm::Function *fn, std::string &name,
                              std::string &val) { fn->addFnAttr(name, val); })
-      .def("set_fn_arg_inreg",
-           [](llvm::Function *fn) {
-             for (unsigned I = 0; I < fn->arg_size(); ++I) {
-               Argument &Arg = *fn->getArg(I);
-               // Check for incompatible attributes.
-               if (Arg.hasByRefAttr() || Arg.hasNestAttr())
-                 break;
-               Arg.addAttr(llvm::Attribute::InReg);
-             }
-           })
       .def("has_public_visibility",
            [](llvm::Function *fn) {
              return fn->getVisibility() == llvm::GlobalValue::DefaultVisibility;

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -157,6 +157,16 @@ void init_triton_llvm(py::module &&m) {
       .def("set_calling_conv", &llvm::Function::setCallingConv)
       .def("add_fn_attr", [](llvm::Function *fn, std::string &name,
                              std::string &val) { fn->addFnAttr(name, val); })
+      .def("set_fn_arg_inreg",
+           [](llvm::Function *fn) {
+             for (unsigned I = 0; I < fn->arg_size(); ++I) {
+               Argument &Arg = *fn->getArg(I);
+               // Check for incompatible attributes.
+               if (Arg.hasByRefAttr() || Arg.hasNestAttr())
+                 break;
+               Arg.addAttr(llvm::Attribute::InReg);
+             }
+           })
       .def("has_public_visibility",
            [](llvm::Function *fn) {
              return fn->getVisibility() == llvm::GlobalValue::DefaultVisibility;

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -204,7 +204,7 @@ class HIPBackend(BaseBackend):
         # Hint the compiler that we'd like the firmware to set the kernel arguments
         # to user SGPRs so that the kernel does not need to s_load its arguments
         # from memory.
-        kernels[0].set_fn_arg_inreg()
+        amd.set_fn_arg_inreg(kernels[0])
 
         if options.extern_libs:
             paths = [path for (name, path) in options.extern_libs]

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -204,7 +204,7 @@ class HIPBackend(BaseBackend):
         # Hint the compiler that we'd like the firmware to set the kernel arguments
         # to user SGPRs so that the kernel does not need to s_load its arguments
         # from memory.
-        amd.set_fn_arg_inreg(kernels[0])
+        amd.set_all_fn_arg_inreg(kernels[0])
 
         if options.extern_libs:
             paths = [path for (name, path) in options.extern_libs]

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -201,6 +201,10 @@ class HIPBackend(BaseBackend):
         kernels[0].add_fn_attr("amdgpu-flat-work-group-size", f"1,{options.num_warps*options.warp_size}")
         kernels[0].add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}")
         kernels[0].add_fn_attr("denormal-fp-math-f32", "preserve-sign")
+        # Hint the compiler that we'd like the firmware to set the kernel arguments
+        # to user SGPRs so that the kernel does not need to s_load its arguments
+        # from memory.
+        kernels[0].set_fn_arg_inreg()
 
         if options.extern_libs:
             paths = [path for (name, path) in options.extern_libs]

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -200,4 +200,14 @@ void init_triton_amd(py::module &&m) {
         return py::bytes(std::string(result.begin(), result.end()));
       },
       py::return_value_policy::take_ownership);
+
+  m.def("set_fn_arg_inreg", [](llvm::Function *fn) {
+    for (unsigned I = 0; I < fn->arg_size(); ++I) {
+      llvm::Argument &Arg = *fn->getArg(I);
+      // Check for incompatible attributes.
+      if (Arg.hasByRefAttr() || Arg.hasNestAttr())
+        break;
+      Arg.addAttr(llvm::Attribute::InReg);
+    }
+  });
 }

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -201,13 +201,12 @@ void init_triton_amd(py::module &&m) {
       },
       py::return_value_policy::take_ownership);
 
-  m.def("set_fn_arg_inreg", [](llvm::Function *fn) {
-    for (unsigned I = 0; I < fn->arg_size(); ++I) {
-      llvm::Argument &Arg = *fn->getArg(I);
+  m.def("set_all_fn_arg_inreg", [](llvm::Function *fn) {
+    for (llvm::Argument &arg : fn->args()) {
       // Check for incompatible attributes.
-      if (Arg.hasByRefAttr() || Arg.hasNestAttr())
-        break;
-      Arg.addAttr(llvm::Attribute::InReg);
+      if (arg.hasByRefAttr() || arg.hasNestAttr())
+        continue;
+      arg.addAttr(llvm::Attribute::InReg);
     }
   });
 }


### PR DESCRIPTION
This PR adds `InReg` attributes to all kernel arguments. This tells the backend compiler to try to set things up so that the firmware will set kernel args to user SGPRs instead of using `s_load` at the beginning of the kernel.
Note that though we set `InReg` to all kernel args,  the backend compiler will decide the actual number of args that can be pre-set.

Performance context: this PR can improve kernel execution time by about 5 ~ 10 us.