### PR TITLE
Switch calls to `isa/dyn_cast/cast/...` members to free functions.

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -12,7 +12,7 @@ class ReduceOpHelper {
 public:
   explicit ReduceOpHelper(triton::ReduceOp op)
       : op(op.getOperation()), axis(op.getAxis()) {
-    auto firstTy = op.getOperands()[0].getType().cast<RankedTensorType>();
+    auto firstTy = cast<RankedTensorType>(op.getOperands()[0].getType());
     srcShape = firstTy.getShape();
     srcEncoding = firstTy.getEncoding();
     srcElementTypes = op.getElementTypes();
@@ -72,7 +72,7 @@ private:
 class ScanLoweringHelper {
 public:
   explicit ScanLoweringHelper(triton::ScanOp op) : scanOp(op) {
-    auto firstTy = op.getOperands()[0].getType().cast<RankedTensorType>();
+    auto firstTy = cast<RankedTensorType>(op.getOperands()[0].getType());
     srcShape = firstTy.getShape();
     srcEncoding = firstTy.getEncoding();
     srcElementTypes = op.getElementTypes();

--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -85,7 +85,7 @@ public:
     Type type = result.getType();
     if (!type)
       return resultVals;
-    RankedTensorType rtType = type.dyn_cast<RankedTensorType>();
+    RankedTensorType rtType = dyn_cast<RankedTensorType>(type);
     if (!rtType)
       // the result must be a tensor
       return resultVals;

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -1340,10 +1340,10 @@ inline SmallVector<Value>
 loadSharedToDistributed(Value dst, Value src, SharedMemoryObject smemObj,
                         Type elemTy, Location loc,
                         ConversionPatternRewriter &rewriter) {
-  auto dstTy = dst.getType().cast<RankedTensorType>();
+  auto dstTy = cast<RankedTensorType>(dst.getType());
   auto dstShape = dstTy.getShape();
   assert(dstShape.size() <= 2 && "Unexpected rank of loadSharedToDistributed");
-  auto srcTy = src.getType().cast<MemDescType>();
+  auto srcTy = cast<MemDescType>(src.getType());
   auto dstDistributedLayout = dstTy.getEncoding();
   if (auto mmaLayout = dstDistributedLayout.dyn_cast<NvidiaMmaEncodingAttr>()) {
     assert((!mmaLayout.isVolta()) &&
@@ -1396,12 +1396,12 @@ inline void storeDistributedToShared(Value src, ArrayRef<Value> inVals,
                                      ArrayRef<Value> dstStrides, Value dst,
                                      Value smemBase, Type elemTy, Location loc,
                                      ConversionPatternRewriter &rewriter) {
-  auto srcTy = src.getType().cast<RankedTensorType>();
+  auto srcTy = cast<RankedTensorType>(src.getType());
   auto srcShape = srcTy.getShape();
   auto rank = srcShape.size();
   assert(rank == 2 ||
          rank == 3 && "Unexpected rank of storeDistributedToShared");
-  auto dstTy = dst.getType().cast<MemDescType>();
+  auto dstTy = cast<MemDescType>(dst.getType());
   auto srcDistributedLayout = srcTy.getEncoding();
   if (auto mmaLayout = srcDistributedLayout.dyn_cast<NvidiaMmaEncodingAttr>()) {
     assert((!mmaLayout.isVolta()) &&
@@ -1470,11 +1470,11 @@ unpackLLElements(Location loc, Value llvmStruct,
                  ConversionPatternRewriter &rewriter) {
   assert(bool(llvmStruct) && "can not unpack null values");
   if (llvmStruct.getType().isIntOrIndexOrFloat() ||
-      llvmStruct.getType().isa<triton::PointerType>() ||
-      llvmStruct.getType().isa<LLVM::LLVMPointerType>())
+      isa<triton::PointerType>(llvmStruct.getType()) ||
+      isa<LLVM::LLVMPointerType>(llvmStruct.getType()))
     return {llvmStruct};
   ArrayRef<Type> types =
-      llvmStruct.getType().cast<LLVM::LLVMStructType>().getBody();
+      cast<LLVM::LLVMStructType>(llvmStruct.getType()).getBody();
   SmallVector<Value> results(types.size());
   for (unsigned i = 0; i < types.size(); ++i) {
     Type type = types[i];
@@ -1488,7 +1488,7 @@ inline Value packLLElements(Location loc,
                             ValueRange resultVals,
                             ConversionPatternRewriter &rewriter, Type type) {
   auto structType =
-      typeConverter->convertType(type).dyn_cast<LLVM::LLVMStructType>();
+      dyn_cast<LLVM::LLVMStructType>(typeConverter->convertType(type));
   if (!structType) {
     assert(resultVals.size() == 1);
     return *resultVals.begin();

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -37,7 +37,7 @@ void SharedMemoryAliasAnalysis::visitOperation(
     aliasInfo = AliasInfo(operands[0]->getValue());
     pessimistic = false;
   } else {
-    assert(!result.getType().isa<triton::MemDescType>() &&
+    assert(!isa<triton::MemDescType>(result.getType()) &&
            "unknown operation creating memory descriptor");
   }
 

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -156,7 +156,7 @@ getScratchConfigForCvtLayout(triton::gpu::ConvertLayoutOp op, unsigned &inVec,
 // TODO: extend beyond scalars
 SmallVector<unsigned> getScratchConfigForAtomicRMW(triton::AtomicRMWOp op) {
   SmallVector<unsigned> smemShape;
-  if (op.getPtr().getType().isa<RankedTensorType>()) {
+  if (isa<RankedTensorType>(op.getPtr().getType())) {
     // do nothing or just assert because shared memory is not used in tensor up
     // to now
   } else {
@@ -284,7 +284,7 @@ private:
       unsigned elems = std::accumulate(smemShape.begin(), smemShape.end(), 1,
                                        std::multiplies{});
       auto bytes =
-          srcTy.getElementType().isa<triton::PointerType>()
+          isa<triton::PointerType>(srcTy.getElementType())
               ? elems * kPtrBitWidth / 8
               : elems * std::max<int>(8, srcTy.getElementTypeBitWidth()) / 8;
       maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, bytes,
@@ -293,16 +293,16 @@ private:
       auto value = op->getOperand(0);
       // only scalar requires scratch memory
       // make it explicit for readability
-      if (value.getType().dyn_cast<RankedTensorType>()) {
+      if (dyn_cast<RankedTensorType>(value.getType())) {
         // nothing to do
       } else {
         auto smemShape = getScratchConfigForAtomicRMW(atomicRMWOp);
         unsigned elems = std::accumulate(smemShape.begin(), smemShape.end(), 1,
                                          std::multiplies{});
         auto elemTy =
-            value.getType().cast<triton::PointerType>().getPointeeType();
+            cast<triton::PointerType>(value.getType()).getPointeeType();
         auto bytes =
-            elemTy.isa<triton::PointerType>()
+            isa<triton::PointerType>(elemTy)
                 ? elems * kPtrBitWidth / 8
                 : elems * std::max<int>(8, elemTy.getIntOrFloatBitWidth()) / 8;
         maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, bytes,
@@ -312,15 +312,15 @@ private:
       // only scalar requires scratch memory
       // make it explicit for readability
       auto value = op->getOperand(0);
-      if (value.getType().dyn_cast<RankedTensorType>()) {
+      if (dyn_cast<RankedTensorType>(value.getType())) {
         // nothing to do
       } else {
         auto smemShape = getScratchConfigForAtomicCAS(atomicCASOp);
         unsigned elems = std::accumulate(smemShape.begin(), smemShape.end(), 1,
                                          std::multiplies{});
         auto elemTy =
-            value.getType().cast<triton::PointerType>().getPointeeType();
-        auto bytes = elemTy.isa<triton::PointerType>()
+            cast<triton::PointerType>(value.getType()).getPointeeType();
+        auto bytes = isa<triton::PointerType>(elemTy)
                          ? elems * kPtrBitWidth / 8
                          : elems * elemTy.getIntOrFloatBitWidth() / 8;
         maybeAddScratchBuffer<BufferT::BufferKind::Scratch>(op, bytes,

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -256,7 +256,7 @@ public:
     auto splatAttr = op.getValue().template dyn_cast<SplatElementsAttr>();
     if (splatAttr && splatAttr.getElementType().isIntOrIndex()) {
       int64_t value = splatAttr.template getSplatValue<APInt>().getZExtValue();
-      TensorType ty = splatAttr.getType().template cast<TensorType>();
+      TensorType ty = cast<TensorType>(splatAttr.getType());
       return AxisInfo(
           /*contiguity=*/AxisInfo::DimVectorT(ty.getRank(), 1),
           /*divisibility=*/
@@ -405,7 +405,7 @@ private:
 
   int64_t getConstancy(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                        int dim) override {
-    auto resTy = op.getType().template dyn_cast<RankedTensorType>();
+    auto resTy = dyn_cast<RankedTensorType>(op.getType());
     if (!resTy)
       return BinaryOpVisitorImpl<OpTy>::getConstancy(op, lhs, rhs, dim);
     auto shape = resTy.getShape();
@@ -460,7 +460,7 @@ public:
 private:
   int64_t getContiguity(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                         int dim) override {
-    auto resTy = op.getType().template dyn_cast<RankedTensorType>();
+    auto resTy = dyn_cast<RankedTensorType>(op.getType());
     if (!resTy)
       return BinaryOpVisitorImpl<OpTy>::getContiguity(op, lhs, rhs, dim);
     auto shape = resTy.getShape();
@@ -494,7 +494,7 @@ private:
 
   int64_t getConstancy(OpTy op, const AxisInfo &lhs, const AxisInfo &rhs,
                        int dim) override {
-    auto resTy = op.getType().template dyn_cast<RankedTensorType>();
+    auto resTy = dyn_cast<RankedTensorType>(op.getType());
     if (!resTy)
       return BinaryOpVisitorImpl<OpTy>::getConstancy(op, lhs, rhs, dim);
     auto shape = resTy.getShape();
@@ -526,7 +526,7 @@ public:
   getAxisInfo(triton::SplatOp op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
     Type _retTy = *op->result_type_begin();
-    TensorType retTy = _retTy.cast<TensorType>();
+    TensorType retTy = cast<TensorType>(_retTy);
     AxisInfo opInfo = operands[0]->getValue();
     AxisInfo::DimVectorT contiguity;
     AxisInfo::DimVectorT divisibility;
@@ -616,8 +616,8 @@ public:
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
     Type _retTy = *op->result_type_begin();
     Type _opTy = *op->operand_type_begin();
-    TensorType retTy = _retTy.cast<TensorType>();
-    TensorType opTy = _opTy.cast<TensorType>();
+    TensorType retTy = cast<TensorType>(_retTy);
+    TensorType opTy = cast<TensorType>(_opTy);
     ArrayRef<int64_t> retShape = retTy.getShape();
     ArrayRef<int64_t> opShape = opTy.getShape();
     AxisInfo opInfo = operands[0]->getValue();
@@ -643,7 +643,7 @@ public:
   AxisInfo
   getAxisInfo(OpTy op,
               ArrayRef<const dataflow::Lattice<AxisInfo> *> operands) override {
-    auto resTy = op.getType().template dyn_cast<RankedTensorType>();
+    auto resTy = dyn_cast<RankedTensorType>(op.getType());
     if (!resTy)
       return AxisInfo();
     auto shape = resTy.getShape();
@@ -794,7 +794,7 @@ public:
       // The condition can be either a tensor or i1.
       // If i1 is used as the condition, the entire tensor of either
       // lhs or rhs is selected.
-      bool i1Cond = op.getOperand(0).getType().template isa<IntegerType>();
+      bool i1Cond = isa<IntegerType>(op.getOperand(0).getType());
       for (auto d = 0; d < rank; ++d) {
         if (i1Cond) {
           constancy.push_back(
@@ -1116,10 +1116,10 @@ void AxisInfo::initPessimisticStateFromFunc(int argNumber, T funcOp,
 
 /*static*/ AxisInfo AxisInfo::getPessimisticValueState(Value value) {
   auto rank = 1;
-  if (TensorType ty = value.getType().dyn_cast<TensorType>())
+  if (TensorType ty = dyn_cast<TensorType>(value.getType()))
     rank = ty.getRank();
-  if (triton::PointerType ty = value.getType().dyn_cast<triton::PointerType>())
-    if (TensorType elemTy = ty.getPointeeType().dyn_cast<TensorType>())
+  if (triton::PointerType ty = dyn_cast<triton::PointerType>(value.getType()))
+    if (TensorType elemTy = dyn_cast<TensorType>(ty.getPointeeType()))
       rank = elemTy.getRank();
 
   DimVectorT knownContiguity(rank, 1);
@@ -1191,7 +1191,7 @@ void AxisInfo::initPessimisticStateFromFunc(int argNumber, T funcOp,
 }
 
 unsigned ModuleAxisInfoAnalysis::getPtrContiguity(Value ptr) {
-  auto tensorTy = ptr.getType().dyn_cast<RankedTensorType>();
+  auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
   if (!tensorTy)
     return 1;
   auto layout = tensorTy.getEncoding();
@@ -1213,7 +1213,7 @@ unsigned ModuleAxisInfoAnalysis::getPtrContiguity(Value ptr) {
 }
 
 unsigned ModuleAxisInfoAnalysis::getPtrAlignment(Value ptr) {
-  auto tensorTy = ptr.getType().dyn_cast<RankedTensorType>();
+  auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
   if (!tensorTy)
     return 1;
   auto *axisInfo = getAxisInfo(ptr);
@@ -1241,7 +1241,7 @@ unsigned ModuleAxisInfoAnalysis::getPtrAlignment(Value ptr) {
 }
 
 unsigned ModuleAxisInfoAnalysis::getMaskAlignment(Value mask) {
-  auto tensorTy = mask.getType().dyn_cast<RankedTensorType>();
+  auto tensorTy = dyn_cast<RankedTensorType>(mask.getType());
   if (!tensorTy)
     return 1;
   auto *axisInfo = getAxisInfo(mask);

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -453,8 +453,8 @@ bool supportMFMATypes(Type a, Type b) {
 }
 
 bool supportMFMA(triton::DotOp op) {
-  auto aTy = op.getA().getType().cast<RankedTensorType>();
-  auto bTy = op.getB().getType().cast<RankedTensorType>();
+  auto aTy = cast<RankedTensorType>(op.getA().getType());
+  auto bTy = cast<RankedTensorType>(op.getB().getType());
 
   auto aElemTy = aTy.getElementType();
   auto bElemTy = bTy.getElementType();
@@ -491,7 +491,7 @@ static bool supportWMMATypes(Type a, Type b, Type c, Type d) {
     bool aValid = a.isUnsignedInteger() && aWidth <= 8;
     bool cValid = cWidth <= 32;
     return aValid && cValid;
-  } else if (a.isa<FloatType>()) {
+  } else if (isa<FloatType>(a)) {
     if (a.isBF16())
       return c.isBF16() || c.isF32();
     if (a.isF16())
@@ -501,10 +501,10 @@ static bool supportWMMATypes(Type a, Type b, Type c, Type d) {
 }
 
 bool supportWMMA(triton::DotOp op) {
-  auto aTy = op.getA().getType().cast<RankedTensorType>();
-  auto bTy = op.getB().getType().cast<RankedTensorType>();
-  auto cTy = op.getC().getType().cast<RankedTensorType>();
-  auto dTy = op.getResult().getType().cast<RankedTensorType>();
+  auto aTy = cast<RankedTensorType>(op.getA().getType());
+  auto bTy = cast<RankedTensorType>(op.getB().getType());
+  auto cTy = cast<RankedTensorType>(op.getC().getType());
+  auto dTy = cast<RankedTensorType>(op.getResult().getType());
 
   auto aElemTy = aTy.getElementType();
   auto bElemTy = bTy.getElementType();
@@ -548,7 +548,7 @@ bool supportMMA(triton::DotOp op, int version) {
     // We cannot use MMA_V3 if we need to accumulate in F32 within the MMA op.
     if (op.getMaxNumImpreciseAcc() < 32 &&
         (aElemTy.isFloat8E5M2() || aElemTy.isFloat8E4M3FNUZ()) &&
-        op.getType().cast<RankedTensorType>().getElementType().isF32()) {
+        cast<RankedTensorType>(op.getType()).getElementType().isF32()) {
       return false;
     }
   }
@@ -564,7 +564,7 @@ bool supportMMA(Value value, int version) {
   // types of both the operands are identical here.
   assert((version == 1 || version == 2 || version == 3) &&
          "Unexpected MMA layout version found");
-  auto elemTy = value.getType().cast<TensorOrMemDesc>().getElementType();
+  auto elemTy = cast<TensorOrMemDesc>(value.getType()).getElementType();
   // FP8 is not natively supported on all mma versions but it can always be
   // promoted to fp16 therefore we can always support it.
   bool isFP8 = elemTy.isFloat8E5M2() || elemTy.isFloat8E4M3FN() ||

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -154,7 +154,7 @@ private:
     }
     auto elemTy = type.getElementType();
     bool isInt1 = elemTy.isInteger(1);
-    bool isPtr = elemTy.isa<triton::PointerType>();
+    bool isPtr = isa<triton::PointerType>(elemTy);
     auto llvmElemTyOrig = getTypeConverter()->convertType(elemTy);
     if (isInt1)
       elemTy = IntegerType::get(elemTy.getContext(), 8);

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -91,7 +91,7 @@ ValueTable getValueTableFromStruct(Value val, int K, int n0, int shapePerCTA,
 Value loadAFMA(Value A, Value llA, BlockedEncodingAttr dLayout, Value thread,
                Location loc, const LLVMTypeConverter *typeConverter,
                ConversionPatternRewriter &rewriter) {
-  auto aTensorTy = A.getType().cast<MemDescType>();
+  auto aTensorTy = cast<MemDescType>(A.getType());
   auto aLayout = aTensorTy.getEncoding().cast<SharedEncodingAttr>();
   auto aShapePerCTA = getShapePerCTA(aTensorTy);
 
@@ -157,7 +157,7 @@ Value loadAFMA(Value A, Value llA, BlockedEncodingAttr dLayout, Value thread,
 Value loadBFMA(Value B, Value llB, BlockedEncodingAttr dLayout, Value thread,
                Location loc, const LLVMTypeConverter *typeConverter,
                ConversionPatternRewriter &rewriter) {
-  auto bTensorTy = B.getType().cast<MemDescType>();
+  auto bTensorTy = cast<MemDescType>(B.getType());
   auto bLayout = bTensorTy.getEncoding().cast<SharedEncodingAttr>();
   auto bShapePerCTA = getShapePerCTA(bTensorTy);
 

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -37,9 +37,9 @@ LogicalResult convertFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   auto C = op.getC();
   auto D = op.getResult();
 
-  auto aTensorTy = A.getType().cast<RankedTensorType>();
-  auto bTensorTy = B.getType().cast<RankedTensorType>();
-  auto dTensorTy = D.getType().cast<RankedTensorType>();
+  auto aTensorTy = cast<RankedTensorType>(A.getType());
+  auto bTensorTy = cast<RankedTensorType>(B.getType());
+  auto dTensorTy = cast<RankedTensorType>(D.getType());
 
   auto aShapePerCTA = getShapePerCTA(aTensorTy);
   auto bShapePerCTA = getShapePerCTA(bTensorTy);

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -45,7 +45,7 @@ struct LocalAllocOpConversion
     Location loc = op->getLoc();
     Value smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, op.getOperation());
-    auto resultTy = op.getType().cast<MemDescType>();
+    auto resultTy = cast<MemDescType>(op.getType());
     auto typeConverter = getTypeConverter();
     auto sharedLayout =
         resultTy.getEncoding().cast<triton::gpu::SharedEncodingAttr>();

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -205,7 +205,7 @@ private:
     SmallVector<Value> results(op.getNumOperands());
     for (unsigned i = 0; i < op.getNumOperands(); ++i) {
       if (auto resultTy =
-              op.getResult()[i].getType().dyn_cast<RankedTensorType>()) {
+              dyn_cast<RankedTensorType>(op.getResult()[i].getType())) {
         auto resultLayout = resultTy.getEncoding().cast<SliceEncodingAttr>();
         unsigned resultElems = getTotalElemsPerThread(resultTy);
         SmallVector<SmallVector<unsigned>> resultOffset =
@@ -373,7 +373,7 @@ private:
     for (unsigned i = 0; i < op.getNumOperands(); ++i) {
       auto elemTy = getElementType(op, i);
       if (auto resultTy =
-              op.getResult()[i].getType().dyn_cast<RankedTensorType>()) {
+              dyn_cast<RankedTensorType>(op.getResult()[i].getType())) {
         // nd-tensor where n >= 1
         auto resultLayout = resultTy.getEncoding().cast<SliceEncodingAttr>();
         unsigned resultElems = getTotalElemsPerThread(resultTy);

--- a/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
@@ -572,7 +572,7 @@ ScanOpConversion::emitFastScan(triton::ScanOp op, triton::ScanOpAdaptor adaptor,
 
   auto valuesTransposed = transpose(srcValues);
   for (unsigned i = 0; i < op.getNumOperands(); ++i) {
-    auto resultTy = op.getResult()[i].getType().dyn_cast<RankedTensorType>();
+    auto resultTy = dyn_cast<RankedTensorType>(op.getResult()[i].getType());
     results[i] = packLLElements(loc, getTypeConverter(), valuesTransposed[i],
                                 rewriter, resultTy);
   }

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -48,8 +48,8 @@ Type TritonGPUToLLVMTypeConverter::convertTritonPointerType(
     triton::PointerType type) {
   auto ctx = type.getContext();
   auto pointeeType = type.getPointeeType();
-  if (pointeeType.isa<RankedTensorType>()) {
-    auto rankedTensorType = pointeeType.cast<RankedTensorType>();
+  if (isa<RankedTensorType>(pointeeType)) {
+    auto rankedTensorType = cast<RankedTensorType>(pointeeType);
     // struct { offset0, offset1, shape0, shape1, stride0,
     // stride1, base_ptr};
     auto eleType = rankedTensorType.getElementType();

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -145,11 +145,11 @@ Value createConstantF64(Location loc, OpBuilder &rewriter, double v) {
 }
 
 Value createNaNConstant(Location loc, OpBuilder &rewriter, Type type) {
-  if (!type.isa<FloatType>()) {
+  if (!isa<FloatType>(type)) {
     llvm::report_fatal_error("Creating NaN constant for non-float type!");
   }
   return rewriter.create<LLVM::ConstantOp>(
-      loc, type, APFloat::getNaN(type.cast<FloatType>().getFloatSemantics()));
+      loc, type, APFloat::getNaN(cast<FloatType>(type).getFloatSemantics()));
 }
 
 // Create an index type constant.
@@ -174,9 +174,8 @@ Value createLLVMIntegerConstant(OpBuilder &builder, Location loc, short width,
 // (3) Bitcast result from dataTy (u16/u32/u64) back to elemTy
 Value createLoadDSmem(Location loc, PatternRewriter &rewriter, Value addr,
                       Value ctaId, Type elemTy) {
-  assert(addr.getType().isa<LLVMPointerType>() &&
-         "addr must be a pointer type");
-  auto ptrTy = addr.getType().cast<LLVMPointerType>();
+  assert(isa<LLVMPointerType>(addr.getType()) && "addr must be a pointer type");
+  auto ptrTy = cast<LLVMPointerType>(addr.getType());
   assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
   unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
   Value ret =
@@ -191,9 +190,8 @@ Value createLoadDSmem(Location loc, PatternRewriter &rewriter, Value addr,
 SmallVector<Value> createLoadDSmem(Location loc, PatternRewriter &rewriter,
                                    Value addr, Value ctaId, unsigned vec,
                                    Type elemTy) {
-  assert(addr.getType().isa<LLVMPointerType>() &&
-         "addr must be a pointer type");
-  auto ptrTy = addr.getType().cast<LLVMPointerType>();
+  assert(isa<LLVMPointerType>(addr.getType()) && "addr must be a pointer type");
+  auto ptrTy = cast<LLVMPointerType>(addr.getType());
   assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
   unsigned bitwidth = elemTy.getIntOrFloatBitWidth();
   Value retStruct = rewriter.create<triton::nvgpu::LoadDSmemOp>(
@@ -213,9 +211,8 @@ SmallVector<Value> createLoadDSmem(Location loc, PatternRewriter &rewriter,
 // (3) Create StoreDSmemOp
 void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
                       Value ctaId, Value value, Value pred) {
-  assert(addr.getType().isa<LLVMPointerType>() &&
-         "addr must be a pointer type");
-  auto ptrTy = addr.getType().cast<LLVMPointerType>();
+  assert(isa<LLVMPointerType>(addr.getType()) && "addr must be a pointer type");
+  auto ptrTy = cast<LLVMPointerType>(addr.getType());
   assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
   unsigned bitwidth = value.getType().getIntOrFloatBitWidth();
   auto dataTy = rewriter.getIntegerType(bitwidth);
@@ -236,9 +233,8 @@ void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
 // (3) Create StoreDSmemOp
 void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
                       Value ctaId, ArrayRef<Value> values, Value pred) {
-  assert(addr.getType().isa<LLVMPointerType>() &&
-         "addr must be a pointer type");
-  auto ptrTy = addr.getType().cast<LLVMPointerType>();
+  assert(isa<LLVMPointerType>(addr.getType()) && "addr must be a pointer type");
+  auto ptrTy = cast<LLVMPointerType>(addr.getType());
   assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for load_dsmem");
   unsigned bitwidth = 0;
   if (!values.empty()) {
@@ -262,7 +258,7 @@ SharedMemoryObject
 getSharedMemoryObjectFromStruct(Location loc, Value llvmStruct, Type elemTy,
                                 ConversionPatternRewriter &rewriter) {
   ArrayRef<Type> types =
-      llvmStruct.getType().cast<LLVM::LLVMStructType>().getBody();
+      cast<LLVM::LLVMStructType>(llvmStruct.getType()).getBody();
   SmallVector<Value> elems(types.size());
   for (unsigned i = 0; i < types.size(); ++i) {
     Type type = types[i];

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -19,7 +19,7 @@ struct SplatOpConversion : public ConvertOpToLLVMPattern<triton::SplatOp> {
                                   const LLVMTypeConverter *typeConverter,
                                   ConversionPatternRewriter &rewriter,
                                   Location loc) {
-    auto tensorTy = resType.cast<RankedTensorType>();
+    auto tensorTy = cast<RankedTensorType>(resType);
     // Check the converted type for the tensor as depending on the encoding the
     // converter may pick different element types.
     auto srcType = typeConverter->convertType(tensorTy);
@@ -99,7 +99,7 @@ struct CatOpConversion : public ConvertOpToLLVMPattern<CatOp> {
   matchAndRewrite(CatOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
-    auto resultTy = op.getType().template cast<RankedTensorType>();
+    auto resultTy = cast<RankedTensorType>(op.getType());
     unsigned elems = getTotalElemsPerThread(resultTy);
     auto typeConverter = getTypeConverter();
     Type elemTy = typeConverter->convertType(resultTy.getElementType());
@@ -139,7 +139,7 @@ struct JoinOpConversion : public ConvertOpToLLVMPattern<JoinOp> {
     // With these invariants, join is trivial: We just return the i'th element
     // from lhs, followed by the i'th elem from rhs.
     Location loc = op->getLoc();
-    auto resultTy = op.getType().cast<RankedTensorType>();
+    auto resultTy = cast<RankedTensorType>(op.getType());
     auto typeConverter = getTypeConverter();
     SmallVector<Value> lhsVals =
         unpackLLElements(loc, adaptor.getLhs(), rewriter);
@@ -183,7 +183,7 @@ struct SplitOpConversion : public ConvertOpToLLVMPattern<SplitOp> {
       outLhsVals.push_back(srcVals[i]);
       outRhsVals.push_back(srcVals[i + 1]);
     }
-    auto resultTy = op.getResult(0).getType().cast<RankedTensorType>();
+    auto resultTy = cast<RankedTensorType>(op.getResult(0).getType());
     Value retLhs =
         packLLElements(loc, typeConverter, outLhsVals, rewriter, resultTy);
     Value retRhs =
@@ -205,8 +205,8 @@ struct ReshapeOpConversion : public ConvertOpToLLVMPattern<ReshapeOp> {
       return emitOptionalError(loc,
                                "expensive view not supported on reshape op");
     }
-    auto resultTy = op.getType().template cast<RankedTensorType>();
-    auto srcTy = op.getSrc().getType().template cast<RankedTensorType>();
+    auto resultTy = cast<RankedTensorType>(op.getType());
+    auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
     auto typeConverter = getTypeConverter();
     auto vals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
     Value ret = packLLElements(loc, typeConverter, vals, rewriter, resultTy);
@@ -226,8 +226,8 @@ struct ExpandDimsOpConversion : public ConvertOpToLLVMPattern<ExpandDimsOp> {
     Location loc = op->getLoc();
     auto typeConverter = getTypeConverter();
     auto srcVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
-    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
-    auto resultTy = op.getType().template cast<RankedTensorType>();
+    auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
+    auto resultTy = cast<RankedTensorType>(op.getType());
     auto srcLayout = srcTy.getEncoding().dyn_cast<SliceEncodingAttr>();
     if (!srcLayout) {
       return emitOptionalError(
@@ -258,7 +258,7 @@ struct TransOpConversion : public ConvertOpToLLVMPattern<TransOp> {
   matchAndRewrite(TransOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
-    auto resultTy = op.getType().cast<TensorOrMemDesc>();
+    auto resultTy = cast<TensorOrMemDesc>(op.getType());
     if (auto enc = resultTy.getEncoding().dyn_cast<SharedEncodingAttr>()) {
       auto llvmElemTy =
           getTypeConverter()->convertType(resultTy.getElementType());
@@ -310,8 +310,8 @@ struct BroadcastOpConversion
     Location loc = op->getLoc();
     Value src = adaptor.getSrc();
     Value result = op.getResult();
-    auto srcTy = op.getSrc().getType().cast<RankedTensorType>();
-    auto resultTy = result.getType().cast<RankedTensorType>();
+    auto srcTy = cast<RankedTensorType>(op.getSrc().getType());
+    auto resultTy = cast<RankedTensorType>(result.getType());
     auto srcLayout = srcTy.getEncoding();
     auto resultLayout = resultTy.getEncoding();
     auto srcShape = srcTy.getShape();

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -36,7 +36,7 @@ TritonGPUTypeConverter::TritonGPUTypeConverter(MLIRContext *context,
   addConversion([this](triton::PointerType ptrType) -> triton::PointerType {
     // Check whether tensor pointer `tt.ptr<tensor<>>`
     auto pointeeTensorType =
-        ptrType.getPointeeType().dyn_cast<RankedTensorType>();
+        dyn_cast<RankedTensorType>(ptrType.getPointeeType());
     if (pointeeTensorType == nullptr)
       return ptrType;
 
@@ -109,9 +109,9 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
   // We have requirements for the data layouts
   addDynamicallyLegalOp<triton::DotOp>([](triton::DotOp dotOp) -> bool {
     Attribute aEncoding =
-        dotOp.getA().getType().cast<RankedTensorType>().getEncoding();
+        cast<RankedTensorType>(dotOp.getA().getType()).getEncoding();
     Attribute bEncoding =
-        dotOp.getB().getType().cast<RankedTensorType>().getEncoding();
+        cast<RankedTensorType>(dotOp.getB().getType()).getEncoding();
     if (aEncoding && aEncoding.isa<triton::gpu::DotOperandEncodingAttr>() &&
         bEncoding && bEncoding.isa<triton::gpu::DotOperandEncodingAttr>())
       return true;

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -56,7 +56,7 @@ public:
   matchAndRewrite(arith::ConstantOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Type retType = getTypeConverter()->convertType(op.getType());
-    auto retShapedType = retType.cast<ShapedType>();
+    auto retShapedType = cast<ShapedType>(retType);
     auto value = adaptor.getValue().dyn_cast<DenseElementsAttr>();
     if (dyn_cast<RankedTensorType>(retShapedType)) {
       assert(value);
@@ -145,7 +145,7 @@ struct TritonExpandDimsPattern
                   ConversionPatternRewriter &rewriter) const override {
     // Type retType = op.getType());
     RankedTensorType argType =
-        adaptor.getSrc().getType().cast<RankedTensorType>();
+        cast<RankedTensorType>(adaptor.getSrc().getType());
     Attribute _argEncoding = argType.getEncoding();
     if (!_argEncoding)
       return failure();
@@ -242,8 +242,8 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
     RankedTensorType retType =
         RankedTensorType::get(origShape, origType.getElementType(), dEncoding);
     // a & b must be of smem layout
-    auto aType = adaptor.getA().getType().cast<RankedTensorType>();
-    auto bType = adaptor.getB().getType().cast<RankedTensorType>();
+    auto aType = cast<RankedTensorType>(adaptor.getA().getType());
+    auto bType = cast<RankedTensorType>(adaptor.getB().getType());
     Type aEltType = aType.getElementType();
     Type bEltType = bType.getElementType();
     Attribute aEncoding = aType.getEncoding();
@@ -289,9 +289,8 @@ struct TritonCatPattern : public OpConversionPattern<triton::CatOp> {
     // next_power_of_2(lhs.total_elems_per_thread + rhs.total_elems_per_thread)
     // For now, this behaves like generic, but this
     // will evolve when we add support for `can_reorder=False`.
-    auto retType = this->getTypeConverter()
-                       ->convertType(op.getType())
-                       .cast<RankedTensorType>();
+    auto retType = cast<RankedTensorType>(
+        this->getTypeConverter()->convertType(op.getType()));
     auto retEncoding =
         retType.getEncoding().cast<triton::gpu::BlockedEncodingAttr>();
     auto lhsType = adaptor.getLhs().getType();
@@ -346,7 +345,7 @@ struct TritonSplitOpPattern : public OpConversionPattern<triton::SplitOp> {
   LogicalResult matchAndRewrite(SplitOp op, OpAdaptor adaptor,
                                 ConversionPatternRewriter &rewriter) const {
     auto src = adaptor.getSrc();
-    auto srcTy = src.getType().cast<RankedTensorType>();
+    auto srcTy = cast<RankedTensorType>(src.getType());
     auto srcEnc = srcTy.getEncoding().dyn_cast<BlockedEncodingAttr>();
     int rank = srcEnc.getOrder().size();
     auto typeConverter = getTypeConverter<TritonGPUTypeConverter>();
@@ -365,7 +364,7 @@ struct TritonSplitOpPattern : public OpConversionPattern<triton::SplitOp> {
       // it'll get fixed by RemoveLayoutConversions.
       auto defaultEnc = getDefaultBlockedEncoding(
           getContext(),
-          op.getResult(0).getType().cast<RankedTensorType>().getShape(),
+          cast<RankedTensorType>(op.getResult(0).getType()).getShape(),
           typeConverter->getNumWarps(), typeConverter->getThreadsPerWarp(),
           typeConverter->getNumCTAs());
 
@@ -408,7 +407,7 @@ struct TritonTransPattern : public OpConversionPattern<TransOp> {
   matchAndRewrite(TransOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Value src = adaptor.getSrc();
-    auto srcTy = src.getType().cast<RankedTensorType>();
+    auto srcTy = cast<RankedTensorType>(src.getType());
     auto srcEnc = srcTy.getEncoding();
     if (!srcEnc)
       return failure();
@@ -426,7 +425,7 @@ struct TritonBroadcastPattern
   LogicalResult
   matchAndRewrite(BroadcastOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto srcType = adaptor.getSrc().getType().cast<RankedTensorType>();
+    auto srcType = cast<RankedTensorType>(adaptor.getSrc().getType());
     auto srcEncoding = srcType.getEncoding();
     if (!srcEncoding)
       return failure();

--- a/lib/Dialect/NVGPU/IR/Dialect.cpp
+++ b/lib/Dialect/NVGPU/IR/Dialect.cpp
@@ -35,7 +35,7 @@ using namespace mlir::triton::nvgpu;
 void LoadDSmemOp::build(OpBuilder &builder, OperationState &state,
                         Type resultTy, Value addr, Value ctaId) {
   unsigned vec, bitwidth;
-  if (auto structTy = resultTy.dyn_cast<LLVM::LLVMStructType>()) {
+  if (auto structTy = dyn_cast<LLVM::LLVMStructType>(resultTy)) {
     auto types = structTy.getBody();
     assert(types.size() > 0 && "Invalid result type of LoadDSmemOp");
     vec = types.size();
@@ -72,7 +72,7 @@ void StoreDSmemOp::build(OpBuilder &builder, OperationState &state, Value addr,
 
 unsigned StoreDSmemOp::getBitwidth() {
   auto addrTy = getAddr().getType();
-  assert(addrTy.isa<LLVM::LLVMPointerType>() && "addr must be a pointer type");
+  assert(isa<LLVM::LLVMPointerType>(addrTy) && "addr must be a pointer type");
   if (getValues().empty())
     return 0;
   auto elemTy = getValues().back().getType();

--- a/lib/Dialect/Triton/IR/Types.cpp
+++ b/lib/Dialect/Triton/IR/Types.cpp
@@ -98,27 +98,27 @@ namespace triton {
 
 unsigned getPointeeBitWidth(Type type) {
   auto pointeeType = getPointeeType(type);
-  if (auto tensorTy = pointeeType.dyn_cast<RankedTensorType>())
+  if (auto tensorTy = dyn_cast<RankedTensorType>(pointeeType))
     return tensorTy.getElementType().getIntOrFloatBitWidth();
   return pointeeType.getIntOrFloatBitWidth();
 }
 
 Type getI1SameShape(Type type) {
   auto i1Type = IntegerType::get(type.getContext(), 1);
-  if (auto tensorTy = type.dyn_cast<RankedTensorType>())
+  if (auto tensorTy = dyn_cast<RankedTensorType>(type))
     return RankedTensorType::get(tensorTy.getShape(), i1Type,
                                  tensorTy.getEncoding());
   return i1Type;
 }
 
 Type getPointeeType(Type type) {
-  if (auto tensorTy = type.dyn_cast<RankedTensorType>()) {
+  if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
     // Tensor of pointers
     auto shape = tensorTy.getShape();
-    auto ptrType = tensorTy.getElementType().dyn_cast<PointerType>();
+    auto ptrType = dyn_cast<PointerType>(tensorTy.getElementType());
     Type pointeeType = ptrType.getPointeeType();
     return RankedTensorType::get(shape, pointeeType, tensorTy.getEncoding());
-  } else if (auto ptrType = type.dyn_cast<PointerType>()) {
+  } else if (auto ptrType = dyn_cast<PointerType>(type)) {
     // scalar pointer
     Type pointeeType = ptrType.getPointeeType();
     return pointeeType;
@@ -128,14 +128,14 @@ Type getPointeeType(Type type) {
 
 Type getI32SameShape(Type type) {
   auto i32Type = IntegerType::get(type.getContext(), 32);
-  if (auto tensorTy = type.dyn_cast<RankedTensorType>())
+  if (auto tensorTy = dyn_cast<RankedTensorType>(type))
     return RankedTensorType::get(tensorTy.getShape(), i32Type,
                                  tensorTy.getEncoding());
   return i32Type;
 }
 
 Type getPointerTypeSameShape(Type type) {
-  if (auto tensorTy = type.dyn_cast<RankedTensorType>()) {
+  if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
     Type elementType = tensorTy.getElementType();
     auto shape = tensorTy.getShape();
     PointerType ptrType = PointerType::get(elementType, 1);
@@ -148,18 +148,18 @@ Type getPointerTypeSameShape(Type type) {
 Type getPointerType(Type type) { return PointerType::get(type, 1); }
 
 bool isTensorPointerType(Type type) {
-  if (auto ptrType = type.dyn_cast<PointerType>())
-    return ptrType.getPointeeType().isa<RankedTensorType>();
+  if (auto ptrType = dyn_cast<PointerType>(type))
+    return isa<RankedTensorType>(ptrType.getPointeeType());
   return false;
 }
 
 bool isTensorOrTensorPointerType(Type type) {
-  return type.isa<RankedTensorType>() || isTensorPointerType(type);
+  return isa<RankedTensorType>(type) || isTensorPointerType(type);
 }
 
 Type getElementTypeOfTensorPointerType(Type type) {
-  if (auto ptrType = type.dyn_cast<PointerType>())
-    if (auto tensorTy = ptrType.getPointeeType().dyn_cast<RankedTensorType>())
+  if (auto ptrType = dyn_cast<PointerType>(type))
+    if (auto tensorTy = dyn_cast<RankedTensorType>(ptrType.getPointeeType()))
       return tensorTy.getElementType();
   return {};
 }

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -38,7 +38,7 @@ bool isBroadcastConstantCombinable(Attribute value) {
 
 DenseElementsAttr getConstantValue(Builder &builder, Attribute value,
                                    Value bcast_res) {
-  auto resType = bcast_res.getType().cast<ShapedType>();
+  auto resType = cast<ShapedType>(bcast_res.getType());
   DenseElementsAttr res;
   if (auto denseValue = value.dyn_cast<DenseElementsAttr>()) {
     res =
@@ -203,14 +203,14 @@ public:
     if (expandLhsAxis != 2 || expandRhsAxis != 0)
       return failure();
     auto broadcastLhsShape =
-        broadcastLhsOp.getType().cast<ShapedType>().getShape();
+        cast<ShapedType>(broadcastLhsOp.getType()).getShape();
     auto broadcastRhsShape =
-        broadcastLhsOp.getType().cast<ShapedType>().getShape();
+        cast<ShapedType>(broadcastLhsOp.getType()).getShape();
     if (broadcastLhsShape[2] < 16 || broadcastRhsShape[0] < 16)
       return failure();
     Type newAccType = RankedTensorType::get(
         {broadcastLhsShape[0], broadcastRhsShape[2]},
-        broadcastLhsOp.getSrc().getType().cast<ShapedType>().getElementType());
+        cast<ShapedType>(broadcastLhsOp.getSrc().getType()).getElementType());
     rewriter.setInsertionPoint(op);
     auto newAcc = rewriter.create<SplatOp>(
         op->getLoc(), newAccType,

--- a/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
+++ b/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
@@ -84,7 +84,7 @@ struct MoveSplatAfterElementwisePattern
     auto resultTypes = op->getResultTypes();
     llvm::SmallVector<Type, 4> scalarResultTys;
     for (auto resultTy : resultTypes) {
-      auto elemTy = resultTy.dyn_cast<TensorType>().getElementType();
+      auto elemTy = dyn_cast<TensorType>(resultTy).getElementType();
       scalarResultTys.push_back(elemTy);
     }
 
@@ -166,7 +166,7 @@ struct MoveBroadcastAfterElementwisePattern
         continue;
       }
       auto elemTy =
-          operand.getType().dyn_cast<RankedTensorType>().getElementType();
+          dyn_cast<RankedTensorType>(operand.getType()).getElementType();
       auto newTy = RankedTensorType::get(srcShape, elemTy, srcEncoding);
       if (auto splatOp = llvm::dyn_cast<SplatOp>(definingOp)) {
         auto newSplat = rewriter.create<SplatOp>(loc, newTy, splatOp.getSrc());
@@ -190,7 +190,7 @@ struct MoveBroadcastAfterElementwisePattern
     llvm::SmallVector<Type, 4> newResultTypes;
     auto resultTypes = op->getResultTypes();
     for (auto resultTy : resultTypes) {
-      auto elemTy = resultTy.dyn_cast<RankedTensorType>().getElementType();
+      auto elemTy = dyn_cast<RankedTensorType>(resultTy).getElementType();
       newResultTypes.push_back(
           RankedTensorType::get(srcShape, elemTy, srcEncoding));
     }

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -92,7 +92,7 @@ public:
            tensorShape.size() == strides.size());
     auto indexTensorType =
         RankedTensorType::get(tensorShape, builder.getI64Type());
-    auto ptrType = base.getType().cast<triton::PointerType>();
+    auto ptrType = cast<triton::PointerType>(base.getType());
     auto ptrTensorType = RankedTensorType::get(tensorShape, ptrType);
 
     // Generate offsets per dimension
@@ -166,7 +166,7 @@ public:
 
     // Create element attribute
     auto elementType =
-        base.getType().cast<triton::PointerType>().getPointeeType();
+        cast<triton::PointerType>(base.getType()).getPointeeType();
     auto otherTensorType = RankedTensorType::get(tensorShape, elementType);
 
     // Set zero padding value
@@ -226,8 +226,8 @@ public:
                                     triton::MakeTensorPtrOp op,
                                     std::stack<Operation *> &eraser) {
     // Save info for later use
-    auto ptrType = op.getType().cast<triton::PointerType>();
-    auto tensorType = ptrType.getPointeeType().cast<RankedTensorType>();
+    auto ptrType = cast<triton::PointerType>(op.getType());
+    auto tensorType = cast<RankedTensorType>(ptrType.getPointeeType());
 
     // Cast I32 offsets into I64
     SmallVector<Value> i64Offsets;

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -21,12 +21,12 @@ namespace triton {
 
 static Type getI1SameShapeFromTensorOrTensorPtr(Type type) {
   auto i1Type = IntegerType::get(type.getContext(), 1);
-  if (auto tensorType = type.dyn_cast<RankedTensorType>()) {
+  if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
     return RankedTensorType::get(tensorType.getShape(), i1Type,
                                  tensorType.getEncoding());
-  } else if (auto ptrType = type.dyn_cast<triton::PointerType>()) {
+  } else if (auto ptrType = dyn_cast<triton::PointerType>(type)) {
     Type pointeeType = ptrType.getPointeeType();
-    if (auto tensorType = pointeeType.dyn_cast<RankedTensorType>()) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(pointeeType)) {
       return RankedTensorType::get(tensorType.getShape(), i1Type,
                                    tensorType.getEncoding());
     }
@@ -61,17 +61,17 @@ SmallVector<unsigned> getElemsPerThread(Attribute layout,
 }
 
 SmallVector<unsigned> getElemsPerThread(Type type) {
-  if (type.isIntOrIndexOrFloat() || type.isa<triton::PointerType>())
+  if (type.isIntOrIndexOrFloat() || isa<triton::PointerType>(type))
     return SmallVector<unsigned>(1, 1);
-  auto tensorType = type.cast<RankedTensorType>();
+  auto tensorType = cast<RankedTensorType>(type);
   return getElemsPerThread(tensorType.getEncoding(), tensorType.getShape(),
                            tensorType.getElementType());
 }
 
 unsigned getTotalElemsPerThread(Type type) {
-  if (type.isIntOrIndexOrFloat() || type.isa<triton::PointerType>())
+  if (type.isIntOrIndexOrFloat() || isa<triton::PointerType>(type))
     return 1;
-  auto tensorType = type.cast<RankedTensorType>();
+  auto tensorType = cast<RankedTensorType>(type);
   return getTotalElemsPerThread(tensorType.getEncoding(), tensorType.getShape(),
                                 tensorType.getElementType());
 }
@@ -369,7 +369,7 @@ SmallVector<int64_t> getShapePerCTA(Attribute layout, ArrayRef<int64_t> shape) {
 }
 
 SmallVector<int64_t> getShapePerCTA(Type type) {
-  auto tensorType = type.cast<TensorOrMemDesc>();
+  auto tensorType = cast<TensorOrMemDesc>(type);
   return getShapePerCTA(tensorType.getEncoding(), tensorType.getShape());
 }
 
@@ -407,7 +407,7 @@ bool isaDistributedLayout(Attribute layout) {
 
 template <typename T> bool hasEncoding(Value value) {
   auto type = value.getType();
-  if (auto tensorType = type.dyn_cast<TensorOrMemDesc>()) {
+  if (auto tensorType = dyn_cast<TensorOrMemDesc>(type)) {
     auto encoding = tensorType.getEncoding();
     return encoding && encoding.isa<T>();
   }
@@ -2755,7 +2755,7 @@ struct CanonicalizeConvertFromConvert
     // cvt(type, constant) -> constant
     if (auto cst = llvm::dyn_cast<arith::ConstantOp>(arg))
       if (auto ret = cst.getValue().dyn_cast<SplatElementsAttr>()) {
-        auto ty = op->getResultTypes().front().cast<ShapedType>();
+        auto ty = cast<ShapedType>(op->getResultTypes().front());
         auto newRet =
             SplatElementsAttr::get(ty, ret.getSplatValue<Attribute>());
         rewriter.replaceOpWithNewOp<arith::ConstantOp>(op, newRet);

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -160,7 +160,7 @@ class BlockedToMMA : public mlir::RewritePattern {
     getBackwardSlice(x, &slice, opt);
     for (auto op : slice) {
       if (Value arg = op->getOperand(0))
-        if (auto argTy = arg.getType().dyn_cast<RankedTensorType>()) {
+        if (auto argTy = dyn_cast<RankedTensorType>(arg.getType())) {
           auto argBitWidth = argTy.getElementType().getIntOrFloatBitWidth();
           if (argBitWidth != origBitWidth) {
             origBitWidth = std::min<int>(origBitWidth, argBitWidth);
@@ -196,7 +196,7 @@ public:
     Value arg = v;
     if (auto cvtOp = v.getDefiningOp<ttg::ConvertLayoutOp>())
       arg = cvtOp.getSrc();
-    auto argType = arg.getType().cast<RankedTensorType>();
+    auto argType = cast<RankedTensorType>(arg.getType());
     auto eltType = argType.getElementType();
     assert(argType.getEncoding() && "unexpected tensor type");
     auto newOrder = ttg::getOrder(argType.getEncoding());
@@ -340,9 +340,8 @@ public:
 
 static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
                             Type promotedType) {
-  Type tensorPromotedType =
-      operand.getType().cast<RankedTensorType>().cloneWith(std::nullopt,
-                                                           promotedType);
+  Type tensorPromotedType = cast<RankedTensorType>(operand.getType())
+                                .cloneWith(std::nullopt, promotedType);
   return builder.create<tt::FpToFpOp>(loc, tensorPromotedType, operand);
 }
 

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeThreadLocality.cpp
@@ -102,7 +102,7 @@ class TritonGPUOptimizeThreadLocalityPass
 
     DenseSet<triton::ReduceOp> reduceOps;
     mod.walk([&](triton::ReduceOp reduce) -> void {
-      auto srcType = reduce.getOperands()[0].getType().cast<RankedTensorType>();
+      auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
       auto rank = srcType.getShape().size();
       auto srcEncoding = srcType.getEncoding();
       auto reductionOp = getReductionOp(reduce);
@@ -151,7 +151,7 @@ class TritonGPUOptimizeThreadLocalityPass
     IRRewriter builder(&getContext());
     for (auto reduce : reduceOps) {
       builder.setInsertionPoint(reduce);
-      auto srcType = reduce.getOperands()[0].getType().cast<RankedTensorType>();
+      auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
       auto srcShape = srcType.getShape();
       auto srcEncoding = srcType.getEncoding();
       assert(srcEncoding.isa<triton::gpu::BlockedEncodingAttr>() &&
@@ -299,7 +299,7 @@ private:
 
   Operation *createReduce(OpBuilder &builder, triton::ReduceOp reduce,
                           Type viewOpTensorType) const {
-    auto srcType = reduce.getOperands()[0].getType().cast<RankedTensorType>();
+    auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
     auto rank = srcType.getShape().size();
     builder.setInsertionPointAfter(reduce);
     IRMapping mapping;
@@ -356,8 +356,7 @@ private:
                          Attribute &slice2d) const {
     // Drop the last dimension (thread locality dimension)
     SmallVector<int64_t> accumShape(shape.begin(), shape.end() - 1);
-    auto elemType =
-        oldAccum.getType().cast<RankedTensorType>().getElementType();
+    auto elemType = cast<RankedTensorType>(oldAccum.getType()).getElementType();
     // Create tensor type for the new accumulator
     auto accumType = RankedTensorType::get(accumShape, elemType, slice2d);
     // Create new accumulator
@@ -374,7 +373,7 @@ private:
 
   SmallVector<int64_t>
   getThreadLocalityOptimizedShape(triton::ReduceOp reduce) const {
-    auto srcType = reduce.getOperands()[0].getType().cast<RankedTensorType>();
+    auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
     auto srcShape = srcType.getShape();
     auto rank = srcShape.size();
     auto elemsPerThread =
@@ -386,7 +385,7 @@ private:
   }
 
   Attribute getThreadLocalityOptimizedEncoding(triton::ReduceOp reduce) const {
-    auto srcType = reduce.getOperands()[0].getType().cast<RankedTensorType>();
+    auto srcType = cast<RankedTensorType>(reduce.getOperands()[0].getType());
     auto rank = srcType.getShape().size();
     auto srcEncoding = srcType.getEncoding();
     auto blocked = srcEncoding.dyn_cast<triton::gpu::BlockedEncodingAttr>();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -17,7 +17,7 @@ static Value getPredMask(RewriterBase &rewriter, Type typeLike,
   Type maskType = tt::getI1SameShape(typeLike);
   Location loc = pred.getLoc();
   Value mask = pred;
-  if (maskType.isa<RankedTensorType>()) {
+  if (isa<RankedTensorType>(maskType)) {
     mask = rewriter.create<tt::SplatOp>(loc, maskType, pred);
   }
   if (currentMask) {

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -92,14 +92,11 @@ void Prefetcher::cloneElementwiseOps(Value &ret, const SmallVector<Value> &vals,
   for (int i = 2; i < vals.size(); i++) {
     Value v = vals[i];
     Value curr = builder.clone(*v.getDefiningOp(), mapping)->getResult(0);
-    if (curr.getType().isa<RankedTensorType>()) {
+    if (isa<RankedTensorType>(curr.getType())) {
       auto retType = RankedTensorType::get(
-          ret.getType().cast<RankedTensorType>().getShape(),
-          curr.getType().cast<RankedTensorType>().getElementType(),
-          curr.getDefiningOp()
-              ->getOperand(0)
-              .getType()
-              .cast<RankedTensorType>()
+          cast<RankedTensorType>(ret.getType()).getShape(),
+          cast<RankedTensorType>(curr.getType()).getElementType(),
+          cast<RankedTensorType>(curr.getDefiningOp()->getOperand(0).getType())
               .getEncoding());
       curr.setType(retType);
     }
@@ -114,7 +111,7 @@ Value Prefetcher::generatePrefetch(Value v, unsigned opIdx, bool isPrologue,
                                    std::optional<int64_t> offsetK,
                                    std::optional<int64_t> shapeK) {
   // opIdx: 0 => a, 1 => b
-  auto type = v.getType().cast<triton::MemDescType>();
+  auto type = cast<triton::MemDescType>(v.getType());
   SmallVector<int64_t> shape{type.getShape().begin(), type.getShape().end()};
   SmallVector<int64_t> offset{0, 0};
   Type elementType = type.getElementType();

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -31,8 +31,8 @@ public:
     ModuleOp mod = getOperation();
     mod.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
       OpBuilder builder(cvtOp);
-      auto srcType = cvtOp.getSrc().getType().cast<RankedTensorType>();
-      auto dstType = cvtOp.getType().cast<RankedTensorType>();
+      auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
+      auto dstType = cast<RankedTensorType>(cvtOp.getType());
       auto srcEncoding = srcType.getEncoding();
       if (srcEncoding.isa<triton::gpu::SharedEncodingAttr>())
         return;

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -37,12 +37,12 @@ mlir::LogicalResult DotAsyncOp::inferReturnTypes(
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   // type is the same as the accumulator
-  auto accTy = operands[2].getType().cast<RankedTensorType>();
+  auto accTy = cast<RankedTensorType>(operands[2].getType());
   inferredReturnTypes.push_back(accTy);
 
   // verify encodings
-  auto aEnc = operands[0].getType().cast<TensorOrMemDesc>().getEncoding();
-  auto bEnc = operands[1].getType().cast<TensorOrMemDesc>().getEncoding();
+  auto aEnc = cast<TensorOrMemDesc>(operands[0].getType()).getEncoding();
+  auto bEnc = cast<TensorOrMemDesc>(operands[1].getType()).getEncoding();
   auto retEnc = accTy.getEncoding();
   if (aEnc) {
     assert(bEnc);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -49,9 +49,7 @@ public:
       OpBuilder builder(op);
       auto a = op->getOperand(0);
       auto b = op->getOperand(1);
-      auto mmaEncoding = op->getResult(0)
-                             .getType()
-                             .cast<RankedTensorType>()
+      auto mmaEncoding = cast<RankedTensorType>(op->getResult(0).getType())
                              .getEncoding()
                              .dyn_cast<ttg::NvidiaMmaEncodingAttr>();
       if (!mmaEncoding || !mmaEncoding.isHopper())

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PlanCTA.cpp
@@ -44,10 +44,10 @@ unsigned getNumUsers(Value value) {
 
 Type replaceLayout(const Type &type, const Attribute &newLayout) {
   Type curType = type;
-  auto ptrTy = curType.dyn_cast<triton::PointerType>();
+  auto ptrTy = dyn_cast<triton::PointerType>(curType);
   if (ptrTy)
     curType = ptrTy.getPointeeType();
-  if (auto tensorTy = curType.dyn_cast<RankedTensorType>())
+  if (auto tensorTy = dyn_cast<RankedTensorType>(curType))
     curType = RankedTensorType::get(tensorTy.getShape(),
                                     tensorTy.getElementType(), newLayout);
   if (ptrTy)
@@ -256,9 +256,9 @@ bool CTAPlanner::processDot(triton::FuncOp &funcOp) {
   funcOp.walk([&](triton::DotOp dot) {
     MLIRContext *ctx = dot.getContext();
 
-    auto aTy = dot.getA().getType().cast<RankedTensorType>();
-    auto bTy = dot.getB().getType().cast<RankedTensorType>();
-    auto dTy = dot.getD().getType().cast<RankedTensorType>();
+    auto aTy = cast<RankedTensorType>(dot.getA().getType());
+    auto bTy = cast<RankedTensorType>(dot.getB().getType());
+    auto dTy = cast<RankedTensorType>(dot.getD().getType());
 
     assert(aTy.getEncoding().isa<ttg::DotOperandEncodingAttr>() &&
            bTy.getEncoding().isa<ttg::DotOperandEncodingAttr>() &&
@@ -304,7 +304,7 @@ bool CTAPlanner::processReduce(triton::FuncOp &funcOp) {
     Value src = reduce.getOperands()[0];
     unsigned axis = reduce.getAxis();
 
-    auto srcTy = src.getType().cast<RankedTensorType>();
+    auto srcTy = cast<RankedTensorType>(src.getType());
     auto srcShape = srcTy.getShape();
     auto srcLayout = srcTy.getEncoding();
 
@@ -374,7 +374,7 @@ void CTAPlanner::processStoreLikeOps(triton::FuncOp &funcOp) {
   ttg::CTALayoutAttr CTALayout;
   for (Operation *store : stores) {
     if (auto tensorTy =
-            store->getOperand(0).getType().dyn_cast<RankedTensorType>()) {
+            dyn_cast<RankedTensorType>(store->getOperand(0).getType())) {
       if (!tiled) {
         // Use CTA tiling of the first store-like op as global CTA tiling
         CTALayout = ttg::getCTALayout(tensorTy.getEncoding());
@@ -406,9 +406,9 @@ bool CTAPlanner::propagateBackward(CastOp cast) {
     return false;
   } else if (numUsers == 1) {
     Type outTy = output.getType();
-    if (auto ptrTy = outTy.dyn_cast<triton::PointerType>())
+    if (auto ptrTy = dyn_cast<triton::PointerType>(outTy))
       outTy = ptrTy.getPointeeType();
-    Attribute layout = outTy.cast<RankedTensorType>().getEncoding();
+    Attribute layout = mlir::cast<RankedTensorType>(outTy).getEncoding();
     Operation *op = input.getDefiningOp();
     if (op == nullptr) {
       assert(input.isa<BlockArgument>() &&
@@ -461,9 +461,9 @@ bool CTAPlanner::propagateForward(CastOp cast) {
     cast.erase();
   } else if (numUsers == 1) {
     Type inTy = input.getType();
-    if (auto ptrTy = inTy.dyn_cast<triton::PointerType>())
+    if (auto ptrTy = dyn_cast<triton::PointerType>(inTy))
       inTy = ptrTy.getPointeeType();
-    Attribute layout = inTy.cast<RankedTensorType>().getEncoding();
+    Attribute layout = mlir::cast<RankedTensorType>(inTy).getEncoding();
     Operation *op = *output.user_begin();
     if (auto nextCast = llvm::dyn_cast<CastOp>(op)) {
       eliminateAdjacentCasts(cast, nextCast);
@@ -598,7 +598,7 @@ bool CTAPlanner::processLoadStore(Operation *op, Attribute layout) {
       Value val =
           op->getNumResults() > 0 ? op->getResult(0) : op->getOperand(0);
       Attribute originalLayout =
-          val.getType().cast<RankedTensorType>().getEncoding();
+          cast<RankedTensorType>(val.getType()).getEncoding();
       // Insert casts using originalLayout. Adjacent casts will be eliminated
       // and generate a ConvertLayoutOp with DSmem access
       return processLoadStore(op, originalLayout);
@@ -610,9 +610,9 @@ bool CTAPlanner::processLoadStore(Operation *op, Attribute layout) {
   llvm::SmallVector<Attribute> newOperandLayouts;
   for (unsigned i = 0; i < op->getNumOperands(); ++i) {
     auto type = op->getOperand(i).getType();
-    if (auto ptrTy = type.dyn_cast<triton::PointerType>())
+    if (auto ptrTy = dyn_cast<triton::PointerType>(type))
       type = ptrTy.getPointeeType();
-    auto tensorTy = type.cast<RankedTensorType>();
+    auto tensorTy = cast<RankedTensorType>(type);
     auto newLayout = replaceCTALayout(tensorTy.getEncoding(),
                                       tensorTy.getShape(), CTALayout);
     newOperandLayouts.push_back(newLayout);
@@ -621,9 +621,9 @@ bool CTAPlanner::processLoadStore(Operation *op, Attribute layout) {
   llvm::SmallVector<Attribute> newResultLayouts;
   for (unsigned i = 0; i < op->getNumResults(); ++i) {
     auto type = op->getResult(i).getType();
-    if (auto ptrTy = type.dyn_cast<triton::PointerType>())
+    if (auto ptrTy = dyn_cast<triton::PointerType>(type))
       type = ptrTy.getPointeeType();
-    auto tensorTy = type.cast<RankedTensorType>();
+    auto tensorTy = cast<RankedTensorType>(type);
     auto newLayout = replaceCTALayout(tensorTy.getEncoding(),
                                       tensorTy.getShape(), CTALayout);
     newResultLayouts.push_back(newLayout);
@@ -675,7 +675,7 @@ bool CTAPlanner::processElementwise(Operation *op, Attribute layout) {
 }
 
 bool CTAPlanner::processConstant(arith::ConstantOp constant, Attribute layout) {
-  if (auto tensorTy = constant.getType().dyn_cast<RankedTensorType>()) {
+  if (auto tensorTy = dyn_cast<RankedTensorType>(constant.getType())) {
     if (auto attr = constant.getValue().dyn_cast<SplatElementsAttr>()) {
 
       auto newTensorTy = RankedTensorType::get(

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -98,7 +98,7 @@ public:
     auto isConstraintNumber = isNumber(constraint);
     if (!isConstraintNumber) {
       auto ty = getTypeFromConstraint(constraint[0], rewriter);
-      if (val.getType().isa<LLVM::LLVMPointerType>()) {
+      if (isa<LLVM::LLVMPointerType>(val.getType())) {
         return ptrtoint(ty, val);
       } else {
         assert(val.getType().getIntOrFloatBitWidth() <=
@@ -479,7 +479,7 @@ public:
 
   std::vector<std::string>
   getOutputConstraints(ttn::WGMMAWaitGroupOp op) const {
-    auto outputStructType = op.getType().cast<LLVM::LLVMStructType>();
+    auto outputStructType = cast<LLVM::LLVMStructType>(op.getType());
     uint32_t numOutputRegs = outputStructType.getBody().size();
     std::string output =
         outputStructType.getBody().front().isF32() ? "=f" : "=r";
@@ -495,7 +495,7 @@ public:
   }
 
   std::string getPtxAsm(ttn::WGMMAWaitGroupOp op) const {
-    auto outputStructType = op.getType().dyn_cast<LLVM::LLVMStructType>();
+    auto outputStructType = dyn_cast<LLVM::LLVMStructType>(op.getType());
     uint32_t numCRegs = outputStructType.getBody().size();
     std::string args = "";
     uint32_t asmOpIdx = 0;
@@ -519,7 +519,7 @@ public:
     // the output is a struct or not. We should find a way to pass this info
     auto resultType = op.getType();
 
-    auto outputStructType = resultType.dyn_cast<LLVM::LLVMStructType>();
+    auto outputStructType = dyn_cast<LLVM::LLVMStructType>(resultType);
     uint32_t numOutputRegs = outputStructType.getBody().size();
     std::string output =
         outputStructType.getBody().front().isF32() ? "=f" : "=r";
@@ -533,7 +533,7 @@ public:
     auto opC = op.getOpC();
     auto typeA = opA.getType();
 
-    auto structTypeA = typeA.dyn_cast<LLVM::LLVMStructType>();
+    auto structTypeA = dyn_cast<LLVM::LLVMStructType>(typeA);
 
     // TODO (zahi): is this the best way to tie inputs/outputs ?
     if (opC)
@@ -567,9 +567,9 @@ public:
     auto typeA = opA.getType();
     auto typeB = opB.getType();
     auto typeOutput = op.getType();
-    auto structTypeA = typeA.dyn_cast<LLVM::LLVMStructType>();
-    auto structTypeB = typeB.dyn_cast<LLVM::LLVMStructType>();
-    auto structTypeOutput = typeOutput.dyn_cast<LLVM::LLVMStructType>();
+    auto structTypeA = dyn_cast<LLVM::LLVMStructType>(typeA);
+    auto structTypeB = dyn_cast<LLVM::LLVMStructType>(typeB);
+    auto structTypeOutput = dyn_cast<LLVM::LLVMStructType>(typeOutput);
     assert(!structTypeB && "Operand B can not be registers");
     assert(structTypeOutput && "Output and C operand must be registers");
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -251,7 +251,7 @@ private:
     }
     auto elemTy = type.getElementType();
     bool isInt1 = elemTy.isInteger(1);
-    bool isPtr = elemTy.isa<triton::PointerType>();
+    bool isPtr = isa<triton::PointerType>(elemTy);
     auto llvmElemTyOrig = getTypeConverter()->convertType(elemTy);
     if (isInt1)
       elemTy = IntegerType::get(elemTy.getContext(), 8);
@@ -695,7 +695,7 @@ private:
       // instructions to pack & unpack sub-word integers. A workaround is to
       // store the results of ldmatrix in i32
       auto elemSize = elemTy.getIntOrFloatBitWidth();
-      if (auto intTy = elemTy.dyn_cast<IntegerType>() && elemSize <= 16) {
+      if (auto intTy = dyn_cast<IntegerType>(elemTy) && elemSize <= 16) {
         auto fold = 32 / elemSize;
         for (unsigned i = 0; i < elems; i += fold) {
           Value val = i32_val(0);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv1.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv1.cpp
@@ -26,7 +26,7 @@ computeOffsets(Value threadId, bool isARow, bool isBRow, ArrayRef<int> fpw,
                ConversionPatternRewriter &rewriter, Location loc,
                Type resultTy) {
   auto *ctx = rewriter.getContext();
-  auto wpt = resultTy.cast<RankedTensorType>()
+  auto wpt = cast<RankedTensorType>(resultTy)
                  .getEncoding()
                  .cast<DotOperandEncodingAttr>()
                  .getParent()
@@ -92,7 +92,7 @@ static Value loadA(Value tensor, const SharedMemoryObject &smemObj,
                    const LLVMTypeConverter *typeConverter,
                    ConversionPatternRewriter &rewriter, Type resultTy) {
   static constexpr std::array<int, 3> fpw{{2, 2, 1}};
-  auto mmaEncoding = resultTy.cast<RankedTensorType>()
+  auto mmaEncoding = cast<RankedTensorType>(resultTy)
                          .getEncoding()
                          .cast<DotOperandEncodingAttr>()
                          .getParent()
@@ -100,7 +100,7 @@ static Value loadA(Value tensor, const SharedMemoryObject &smemObj,
   auto wpt = mmaEncoding.getWarpsPerCTA();
 
   auto *ctx = rewriter.getContext();
-  auto tensorTy = tensor.getType().cast<MemDescType>();
+  auto tensorTy = cast<MemDescType>(tensor.getType());
   auto sharedLayout = tensorTy.getEncoding().cast<SharedEncodingAttr>();
   auto shape = tensorTy.getShape();
   auto order = sharedLayout.getOrder();
@@ -109,7 +109,7 @@ static Value loadA(Value tensor, const SharedMemoryObject &smemObj,
   Value smemBase = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
 
   bool isARow = order[0] != 0;
-  auto resultEncoding = resultTy.cast<RankedTensorType>()
+  auto resultEncoding = cast<RankedTensorType>(resultTy)
                             .getEncoding()
                             .cast<DotOperandEncodingAttr>();
   auto [offsetAM, offsetAK, _3, _4] = computeOffsets(
@@ -219,7 +219,7 @@ static Value loadB(Value tensor, const SharedMemoryObject &smemObj,
                    const LLVMTypeConverter *typeConverter,
                    ConversionPatternRewriter &rewriter, Type resultTy) {
   static constexpr std::array<int, 3> fpw{{2, 2, 1}};
-  auto mmaEncoding = resultTy.cast<RankedTensorType>()
+  auto mmaEncoding = cast<RankedTensorType>(resultTy)
                          .getEncoding()
                          .cast<DotOperandEncodingAttr>()
                          .getParent()
@@ -229,7 +229,7 @@ static Value loadB(Value tensor, const SharedMemoryObject &smemObj,
   auto strides = smemObj.strides;
 
   auto *ctx = rewriter.getContext();
-  auto tensorTy = tensor.getType().cast<MemDescType>();
+  auto tensorTy = cast<MemDescType>(tensor.getType());
   auto sharedLayout = tensorTy.getEncoding().cast<SharedEncodingAttr>();
 
   auto shape = tensorTy.getShape();
@@ -238,7 +238,7 @@ static Value loadB(Value tensor, const SharedMemoryObject &smemObj,
   Value smem = smemObj.getBaseBeforeSlice(order[0], loc, rewriter);
   bool isBRow = order[0] != 0; // is row-major in shared memory layout
   // isBRow_ indicates whether B is row-major in DotOperand layout
-  auto resultEncoding = resultTy.cast<RankedTensorType>()
+  auto resultEncoding = cast<RankedTensorType>(resultTy)
                             .getEncoding()
                             .cast<DotOperandEncodingAttr>();
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMMAv2.cpp
@@ -319,15 +319,15 @@ MMA16816SmemLoader::loadX4(int batch, int mat0, int mat1, ArrayRef<Value> ptrs,
   Value ptr = getPtr(ptrIdx);
 
   // The struct should have exactly the same element types.
-  auto resTy = matTy.cast<LLVM::LLVMStructType>();
-  Type elemTy = matTy.cast<LLVM::LLVMStructType>().getBody()[0];
+  auto resTy = cast<LLVM::LLVMStructType>(matTy);
+  Type elemTy = cast<LLVM::LLVMStructType>(matTy).getBody()[0];
 
   // For some reasons, LLVM's NVPTX backend inserts unnecessary (?) integer
   // instructions to pack & unpack sub-word integers. A workaround is to
   // store the results of ldmatrix in i32
-  if (auto vecElemTy = elemTy.dyn_cast<VectorType>()) {
+  if (auto vecElemTy = dyn_cast<VectorType>(elemTy)) {
     Type elemElemTy = vecElemTy.getElementType();
-    if (auto intTy = elemElemTy.dyn_cast<IntegerType>()) {
+    if (auto intTy = dyn_cast<IntegerType>(elemElemTy)) {
       if (intTy.getWidth() <= 16) {
         elemTy = rewriter.getI32Type();
         resTy =
@@ -763,7 +763,7 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
                     const SharedMemoryObject &smemObj,
                     const LLVMTypeConverter *typeConverter, Value thread) {
   // Expand shared/dotOp to 3D before calling loadArg.
-  auto descTy = tensor.getType().cast<MemDescType>();
+  auto descTy = cast<MemDescType>(tensor.getType());
   auto expandedDescTy = getExpandedDesc(descTy);
   auto expandedEncoding =
       getExpandedEncoding(encoding).cast<DotOperandEncodingAttr>();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv1.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv1.cpp
@@ -45,22 +45,19 @@ LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   Value A = op.getA();
   Value B = op.getB();
   Value D = op.getResult();
-  auto mmaLayout = D.getType()
-                       .cast<RankedTensorType>()
+  auto mmaLayout = cast<RankedTensorType>(D.getType())
                        .getEncoding()
                        .cast<NvidiaMmaEncodingAttr>();
-  auto ALayout = A.getType()
-                     .cast<RankedTensorType>()
+  auto ALayout = cast<RankedTensorType>(A.getType())
                      .getEncoding()
                      .cast<DotOperandEncodingAttr>();
-  auto BLayout = B.getType()
-                     .cast<RankedTensorType>()
+  auto BLayout = cast<RankedTensorType>(B.getType())
                      .getEncoding()
                      .cast<DotOperandEncodingAttr>();
 
-  auto ATensorTy = A.getType().cast<RankedTensorType>();
-  auto BTensorTy = B.getType().cast<RankedTensorType>();
-  auto DTensorTy = D.getType().cast<RankedTensorType>();
+  auto ATensorTy = cast<RankedTensorType>(A.getType());
+  auto BTensorTy = cast<RankedTensorType>(B.getType());
+  auto DTensorTy = cast<RankedTensorType>(D.getType());
   auto AShape = ATensorTy.getShape();
   auto BShape = BTensorTy.getShape();
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -14,14 +14,14 @@ Value loadC(Value tensor, Value llTensor,
             const LLVMTypeConverter *typeConverter, Location loc,
             ConversionPatternRewriter &rewriter) {
   MLIRContext *ctx = tensor.getContext();
-  auto tensorTy = tensor.getType().cast<RankedTensorType>();
+  auto tensorTy = cast<RankedTensorType>(tensor.getType());
   size_t fcSize = triton::gpu::getTotalElemsPerThread(tensor.getType());
 
   assert(tensorTy.getEncoding().isa<NvidiaMmaEncodingAttr>() &&
          "Currently, we only support $c with a mma layout.");
   // Load a normal C tensor with mma layout, that should be a
   // LLVM::struct with fcSize elements.
-  auto structTy = llTensor.getType().cast<LLVM::LLVMStructType>();
+  auto structTy = cast<LLVM::LLVMStructType>(llTensor.getType());
   assert(structTy.getBody().size() == fcSize &&
          "DotOp's $c operand should pass the same number of values as $d in "
          "mma layout.");
@@ -307,9 +307,9 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
                          Value loadedB, Value loadedC, DotOp op,
                          DotOpAdaptor adaptor, bool isTuring) {
   MLIRContext *ctx = c.getContext();
-  auto aTensorTy = a.getType().cast<RankedTensorType>();
-  auto bTensorTy = b.getType().cast<RankedTensorType>();
-  auto dTensorTy = d.getType().cast<RankedTensorType>();
+  auto aTensorTy = cast<RankedTensorType>(a.getType());
+  auto bTensorTy = cast<RankedTensorType>(b.getType());
+  auto dTensorTy = cast<RankedTensorType>(d.getType());
 
   auto aShapePerCTA = triton::gpu::getShapePerCTA(aTensorTy);
   auto bShapePerCTA = triton::gpu::getShapePerCTA(bTensorTy);
@@ -371,7 +371,7 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
     Value mmaOut =
         builder.launch(rewriter, loc, getMmaRetType(mmaType, op.getContext()));
 
-    Type elemTy = mmaOut.getType().cast<LLVM::LLVMStructType>().getBody()[0];
+    Type elemTy = cast<LLVM::LLVMStructType>(mmaOut.getType()).getBody()[0];
     for (int i = 0; i < numMmaRets; ++i) {
       fc[(m * colsPerThread + 4 * n) / numCPackedElem + i + batchOffset * b] =
           extract_val(elemTy, mmaOut, i);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -33,7 +33,7 @@ using ::mlir::triton::gpu::NvidiaMmaEncodingAttr;
 using ::mlir::triton::gpu::SharedEncodingAttr;
 
 triton::nvgpu::WGMMAEltType getMmaRetType(Value d) {
-  auto dTy = d.getType().cast<RankedTensorType>().getElementType();
+  auto dTy = cast<RankedTensorType>(d.getType()).getElementType();
   if (dTy.isF32()) {
     return triton::nvgpu::WGMMAEltType::f32;
   } else if (dTy.isF16()) {
@@ -46,7 +46,7 @@ triton::nvgpu::WGMMAEltType getMmaRetType(Value d) {
 }
 
 triton::nvgpu::WGMMAEltType getMmaOperandType(Value a, bool allowTF32) {
-  auto aTy = a.getType().cast<TensorOrMemDesc>().getElementType();
+  auto aTy = cast<TensorOrMemDesc>(a.getType()).getElementType();
   if (aTy.isF16()) {
     return triton::nvgpu::WGMMAEltType::f16;
   } else if (aTy.isBF16()) {
@@ -139,7 +139,7 @@ public:
                        ConversionPatternRewriter &rewriter, Location loc)
       : base(base), shape(shape), warpId(warpId), dimWpt(dimWpt), trans(trans),
         instrShape(instrShape) {
-    auto ty = tensor.getType().cast<MemDescType>();
+    auto ty = cast<MemDescType>(tensor.getType());
     auto sharedLayout = ty.getEncoding().cast<SharedEncodingAttr>();
     ord = sharedLayout.getOrder();
     const int perPhase = sharedLayout.getPerPhase();
@@ -196,7 +196,7 @@ DotOpMmaV3SmemLoader loadA(const LLVMTypeConverter *typeConverter,
                            ConversionPatternRewriter &rewriter, Location loc,
                            const NvidiaMmaEncodingAttr &mmaEncoding,
                            Value tensor, Value smemObjBase, Value thread) {
-  auto aTy = tensor.getType().cast<TensorOrMemDesc>();
+  auto aTy = cast<TensorOrMemDesc>(tensor.getType());
   auto aSharedLayout = aTy.getEncoding().dyn_cast<SharedEncodingAttr>();
   assert(aSharedLayout && "only support load dot operand from shared.");
   auto instrShape = mmaEncoding.getInstrShape();
@@ -233,7 +233,7 @@ DotOpMmaV3SmemLoader loadB(const LLVMTypeConverter *typeConverter,
                            ConversionPatternRewriter &rewriter, Location loc,
                            NvidiaMmaEncodingAttr &mmaEncoding, Value tensor,
                            Value base, Value thread) {
-  auto bTy = tensor.getType().cast<MemDescType>();
+  auto bTy = cast<MemDescType>(tensor.getType());
   auto bSharedLayout = bTy.getEncoding().cast<SharedEncodingAttr>();
   assert(bSharedLayout && "only support load B from shared.");
   auto instrShape = mmaEncoding.getInstrShape();
@@ -322,7 +322,7 @@ static bool isFP8(triton::nvgpu::WGMMAEltType eltType) {
 
 static Value faddAccumulate(ConversionPatternRewriter &rewriter, Location loc,
                             Value a, Value b) {
-  int numEl = a.getType().cast<LLVM::LLVMStructType>().getBody().size();
+  int numEl = cast<LLVM::LLVMStructType>(a.getType()).getBody().size();
   Value newStruct = rewriter.create<LLVM::UndefOp>(loc, a.getType());
   for (int i = 0; i < numEl; ++i) {
     Value lhs = rewriter.create<LLVM::ExtractValueOp>(loc, a, i);
@@ -371,9 +371,9 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
                          Value loadedA, Value loadedB, Value loadedC,
                          bool allowTF32, uint32_t maxNumImpreciseAcc, bool sync,
                          Value thread) {
-  auto aTensorTy = a.getType().cast<TensorOrMemDesc>();
-  auto bTensorTy = b.getType().cast<TensorOrMemDesc>();
-  auto dTensorTy = d.getType().cast<RankedTensorType>();
+  auto aTensorTy = cast<TensorOrMemDesc>(a.getType());
+  auto bTensorTy = cast<TensorOrMemDesc>(b.getType());
+  auto dTensorTy = cast<RankedTensorType>(d.getType());
   auto aSharedLayout = aTensorTy.getEncoding().dyn_cast<SharedEncodingAttr>();
   auto bSharedLayout = bTensorTy.getEncoding().cast<SharedEncodingAttr>();
   auto mmaEncoding = dTensorTy.getEncoding().cast<NvidiaMmaEncodingAttr>();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -190,7 +190,7 @@ static std::optional<NVVM::ReduxKind> matchReduxKind(triton::ReduceOp op,
   if (!reduceOp || reduceOp->getNumOperands() != 2 ||
       reduceOp->getNumResults() != 1)
     return std::nullopt;
-  auto intType = reduceOp->getResultTypes()[0].dyn_cast<IntegerType>();
+  auto intType = dyn_cast<IntegerType>(reduceOp->getResultTypes()[0]);
   if (!intType || intType.getWidth() > 32)
     return std::nullopt;
   if (reduceOp->getOperand(0) != block->getArgument(0) ||
@@ -241,7 +241,7 @@ Value TargetInfo::loadShared(ConversionPatternRewriter &rewriter, Location loc,
                              const TypeConverter *converter, Value ptr,
                              Type elemTy, Value pred) const {
   MLIRContext *ctx = rewriter.getContext();
-  auto ptrTy = ptr.getType().cast<LLVM::LLVMPointerType>();
+  auto ptrTy = cast<LLVM::LLVMPointerType>(ptr.getType());
   assert(ptrTy.getAddressSpace() == 3 && "Invalid addr space for loadShared");
   unsigned bitwidth = std::max(8u, elemTy.getIntOrFloatBitWidth());
 
@@ -301,7 +301,7 @@ bool TargetInfo::warpReduce(ConversionPatternRewriter &rewriter, Location loc,
                    and_(laneId, i32_val(~(numLaneToReduce - 1))));
       }
       for (unsigned i = 0; i < acc.size(); ++i) {
-        unsigned bitwidth = acc[i].getType().cast<IntegerType>().getWidth();
+        unsigned bitwidth = cast<IntegerType>(acc[i].getType()).getWidth();
         if (bitwidth < 32) {
           if (*kind == NVVM::ReduxKind::MIN || *kind == NVVM::ReduxKind::MAX)
             acc[i] = sext(i32_ty, acc[i]);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -208,9 +208,8 @@ private:
 
   static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
                               Type promotedType) {
-    Type tensorPromotedType =
-        operand.getType().cast<RankedTensorType>().cloneWith(std::nullopt,
-                                                             promotedType);
+    Type tensorPromotedType = cast<RankedTensorType>(operand.getType())
+                                  .cloneWith(std::nullopt, promotedType);
     return builder.create<triton::FpToFpOp>(loc, tensorPromotedType, operand);
   }
 };

--- a/unittest/Conversion/TritonGPUToLLVM/DumpLayout.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/DumpLayout.cpp
@@ -140,7 +140,7 @@ int evalGEPOp(mlir::LLVM::GEPOp gepOp, int ctaid, int tid) {
   assert(gepOp.getNumOperands() == 2 && "Unrecognized format of GEPOp");
   int base = eval(gepOp.getBase(), ctaid, tid);
   int offset = eval(gepOp.getOperand(1), ctaid, tid);
-  auto llPtrTy = gepOp.getRes().getType().cast<LLVM::LLVMPointerType>();
+  auto llPtrTy = cast<LLVM::LLVMPointerType>(gepOp.getRes().getType());
   int bytesPerElem = llPtrTy.getIntOrFloatBitWidth() / 8;
   return base + offset * bytesPerElem;
 }

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -345,11 +345,11 @@ TEST_P(InferReshapeOpNoReorderEncodingTest, DoIt) {
     FAIL() << "Could not parse destination type: " << dstTyStr;
 
   std::optional<BlockedEncodingAttr> expectedDstEnc;
-  if (auto dstEnc = dst.cast<RankedTensorType>().getEncoding()) {
+  if (auto dstEnc = cast<RankedTensorType>(dst).getEncoding()) {
     expectedDstEnc = dstEnc.cast<BlockedEncodingAttr>();
   }
 
-  testReshape(src.cast<RankedTensorType>(), dst.cast<RankedTensorType>(),
+  testReshape(cast<RankedTensorType>(src), cast<RankedTensorType>(dst),
               expectedDstEnc, expectSuccess, inferLayout, /*longErrors=*/true);
 }
 


### PR DESCRIPTION
These member functions are deprecated.

See https://mlir.llvm.org/deprecation and
https://discourse.llvm.org/t/preferred-casting-style-going-forward.