### PR TITLE
[remove-layout] try to align remat of YeildOp with ForOp

### DIFF
--- a/test/TritonGPU/combine.mlir
+++ b/test/TritonGPU/combine.mlir
@@ -2311,3 +2311,28 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 8 :
     tt.return %3 : tensor<128x256xf32, #blocked>
   }
 }
+
+
+// -----
+#blocked = #triton_gpu.blocked<{sizePerThread = [2], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+  tt.func public @rematerialize_loop_arg() -> (tensor<32xf32, #blocked>, tensor<32xf32, #blocked>, tensor<32xf32, #blocked1>) {
+    // CHECK-LABEL: @rematerialize_loop_arg
+    %cst = arith.constant dense<1.000000e+00> : tensor<32xf32, #blocked1>
+    %cst_0 = arith.constant dense<2.000000e+00> : tensor<32xf32, #blocked>
+    %c0_i32 = arith.constant 0 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %c4096_i32 = arith.constant 4096 : i32
+    %1:3 = scf.for %arg0 = %c0_i32 to %c4096_i32 step %c32_i32 iter_args(%arg1 = %cst, %arg3 = %cst_0, %arg4 = %cst) -> (tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>, tensor<32xf32, #blocked1>) : i32 {
+      %4 = arith.addf %arg1, %cst : tensor<32xf32, #blocked1>
+      %5 = triton_gpu.convert_layout %4 : tensor<32xf32, #blocked1> -> tensor<32xf32, #blocked>
+      %6 = arith.mulf %arg3, %5 : tensor<32xf32, #blocked>
+      // CHECK:  scf.yield %2, %3, %2, %1
+      scf.yield %4, %6, %4 : tensor<32xf32, #blocked1>, tensor<32xf32, #blocked>, tensor<32xf32, #blocked1>
+    }
+    %7 = triton_gpu.convert_layout %1#0 : tensor<32xf32, #blocked1> -> tensor<32xf32, #blocked>
+    tt.return %7, %1#1, %1#2 : tensor<32xf32, #blocked>, tensor<32xf32, #blocked>, tensor<32xf32, #blocked1>
+  }
+}


### PR DESCRIPTION
Summary: In rewriteSlice, when a BlockArgument is in the slice, the associated forOp and yieldOp will be added to opsToRewrite. When rewriting the forOp, we go through the BlockArguments and check the slice to figure out which arguments will need to have a remat'ed version. For YieldOp, we go through the operands and check if the operands are in the slice. This can cause issues if the same argument appears multiple times in the YieldOp, adding multiple operands to YieldOp while only adding one to ForOp.

This diff uses the BlockArguments associated with the ForOp to decide which operand of YieldOp needs to be remat'ed.

Also see discussions in https://github.com/openai/triton/pull/3650.