### PR TITLE
[DOC] Update LLVM build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ arbitrary LLVM version.
        $ cd $HOME/llvm-project  # your clone of LLVM.
        $ mkdir build
        $ cd build
-       $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON  ../llvm -DLLVM_ENABLE_PROJECTS="mlir;llvm"
+       $ cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_ASSERTIONS=ON ../llvm -DLLVM_ENABLE_PROJECTS="mlir;llvm" -DLLVM_TARGETS_TO_BUILD="host;NVPTX;AMDGPU"
        $ ninja
 
 4. Grab a snack, this will take a while.


### PR DESCRIPTION
This commit updates the LLVM build instructions in the readme file. The current instructions result in a triton build that fails at load-time with the following error:

```
ImportError: /home/.../triton/python/triton/_C/libtriton.so: undefined symbol: LLVMInitializeSparcTarget
```

This flag is used in the triton docker files.