### PR TITLE
Enable MLIR_ENABLE_DIAGNOSTICS for pm.run

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1575,6 +1575,19 @@ void init_triton_ir(py::module &&m) {
         if (triton::tools::getBoolEnv("TRITON_ENABLE_LLVM_DEBUG")) {
           ::llvm::DebugFlag = true;
         }
+
+        auto *context = self.getContext();
+        bool haveDiagnostics =
+            ::triton::tools::getBoolEnv("MLIR_ENABLE_DIAGNOSTICS");
+        if (haveDiagnostics) {
+          context->printOpOnDiagnostic(true);
+          context->printStackTraceOnDiagnostic(true);
+          context->getDiagEngine().registerHandler([](Diagnostic &diag) {
+            llvm::outs() << diag << "\n";
+            return success();
+          });
+        }
+
         if (failed(self.run(mod.getOperation())))
           throw std::runtime_error("PassManager::run failed");
       });


### PR DESCRIPTION
This enables MLIR diagnostics for Triton's "run" path to running the pass manager.
The reason being that without it, there are MLIR emitError messages that are not displayed.

I am not entirely certain if I could have gotten these diagnostics through the "enable_debug" path, but this change was helpful for me in some of my work when I was reading type errors after the LLIR is generated.