### PR TITLE
[AMD backend] fix test reproducer

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -291,7 +291,6 @@ jobs:
         run: |
           cd python/test/unit
           pytest --capture=tee-sys -rfs -vvv -n 32 language operators \
-                 --ignore=language/test_reproducer.py \
                  --ignore=language/test_conversions.py \
                  --ignore=language/test_line_info.py \
                  --ignore=operators/test_blocksparse.py

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1567,7 +1567,11 @@ void init_triton_ir(py::module &&m) {
         auto reproducerPath = triton::tools::getenv("TRITON_REPRODUCER_PATH");
         if (!reproducerPath.empty()) {
           auto anchorName = self.getOpAnchorName();
+          llvm::outs() << "anchorName = " << anchorName << "\n";
           auto passes = self.getPasses();
+          for (auto& p : passes) {
+            llvm::outs() << "passName = " << p.getName() << "\n";
+          }
           Operation *op = mod.getOperation();
           makeReproducer(anchorName, passes, op, reproducerPath);
         }

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1567,11 +1567,7 @@ void init_triton_ir(py::module &&m) {
         auto reproducerPath = triton::tools::getenv("TRITON_REPRODUCER_PATH");
         if (!reproducerPath.empty()) {
           auto anchorName = self.getOpAnchorName();
-          llvm::outs() << "anchorName = " << anchorName << "\n";
           auto passes = self.getPasses();
-          for (auto& p : passes) {
-            llvm::outs() << "passName = " << p.getName() << "\n";
-          }
           Operation *op = mod.getOperation();
           makeReproducer(anchorName, passes, op, reproducerPath);
         }

--- a/python/test/unit/language/test_reproducer.py
+++ b/python/test/unit/language/test_reproducer.py
@@ -6,6 +6,8 @@ import pytest
 import torch
 import triton
 
+def is_hip():
+    return triton.runtime.driver.active.get_current_target()[0] == "hip"
 
 @triton.jit
 def triton_():
@@ -22,17 +24,20 @@ def test_reproducer():
         os.remove(reproducer)
     os.environ["TRITON_CACHE_DIR"] = tmpdir
     os.environ["TRITON_REPRODUCER_PATH"] = reproducer
-    print(f"tmp_dir = {tmpdir}, reproduer = {reproducer}")
     triton_[(1, )]()
     foundPipeline = ""
     with open(reproducer, 'r') as f:
         line = f.read()
-        print(f"line = {line}")
         if 'pipeline:' in line:
             foundPipeline = line
     if 0 == len(foundPipeline):
         raise Exception("Failed to find pipeline info in reproducer file.")
-    if "convert-triton-amdgpu-to-llvm" not in foundPipeline:
+    ttgir_to_llvm_pass = "convert-triton-"
+    if is_hip():
+        ttgir_to_llvm_pass += "amd"
+    ttgir_to_llvm_pass += "gpu-to-llv"
+
+    if ttgir_to_llvm_pass not in foundPipeline:
         raise Exception("Failed to find triton passes in pipeline")
     # cleanup
     if os.path.exists(tmpdir):

--- a/python/test/unit/language/test_reproducer.py
+++ b/python/test/unit/language/test_reproducer.py
@@ -22,15 +22,17 @@ def test_reproducer():
         os.remove(reproducer)
     os.environ["TRITON_CACHE_DIR"] = tmpdir
     os.environ["TRITON_REPRODUCER_PATH"] = reproducer
+    print(f"tmp_dir = {tmpdir}, reproduer = {reproducer}")
     triton_[(1, )]()
     foundPipeline = ""
     with open(reproducer, 'r') as f:
         line = f.read()
+        print(f"line = {line}")
         if 'pipeline:' in line:
             foundPipeline = line
     if 0 == len(foundPipeline):
         raise Exception("Failed to find pipeline info in reproducer file.")
-    if "convert-triton-gpu-to-llvm" not in foundPipeline:
+    if "convert-triton-amdgpu-to-llvm" not in foundPipeline:
         raise Exception("Failed to find triton passes in pipeline")
     # cleanup
     if os.path.exists(tmpdir):

--- a/python/test/unit/language/test_reproducer.py
+++ b/python/test/unit/language/test_reproducer.py
@@ -6,8 +6,10 @@ import pytest
 import torch
 import triton
 
+
 def is_hip():
     return triton.runtime.driver.active.get_current_target()[0] == "hip"
+
 
 @triton.jit
 def triton_():

--- a/python/test/unit/language/test_reproducer.py
+++ b/python/test/unit/language/test_reproducer.py
@@ -5,10 +5,7 @@ import pytest
 
 import torch
 import triton
-
-
-def is_hip():
-    return triton.runtime.driver.active.get_current_target()[0] == "hip"
+import re
 
 
 @triton.jit
@@ -34,12 +31,9 @@ def test_reproducer():
             foundPipeline = line
     if 0 == len(foundPipeline):
         raise Exception("Failed to find pipeline info in reproducer file.")
-    ttgir_to_llvm_pass = "convert-triton-"
-    if is_hip():
-        ttgir_to_llvm_pass += "amd"
-    ttgir_to_llvm_pass += "gpu-to-llvm"
 
-    if ttgir_to_llvm_pass not in foundPipeline:
+    ttgir_to_llvm_pass = re.compile("convert-triton-{{.*}}gpu-to-llvm")
+    if ttgir_to_llvm_pass.search(foundPipeline):
         raise Exception("Failed to find triton passes in pipeline")
     # cleanup
     if os.path.exists(tmpdir):

--- a/python/test/unit/language/test_reproducer.py
+++ b/python/test/unit/language/test_reproducer.py
@@ -35,7 +35,7 @@ def test_reproducer():
     ttgir_to_llvm_pass = "convert-triton-"
     if is_hip():
         ttgir_to_llvm_pass += "amd"
-    ttgir_to_llvm_pass += "gpu-to-llv"
+    ttgir_to_llvm_pass += "gpu-to-llvm"
 
     if ttgir_to_llvm_pass not in foundPipeline:
         raise Exception("Failed to find triton passes in pipeline")

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -155,18 +155,12 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_decompose_unsupported_conversions(pm)
         passes.convert.add_scf_to_cf(pm)
         passes.convert.add_index_to_llvmir(pm)
-        pm.run(mod)
 
-        pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
         passes.ttgpuir.add_allocate_shared_memory(pm)
         amd.passes.ttgpuir.add_to_llvmir(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
-        pm.run(mod)
 
-        pm = ir.pass_manager(mod.context)
-        pm.enable_debug()
         passes.convert.add_scf_to_cf(pm)
         passes.convert.add_cf_to_llvmir(pm)
         passes.convert.add_arith_to_llvmir(pm)


### PR DESCRIPTION
This PR is to fix the unit test `test_reproducer.py`. 

Reason of the failure is that compiler in amd backend calls the function `pm.run(mod)` multiple times, reproducer is only for the passes in the last call of the function `pm.run(mod)`, so ttgir->llvm pass is not included in the last call. 

Fix is to call the `pm.run(mod)` only once in the function `make_llir()`.