### PR TITLE
[Frontend] Disallow global variable accesses from @triton.jit functions.

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -226,3 +226,30 @@ def test_power_of_two_shapes_2():
     with pytest.raises(CompilationError) as e:
         triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
     assert str(e.value.__cause__) == "Shape element 0 must be a power of 2"
+
+
+def test_captured_var_access():
+
+    CAPTURED = 42
+
+    @triton.jit
+    def kernel():
+        a = CAPTURED  # noqa
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
+    assert "CAPTURED is not defined" in str(e.value)
+
+
+GLOBAL = 42
+
+
+def test_global_var_access():
+
+    @triton.jit
+    def kernel():
+        a = GLOBAL  # noqa
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constants={}))
+    assert "global variable" in str(e.value)


### PR DESCRIPTION
We do this because the value of the global may end up baked into the compiled
Triton kernel, but if you then change its value, Triton will not recompile the
kernel.  As a result, the global will effectively have a stale value.

Instead, you should pass globals as arguments to your top-level @triton.jit
function.

Because this is a breaking change, we add an escape hatch for now,
TRITON_ALLOW_GLOBAL_VARS=1.  We do not promise to support this forever.
