### PR TITLE
[TEST] disable certain tests on pre-hopper devices.

### DIFF
--- a/python/test/unit/hopper/test_experimental_tma.py
+++ b/python/test/unit/hopper/test_experimental_tma.py
@@ -6,11 +6,11 @@ import tempfile
 import triton
 import triton.language as tl
 
+skip_pre_hopper = triton.testing.cuda_device_capability(9)
 
+
+@skip_pre_hopper
 def test_descriptor_load_ttgir():
-    if not torch.cuda.is_available() or not torch.cuda.get_device_capability()[0] == 9:
-        pytest.skip("Test requires Hopper target.")
-        return
     device = "cuda"
     SIZE = 128
 
@@ -48,10 +48,8 @@ def test_descriptor_load_ttgir():
     assert torch.equal(x, z_tri)
 
 
+@skip_pre_hopper
 def test_experimetal_descriptor_load():
-    if not torch.cuda.is_available() or not torch.cuda.get_device_capability()[0] == 9:
-        pytest.skip("Test requires Hopper target.")
-        return
     device = "cuda"
     SIZE = 128
 

--- a/python/test/unit/hopper/test_flashattention.py
+++ b/python/test/unit/hopper/test_flashattention.py
@@ -32,6 +32,8 @@ import torch
 import triton
 import triton.language as tl
 
+skip_pre_hopper = triton.testing.cuda_device_capability(9)
+
 
 @triton.jit
 def _fwd_kernel(Q, K, V, sm_scale,  #
@@ -367,7 +369,7 @@ attention = _attention.apply
     (4, 48, 4096, 64),
     #  (4, 48, 8192, 64), out of memory
 ])
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="requires arch 9+")
+@skip_pre_hopper
 def test_op(Z, H, N_CTX, D_HEAD, dtype=torch.float16):
     torch.manual_seed(20)
     q = torch.empty((Z, H, N_CTX, D_HEAD), dtype=dtype, device="cuda").normal_(mean=0.1, std=0.2).requires_grad_()

--- a/python/test/unit/hopper/test_gemm.py
+++ b/python/test/unit/hopper/test_gemm.py
@@ -35,6 +35,9 @@ def is_hip():
     return triton.runtime.driver.active.get_current_target().backend == "hip"
 
 
+skip_pre_hopper = triton.testing.cuda_device_capability(9)
+
+
 @triton.jit
 def matmul_no_scf_kernel(a_ptr, b_ptr, c_ptr,  #
                          M, N, K,  #
@@ -103,7 +106,7 @@ def matmul_no_scf_kernel(a_ptr, b_ptr, c_ptr,  #
         [32, 16, 16, 1, 4, False, True, "float32", USE_TMA_EPILOGUE],
         [32, 32, 16, 1, 4, False, True, "float32", USE_TMA_EPILOGUE],
     ] for USE_TMA_EPILOGUE in [True, False]]))
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="Requires compute capability >= 9")
+@skip_pre_hopper
 def test_gemm_no_scf(M, N, K, NUM_CTAS, NUM_WARPS, TRANS_A, TRANS_B, OUTPUT_TYPE, USE_TMA_EPILOGUE):
     if is_hip() and NUM_CTAS > 1:
         pytest.skip("NUM_CTAS > 1 is not supported in HIP backend")
@@ -319,7 +322,7 @@ def matmul_kernel(a_ptr, b_ptr, w_ptr, bias_ptr, z_ptr,  #
         ] for trans_output in [False] for out_dtype in ['float32'] for use_tma_store in [False, True] for num_stages in
         [3, 4]
     ])
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="Requires compute capability >= 9")
+@skip_pre_hopper
 def test_gemm(BLOCK_M, BLOCK_N, BLOCK_K, NUM_WARPS, NUM_CTAS, M, N, K, TRANS_A, TRANS_B, TRANS_OUTPUT, epilogue,
               out_dtype, USE_TMA_STORE, NUM_STAGES):
     if '-'.join(map(str, [BLOCK_M, BLOCK_N, BLOCK_K, NUM_WARPS, NUM_CTAS, M, N, K, TRANS_A, TRANS_B])) in [

--- a/python/test/unit/hopper/test_gemm_fusion.py
+++ b/python/test/unit/hopper/test_gemm_fusion.py
@@ -25,6 +25,8 @@ import torch
 import triton
 import triton.language as tl
 
+skip_pre_hopper = triton.testing.cuda_device_capability(9)
+
 
 @triton.jit
 def gemm_fusion_kernel(A, B, C, E,  #
@@ -57,7 +59,7 @@ def gemm_fusion_kernel(A, B, C, E,  #
     tl.store(e_tile_ptr, acc_e)
 
 
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="not passed on ampere")
+@skip_pre_hopper
 def test_gemm_fusion():
     M, N, K = 4096, 4096, 64
     BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 64

--- a/python/test/unit/hopper/test_mixed_io.py
+++ b/python/test/unit/hopper/test_mixed_io.py
@@ -5,6 +5,8 @@ from torch.testing import assert_close
 import triton
 import triton.language as tl
 
+skip_pre_hopper = triton.testing.cuda_device_capability(9)
+
 dtype_mapping = {
     'float16': torch.float16,
     'float32': torch.float32,
@@ -68,6 +70,7 @@ def load_reduce_kernel(
     tl.store(y_ptr + tl.arange(0, BLOCK_M), y)
 
 
+@skip_pre_hopper
 @pytest.mark.parametrize('BLOCK_M,BLOCK_N,dtype_str', [(128, 64, dtype_str) for dtype_str in ['float16']])
 def test_load_reduce(BLOCK_M, BLOCK_N, dtype_str):
     dtype = dtype_mapping[dtype_str]

--- a/python/test/unit/hopper/test_persistent_warp_specialized_gemm.py
+++ b/python/test/unit/hopper/test_persistent_warp_specialized_gemm.py
@@ -28,8 +28,11 @@ import triton
 import triton.language as tl
 from triton.runtime import driver
 
+skip_pre_hopper = triton.testing.cuda_device_capability(9)
 
 # kernel used to query max clusters for persistent kernel when NUM_CTAS > 1
+
+
 @triton.jit
 def empty_kernel(null, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
     pass
@@ -137,7 +140,7 @@ def static_persistent_tma_matmul_kernel(  #
     # [4096, 4096, 64, 128, 128, 16, 8, 1, False, True],
     # [4096, 4096, 64, 128, 256, 16, 8, 1, False, True],
 ] for use_tma in [False, True]])
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="Requires compute capability >= 9")
+@skip_pre_hopper
 def test_user_defined_persistent_non_warp_specialized_gemm(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_WARPS, NUM_CTAS,
                                                            TRANS_A, TRANS_B, USE_TMA):
     if (TRANS_A):
@@ -276,7 +279,7 @@ def tma_warp_specialized_matmul_kernel(  #
                              [4096, 4096, 256, 128, 256, 64, 4, False, True],
                              [4096, 4096, 256, 256, 256, 64, 4, False, True],
                          ] for use_tma in [False, True]])
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="Requires compute capability >= 9")
+@skip_pre_hopper
 def test_non_persistent_warp_specialized_gemm(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_CTAS, TRANS_A, TRANS_B, USE_TMA):
     if (TRANS_A):
         a = .1 * torch.randn((K, M), device='cuda', dtype=torch.float16).T
@@ -431,7 +434,7 @@ def static_persistent_tma_warp_specialized_matmul_kernel(  #
                              [4096, 4096, 256, 128, 256, 64, 4, False, True],
                              [4096, 4096, 256, 256, 256, 64, 4, False, True],
                          ] for use_tma in [False, True]])
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="Requires compute capability >= 9")
+@skip_pre_hopper
 def test_user_defined_persistent_warp_specialized_gemm(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, NUM_CTAS, TRANS_A, TRANS_B,
                                                        USE_TMA):
     if (TRANS_A):
@@ -550,7 +553,7 @@ def static_persistent_matmul_no_scf_kernel(a_ptr, b_ptr, c_ptr,  #
         [32, 16, 16, 1, 4, False, True, "float32", USE_TMA_EPILOGUE, USE_TMA_LOAD],
         [32, 32, 16, 1, 4, False, True, "float32", USE_TMA_EPILOGUE, USE_TMA_LOAD],
     ] for USE_TMA_EPILOGUE in [True, False] for USE_TMA_LOAD in [True, False]]))
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="Requires compute capability >= 9")
+@skip_pre_hopper
 def test_static_persistent_matmul_no_scf_kernel(M, N, K, NUM_CTAS, NUM_WARPS, TRANS_A, TRANS_B, OUTPUT_TYPE,
                                                 USE_TMA_EPILOGUE, USE_TMA_LOAD):
     if (TRANS_A):
@@ -790,7 +793,7 @@ def full_static_persistent_matmul_kernel(a_ptr, b_ptr, w_ptr, bias_ptr, z_ptr,  
         [128, 1024, 64, 4, 8, 800, 30000, 10000, True, True, 'none', 'float16', True, 5],
         [512, 256, 64, 4, 8, 1800, 10000, 15000, True, True, 'none', 'float16', True, 5],
     ])
-@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason="Requires compute capability >= 9")
+@skip_pre_hopper
 def test_full_static_persistent_matmul_kernel(BLOCK_M, BLOCK_N, BLOCK_K, NUM_WARPS, NUM_CTAS, M, N, K, TRANS_A, TRANS_B,
                                               epilogue, out_dtype, USE_TMA_STORE, NUM_STAGES):
     if '-'.join(

--- a/python/test/unit/hopper/test_tma_store_gemm.py
+++ b/python/test/unit/hopper/test_tma_store_gemm.py
@@ -26,7 +26,10 @@ from torch.testing import assert_close
 import triton
 import triton.language as tl
 
+skip_pre_hopper = triton.testing.cuda_device_capability(9)
 
+
+@skip_pre_hopper
 @triton.jit
 def matmul_tma_load_store(  #
         a_ptr, b_ptr, c_ptr,  #
@@ -53,6 +56,7 @@ def matmul_tma_load_store(  #
     tl.store(c_block_ptr, c)
 
 
+@skip_pre_hopper
 @pytest.mark.parametrize('M,N,K,NUM_CTAS,NUM_WARPS,TRANS_A,TRANS_B,OUTPUT_F16', [
     [64, 64, 16, 1, 4, False, True, False],
     [64, 64, 16, 1, 4, False, True, True],

--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -491,3 +491,15 @@ def get_max_simd_tflops(dtype, clock_rate, device=None):
             raise RuntimeError("dtype not supported")
     tflops = num_subcores * clock_rate * ops_per_sub_core * 1e-9
     return tflops
+
+
+def cuda_device_capability(min_capability):
+    """
+    Creates a decorator that checks that a cuda device with minimum capability exists.
+    """
+    import torch
+    import pytest
+    return pytest.mark.skipif(
+        not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < min_capability,
+        reason="cuda device does not support the required capabilities"
+    )


### PR DESCRIPTION
Several tests are crashing inside LLVM (SelectionDAG can't select instructions for the device). The problem is that the tests require cuda capabilities that are not available.

I added a utility to 'testing.py' that creates a configurable decorator, and used it in the 'hopper' test directory to ensure that a Hopper device (level-9) exists.

Tested on Pascal-grade hardware.