### PR TITLE
Add TMA matmul test

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -32,8 +32,13 @@ public:
         MemDescType::get(tensorType.getShape(), tensorType.getElementType(),
                          encoding, /*mutableMemory=*/true);
     Value alloc = rewriter.create<LocalAllocOp>(loc, memDescType, Value());
+    auto barrierCTALayout = CTALayoutAttr::get(
+        /*context=*/tensorType.getContext(), /*CTAsPerCGA=*/{1},
+        /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
+    auto barrierEncoding = SharedEncodingAttr::get(tensorType.getContext(), 1,
+                                                   1, 1, {0}, barrierCTALayout);
     MemDescType barrierMemDescType = MemDescType::get(
-        {1}, rewriter.getI64Type(), encoding, /*mutableMemory=*/true);
+        {1}, rewriter.getI64Type(), barrierEncoding, /*mutableMemory=*/true);
     Value barrierAlloc =
         rewriter.create<LocalAllocOp>(loc, barrierMemDescType, Value());
     rewriter.create<InitBarrierOp>(loc, barrierAlloc, 1);

--- a/python/test/unit/hopper/test_experimental_tma.py
+++ b/python/test/unit/hopper/test_experimental_tma.py
@@ -41,7 +41,7 @@ def test_descriptor_load_ttgir():
 
     x = torch.randn(SIZE, dtype=torch.float32, device=device)
     desc = np.empty(SIZE, dtype=np.int8)
-    triton.runtime.driver.active.utils.fill_1d_tma_descriptor(x.data_ptr(), SIZE, 4, desc)
+    triton.runtime.driver.active.utils.fill_1d_tma_descriptor(x.data_ptr(), SIZE, SIZE, x.element_size(), desc)
     desc = torch.tensor(desc, device=device)
     z_tri = torch.empty_like(x)
     kernel[(1, 1, 1)](z_tri, desc)
@@ -59,13 +59,66 @@ def test_experimetal_descriptor_load():
     def kernel(Z, desc, SIZE: tl.constexpr):
         off_desc = 0
         off = tl.arange(0, SIZE)
-        x = tl._experimental_descriptor_load(desc, [off_desc], [SIZE], Z.dtype)
+        x = tl._experimental_descriptor_load(desc, [off_desc], [SIZE], Z.dtype.element_ty)
         tl.store(Z + off, x)
 
     x = torch.randn(SIZE, dtype=torch.float32, device=device)
     desc = np.empty(SIZE, dtype=np.int8)
-    triton.runtime.driver.active.utils.fill_1d_tma_descriptor(x.data_ptr(), SIZE, 4, desc)
+    triton.runtime.driver.active.utils.fill_1d_tma_descriptor(x.data_ptr(), SIZE, SIZE, x.element_size(), desc)
     desc = torch.tensor(desc, device=device)
     z_tri = torch.empty_like(x)
     kernel[(1, )](z_tri, desc, SIZE=SIZE, num_warps=4)
     assert torch.equal(x, z_tri)
+
+
+@triton.jit
+def matmul_kernel_tma(a_desc_ptr, b_desc_ptr, c_ptr,  #
+                      M, N, K,  #
+                      stride_cm, stride_cn,  #
+                      BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    pid_m = pid % num_pid_m
+    pid_n = pid // num_pid_m
+    offs_am = pid_m * BLOCK_SIZE_M
+    offs_bn = pid_n * BLOCK_SIZE_N
+    offs_k = 0
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+        a = tl._experimental_descriptor_load(a_desc_ptr, [offs_am, offs_k], [BLOCK_SIZE_M, BLOCK_SIZE_K], tl.float16)
+        b = tl._experimental_descriptor_load(b_desc_ptr, [offs_k, offs_bn], [BLOCK_SIZE_K, BLOCK_SIZE_N], tl.float16)
+        accumulator = tl.dot(a, b, acc=accumulator)
+        offs_k += BLOCK_SIZE_K
+    offs_cm = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
+    tl.store(c_ptrs, accumulator)
+
+
+def test_experimental_tma_matmul():
+    if not torch.cuda.is_available() or not torch.cuda.get_device_capability()[0] == 9:
+        pytest.skip("Test requires Hopper target.")
+        return
+    device = "cuda"
+    M, N, K = 1024, 512, 256
+    BLOCK_M, BLOCK_N, BLOCK_K = 128, 256, 64
+    torch.manual_seed(42)
+    A = torch.randn((M, K), dtype=torch.float16, device=device)
+    B = torch.randn((K, N), dtype=torch.float16, device=device)
+    C = torch.empty((M, N), dtype=torch.float32, device=device)
+    TMA_SIZE = 128
+    desc_a = np.empty(TMA_SIZE, dtype=np.int8)
+    desc_b = np.empty(TMA_SIZE, dtype=np.int8)
+    triton.runtime.driver.active.utils.fill_2d_tma_descriptor(A.data_ptr(), M, K, BLOCK_M, BLOCK_K, A.element_size(),
+                                                              desc_a)
+    triton.runtime.driver.active.utils.fill_2d_tma_descriptor(B.data_ptr(), K, N, BLOCK_K, BLOCK_N, B.element_size(),
+                                                              desc_b)
+
+    desc_a = torch.tensor(desc_a, device=device)
+    desc_b = torch.tensor(desc_b, device=device)
+    matmul_kernel_tma[(triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), 1, 1)](desc_a,
+                                                                                 desc_b, C, M, N, K, C.stride(0),
+                                                                                 C.stride(1), BLOCK_M, BLOCK_N, BLOCK_K,
+                                                                                 num_warps=4)
+    ref_out = torch.matmul(A.to(torch.float32), B.to(torch.float32))
+    torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1598,7 +1598,7 @@ def _experimental_descriptor_load(desc_pointer, offsets, shape, dtype, _builder=
 
     This loads a tensor of data based on the descriptor and offsets.
     """
-    type = block_type(dtype.element_ty, shape)
+    type = block_type(dtype, shape)
     return semantic.descriptor_load(desc_pointer, offsets, "", "", type, _builder)
 
 

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -254,16 +254,17 @@ static PyObject *setPrintfFifoSize(PyObject *self, PyObject *args) {
 static PyObject *fill1DTMADescriptor(PyObject *self, PyObject *args) {
   unsigned long long global_address;
   uint64_t dim;
+  uint32_t tensorDim;
   int elementSize;
   Py_buffer desc_buffer;
-  if (!PyArg_ParseTuple(args, "KKiy*", &global_address, &dim, &elementSize,
-                        &desc_buffer)) {
+  if (!PyArg_ParseTuple(args, "KKiiy*", &global_address, &dim, &tensorDim,
+                        &elementSize, &desc_buffer)) {
     return NULL;
   }
   char *desc = (char *)desc_buffer.buf;
   uint64_t dims[1] = {dim};
-  uint64_t globalStrides[1] = {1};
-  uint32_t boxDim[1] = {dim};
+  uint64_t globalStrides[1] = {dim * elementSize};
+  uint32_t boxDim[1] = {tensorDim};
   uint32_t elementStrides[1] = {1};
   CUtensorMapDataType type;
   switch (elementSize) {
@@ -279,9 +280,51 @@ static PyObject *fill1DTMADescriptor(PyObject *self, PyObject *args) {
   default:
     PyErr_SetString(PyExc_ValueError, "elementSize must be 1, 2, or 4");
   }
+  int rank = 1;
   CUresult result = cuTensorMapEncodeTiled(
-      (CUtensorMap *)desc, type, 1, (void *)global_address, dims, globalStrides,
-      boxDim, elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE,
+      (CUtensorMap *)desc, type, rank, (void *)global_address, dims,
+      globalStrides, boxDim, elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE,
+      CU_TENSOR_MAP_SWIZZLE_NONE, CU_TENSOR_MAP_L2_PROMOTION_NONE,
+      CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  assert(result == CUDA_SUCCESS);
+  return Py_None;
+}
+
+// Simple helper to experiment creating TMA descriptors on the host.
+// This is a useful to test TMA operations independently.
+static PyObject *fill2DTMADescriptor(PyObject *self, PyObject *args) {
+  unsigned long long global_address;
+  uint64_t dims[2];
+  uint32_t tensorDims[2];
+  int elementSize;
+  Py_buffer desc_buffer;
+  if (!PyArg_ParseTuple(args, "KKKiiiy*", &global_address, &dims[1], &dims[0],
+                        &tensorDims[1], &tensorDims[0], &elementSize,
+                        &desc_buffer)) {
+    return NULL;
+  }
+  char *desc = (char *)desc_buffer.buf;
+  uint64_t globalStrides[2] = {dims[0] * elementSize,
+                               dims[0] * dims[1] * elementSize};
+  uint32_t elementStrides[2] = {1, 1};
+  CUtensorMapDataType type;
+  switch (elementSize) {
+  case 1:
+    type = CU_TENSOR_MAP_DATA_TYPE_UINT8;
+    break;
+  case 2:
+    type = CU_TENSOR_MAP_DATA_TYPE_UINT16;
+    break;
+  case 4:
+    type = CU_TENSOR_MAP_DATA_TYPE_UINT32;
+    break;
+  default:
+    PyErr_SetString(PyExc_ValueError, "elementSize must be 1, 2, or 4");
+  }
+  int rank = 2;
+  CUresult result = cuTensorMapEncodeTiled(
+      (CUtensorMap *)desc, type, rank, (void *)global_address, dims,
+      globalStrides, tensorDims, elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE,
       CU_TENSOR_MAP_SWIZZLE_NONE, CU_TENSOR_MAP_L2_PROMOTION_NONE,
       CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
   assert(result == CUDA_SUCCESS);
@@ -302,6 +345,8 @@ static PyMethodDef ModuleMethods[] = {
      "particular it's an error to change this value after launching any kernel "
      "that calls printf()."},
     {"fill_1d_tma_descriptor", fill1DTMADescriptor, METH_VARARGS, "doc"},
+    {"fill_2d_tma_descriptor", fill2DTMADescriptor, METH_VARARGS, "doc"},
+
     {NULL, NULL, 0, NULL} // sentinel
 };
 

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -83,6 +83,7 @@ class CudaUtils(object):
         self.cuOccupancyMaxActiveClusters = mod.cuOccupancyMaxActiveClusters
         self.set_printf_fifo_size = mod.set_printf_fifo_size
         self.fill_1d_tma_descriptor = mod.fill_1d_tma_descriptor
+        self.fill_2d_tma_descriptor = mod.fill_2d_tma_descriptor
 
 
 # ------------------------

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -110,6 +110,7 @@ struct WaitBarrierOpConversion
         op.getLoc(), adaptor.getAlloc(),
         typeConverter->convertType(op.getAlloc().getType().getElementType()),
         rewriter);
+    auto loc = op.getLoc();
     const std::string ptx =
         "{                                                           \n\t"
         ".reg .pred P1;                                              \n\t"
@@ -124,6 +125,7 @@ struct WaitBarrierOpConversion
              /*onlyAttachMLIRArgs=*/true);
     auto voidTy = void_ty(op->getContext());
     ptxBuilder.launch(rewriter, op->getLoc(), voidTy);
+    barrier();
     rewriter.eraseOp(op);
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -943,7 +943,8 @@ struct AsyncTMACopyGlobalToLocalOpConversion
         "d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {";
     int operandIdx = 3;
     for (int i = 0; i < rank; i++) {
-      operands.push_back(ptxBuilderTMA.newOperand(adaptor.getCoord()[i], "r"));
+      operands.push_back(
+          ptxBuilderTMA.newOperand(adaptor.getCoord()[rank - i - 1], "r"));
       tmaInst += "$" + std::to_string(operandIdx++);
       if (i != rank - 1)
         tmaInst += ", ";


### PR DESCRIPTION
Add a test to exercise matmul with TMA experimental loads. This ensure we generate correct code for this cases. The next step will be to enable pipelining.
Fix few bugs in the codegen found in the process.