### PR TITLE
Attempt to fix new CI caching.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,7 @@
 # (https://github.com/actions/runner/issues/1182).  pre-commit will do this for
 # you automatically.
 
+
 name: Integration Tests
 on:
   workflow_dispatch:
@@ -63,7 +64,7 @@ jobs:
           LAST_RUN=$(curl -s \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/$REPO_NAME/actions/workflows/$WORKFLOW_ID/runs?status=success&per_page=1" \
+            "https://api.github.com/repos/$REPO_NAME/actions/workflows/$WORKFLOW_ID/runs?branch=main&status=success&per_page=1" \
             | jq -r '.workflow_runs[0].updated_at')
 
           # Convert to timestamp
@@ -147,6 +148,7 @@ jobs:
           git diff
   Integration-Tests:
     needs: Runner-Preparation
+    if: needs.Runner-Preparation.outputs.matrix-CUDA != ''
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
@@ -283,6 +285,7 @@ jobs:
           du -sh ~/.cache/ccache
   Integration-Tests-AMD:
     needs: Runner-Preparation
+    if: needs.Runner-Preparation.outputs.matrix-HIP != ''
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -3,6 +3,7 @@
 # (https://github.com/actions/runner/issues/1182).  pre-commit will do this for
 # you automatically.
 
+
 name: Integration Tests
 
 on:
@@ -69,7 +70,7 @@ jobs:
           LAST_RUN=$(curl -s \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/$REPO_NAME/actions/workflows/$WORKFLOW_ID/runs?status=success&per_page=1" \
+            "https://api.github.com/repos/$REPO_NAME/actions/workflows/$WORKFLOW_ID/runs?branch=main&status=success&per_page=1" \
             | jq -r '.workflow_runs[0].updated_at')
 
           # Convert to timestamp
@@ -163,6 +164,7 @@ jobs:
 
   Integration-Tests:
     needs: Runner-Preparation
+    if: needs.Runner-Preparation.outputs.matrix-CUDA != ''
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -326,6 +328,7 @@ jobs:
 
   Integration-Tests-AMD:
     needs: Runner-Preparation
+    if: needs.Runner-Preparation.outputs.matrix-HIP != ''
 
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30


### PR DESCRIPTION
We were checking for builds in the last N hours, but specifically we need to
check on branch main, not just any branch.

Also we were getting false failures on builds on `main` because the matrix-CUDA
(or matrix-HIP) variable was empty when we didn't want to run any tests.  Try
to fix this.
