### PR TITLE
[DOC][easy] Fix outdated triton.Config argument doc and example

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -207,8 +207,8 @@ class Config:
     """
     An object that represents a possible kernel configuration for the auto-tuner to try.
 
-    :ivar meta: a dictionary of meta-parameters to pass to the kernel as keyword arguments.
-    :type meta: dict[Str, Any]
+    :ivar kwargs: a dictionary of meta-parameters to pass to the kernel as keyword arguments.
+    :type kwargs: dict[Str, Any]
     :ivar num_warps: the number of warps to use for the kernel when compiled for GPUs. For example, if
                       `num_warps=8`, then each kernel instance will be automatically parallelized to
                       cooperatively execute using `8 * 32 = 256` threads.
@@ -247,8 +247,8 @@ def autotune(configs, key, prune_configs_by=None, reset_to_zero=None, restore_va
     .. code-block:: python
 
         @triton.autotune(configs=[
-            triton.Config(meta={'BLOCK_SIZE': 128}, num_warps=4),
-            triton.Config(meta={'BLOCK_SIZE': 1024}, num_warps=8),
+            triton.Config(kwargs={'BLOCK_SIZE': 128}, num_warps=4),
+            triton.Config(kwargs={'BLOCK_SIZE': 1024}, num_warps=8),
           ],
           key=['x_size'] # the two above configs will be evaluated anytime
                          # the value of x_size changes


### PR DESCRIPTION
### Why?

The example code in [autotune](https://triton-lang.org/main/python-api/generated/triton.autotune.html#triton.autotune) fails because of incorrect argument name. 

The issue can be easily reproduced by

```python
>>> import triton
>>> triton.Config(meta={'BLOCK_SIZE': 128}, num_warps=4),
TypeError: Config.__init__() got an unexpected keyword argument 'meta'
```

### What?

1. Fix the inline documentation of argument name
2. Fix example code