### PR TITLE
[backend][amd] Minor improvements definitions and comments

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -33,16 +33,6 @@ class HIPOptions:
     max_num_imprecise_acc_default: int = 0
 
     @staticmethod
-    def get_warp_size(arch: str) -> int:
-        # 64 is not supported for RDNA for now
-        if 'gfx10' in arch or 'gfx11' in arch:
-            return 32
-        if 'gfx9' in arch:
-            return 64
-        print("Warning: Unexpected device. Wave Size is set to 64.")
-        return 64  # Default value
-
-    @staticmethod
     def get_compute_capability(arch: str) -> int:
         arch_dict = {
             'gfx940': 300,
@@ -243,7 +233,7 @@ class HIPBackend(BaseBackend):
         assert len(names) == 1
         metadata["name"] = names[0]
         # llvm -> hsaco
-        amdgcn = llvm.translate_to_asm(src, 'amdgcn-amd-amdhsa', options.arch, '', [], options.enable_fp_fusion, False)
+        amdgcn = llvm.translate_to_asm(src, amd.TARGET_TRIPLE, options.arch, '', [], options.enable_fp_fusion, False)
         if os.environ.get("AMDGCN_ENABLE_DUMP", "0") == "1":
             print("// -----// AMDGCN Dump //----- //")
             print(amdgcn)

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -78,6 +78,10 @@ void init_triton_amd(py::module &&m) {
   auto passes = m.def_submodule("passes");
   init_triton_amd_passes_ttgpuir(passes.def_submodule("ttgpuir"));
 
+  m.attr("TARGET_TRIPLE") = "amdgcn-amd-amdhsa";
+  m.attr("CALLING_CONV_AMDGPU_KERNEL") =
+      (unsigned)llvm::CallingConv::AMDGPU_KERNEL;
+
   m.def("load_dialects", [](mlir::MLIRContext &context) {
     mlir::DialectRegistry registry;
     // registry.insert<mlir::ROCDL::ROCDLDialect>();
@@ -86,12 +90,9 @@ void init_triton_amd(py::module &&m) {
     context.loadAllAvailableDialects();
   });
 
-  m.attr("CALLING_CONV_AMDGPU_KERNEL") =
-      py::int_((unsigned)llvm::CallingConv::AMDGPU_KERNEL);
-
-  // Set target chip ISA version
-  m.def("set_isa_version", [](llvm::Module *module, const std::string &target) {
-    llvm::AMDGPU::IsaVersion version = llvm::AMDGPU::getIsaVersion(target);
+  // Set target architecture ISA version
+  m.def("set_isa_version", [](llvm::Module *module, const std::string &arch) {
+    llvm::AMDGPU::IsaVersion version = llvm::AMDGPU::getIsaVersion(arch);
     addControlConstant(module, "__oclc_ISA_version", /*bitwidth=*/32,
                        version.Major * 1000 + version.Minor * 100 +
                            version.Stepping);
@@ -136,7 +137,7 @@ void init_triton_amd(py::module &&m) {
 
   m.def(
       "assemble_amdgcn",
-      [](const std::string &assembly, const std::string &chip,
+      [](const std::string &assembly, const std::string &arch,
          const std::string &features) {
         std::string error;
 
@@ -157,7 +158,7 @@ void init_triton_amd(py::module &&m) {
         std::unique_ptr<llvm::MCAsmInfo> mai(
             target->createMCAsmInfo(*mri, targetTriple, mcOptions));
         std::unique_ptr<llvm::MCSubtargetInfo> sti(
-            target->createMCSubtargetInfo(targetTriple, chip, features));
+            target->createMCSubtargetInfo(targetTriple, arch, features));
 
         llvm::MCContext ctx(triple, mai.get(), mri.get(), sti.get(), &srcMgr,
                             &mcOptions);
@@ -214,14 +215,14 @@ void init_triton_amd(py::module &&m) {
     for (llvm::Function &f : module->functions()) {
       if (f.hasExternalLinkage() && f.hasName() && !f.hasExactDefinition()) {
         llvm::StringRef funcName = f.getName();
+        // Rules for linking the extern lib:
+        // 1. if __nv_ is found in the module, we'll link all four libs:
+        //    cuda2gcn, opencl, ocml, and ockl. Note that opencl might
+        //    not be needed. But we add it here and will try to remove
+        //    it in the future.
+        // 2. if the function name includes ocml or ockl, only link
+        //    ocml or ockl accordingly.
         if (funcName.contains(lib) || funcName.contains("__nv_"))
-          // Rules for linking the extern lib
-          // 1. if __nv_ is found in the module, we'll link all four libs:
-          //    cuda2gcn, opencl, ocml, and ockl. Note that opencl might
-          //    not be needed. But we add it here and will try to remove
-          //    it in the future.
-          // 2. if the function name includes ocml or ockl, only link
-          //    ocml or ockl accordingly
           return true;
       }
     }


### PR DESCRIPTION
* Define AMD target triple in `triton_amd.cc` for better isolation.
* Make `triton_amd.cc` function parameter names more consistent.
* Drop unused function in `compiler.py`.