### PR TITLE
[BACKEND] Sanitize on num_stages before piplining a loop.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -72,6 +72,9 @@ static bool pipelineLoop(scf::ForOp forOp, int numStages) {
   if (!preCondition(forOp))
     return false;
 
+  if (numStages < 2)
+    return false;
+
   bool foundSchedule = false;
   foundSchedule = preProcessLoopAndGetSchedule(forOp, numStages, options);
 


### PR DESCRIPTION
Doing some basic sanitize checking on `num_stages` before piplining a loop. User may specify `num_stages` in a way below which fails the compilation :

    `for i in tl.range(0, XBLOCK, num_stages=1):`
