### PR TITLE
Remove apt-get install from CI.

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -207,10 +207,6 @@ jobs:
       - name: Update PATH
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - name: Install apt dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y ccache clang lld
       - name: Install pip dependencies
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/integration-tests.yml.in
+++ b/.github/workflows/integration-tests.yml.in
@@ -236,11 +236,6 @@ jobs:
         run: |
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Install apt dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y ccache clang lld
-
       - name: Install pip dependencies
         run: |
           python3 -m pip install --upgrade pip


### PR DESCRIPTION
We now have ccache, clang, and lld installed in the nvidia docker images.

Usually apt-get install'ing these is fast, but sometimes it is slow or hangs, e.g. https://github.com/openai/triton/actions/runs/8754510491/job/24026456975, so using the versions from the docker removes a failure mode in CI.