### PR TITLE
[Build] Fix nightly wheel build.

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -309,7 +309,8 @@ class CMakeBuild(build_ext):
     def get_proton_cmake_args(self):
         cmake_args = ["-DTRITON_BUILD_PROTON=ON"]
         cmake_args += get_thirdparty_packages([get_json_package_info(), get_pybind11_package_info()])
-        if cuda_root := get_env_with_keys(["CUDA_HOME", "CUDA_ROOT"]):
+        cuda_root = get_env_with_keys(["CUDA_HOME", "CUDA_ROOT"])
+        if cuda_root != "":
             cmake_args += ["-DCUDAToolkit_ROOT=" + cuda_root]
         return cmake_args
 


### PR DESCRIPTION
The assignment operator := not supported in Python 3.7, which Triton still releases wheels for.

Failing nightly wheels build[ here](https://github.com/openai/triton/actions/runs/8718345542/job/23915395650#step:7:179).

> File "/tmp/pip-build-env-i3hksojj/overlay/lib/python3.7/site-packages/setuptools/build_meta.py", line 338, in run_setup
            exec(code, locals())
          File "<string>", line 312
            if cuda_root := get_env_with_keys(["CUDA_HOME", "CUDA_ROOT"]):
                          ^
        SyntaxError: invalid syntax