### PR TITLE
[PROTON] Add missing C++ includes

### DIFF
--- a/third_party/proton/csrc/include/Data/TreeData.h
+++ b/third_party/proton/csrc/include/Data/TreeData.h
@@ -3,6 +3,7 @@
 
 #include "Context/Context.h"
 #include "Data.h"
+#include <stdexcept>
 
 namespace proton {
 

--- a/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
@@ -6,6 +6,7 @@
 
 #include <cstdlib>
 #include <memory>
+#include <stdexcept>
 
 namespace proton {
 


### PR DESCRIPTION
Otherwise g++ 13 throws errors like this:
```
FAILED: third_party/proton/CMakeFiles/proton.dir/csrc/lib/Profiler/CuptiProfiler.cpp.o 
ccache /usr/lib/ccache/bin/c++ -Dproton_EXPORTS -I/home/vitalyr/projects/dev/cpp/triton/python/build/cmake.linux-x86_64-cpython-3.11/third_party/proton -I/home/vitalyr/projects/dev/cpp/triton/third_party/proton -I/home/vitalyr/projects/dev/cpp/triton/include -I/home/vitalyr/projects/dev/cpp/triton/. -I/usr/local/opt/llvm-triton/include -I/home/vitalyr/projects/dev/cpp/triton/python/build/cmake.linux-x86_64-cpython-3.11/include -I/home/vitalyr/projects/dev/cpp/triton/third_party -I/home/vitalyr/projects/dev/cpp/triton/python/build/cmake.linux-x86_64-cpython-3.11/third_party -I/home/vitalyr/projects/dev/cpp/triton/python/src -I/opt/miniconda3/envs/py3.11/include/python3.11 -I/home/vitalyr/.triton/pybind11/pybind11-2.11.1/include -I/home/vitalyr/.triton/json/json/include -I/home/vitalyr/projects/dev/cpp/triton/third_party/proton/csrc/include -I/home/vitalyr/projects/dev/cpp/triton/third_party/proton/extern -I/opt/cuda/targets/x86_64-linux/include -I/opt/cuda/extras/CUPTI/include -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -Werror -Wno-covered-switch-default -fvisibility=hidden -O2 -g -std=gnu++17 -fPIC -MD -MT third_party/proton/CMakeFiles/proton.dir/csrc/lib/Profiler/CuptiProfiler.cpp.o -MF third_party/proton/CMakeFiles/proton.dir/csrc/lib/Profiler/CuptiProfiler.cpp.o.d -o third_party/proton/CMakeFiles/proton.dir/csrc/lib/Profiler/CuptiProfiler.cpp.o -c /home/vitalyr/projects/dev/cpp/triton/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
/home/vitalyr/projects/dev/cpp/triton/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp: In static member function ‘static void proton::CuptiProfiler::allocBuffer(uint8_t**, size_t*, size_t*)’:
/home/vitalyr/projects/dev/cpp/triton/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp:121:16: error: ‘runtime_error’ is not a member of ‘std’
  121 |     throw std::runtime_error("aligned_alloc failed");
      |                ^~~~~~~~~~~~~
/home/vitalyr/projects/dev/cpp/triton/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp:8:1: note: ‘std::runtime_error’ is defined in header ‘<stdexcept>’; did you forget to ‘#include <stdexcept>’?
```