### PR TITLE
Use DISABLE_LLVM_OPT to selectively disable llvm optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,12 @@ $ ninja -C build && ( cd build ; lit test )
   performance tools, it can provide a breakdown on ttgir instructions.
 - `TRITON_PRINT_AUTOTUNING=1` prints out the best autotuning config and total time
   spent for each kernel after autotuning is complete.
-- `DISABLE_LLVM_LSR` will disable llvm's loop strength reduction. This pass is
-  known to cause up to 10% performance changes for certain kernels with register
-  pressure.
+- `DISABLE_LLVM_OPT` will disable llvm optimizations for make_llir and make_ptx
+  if its value is true when parsing as Bool. Otherwise, it will be parsed as a list
+  of flags to disable llvm optimizations. One usage case is
+  `DISABLE_LLVM_OPT="disable-lsr"`
+  Loop strength reduction is known to cause up to 10% performance changes for
+  certain kernels with register pressure.
 
 # Changelog
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ $ ninja -C build && ( cd build ; lit test )
   performance tools, it can provide a breakdown on ttgir instructions.
 - `TRITON_PRINT_AUTOTUNING=1` prints out the best autotuning config and total time
   spent for each kernel after autotuning is complete.
+- `DISABLE_LLVM_LSR` will disable llvm's loop strength reduction. This pass is
+  known to cause up to 10% performance changes for certain kernels with register
+  pressure.
 
 # Changelog
 

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -44,7 +44,6 @@ inline const std::set<std::string> ENV_VARS = {
     "MLIR_ENABLE_DIAGNOSTICS",
     "TRITON_ENABLE_LLVM_DEBUG",
     "USE_TTGIR_LOC",
-    "DISABLE_LLVM_LSR",
 };
 
 namespace tools {

--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -44,6 +44,7 @@ inline const std::set<std::string> ENV_VARS = {
     "MLIR_ENABLE_DIAGNOSTICS",
     "TRITON_ENABLE_LLVM_DEBUG",
     "USE_TTGIR_LOC",
+    "DISABLE_LLVM_LSR",
 };
 
 namespace tools {

--- a/python/src/llvm.cc
+++ b/python/src/llvm.cc
@@ -56,6 +56,13 @@ std::string translateLLVMIRToASM(llvm::Module &module,
       *optPtr = true;
     }
   }
+  if (triton::tools::getBoolEnv("DISABLE_LLVM_LSR")) {
+    auto optIt = options.find("disable-lsr");
+    if (optIt != options.end()) {
+      auto optPtr = static_cast<llvm::cl::opt<bool> *>(optIt->second);
+      *optPtr = true;
+    }
+  }
 
   // inline everything
   for (llvm::Function &f : module.functions())


### PR DESCRIPTION
`DISABLE_LLVM_OPT` will disable llvm optimizations for make_llir and make_ptx if its value is true when parsing as Bool. Otherwise, it will be parsed as a list of flags to disable llvm optimizations. One usage case is
`DISABLE_LLVM_OPT="disable-lsr"`
Loop strength reduction is known to cause up to 10% performance changes for certain kernels with register pressure.