### PR TITLE
Modified tests to be more target independent and match Intel fork better

### DIFF
--- a/python/test/regression/test_cast_matmul.py
+++ b/python/test/regression/test_cast_matmul.py
@@ -94,4 +94,9 @@ def test_cast_matmul(M, K, N, w_dtype, x_dtype, out_dtype):
         BLOCK_N=BLOCK_N,  #
         BLOCK_K=BLOCK_K)
 
-    torch.testing.assert_close(out_torch, out_triton, atol=0.3, rtol=0.01)
+    # Torch can compute reference result on CPU using fp32 arithmetics for fp16
+    # test. Such reference requires increased tolerance for big K values.
+    if out_dtype == "float16" and K > 128:
+        torch.testing.assert_close(out_torch, out_triton, atol=2, rtol=0.1)
+    else:
+        torch.testing.assert_close(out_torch, out_triton, atol=0.3, rtol=0.01)

--- a/python/test/unit/operators/test_cross_entropy.py
+++ b/python/test/unit/operators/test_cross_entropy.py
@@ -13,9 +13,10 @@ import triton.ops
     for mode in ['forward', 'backward']
 ])
 def test_op(M, N, dtype, mode, device):
-    capability = torch.cuda.get_device_capability()
-    if capability[0] < 8 and dtype == "bfloat16":
-        pytest.skip("Only test bfloat16 on devices with sm >= 80")
+    if torch.cuda.is_available():
+        capability = torch.cuda.get_device_capability()
+        if capability[0] < 8 and dtype == "bfloat16":
+            pytest.skip("Only test bfloat16 on devices with sm >= 80")
     dtype = {'bfloat16': torch.bfloat16, 'float16': torch.float16, 'float32': torch.float32}[dtype]
     # create inputs
     x = torch.randn(M, N, dtype=dtype, device=device, requires_grad=True)

--- a/python/test/unit/operators/test_flash_attention.py
+++ b/python/test/unit/operators/test_flash_attention.py
@@ -17,9 +17,10 @@ import triton.ops
 @pytest.mark.parametrize('causal', [True, False])
 @pytest.mark.parametrize('seq_par', [True, False])
 def test_op(Z, H, N_CTX, D_HEAD, dtype, causal, seq_par, device):
-    capability = torch.cuda.get_device_capability()
-    if capability[0] < 8:
-        pytest.skip("Flash attention only supported for compute capability >= 80")
+    if torch.cuda.is_available():
+        capability = torch.cuda.get_device_capability()
+        if capability[0] < 8:
+            pytest.skip("Flash attention only supported for compute capability >= 80")
     if dtype == torch.bfloat16 and os.environ.get("TRITON_INTERPRET", "0") == "1":
         pytest.skip("Flash attention bfloat16 not supported in interpreter mode")
     torch.manual_seed(20)


### PR DESCRIPTION
Mostly changes to make tests more target independent.

Change in test_cast_matpul.py is something we found in our intel fork and may be relevant to all backends.