### PR TITLE
[AUTOTUNER] Fix return value of `use_cuda_graph` when `OutOfResources` is raised

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -114,7 +114,7 @@ class Autotuner(KernelInterface):
                 return bench_res
             return do_bench(kernel_call, warmup=self.num_warmups, rep=self.num_reps, quantiles=(0.5, 0.2, 0.8))
         except OutOfResources:
-            return [float("inf"), float("inf"), float("inf")]
+            return float("inf") if self.use_cuda_graph else [float("inf"), float("inf"), float("inf")]
 
     def run(self, *args, **kwargs):
         self.nargs = dict(zip(self.arg_names, args))


### PR DESCRIPTION
Return single inf value after failed bench attempt
in case of use_cuda_graph to properly compare it to other results