### PR TITLE
[AMD] Only link device libs when necessary

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -211,7 +211,7 @@ class HIPBackend(BaseBackend):
         amd.set_all_fn_arg_inreg(kernels[0])
 
         if options.extern_libs:
-            paths = [path for (name, path) in options.extern_libs]
+            paths = [path for (name, path) in options.extern_libs if amd.check_extern_lib(llvm_mod, name)]
             llvm.link_extern_libs(llvm_mod, paths)
 
         llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -211,7 +211,7 @@ class HIPBackend(BaseBackend):
         amd.set_all_fn_arg_inreg(kernels[0])
 
         if options.extern_libs:
-            paths = [path for (name, path) in options.extern_libs if amd.check_extern_lib(llvm_mod, name)]
+            paths = [path for (name, path) in options.extern_libs if amd.need_extern_lib(llvm_mod, name)]
             llvm.link_extern_libs(llvm_mod, paths)
 
         llvm.optimize_module(llvm_mod, llvm.OPTIMIZE_O3)

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -209,4 +209,22 @@ void init_triton_amd(py::module &&m) {
       arg.addAttr(llvm::Attribute::InReg);
     }
   });
+
+  m.def("check_extern_lib", [](llvm::Module *module, const std::string &lib) {
+    for (llvm::Function &f : module->functions()) {
+      if (f.hasExternalLinkage() && f.hasName() && !f.hasExactDefinition()) {
+        llvm::StringRef funcName = f.getName();
+        if (funcName.contains(lib) || funcName.contains("__nv_"))
+          // Rules for linking the extern lib
+          // 1. if __nv_ is found in the module, we'll link all four libs:
+          //    cuda2gcn, opencl, ocml, and ockl. Note that opencl might
+          //    not be needed. But we add it here and will try to remove
+          //    it in the future.
+          // 2. if the function name includes ocml or ockl, only link
+          //    ocml or ockl
+          return true;
+      }
+    }
+    return false;
+  });
 }

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -210,7 +210,7 @@ void init_triton_amd(py::module &&m) {
     }
   });
 
-  m.def("check_extern_lib", [](llvm::Module *module, const std::string &lib) {
+  m.def("need_extern_lib", [](llvm::Module *module, const std::string &lib) {
     for (llvm::Function &f : module->functions()) {
       if (f.hasExternalLinkage() && f.hasName() && !f.hasExactDefinition()) {
         llvm::StringRef funcName = f.getName();
@@ -221,7 +221,7 @@ void init_triton_amd(py::module &&m) {
           //    not be needed. But we add it here and will try to remove
           //    it in the future.
           // 2. if the function name includes ocml or ockl, only link
-          //    ocml or ockl
+          //    ocml or ockl accordingly
           return true;
       }
     }


### PR DESCRIPTION
Device libs are only needed in the following cases
- tl.math functions need ocml.bc or ockl.bc
- extra.cuda.libdevice functions need cuda2gcn.bc
- Some functions in cuda2gcn is lowered into opencl.bc

Linking to these device libs can increase CI time for about 3 minutes. This PR adds a simple logic to check if extern device lib functions are in the module and only link to proper *.bc code when necessary.
Now CI time is reduced from 11 min (after https://github.com/openai/triton/pull/3686) to 8 min.