### PR TITLE
attempt to substantially reduce kernel launch overhead

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -434,7 +434,7 @@ class JITFunction(KernelInterface[T]):
             self.binder = create_function_from_signature(self.signature)
             self.constexpr_indices = [i for (i, p) in enumerate(self.params) if p.is_constexpr]
             self.non_constexpr_indices = [i for (i, p) in enumerate(self.params) if not p.is_constexpr]
-            self.specialised_indices = [i for (i, p) in enumerate(self.params) if not arg.param.do_not_specialize]
+            self.specialised_indices = [i for (i, p) in enumerate(self.params) if not p.do_not_specialize]
 
         kwargs = {k: v for k, v in kwargs.items() if k not in options.__dict__}
         bound_args = self.binder(*args, **kwargs)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -355,7 +355,6 @@ class JITFunction(KernelInterface[T]):
         elif isinstance(key, str):
             return key
 
-
         dtype_str = str(key).split(".")[-1]
         dtype_str = type_canonicalisation_dict[dtype_str]
         const_str = "k" if is_const else ""

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -357,7 +357,7 @@ class JITFunction(KernelInterface[T]):
 
         dtype_str = str(key).split(".")[-1]
         dtype_str = type_canonicalisation_dict[dtype_str]
-        const_str = "k" if is_const else ""
+        const_str = "*k" if is_const else "*"
         return const_str + dtype_str
 
     def _make_constants(self, constexpr_key):

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -243,7 +243,11 @@ def create_function_from_signature(sig):
     func_body = f"def dynamic_func({args_str}):\n    return {{{dict_str}}}"
 
     # Prepare defaults to be inserted into function namespace
-    func_namespace = {f"default_{name}": param.default for name, param in sig.parameters.items() if param.default is not inspect.Parameter.empty}
+    func_namespace = {
+        f"default_{name}": param.default
+        for name, param in sig.parameters.items()
+        if param.default is not inspect.Parameter.empty
+    }
 
     # Execute the function string in func_namespace to create the function
     exec(func_body, func_namespace)
@@ -454,7 +458,7 @@ class JITFunction(KernelInterface[T]):
         # compute cache key
         args = [KernelArg(arg_value, param) for (_, arg_value), param in zip(bound_args.items(), self.params)]
 
-        signature = {args[i].param.name : args[i].mangled_type() for i in self.non_constexpr_indices}
+        signature = {args[i].param.name: args[i].mangled_type() for i in self.non_constexpr_indices}
         sig_key = tuple(signature.values())
         spec_key = tuple(args[i].specialization_key() for i in self.specialised_indices)
         constexpr_key = tuple(args[i].value for i in self.constexpr_indices)


### PR DESCRIPTION
This improves kernel launch latency by 2.2x (from 108us to 49us using @bertmaher's benchmarking script in issue https://github.com/openai/triton/issues/3619 ). Thanks also to @liboyue's analysis and suggestions.

See the discussion in the third-party PR https://github.com/openai/triton/pull/3503#issuecomment-2047718096