### PR TITLE
Add third_party/amd code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,3 +41,8 @@ lib/Dialect/TritonGPU/Transforms/Combine.cpp @ptillet
 # TritonToTritonGPU
 include/triton/Conversion/TritonToTritonGPU/ @ptillet
 lib/Dialect/TritonGPU/Transforms/TritonGPUConversion.cpp @ptillet
+
+# -----------
+# third_party
+# -----------
+third_party/amd/ @antiagainst @zhanglx13


### PR DESCRIPTION
This commit adds code owners for the third_party/amd directory so we can have automatic reviewer assignment.