### PR TITLE
Faster jit

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -175,6 +175,7 @@ def compute_spec_key(v):
 
 dtype2str = {}
 
+
 def mangle_type(arg, is_const=False):
 
     if hasattr(arg, "dtype"):
@@ -498,7 +499,10 @@ class JITFunction(KernelInterface[T]):
         # compute cache key
         args = [KernelArg(arg_value, param) for arg_value, param in zip(bound_args.values(), self.params)]
 
-        signature = {args[i].param.name: mangle_type(args[i].value, args[i].param.is_const) for i in self.non_constexpr_indices}
+        signature = {
+            args[i].param.name: mangle_type(args[i].value, args[i].param.is_const)
+            for i in self.non_constexpr_indices
+        }
         sig_key = ''.join(signature.values())
         spec_key = ''.join(compute_spec_key(args[i].value) for i in self.specialised_indices)
         constexpr_key = tuple(args[i].value for i in self.constexpr_indices)
@@ -512,7 +516,7 @@ class JITFunction(KernelInterface[T]):
             # done here rather than when we build the signature as otherwise
             # the kernel cache key could not distinguish between byte pointers
             # and None arguments, resulting in a downstream mismatch:
-            signature = {k : ('*i8' if (v == 'none') else v) for (k, v) in signature.items()}
+            signature = {k: ('*i8' if (v == 'none') else v) for (k, v) in signature.items()}
 
             backend = make_backend(target)
             options = backend.parse_options(kwargs)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -467,7 +467,8 @@ class JITFunction(KernelInterface[T]):
 
         # compute cache key
         bound_vals = tuple(bound_args.values())
-        sigvals = tuple(mangle_type(bound_vals[i], self.params[i].is_const) for i in self.non_constexpr_indices)
+        sigvals = tuple((self.params[i].annotation_type or mangle_type(bound_vals[i], self.params[i].is_const))
+                        for i in self.non_constexpr_indices)
         spec_key = ''.join(compute_spec_key(bound_vals[i]) for i in self.specialised_indices)
         constexpr_key = tuple(bound_vals[i] for i in self.constexpr_indices)
 

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -199,7 +199,6 @@ class KernelArg:
         return compute_spec_key(self.value)
 
 
-
 class KernelInterface(Generic[T]):
     run: T
 
@@ -448,7 +447,9 @@ class JITFunction(KernelInterface[T]):
             self.binder = create_function_from_signature(self.signature)
             self.constexpr_indices = [i for (i, p) in enumerate(self.params) if p.is_constexpr]
             self.non_constexpr_indices = [i for (i, p) in enumerate(self.params) if not p.is_constexpr]
-            self.specialised_indices = [i for (i, p) in enumerate(self.params) if not p.do_not_specialize]
+            self.specialised_indices = [
+                i for (i, p) in enumerate(self.params) if (not p.do_not_specialize) and (not p.is_constexpr)
+            ]
 
         bound_args, excess_kwargs = self.binder(*args, **kwargs)
         assert len(bound_args) == len(self.params)

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -182,7 +182,7 @@ def mangle_type(arg, is_const=False):
         dsk = (arg.dtype, is_const)
         res = dtype2str.get(dsk, None)
         if res is None:
-            res = ("*k" if dsk[1] else "*") + type_canonicalisation_dict[dsk[0].split('.')[-1]]
+            res = ("*k" if dsk[1] else "*") + type_canonicalisation_dict[str(dsk[0]).split('.')[-1]]
             dtype2str[dsk] = res
         return res
     elif isinstance(arg, bool):

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -243,7 +243,7 @@ def create_function_from_signature(sig):
     # Join all arguments into a function definition string
     args_str = ', '.join(func_args)
     dict_str = ', '.join(dict_entries)
-    func_body = f"def dynamic_func(%s, **excess_kwargs):\n    return {%s}, excess_kwargs" % (args_str, dict_str)
+    func_body = "def dynamic_func(%s, **excess_kwargs):\n    return {%s}, excess_kwargs" % (args_str, dict_str)
 
     # Prepare defaults to be inserted into function namespace
     func_namespace = {

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -175,7 +175,7 @@ def compute_spec_key(v):
 
 dtype2str = {}
 
-def mangle_type(v, is_const=False):
+def mangle_type(arg, is_const=False):
 
     if hasattr(arg, "dtype"):
         # dtypes are hashable so we can memoize this mapping:


### PR DESCRIPTION
This is a further 2.7x speedup (from 49us to 18us) of kernel launch overhead compared with the previous PR, with help from cProfile to find the hotspots.

Also fixes an old compiler bug where the `None`-ness of arguments didn't enter into the cache key, leading to scary bugs.