### PR TITLE
[Build] fix some bugs in cmake when use triton as thirdparty lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 # Options
 option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
 option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
+option(TRITON_BUILD_UT "Build C++ Triton Unit Tests" ON)
 set(TRITON_CODEGEN_BACKENDS "" CACHE STRING "Enable different codegen backends")
 
 # Ensure Python3 vars are set correctly
@@ -270,4 +271,7 @@ endif()
 
 add_subdirectory(bin)
 add_subdirectory(test)
-add_subdirectory(unittest)
+
+if(TRITON_BUILD_UT)
+  add_subdirectory(unittest)
+endif()

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -75,6 +75,7 @@ mlir_check_all_link_libraries(triton-lsp)
 add_llvm_executable(triton-llvm-opt
   triton-llvm-opt.cpp
 
+  PARTIAL_SOURCES_INTENDED
   DEPENDS
   intrinsics_gen
   SUPPORT_PLUGINS


### PR DESCRIPTION
* Add TRITON_BUILD_UT(Default: ON) option to enable a the ability for disabling unit-test build when use triton as thirdparty project.
* Fix  llvm build bugs in bin/CMakeLists.txt when using triton in other projects. 