### PR TITLE
[DOC] Update the testing instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ follow the following recipe.
 ```shell
 # One-time setup.  Note we have to reinstall local Triton because torch
 # overwrites it with the public version.
-$ pip install scipy numpy torch pytest lit && pip install -e python
+$ pip install scipy numpy torch pytest lit pandas matplotlib && pip install -e python
 
 # Run Python tests using your local GPU.
 $ python3 -m pytest python/test/unit


### PR DESCRIPTION
This commit updates the testing instructions in the readme file. The two missing packages are used by triton in "triton/testing.py". Without these dependencies users get the following error:

```
Traceback (most recent call last):
  File "/home/..../test/test.py", line 133, in <module>
    benchmark.run(print_data=True, show_plots=True)
  File "/home/..../triton/python/triton/testing.py", line 346, in run
    result_dfs.append(self._run(bench, save_path, show_plots, print_data, **kwargs))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/..../triton/python/triton/testing.py", line 272, in _run
    import pandas as pd
ModuleNotFoundError: No module named 'pandas'
```
