### PR TITLE
[Frontend] Disallow access to globals that are not tl.constexpr.

### DIFF
--- a/python/test/unit/language/test_random.py
+++ b/python/test/unit/language/test_random.py
@@ -109,7 +109,7 @@ class CustomPhilox(CustomPhilox4x):
 # Unit Tests
 #####################################
 
-BLOCK = 1024
+BLOCK: tl.constexpr = 1024
 
 # test generation of random uint32
 


### PR DESCRIPTION
<git-pr-chain>


[Frontend] Disallow access to globals that are not tl.constexpr.

We've found that users often accidentally access global vars from inside a
Triton kernel that they don't mean to.  Moreover, they sometimes *change* these
global vars after they first run the kernel, but Triton does not notice this
(the initial value of the global is baked into the compiled kernel). As a
result, the following runs have a stale value for the global.

We hope that making users annotate their globals with tl.constexpr will remind
them that they are kernel arguments that they should not change.

In a separate PR, we will additionally explore the possibility of raising an
error when the value of one of these globals changes.

This is a breaking change, so we allow you to opt out of it by setting
TRITON_ALLOW_NON_CONSTEXPR_GLOBALS=1.  But we do not promise to support this
envvar forever.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #3762 👈 **YOU ARE HERE**


</git-pr-chain>


