### PR TITLE
[backend][amd] Make target specification and usage consistent

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -58,7 +58,6 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   // List of undefined symbols:
   // createTritonAMDGPUCoalesce is not defined
   // createTritonAMDGPUOptimizeDotOperands is not defined
-  // createTritonAMDGPUPipeline is not defined
   // createTritonAMDGPUPrefetch is not defined
 
   // mlir::registerTritonAMDGPUPasses();

--- a/include/triton/Conversion/TritonToTritonGPU/Passes.td
+++ b/include/triton/Conversion/TritonToTritonGPU/Passes.td
@@ -29,8 +29,8 @@ def ConvertTritonToTritonGPU: Pass<"convert-triton-to-tritongpu", "mlir::ModuleO
               "int32_t", /*default*/"1",
               "number of ctas in a cga">,
         Option<"computeCapability", "compute-capability",
-              "std::optional<int32_t>", /*default*/"std::nullopt",
-              "optional compute capability for cuda">
+              "int32_t", /*default*/"0",
+              "optional compute capability for cuda; 0 means missing">
    ];
 }
 

--- a/include/triton/Conversion/TritonToTritonGPU/Passes.td
+++ b/include/triton/Conversion/TritonToTritonGPU/Passes.td
@@ -29,8 +29,8 @@ def ConvertTritonToTritonGPU: Pass<"convert-triton-to-tritongpu", "mlir::ModuleO
               "int32_t", /*default*/"1",
               "number of ctas in a cga">,
         Option<"computeCapability", "compute-capability",
-              "int32_t", /*default*/"80",
-              "compute capability">
+              "std::optional<int32_t>", /*default*/"std::nullopt",
+              "optional compute capability for cuda">
    ];
 }
 

--- a/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
+++ b/include/triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h
@@ -2,6 +2,7 @@
 #define TRITON_CONVERSION_TRITONTOTRITONGPU_TRITONTOTRITONGPUPASS_H
 
 #include <memory>
+#include <optional>
 
 namespace mlir {
 
@@ -21,9 +22,9 @@ constexpr static char AttrNumThreadsPerWarp[] = "triton_gpu.threads-per-warp";
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonToTritonGPUPass();
 
 // Create the pass with numWarps set explicitly.
-std::unique_ptr<OperationPass<ModuleOp>>
-createConvertTritonToTritonGPUPass(int numWarps, int threadsPerWarp = 32,
-                                   int numCTAs = 1, int computeCapability = 80);
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonToTritonGPUPass(
+    int numWarps, int threadsPerWarp = 32, int numCTAs = 1,
+    std::optional<int> computeCapability = std::nullopt);
 
 } // namespace triton
 } // namespace mlir

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
@@ -33,11 +33,10 @@ def TritonGPU_Dialect : Dialect {
         return 1;
       return mod->getAttr("triton_gpu.num-ctas").cast<IntegerAttr>().getInt();
     }
-    static int getComputeCapability(ModuleOp mod) {
-      if (!mod->hasAttr("triton_gpu.compute-capability"))
-        llvm::report_fatal_error(
-            "TritonGPU module should contain a triton_gpu.compute-capability attribute");
-      return mod->getAttrOfType<IntegerAttr>("triton_gpu.compute-capability").getInt();
+    static std::optional<int> getComputeCapability(ModuleOp mod) {
+      auto attr = mod->getAttrOfType<IntegerAttr>("triton_gpu.compute-capability");
+      if (attr) return attr.getInt();
+      return std::nullopt;
     }
     void registerTypes();
 

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -749,7 +749,7 @@ public:
     this->numWarps = numWarps;
     this->threadsPerWarp = threadsPerWarp;
     this->numCTAs = numCTAs;
-    this->computeCapability = computeCapability;
+    this->computeCapability = computeCapability.value_or(0);
   }
 
   void runOnOperation() override {
@@ -784,8 +784,10 @@ public:
                  IntegerAttr::get(i32_ty, llvm::APInt(32, numCTAs.getValue())));
 
     if (std::optional<int> cc = computeCapability.getValue()) {
-      mod->setAttr(AttrComputeCapabilityName,
-                   IntegerAttr::get(i32_ty, llvm::APInt(32, cc.value())));
+      if (cc.value() != 0) {
+        mod->setAttr(AttrComputeCapabilityName,
+                     IntegerAttr::get(i32_ty, llvm::APInt(32, cc.value())));
+      }
     }
 
     if (failed(applyPartialConversion(mod, target, std::move(patterns))))

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -327,7 +327,10 @@ public:
 
     mlir::RewritePatternSet patterns(context);
     patterns.add<SwizzleShmemConvert>(context);
-    if (triton::gpu::TritonGPUDialect::getComputeCapability(m) >= 80)
+    // TODO: compute capability is CUDA specific; change it to backend agnostic.
+    std::optional<int> cc =
+        triton::gpu::TritonGPUDialect::getComputeCapability(m);
+    if (cc.value_or(0) >= 80)
       patterns.add<HoistLayoutConversion>(context);
     patterns.add<FuseTransHopper>(context);
     patterns.add<MMAV3UseRegOperand>(context);

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -11,6 +11,7 @@
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Target/LLVMIR/Passes.h"
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 
 namespace py = pybind11;
 
@@ -39,7 +40,8 @@ void init_triton_passes_ttir(py::module &&m) {
   ADD_PASS_WRAPPER_0("add_rewrite_tensor_pointer",
                      createRewriteTensorPointerPass);
   ADD_PASS_WRAPPER_4("add_convert_to_ttgpuir",
-                     createConvertTritonToTritonGPUPass, int, int, int, int);
+                     createConvertTritonToTritonGPUPass, int, int, int,
+                     std::optional<int>);
 }
 
 void init_triton_passes_ttgpuir(py::module &&m) {

--- a/test/Conversion/amd/decompose-unsupported-conversions.mlir
+++ b/test/Conversion/amd/decompose-unsupported-conversions.mlir
@@ -4,7 +4,7 @@
 // CHECK: #[[WMMA:.+]] = #triton_gpu.amd_wmma<{{.*}}>
 // CHECK: #[[SHARED:.+]] = #triton_gpu.shared<{{.*}}>
 #mma = #triton_gpu.amd_wmma<{warpsPerCTA = [2, 2]}>
-module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
   tt.func @wmma_to_wmma_dot_op(%arg0: tensor<16x16xf16, #mma>) {
     // CHECK: %[[SRC_BLOCKED:.+]] = triton_gpu.convert_layout %{{.*}} : tensor<16x16xf16, #[[WMMA]]> -> tensor<16x16xf16, #[[BLOCKED]]>
     // CHECK-NEXT: %[[INT_SHARED:.+]] = triton_gpu.local_alloc %[[SRC_BLOCKED]] : {{.*}} -> !tt.memdesc<16x16xf16, #[[SHARED]]>

--- a/test/Conversion/amd/fp_to_fp.mlir
+++ b/test/Conversion/amd/fp_to_fp.mlir
@@ -1,8 +1,8 @@
-// RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm | FileCheck %s
+// RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s
 
 //  CHECK-LABEL: f16_to_f32
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
   tt.func @f16_to_f32(%arg0: tensor<8x8xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>) {
     // CHECK-COUNT-8: llvm.inline_asm asm_dialect {{.*}}v_cvt_f32_f16 {{.*}}: (f16) -> f32
     %0 = tt.fp_to_fp %arg0 : tensor<8x8xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>> -> tensor<8x8xf32, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>

--- a/test/Conversion/amd/load_store.mlir
+++ b/test/Conversion/amd/load_store.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm | FileCheck %s
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s
 
 #blocked0 = #triton_gpu.blocked<{sizePerThread = [8], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 1 : i32} {

--- a/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
@@ -1,8 +1,8 @@
-// RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm | FileCheck %s
+// RUN: triton-opt %s --split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx942 | FileCheck %s
 
 #shared = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], hasLeadingOffset = false}>
 #mma = #triton_gpu.amd_wmma<{warpsPerCTA = [2, 2]}>
-module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
   //  CHECK-LABEL: wmma_dot_operand
   tt.func @wmma_dot_operand(%arg0: !tt.memdesc<64x64xf16, #shared>) {
     // 2 CTA * 4 rep * load_per_thread_per_instr

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file --pass-pipeline="builtin.module(convert-triton-to-tritongpu{compute-capability=80 num-warps=2})" | FileCheck %s
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='compute-capability=80 num-warps=2' | FileCheck %s
 
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 : i32} {
 tt.func @ops() {

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -1,4 +1,4 @@
-// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu=num-warps=2 | FileCheck %s
+// RUN: triton-opt %s -split-input-file --pass-pipeline="builtin.module(convert-triton-to-tritongpu{compute-capability=80 num-warps=2})" | FileCheck %s
 
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 2 : i32} {
 tt.func @ops() {

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma.mlir
@@ -4,7 +4,7 @@
 // CHECK: #[[WMAA_0:.+]] = #triton_gpu.amd_wmma<{warpsPerCTA = [1, 4]}>
 // CHECK: #[[WMAA_1:.+]] = #triton_gpu.amd_wmma<{warpsPerCTA = [2, 2]}>
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
-module attributes {"triton_gpu.compute-capability" = 90 : i32, "triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-warp" = 32 : i32} {
   tt.func public @wmma_dot_cf32(
    // CHECK: %[[DOT0_ARG_A:.+]]: tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #[[DOT_OP_PARENT]]}>>
    %0: tensor<128x64xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #blocked}>>,

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -31,13 +31,6 @@ class HIPOptions:
     allow_flush_denorm: bool = False
     max_num_imprecise_acc_default: int = 0
 
-    def has_amd_mma_instr(self) -> bool:
-        is_RDNA3 = 'gfx11' in self.arch
-        is_CDNA1 = self.arch in ['gfx908']
-        is_CDNA2 = self.arch in ['gfx90a']
-        is_CDNA3 = self.arch in ['gfx940', 'gfx941', 'gfx942']
-        return is_RDNA3 or is_CDNA1 or is_CDNA2 or is_CDNA3
-
     def __post_init__(self):
         default_libdir = Path(__file__).parent / 'lib'
         extern_libs = {} if self.extern_libs is None else dict(self.extern_libs)

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -26,33 +26,10 @@ class HIPOptions:
     default_dot_input_precision: str = "ieee"
     allowed_dot_input_precisions: Tuple[str] = ("ieee", )
     enable_fp_fusion: bool = True
-    capability: int = None
     matrix_instr_nonkdim: int = 0
     kpack: int = 1
     allow_flush_denorm: bool = False
     max_num_imprecise_acc_default: int = 0
-
-    @staticmethod
-    def get_warp_size(arch: str) -> int:
-        # 64 is not supported for RDNA for now
-        if 'gfx10' in arch or 'gfx11' in arch:
-            return 32
-        if 'gfx9' in arch:
-            return 64
-        print("Warning: Unexpected device. Wave Size is set to 64.")
-        return 64  # Default value
-
-    @staticmethod
-    def get_compute_capability(arch: str) -> int:
-        arch_dict = {
-            'gfx940': 300,
-            'gfx941': 300,
-            'gfx942': 300,
-            'gfx90a': 200,
-            'gfx908': 100,
-            'gfx906': 60,
-        }
-        return arch_dict.get(arch, 0)
 
     def has_amd_mma_instr(self) -> bool:
         is_RDNA3 = 'gfx11' in self.arch
@@ -93,7 +70,6 @@ class HIPBackend(BaseBackend):
     def parse_options(self, opts) -> Any:
         args = {'arch': self.target.arch}
         args.update({k: opts[k] for k in HIPOptions.__dataclass_fields__.keys() if k in opts})
-        args['capability'] = HIPOptions.get_compute_capability(args['arch'])
         return HIPOptions(**args)
 
     def pack_metadata(self, metadata):
@@ -128,7 +104,7 @@ class HIPBackend(BaseBackend):
         raise Exception("ROCm linker /opt/rocm/llvm/bin/ld.lld not found")
 
     @staticmethod
-    def make_ttir(mod, metadata, opt):
+    def make_ttir(mod, metadata, options):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.common.add_inliner(pm)
@@ -143,28 +119,27 @@ class HIPBackend(BaseBackend):
         return mod
 
     @staticmethod
-    def make_ttgir(mod, metadata, opt):
+    def make_ttgir(mod, metadata, options):
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
-        # TODO: capability
-        passes.ttir.add_convert_to_ttgpuir(pm, opt.num_warps, opt.warp_size, opt.num_ctas, 90)
+        passes.ttir.add_convert_to_ttgpuir(pm, options.num_warps, options.warp_size, options.num_ctas, None)
         pm.run(mod)
         pm = ir.pass_manager(mod.context)
         pm.enable_debug()
         passes.ttgpuir.add_coalesce(pm)
         amd.passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_optimize_thread_locality(pm)
-        amd.passes.ttgpuir.add_accelerate_matmul(pm, opt.arch, opt.matrix_instr_nonkdim, opt.kpack)
+        amd.passes.ttgpuir.add_accelerate_matmul(pm, options.arch, options.matrix_instr_nonkdim, options.kpack)
         amd.passes.ttgpuir.add_remove_layout_conversions(pm)
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm)
-        if opt.num_stages == 0 and opt.has_amd_mma_instr():
+        if options.num_stages == 0 and amd.has_matrix_core_feature(options.arch):
             amd.passes.ttgpuir.add_stream_pipeline(pm)
             passes.common.add_canonicalizer(pm)
         passes.ttgpuir.add_optimize_dot_operands(pm)
         amd.passes.ttgpuir.add_remove_layout_conversions(pm)
         passes.ttgpuir.add_reduce_data_duplication(pm)
-        if opt.num_stages != 0:
+        if options.num_stages != 0:
             amd.passes.ttgpuir.add_reorder_instructions(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
@@ -172,7 +147,7 @@ class HIPBackend(BaseBackend):
         return mod
 
     @staticmethod
-    def make_llir(src, metadata, options, capability):
+    def make_llir(src, metadata, options):
         mod = src
         # TritonGPU -> LLVM-IR (MLIR)
         pm = ir.pass_manager(mod.context)
@@ -182,7 +157,7 @@ class HIPBackend(BaseBackend):
         passes.convert.add_index_to_llvmir(pm)
 
         passes.ttgpuir.add_allocate_shared_memory(pm)
-        amd.passes.ttgpuir.add_to_llvmir(pm, capability)
+        amd.passes.ttgpuir.add_to_llvmir(pm, options.arch)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
 
@@ -243,7 +218,7 @@ class HIPBackend(BaseBackend):
         assert len(names) == 1
         metadata["name"] = names[0]
         # llvm -> hsaco
-        amdgcn = llvm.translate_to_asm(src, 'amdgcn-amd-amdhsa', options.arch, '', [], options.enable_fp_fusion, False)
+        amdgcn = llvm.translate_to_asm(src, amd.TARGET_TRIPLE, options.arch, '', [], options.enable_fp_fusion, False)
         if os.environ.get("AMDGCN_ENABLE_DUMP", "0") == "1":
             print("// -----// AMDGCN Dump //----- //")
             print(amdgcn)
@@ -266,7 +241,7 @@ class HIPBackend(BaseBackend):
     def add_stages(self, stages, options):
         stages["ttir"] = lambda src, metadata: self.make_ttir(src, metadata, options)
         stages["ttgir"] = lambda src, metadata: self.make_ttgir(src, metadata, options)
-        stages["llir"] = lambda src, metadata: self.make_llir(src, metadata, options, options.capability)
+        stages["llir"] = lambda src, metadata: self.make_llir(src, metadata, options)
         stages["amdgcn"] = lambda src, metadata: self.make_amdgcn(src, metadata, options)
         stages["hsaco"] = lambda src, metadata: self.make_hsaco(src, metadata, options)
 

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.h
@@ -24,9 +24,9 @@ createDecomposeUnsupportedConversionsPass();
 
 } // namespace AMD
 
-std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonAMDGPUToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertTritonAMDGPUToLLVMPass(int32_t computeCapability);
+createConvertTritonAMDGPUToLLVMPass(StringRef targetArch);
+
 #define GEN_PASS_REGISTRATION
 #include "TritonAMDGPUToLLVM/Passes.h.inc"
 

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
@@ -13,7 +13,7 @@ def ConvertTritonAMDGPUToLLVM : Pass<"convert-triton-amdgpu-to-llvm", "mlir::Mod
     let description = [{
 
     }];
-    let constructor = "mlir::triton::createConvertTritonAMDGPUToLLVMPass()";
+    let constructor = "mlir::triton::createConvertTritonAMDGPUToLLVMPass(\"gfx940\")";
 
     let dependentDialects = ["mlir::arith::ArithDialect",
                              "mlir::math::MathDialect",
@@ -23,14 +23,12 @@ def ConvertTritonAMDGPUToLLVM : Pass<"convert-triton-amdgpu-to-llvm", "mlir::Mod
                              "mlir::tensor::TensorDialect",
                              "mlir::triton::TritonDialect",
                              "mlir::triton::gpu::TritonGPUDialect",
-                             "mlir::triton::nvidia_gpu::TritonNvidiaGPUDialect",
-                             "mlir::ROCDL::ROCDLDialect",
-                             "mlir::NVVM::NVVMDialect"];
+                             "mlir::ROCDL::ROCDLDialect"];
 
     let options = [
-        Option<"computeCapability", "compute-capability",
-               "int32_t", /*default*/"80",
-               "device compute capability">,
+        Option<"arch", "arch",
+               "std::string", /*default*/"\"gfx940\"",
+               "target device architecture">,
     ];
 }
 

--- a/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/Passes.td
@@ -13,7 +13,7 @@ def ConvertTritonAMDGPUToLLVM : Pass<"convert-triton-amdgpu-to-llvm", "mlir::Mod
     let description = [{
 
     }];
-    let constructor = "mlir::triton::createConvertTritonAMDGPUToLLVMPass(\"gfx940\")";
+    let constructor = "mlir::triton::createConvertTritonAMDGPUToLLVMPass(\"\")";
 
     let dependentDialects = ["mlir::arith::ArithDialect",
                              "mlir::math::MathDialect",
@@ -27,7 +27,7 @@ def ConvertTritonAMDGPUToLLVM : Pass<"convert-triton-amdgpu-to-llvm", "mlir::Mod
 
     let options = [
         Option<"arch", "arch",
-               "std::string", /*default*/"\"gfx940\"",
+               "std::string", /*default*/"\"\"",
                "target device architecture">,
     ];
 }

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
@@ -1,0 +1,24 @@
+#ifndef TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETUTILS_H
+#define TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETUTILS_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir::triton::AMD {
+
+// A list of ISA families we care about.
+enum class ISAFamily {
+  Unknown,
+  CDNA1,
+  CDNA2,
+  CDNA3,
+  RDNA1,
+  RDNA2,
+  RDNA3,
+};
+
+// Deduces the corresponding ISA family for the given target gfx |arch|.
+ISAFamily deduceISAFamily(llvm::StringRef arch);
+
+} // namespace mlir::triton::AMD
+
+#endif // TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETUTILS_H

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.h
@@ -6,10 +6,6 @@
 
 namespace mlir {
 
-std::unique_ptr<Pass>
-createTritonAMDGPUPipelinePass(int numStages = 3, int numWarps = 4,
-                               int numCTAs = 1, int computeCapability = 80);
-
 std::unique_ptr<Pass> createTritonAMDGPUStreamPipelinePass();
 
 std::unique_ptr<Pass>

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -3,34 +3,6 @@
 
 include "mlir/Pass/PassBase.td"
 
-def TritonAMDGPUPipeline : Pass<"tritonamdgpu-pipeline", "mlir::ModuleOp"> {
-  let summary = "pipeline";
-
-  let description = [{
-    Applies software pipelining to loops in the module based on number of stages.
-    This may convert some load into asynchronous loads, and multi-buffer the data.
-  }];
-
-  let constructor = "mlir::createTritonAMDGPUPipelinePass()";
-
-  let dependentDialects = [];
-
-  let options = [
-    Option<"numStages", "num-stages",
-           "int32_t", /*default*/"3",
-           "number of pipeline stages">,
-    Option<"numWarps", "num-warps",
-           "int32_t", /*default*/"4",
-           "number of warps per block">,
-    Option<"numCTAs", "num-ctas",
-           "int32_t", /*default*/"1",
-           "number of CTAs per CGA">,
-    Option<"computeCapability", "compute-capability",
-           "int32_t", /*default*/"80",
-           "device compute capability">
-  ];
-}
-
 def TritonAMDGPUStreamPipeline : Pass<"tritonamdgpu-stream-pipeline", "mlir::ModuleOp"> {
   let summary = "pipeline";
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -12,6 +12,7 @@ add_triton_library(TritonAMDGPUToLLVM
     TritonGPUToLLVM.cpp
     Utility.cpp
     TargetInfo.cpp
+    TargetUtils.cpp
     DecomposeUnsupportedConversions.cpp
     SPMDOpToLLVM.cpp
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -19,8 +19,7 @@ void populateDotOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns, int numWarps,
     ModuleAxisInfoAnalysis &axisInfoAnalysis, ModuleAllocation &allocation,
-    int computeCapability, const TargetInfo &targetInfo,
-    PatternBenefit benefit);
+    const TargetInfo &targetInfo, PatternBenefit benefit);
 void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        RewritePatternSet &patterns,
                                        int numWarps,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -52,6 +52,7 @@ Value printfPromoteValue(ConversionPatternRewriter &rewriter, Value value) {
 } // namespace
 
 bool TargetInfo::supportMaximumMinimum() const { return false; }
+
 Value TargetInfo::ballot(ConversionPatternRewriter &rewriter, Location loc,
                          Type type, Value cmp) const {
   auto stringAttr = rewriter.getStringAttr("llvm.amdgcn.ballot");

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -1,11 +1,16 @@
 #ifndef TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOAMD_H
 #define TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOAMD_H
+
+#include "TritonAMDGPUToLLVM/TargetUtils.h"
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include <string>
+
 namespace mlir::triton::AMD {
 class TargetInfo : public mlir::triton::TargetInfoBase {
 public:
-  TargetInfo(std::string arch) : arch(std::move(arch)) {}
+  explicit TargetInfo(std::string arch) : arch(std::move(arch)) {}
+
+  ISAFamily getISAFamily() const { return deduceISAFamily(arch); }
 
   bool supportMaximumMinimum() const override;
 
@@ -55,4 +60,5 @@ private:
   std::string arch;
 };
 } // namespace mlir::triton::AMD
+
 #endif // TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOAMD_H

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
@@ -1,0 +1,37 @@
+#include "TritonAMDGPUToLLVM/TargetUtils.h"
+#include "llvm/TargetParser/TargetParser.h"
+
+namespace mlir::triton::AMD {
+
+ISAFamily deduceISAFamily(llvm::StringRef arch) {
+  llvm::AMDGPU::GPUKind kind = llvm::AMDGPU::parseArchAMDGCN(arch);
+
+  // See https://llvm.org/docs/AMDGPUUsage.html#processors for how to categorize
+  // the following target gfx architectures.
+
+  // CDNA ISA cases
+  switch (kind) {
+  case llvm::AMDGPU::GK_GFX942:
+  case llvm::AMDGPU::GK_GFX941:
+  case llvm::AMDGPU::GK_GFX940:
+    return ISAFamily::CDNA3;
+  case llvm::AMDGPU::GK_GFX90A:
+    return ISAFamily::CDNA2;
+  case llvm::AMDGPU::GK_GFX908:
+    return ISAFamily::CDNA1;
+  default:
+    break;
+  }
+
+  // RNDA ISA cases
+  if (kind >= llvm::AMDGPU::GK_GFX1100 && kind <= llvm::AMDGPU::GK_GFX1201)
+    return ISAFamily::RDNA3;
+  if (kind >= llvm::AMDGPU::GK_GFX1030 && kind <= llvm::AMDGPU::GK_GFX1036)
+    return ISAFamily::RDNA2;
+  if (kind >= llvm::AMDGPU::GK_GFX1010 && kind <= llvm::AMDGPU::GK_GFX1013)
+    return ISAFamily::RDNA1;
+
+  return ISAFamily::Unknown;
+}
+
+} // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -84,24 +84,31 @@ public:
 struct ConvertTritonAMDGPUToLLVM
     : public triton::impl::ConvertTritonAMDGPUToLLVMBase<
           ConvertTritonAMDGPUToLLVM> {
-  using ConvertTritonAMDGPUToLLVMBase<
-      ConvertTritonAMDGPUToLLVM>::ConvertTritonAMDGPUToLLVMBase;
+  explicit ConvertTritonAMDGPUToLLVM(StringRef targetArch) {
+    this->arch = targetArch.str();
+  }
 
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<triton::nvgpu::NVGPUDialect, LLVM::LLVMDialect,
                     NVVM::NVVMDialect, mlir::ROCDL::ROCDLDialect>();
   }
 
-  ConvertTritonAMDGPUToLLVM(int32_t computeCapability)
-      : ConvertTritonAMDGPUToLLVMBase({computeCapability}) {}
-
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     ModuleOp mod = getOperation();
+
+    AMD::TargetInfo targetInfo(this->arch.getValue());
+    if (targetInfo.getISAFamily() == AMD::ISAFamily::Unknown) {
+      mod.emitError("unknown target: ") << this->arch.getValue();
+      return signalPassFailure();
+    }
+
     mlir::LowerToLLVMOptions option(context);
     option.overrideIndexBitwidth(32);
+
     TritonGPUToLLVMTypeConverter typeConverter(context, option);
     TritonLLVMConversionTarget convTarget(*context);
+
     int numWarps = triton::gpu::TritonGPUDialect::getNumWarps(mod);
     int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
     int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(mod);
@@ -159,26 +166,10 @@ struct ConvertTritonAMDGPUToLLVM
     OpBuilder::InsertPoint indexInsertPoint;
 
     RewritePatternSet patterns(context);
-    AMD::TargetInfo targetInfo("gfx1200");
     int benefit = patternBenefitPrioritizeOverLLVMConversions;
     auto populatePatterns1 = [&](auto populateFunc) {
       populateFunc(typeConverter, patterns, numWarps, axisInfoAnalysis,
                    allocation, benefit);
-    };
-
-    auto populatePatterns2 = [&](auto populateFunc) {
-      populateFunc(typeConverter, patterns, numWarps, axisInfoAnalysis,
-                   allocation, benefit);
-    };
-
-    auto populatePatterns3 = [&](auto populateFunc) {
-      populateFunc(typeConverter, patterns, numWarps, axisInfoAnalysis,
-                   allocation, benefit);
-    };
-
-    auto populatePatterns4 = [&](auto populateFunc) {
-      populateFunc(typeConverter, patterns, numWarps, axisInfoAnalysis,
-                   allocation, computeCapability, benefit);
     };
 
     auto populatePatterns5 = [&](auto populateFunc) {
@@ -187,7 +178,7 @@ struct ConvertTritonAMDGPUToLLVM
 
     auto populatePatterns6 = [&](auto populateFunc) {
       populateFunc(typeConverter, patterns, numWarps, axisInfoAnalysis,
-                   allocation, computeCapability, targetInfo, benefit);
+                   allocation, targetInfo, benefit);
     };
 
     auto populatePatterns7 = [&](auto populateFunc) {
@@ -271,15 +262,9 @@ private:
 namespace mlir {
 namespace triton {
 
-// TODO: Clean up the code regarding usage of computeCapability
-// We need to converge on how we define that for AMDGPU
-std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonAMDGPUToLLVMPass() {
-  return std::make_unique<ConvertTritonAMDGPUToLLVM>(90);
-}
-
 std::unique_ptr<OperationPass<ModuleOp>>
-createConvertTritonAMDGPUToLLVMPass(int computeCapability) {
-  return std::make_unique<ConvertTritonAMDGPUToLLVM>(computeCapability);
+createConvertTritonAMDGPUToLLVMPass(StringRef targetArch) {
+  return std::make_unique<ConvertTritonAMDGPUToLLVM>(targetArch);
 }
 
 } // namespace triton

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -99,7 +99,7 @@ struct ConvertTritonAMDGPUToLLVM
 
     AMD::TargetInfo targetInfo(this->arch.getValue());
     if (targetInfo.getISAFamily() == AMD::ISAFamily::Unknown) {
-      mod.emitError("unknown target: ") << this->arch.getValue();
+      mod.emitError("unsupported target: '") << this->arch.getValue() << "'";
       return signalPassFailure();
     }
 


### PR DESCRIPTION
This commit improves how target architecture are handled in the AMD backend.

Previously we have three ways of specifying the target: 1) the `gfx*` target architecture, 2) a compute capability number that matches the CDNA generation, e.g., 300/200/100, 3) a compute capability number that tries to pretend to be CUDA equivalence, e.g., 80/90. These three schemes are quite inconsistently used and not all the places are properly seeing the target it should be--it can be quite confusing.

In general, for CodeGen towards AMD GPU, the `gfx*` target architecture should be the original source of capability and feature information. Further, for AMD, there is no exact correspondance of NVIDIA CUDA compute capability numbers.

So this commit changes to base on the `gfx*` target, and adds utility functions to deduce features and ISA families from it. All existing passes and patterns in the AMD backend are updated to properly use such information. "Compute capability numbers" are removed entirely.

Along the way, also updated TritonToTritonGPUPass to take the compute capability number as optional. We should make it more backend agnostic but that can happen later.