### PR TITLE
[DEBUG] Add support for a Triton envvar to enable LLVM's -debug-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,20 @@ $ ninja -C build && ( cd build ; lit test )
   GPU.  You can insert Python breakpoints in your kernel code!
 - `TRITON_ENABLE_LLVM_DEBUG=1` passes `-debug` to LLVM, printing a lot of
   debugging information to stdout.  If this is too noisy, run with just
+  `TRITON_LLVM_DEBUG_ONLY` instead to limit the output.
+
+  An alternative way to reduce output noisiness is running with
   `LLVM_IR_ENABLE_DUMP=1`, extract the IR before the LLVM pass of interest, and
   then run LLVM's `opt` standalone, perhaps passing `-debug-only=foo` on the
-  command line.
+  command-line.
+- `TRITON_LLVM_DEBUG_ONLY=<comma-separated>` is the equivalent of LLVM's
+  `-debug-only` command-line option. This limits the LLVM debug output to
+  specific pass or component names (which are specified using `#define
+  DEBUG_TYPE` throughout LLVM and Triton) in order to allow the debug output to
+  be less noisy. `TRITON_LLVM_DEBUG_ONLY` allows for one or more comma
+  separated values to be specified (eg
+  `TRITON_LLVM_DEBUG_ONLY="tritongpu-remove-layout-conversions` or
+  `TRITON_LLVM_DEBUG_ONLY="tritongpu-remove-layout-conversions,regalloc"`).
 - `USE_TTGIR_LOC` reparses the ttgir such that the location information will
   be the line number of the ttgir instead of line number of the python file.
   This can provide a direct mapping from ttgir to llir/ptx. When used with

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -26,6 +26,7 @@
 #include <assert.h>
 #include <cstdlib>
 #include <set>
+#include <sstream>
 #include <string>
 
 namespace mlir::triton {


### PR DESCRIPTION
This is for reducing the noise from using TRITON_ENABLE_LLVM_DEBUG.
