### PR TITLE
[FRONTEND][Easy] Fix assert list bug

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1772,9 +1772,10 @@ def test_join_with_mma(device):
 
 
 @pytest.mark.interpreter
-def test_interleave(device):
+@pytest.mark.parametrize("debug", [False, True])
+def test_interleave(device, debug):
 
-    @triton.jit
+    @triton.jit(debug=debug)
     def kernel(Z, N: tl.constexpr):
         z = tl.interleave(tl.arange(0, N), tl.arange(N, 2 * N))
         tl.store(Z + tl.arange(0, 2 * N), z)

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -243,7 +243,7 @@ class CodeGenerator(ast.NodeVisitor):
         self.dereference_name: Callable[[str], Any] = self._define_name_lookup()
         self.fn = None
 
-    builtin_namespace: Dict[str, Any] = {_.__name__: _ for _ in (len, range, float, int, isinstance, getattr)}
+    builtin_namespace: Dict[str, Any] = {_.__name__: _ for _ in (len, list, range, float, int, isinstance, getattr)}
     builtin_namespace.update((
         ('print', language.core.device_print),
         ('min', language.minimum),
@@ -987,7 +987,7 @@ class CodeGenerator(ast.NodeVisitor):
         if not self.debug:
             return
         test = self.visit(node.test)
-        msg = self.visit(node.msg)
+        msg = self.visit(node.msg) if node.msg is not None else ""
         # Convert assert to triton's device_assert which happens on the device
         return language.core.device_assert(test, msg, _builder=self.builder)
 


### PR DESCRIPTION
https://github.com/openai/triton/commit/99b024bb3a81e9aa5c94d4a63fc9e2c60da5e6da introduced a bug in debug mode where `assert isintance(..., list)` fails in `tl.interleave` with

```
    assert isinstance(c.shape, list)
                               ^
NameError('list is not defined')
```
This was reported to PyTorch as https://github.com/pytorch/pytorch/issues/123967