### PR TITLE
Persistent softmax kernel

### DIFF
--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -25,6 +25,7 @@ import torch
 
 import triton
 import triton.language as tl
+from triton.runtime import driver
 
 
 @torch.jit.script
@@ -62,7 +63,7 @@ def naive_softmax(x):
 # Compute Kernel
 # --------------
 #
-# Our softmax kernel works as follows: each program loads a row of the input matrix X,
+# Our softmax kernel works as follows: each program loads a chunk of consecutive row of the input matrix X,
 # normalizes it and writes back the result to the output Y.
 #
 # Note that one important limitation of Triton is that each block must have a
@@ -71,58 +72,85 @@ def naive_softmax(x):
 
 
 @triton.jit
-def softmax_kernel(output_ptr, input_ptr, input_row_stride, output_row_stride, n_cols, BLOCK_SIZE: tl.constexpr):
-    # The rows of the softmax are independent, so we parallelize across those
-    row_idx = tl.program_id(0)
-    # The stride represents how much we need to increase the pointer to advance 1 row
-    row_start_ptr = input_ptr + row_idx * input_row_stride
-    # The block size is the next power of two greater than n_cols, so we can fit each
-    # row in a single block
-    col_offsets = tl.arange(0, BLOCK_SIZE)
-    input_ptrs = row_start_ptr + col_offsets
-    # Load the row into SRAM, using a mask since BLOCK_SIZE may be > than n_cols
-    row = tl.load(input_ptrs, mask=col_offsets < n_cols, other=-float('inf'))
-    # Subtract maximum for numerical stability
-    row_minus_max = row - tl.max(row, axis=0)
-    # Note that exponentiation in Triton is fast but approximate (i.e., think __expf in CUDA)
-    numerator = tl.exp(row_minus_max)
-    denominator = tl.sum(numerator, axis=0)
-    softmax_output = numerator / denominator
-    # Write back output to DRAM
-    output_row_start_ptr = output_ptr + row_idx * output_row_stride
-    output_ptrs = output_row_start_ptr + col_offsets
-    tl.store(output_ptrs, softmax_output, mask=col_offsets < n_cols)
+def softmax_kernel(output_ptr, input_ptr, input_row_stride, output_row_stride, n_rows, n_cols, XBLOCK: tl.constexpr,
+                   RBLOCK: tl.constexpr, NUM_REMAINDER_ROWS: tl.constexpr, num_stages: tl.constexpr):
+    pid = tl.program_id(0)
+    # starting row of the program
+    row_start = pid * (XBLOCK - 1) + min(pid, NUM_REMAINDER_ROWS)
+
+    for i in tl.range(0, XBLOCK, num_stages=num_stages):
+        row_idx = row_start + i
+        # The stride represents how much we need to increase the pointer to advance 1 row
+        row_start_ptr = input_ptr + row_idx * input_row_stride
+        # The block size is the next power of two greater than n_cols, so we can fit each
+        # row in a single block
+        col_offsets = tl.arange(0, RBLOCK)
+        input_ptrs = row_start_ptr + col_offsets
+        # Load the row into SRAM, using a mask since BLOCK_SIZE may be > than n_cols
+        mask = (i < XBLOCK - 1 or pid < NUM_REMAINDER_ROWS) and col_offsets < n_cols
+        row = tl.load(input_ptrs, mask=mask, other=-float('inf'))
+        # Subtract maximum for numerical stability
+        row_minus_max = row - tl.max(row, axis=0)
+        # Note that exponentiation in Triton is fast but approximate (i.e., think __expf in CUDA)
+        numerator = tl.exp(row_minus_max)
+        denominator = tl.sum(numerator, axis=0)
+        softmax_output = numerator / denominator
+        # Write back output to DRAM
+        output_row_start_ptr = output_ptr + row_idx * output_row_stride
+        output_ptrs = output_row_start_ptr + col_offsets
+        tl.store(output_ptrs, softmax_output, mask=mask)
 
 
 # %%
 # We can create a helper function that enqueues the kernel and its (meta-)arguments for any given input tensor.
 
+device = torch.cuda.current_device()
+NUM_SM = driver.active.utils.get_device_properties(device)["multiprocessor_count"]
+
 
 def softmax(x):
     n_rows, n_cols = x.shape
-    # The block size is the smallest power of two greater than the number of columns in `x`
-    BLOCK_SIZE = triton.next_power_of_2(n_cols)
+    num_programs = NUM_SM
+
+    # Create a number of persistent programs as many as SMs.
+    grid = lambda meta: (num_programs, )
+
+    # Each program handle a chunk of consecutive rows in a loop. If the number of rows is not a multiple of
+    # the number of programs, the remainder number of rows (R) are distributed evenly to the first R number
+    # of programs. Here the chunk size (XBLOCK) is to the number of rows handled by that portion of programs.
+    # The rest of programs will be masked off when accessing the XBLOCK-th row. When R=0, XBLOCK is always set
+    # to the size of the chunk plus one for universal handling in the kernel.
+    XBLOCK = (n_rows + num_programs) // num_programs
+    R = n_rows % num_programs
+
+    # The block size of each loop iteration is the smallest power of two greater than the number of columns in `x`
+    RBLOCK = triton.next_power_of_2(n_cols)
+
     # Another trick we can use is to ask the compiler to use more threads per row by
     # increasing the number of warps (`num_warps`) over which each row is distributed.
     # You will see in the next tutorial how to auto-tune this value in a more natural
     # way so you don't have to come up with manual heuristics yourself.
-    num_warps = 4
-    if BLOCK_SIZE >= 2048:
-        num_warps = 8
-    if BLOCK_SIZE >= 4096:
-        num_warps = 16
+    num_warps = 8
+
+    # Number of software piepling stages.
+    num_stages = 4
     # Allocate output
     y = torch.empty_like(x)
-    # Enqueue kernel. The 1D launch grid is simple: we have one kernel instance per row o
-    # f the input matrix
-    softmax_kernel[(n_rows, )](
+
+    # Enqueue kernel. The 1D launch grid is simple: we have one kernel instance per chunk of rows of
+    # the input matrix
+    softmax_kernel[grid](
         y,
         x,
         x.stride(0),
         y.stride(0),
+        n_rows,
         n_cols,
         num_warps=num_warps,
-        BLOCK_SIZE=BLOCK_SIZE,
+        XBLOCK=XBLOCK,
+        RBLOCK=RBLOCK,
+        NUM_REMAINDER_ROWS=R,
+        num_stages=num_stages,
     )
     return y
 


### PR DESCRIPTION
Rewriting the tutorial softmax kernel in a persistent way. 

Some perf numbers on H100:

1. Before (non-persistent):

```
	softmax-performance:
	          N       Triton  Torch (native)  Torch (jit)
	0     256.0   809.086437      840.205157   341.111242
	1     384.0  1043.013292     1054.198425   438.123694
	2     512.0  1236.528308     1224.971964   489.074621
	3     640.0  1323.959634     1356.852972   541.843731
	4     768.0  1432.480902     1461.769457   579.537226
	..      ...          ...             ...          ...
	93  12160.0  1900.754134     1668.141169   619.802865
	94  12288.0  1907.079736     1623.706355   621.746785
	95  12416.0  1909.006619     1610.588287   621.224670
	96  12544.0  1922.336989     1613.700487   622.428454
	97  12672.0  1929.822731     1594.314727   621.224030

```

2. After (persistent) with num_warps=4, num_stages=4

```
softmax-performance:
	          N       Triton  Torch (native)  Torch (jit)
	0     256.0   431.157914      832.203143   326.252642
	1     384.0   587.766841     1048.575991   429.744271
	2     512.0   768.750719     1219.274460   477.493634
	3     640.0   792.454645     1351.257741   531.301192
	4     768.0   947.508462     1453.663622   565.982013
	..      ...          ...             ...          ...
	93  12160.0  1894.824594     1663.350211   619.186477
	94  12288.0  1923.992668     1624.335127   621.087010
	95  12416.0  1917.066285     1609.365141   620.436448
	96  12544.0  1910.897958     1610.766351   621.825846
	97  12672.0  1911.909175     1593.336028   620.273831
```

3. After (persistent) with num_warps=8, num_stages=4, which creates double threads of hardware cores

```
softmax-performance:
	          N       Triton  Torch (native)  Torch (jit)
	0     256.0   405.795684      837.520775   342.671893
	1     384.0   579.110465     1062.745962   441.815718
	2     512.0   756.548362     1224.971964   480.998150
	3     640.0   860.052514     1354.049617   537.621015
	4     768.0  1012.139023     1464.491581   574.037975
	..      ...          ...             ...          ...
	93  12160.0  1988.159042     1657.372518   618.663478
	94  12288.0  1982.029132     1609.273882   620.138051
	95  12416.0  1980.062847     1603.782335   619.257886
	96  12544.0  1997.054701     1601.927508   620.429199
	97  12672.0  1974.306315     1594.119001   620.600119
```
#3 seems to give the best performance for larger tensors. For smaller tensors, the non-persistent kernel still performs the best.



