### PR TITLE
[AMD] Run hopper/ tests in parallel to reduce CI time

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -368,7 +368,7 @@ jobs:
         run: |
           pytest --capture=tee-sys -rfs -vvv python/tutorials/06-fused-attention.py
           cd python/test/unit
-          pytest --capture=tee-sys -rfs -vvv -n 32 language operators \
+          pytest --capture=tee-sys -rfs -vvv -n 32 language operators hopper/test_gemm.py \
                  --ignore=language/test_conversions.py \
                  --ignore=language/test_line_info.py
           # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
@@ -378,7 +378,6 @@ jobs:
           python3 -m pytest -vvv runtime
           # Run hopper tests
           python3 -m pytest -vs hopper/test_mixed_io.py \
-                                hopper/test_gemm.py \
                                 hopper/test_tma_store_gemm.py \
                                 hopper/test_persistent_warp_specialized_fused-attention.py
       - name: Run C++ unittests

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -368,7 +368,11 @@ jobs:
         run: |
           pytest --capture=tee-sys -rfs -vvv python/tutorials/06-fused-attention.py
           cd python/test/unit
-          pytest --capture=tee-sys -rfs -vvv -n 32 language operators hopper/test_gemm.py \
+          pytest --capture=tee-sys -rfs -vvv -n 32 language operators \
+                 hopper/test_mixed_io.py \
+                 hopper/test_gemm.py \
+                 hopper/test_tma_store_gemm.py \
+                 hopper/test_persistent_warp_specialized_fused-attention.py \
                  --ignore=language/test_conversions.py \
                  --ignore=language/test_line_info.py
           # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
@@ -376,10 +380,6 @@ jobs:
 
           # Run runtime tests serially to avoid race condition with cache handling
           python3 -m pytest -vvv runtime
-          # Run hopper tests
-          python3 -m pytest -vs hopper/test_mixed_io.py \
-                                hopper/test_tma_store_gemm.py \
-                                hopper/test_persistent_warp_specialized_fused-attention.py
       - name: Run C++ unittests
         run: |
           cd python

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -374,6 +374,10 @@ jobs:
           pytest --capture=tee-sys -rfs -vvv python/tutorials/06-fused-attention.py
           cd python/test/unit
           pytest --capture=tee-sys -rfs -vvv -n 32 language operators \
+                 hopper/test_mixed_io.py \
+                 hopper/test_gemm.py \
+                 hopper/test_tma_store_gemm.py \
+                 hopper/test_persistent_warp_specialized_fused-attention.py \
                  --ignore=language/test_conversions.py \
                  --ignore=language/test_line_info.py
           # Run test_line_info.py separately with TRITON_DISABLE_LINE_INFO=0
@@ -381,11 +385,6 @@ jobs:
 
           # Run runtime tests serially to avoid race condition with cache handling
           python3 -m pytest -vvv runtime
-          # Run hopper tests
-          python3 -m pytest -vs hopper/test_mixed_io.py \
-                                hopper/test_gemm.py \
-                                hopper/test_tma_store_gemm.py \
-                                hopper/test_persistent_warp_specialized_fused-attention.py
 
       - *run-cpp-unittests-step
       - *save-build-artifacts-step


### PR DESCRIPTION
from 13 m to 11m (it's mainly contributed by hopper/test_gemm)