### PR TITLE
[AMD backend] turn on persistent fused attn by increasing atol for MI200

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -313,7 +313,8 @@ jobs:
           # Run hopper tests
           python3 -m pytest -vs hopper/test_mixed_io.py \
                                 hopper/test_gemm.py \
-                                hopper/test_tma_store_gemm.py
+                                hopper/test_tma_store_gemm.py \
+                                hopper/test_persistent_warp_specialized_fused-attention.py
 
       - name: Run C++ unittests
         run: |

--- a/python/test/unit/hopper/test_persistent_warp_specialized_fused-attention.py
+++ b/python/test/unit/hopper/test_persistent_warp_specialized_fused-attention.py
@@ -32,6 +32,14 @@ import triton
 import triton.language as tl
 
 
+def is_hip():
+    return triton.runtime.driver.active.get_current_target()[0] == "hip"
+
+
+def get_target():
+    return triton.runtime.driver.active.get_current_target()
+
+
 @triton.autotune(
     configs=[
         triton.Config({}, num_warps=4, num_stages=2),
@@ -321,7 +329,8 @@ def test_op(Z, H, N_CTX, D_HEAD, dtype=torch.float16):
     tri_dq, q.grad = q.grad.clone(), None
     # compare
     assert torch.allclose(ref_out, tri_out, atol=1e-2, rtol=0)
-    assert torch.allclose(ref_dv, tri_dv, atol=1e-2, rtol=0)
+    atol = 4e-2 if is_hip() and get_target()[1] == 'gfx90a' else 1e-2
+    assert torch.allclose(ref_dv, tri_dv, atol=atol, rtol=0)
     assert torch.allclose(ref_dk, tri_dk, atol=1e-2, rtol=0)
     assert torch.allclose(ref_dq, tri_dq, atol=1e-2, rtol=0)
 


### PR DESCRIPTION
This PR is to turn on the test `hopper/test_persistent_warp_specialized_fused-attention.py` by increasing the tolerance on MI200 (due to the denorm issue related to [reduced precision on MI200](https://pytorch.org/docs/stable/notes/numerical_accuracy.html#reduced-precision-fp16-and-bf16-gemms-and-convolutions-on-amd-instinct-mi200-devices)) .