### PR TITLE
[BACKEND][AMD] Enable swizzling SMEM for transposed operand

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -230,6 +230,8 @@ compared to 1*64 when the hasLeadingOffset is false.
         // ---- begin GFX908/GFX90A ----
         if (auto mfmaEnc = dotOpEnc.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
           int kDimNum = dotOpEnc.getOpIdx() == 0 ? 1 : 0;
+          if (needTrans)
+            kDimNum = 1 - kDimNum;
           bool isKDimInner = (order[0] == kDimNum);
           if (isKDimInner) {
             const int numBanks = 32;


### PR DESCRIPTION
Transposed operand will be accessed in an opposite order from the original operand. Enabling swizzling seems to help performance. I'm seeing 10% performance improvement for our internal model.

This is a backport of https://github.com/ROCm/triton/pull/474.