### PR TITLE
[AMD] Search backend for ld.lld before /opt/rocm

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -102,6 +102,10 @@ class HIPBackend(BaseBackend):
 
     @staticmethod
     def path_to_rocm_lld():
+        # First check backend for ld.lld (used for pytorch wheels)
+        lld = Path(__file__).parent / "llvm/bin/ld.lld"
+        if lld.is_file():
+            return lld
         lld = Path("/opt/rocm/llvm/bin/ld.lld")
         if lld.is_file():
             return lld


### PR DESCRIPTION
Required for triton wheels as part of ROCm-pytorch's migration to use upstream triton.

In https://github.com/pytorch/pytorch/pull/121801 we package libraries and ld.lld into `third_party/amd/backend`. This change will look for the linker in `third_party/amd/backend/llvm/bin` before looking out to `/opt/rocm`