### PR TITLE
[AMD backend] turn on test_blocksparse.py

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -303,8 +303,7 @@ jobs:
           cd python/test/unit
           pytest --capture=tee-sys -rfs -vvv -n 32 language operators \
                  --ignore=language/test_conversions.py \
-                 --ignore=language/test_line_info.py \
-                 --ignore=operators/test_blocksparse.py
+                 --ignore=language/test_line_info.py
           # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
           TRITON_DISABLE_LINE_INFO=0 python3 -m pytest -vvv -n 8 language/test_line_info.py
 

--- a/python/test/unit/operators/test_blocksparse.py
+++ b/python/test/unit/operators/test_blocksparse.py
@@ -92,11 +92,15 @@ def test_matmul(MODE, TRANS_A, TRANS_B, BLOCK, DTYPE, device, Z=3, H=2, M=512, N
     c_tri.backward(dc_tri)
     da_tri = a_tri.grad
     db_tri = b_tri.grad
-    atol = 1e-3 if is_hip() and get_target()[1] == "gfx90a" else 0
+    tol = {}
+    if is_hip() and get_target()[1] == 'gfx90a':
+        tol["atol"] = 1e-3
+        tol["rtol"] = 0
+
     # compare
-    torch.testing.assert_close(c_ref, c_tri, atol=atol, rtol=0)
-    torch.testing.assert_close(da_ref, da_tri, atol=atol, rtol=0)
-    torch.testing.assert_close(db_ref, db_tri, atol=atol, rtol=0)
+    torch.testing.assert_close(c_ref, c_tri, **tol)
+    torch.testing.assert_close(da_ref, da_tri, **tol)
+    torch.testing.assert_close(db_ref, db_tri, **tol)
 
 
 configs = [
@@ -205,9 +209,12 @@ def test_attention_fwd_bwd(
     # comparison
     # print(f"Triton loss {loss} and torch loss {torch_loss}.  Also checking grads...")
     torch.testing.assert_close(loss, torch_loss, atol=1e-3, rtol=0)
-    atol = 1e-3 if is_hip() and get_target()[1] == "gfx90a" else 0
+    tol = {}
+    if is_hip() and get_target()[1] == 'gfx90a':
+        tol["atol"] = 1e-3
+        tol["rtol"] = 0
     for g1, g2 in zip(grads, torch_grads):
-        torch.testing.assert_close(g1, g2, atol=atol, rtol=0)
+        torch.testing.assert_close(g1, g2, **tol)
 
 
 @pytest.mark.parametrize("block", [16, 32, 64])

--- a/python/test/unit/operators/test_blocksparse.py
+++ b/python/test/unit/operators/test_blocksparse.py
@@ -5,6 +5,10 @@ import triton
 import triton.ops
 
 
+def is_hip():
+    return triton.runtime.driver.active.get_current_target()[0] == "hip"
+
+
 def sparsify_tensor(x, mask, block):
     ret = torch.empty((x.size(0), mask.sum(), block, block), dtype=x.dtype, device=x.device)
     for idx, (h, i, j) in enumerate(zip(*mask.nonzero(as_tuple=True))):
@@ -84,10 +88,11 @@ def test_matmul(MODE, TRANS_A, TRANS_B, BLOCK, DTYPE, device, Z=3, H=2, M=512, N
     c_tri.backward(dc_tri)
     da_tri = a_tri.grad
     db_tri = b_tri.grad
+    atol = 1e-3 if is_hip() else 0
     # compare
-    torch.testing.assert_close(c_ref, c_tri)
-    torch.testing.assert_close(da_ref, da_tri)
-    torch.testing.assert_close(db_ref, db_tri)
+    torch.testing.assert_close(c_ref, c_tri, atol=atol, rtol=0)
+    torch.testing.assert_close(da_ref, da_tri, atol=atol, rtol=0)
+    torch.testing.assert_close(db_ref, db_tri, atol=atol, rtol=0)
 
 
 configs = [
@@ -196,8 +201,9 @@ def test_attention_fwd_bwd(
     # comparison
     # print(f"Triton loss {loss} and torch loss {torch_loss}.  Also checking grads...")
     torch.testing.assert_close(loss, torch_loss, atol=1e-3, rtol=0)
+    atol = 1e-3 if is_hip() else 0
     for g1, g2 in zip(grads, torch_grads):
-        torch.testing.assert_close(g1, g2)
+        torch.testing.assert_close(g1, g2, atol=atol, rtol=0)
 
 
 @pytest.mark.parametrize("block", [16, 32, 64])

--- a/python/test/unit/operators/test_blocksparse.py
+++ b/python/test/unit/operators/test_blocksparse.py
@@ -6,7 +6,11 @@ import triton.ops
 
 
 def is_hip():
-    return triton.runtime.driver.active.get_current_target()[0] == "hip"
+    return triton.runtime.driver.active.get_current_target()[0] == 'hip'
+
+
+def get_target():
+    return triton.runtime.driver.active.get_current_target()
 
 
 def sparsify_tensor(x, mask, block):
@@ -88,7 +92,7 @@ def test_matmul(MODE, TRANS_A, TRANS_B, BLOCK, DTYPE, device, Z=3, H=2, M=512, N
     c_tri.backward(dc_tri)
     da_tri = a_tri.grad
     db_tri = b_tri.grad
-    atol = 1e-3 if is_hip() else 0
+    atol = 1e-3 if is_hip() and get_target()[1] == "gfx90a" else 0
     # compare
     torch.testing.assert_close(c_ref, c_tri, atol=atol, rtol=0)
     torch.testing.assert_close(da_ref, da_tri, atol=atol, rtol=0)
@@ -201,7 +205,7 @@ def test_attention_fwd_bwd(
     # comparison
     # print(f"Triton loss {loss} and torch loss {torch_loss}.  Also checking grads...")
     torch.testing.assert_close(loss, torch_loss, atol=1e-3, rtol=0)
-    atol = 1e-3 if is_hip() else 0
+    atol = 1e-3 if is_hip() and get_target()[1] == "gfx90a" else 0
     for g1, g2 in zip(grads, torch_grads):
         torch.testing.assert_close(g1, g2, atol=atol, rtol=0)
 


### PR DESCRIPTION
It seems like the test `test_blocksparse.py` pass by increasing the `atol` from 1e-5 to 1e-3, so turn it on in CI.