### PR TITLE
gitignore proton's shared library on mac.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@ build-*/
 python/build/
 python/dist/
 python/triton*.egg-info/
-python/triton/_C/libtriton.pyd
-python/triton/_C/libtriton.so
-python/triton/_C/libproton.so
+
+python/triton/_C/*.pyd
+python/triton/_C/*.so
+python/triton/_C/*.dylib
 
 # Backends copied from submodules
 python/triton/backends/


### PR DESCRIPTION
We were creating libproton.dylib, which was not being gitignored.
