### PR TITLE
[BACKEND] Fix printing of pointer types

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
@@ -171,13 +171,11 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
   std::string getFormatSubstr(Value value, bool hex = false,
                               std::optional<int> width = std::nullopt) const {
     Type type = value.getType();
-    if (type.isa<LLVM::PointerType>()) {
+    if (type.isa<LLVM::LLVMPointerType>()) {
       return "%p";
     }
-
     // Hex is "0x%0nx" or "0x%0nllx", where n is the number of hex digits in the
     // type (so 4 for fp16, 8 for int32, 16 for int64).
-    int typeBits = type.getIntOrFloatBitWidth();
     if (hex) {
       // Ignore `width` for `hex` values, pad to typeWidth.
       std::string ret =
@@ -197,9 +195,7 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
       prefix += std::to_string(value.getType().getIntOrFloatBitWidth() / 4);
     }
 
-    if (type.isa<LLVM::LLVMPointerType>()) {
-      return prefix + "p";
-    } else if (type.isBF16() || type.isF16() || type.isF32() || type.isF64()) {
+    if (type.isBF16() || type.isF16() || type.isF32() || type.isF64()) {
       return prefix + "f";
     } else if (type.isSignedInteger()) {
       if (type.getIntOrFloatBitWidth() == 64)

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1577,3 +1577,15 @@ module attributes {"triton_gpu.compute-capability" = 80 : i32, "triton_gpu.num-c
     tt.return
   }
 }
+
+// -----
+
+#blocked0 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {
+  // CHECK-LABEL: print_ptr
+  // CHECK: llvm.call @vprintf(%{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr) -> i32
+  tt.func @print_ptr(%arg0 : tensor<256x!tt.ptr<i32>, #blocked0>) {
+    tt.print "ptr: " {hex = false} : %arg0 : tensor<256x!tt.ptr<i32>, #blocked0>
+    tt.return
+  }
+}


### PR DESCRIPTION
Printing of pointers used to crash because we were checking for LLVM::PointerType instead of LLVM::LLVMPointerType