### PR TITLE
[TEST] Fix a broken MLIR test (reorder-instr)

### DIFF
--- a/test/TritonGPU/reorder-instructions.mlir
+++ b/test/TritonGPU/reorder-instructions.mlir
@@ -28,7 +28,8 @@ module attributes {"triton_gpu.num-warps" = 4 : i32, "triton_gpu.threads-per-war
 //       CHECK: triton_gpu.async_wait {num = 0 : i32}
 //       CHECK: triton_gpu.local_dealloc %0 : !tt.memdesc<4x128x64xf16, #shared>
 //       CHECK: triton_gpu.local_dealloc %1 : !tt.memdesc<4x128x64xf16, #shared>
-//       CHECK: %3 = triton_gpu.convert_layout %arg0 : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked1>
+//       CHECK: %2 = triton_gpu.convert_layout %arg0 : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked1>
+//       CHECK-NEXT: %3 = arith.addf %2, %2 : tensor<32x32xf32, #blocked1>
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
 #blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
 #shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>


### PR DESCRIPTION
Fix a broken unit test. I didn't check when the test broke, but it looks like the pass does that it was intended.  The test sink_convert_dealloc checks that we are able to sink convert_layout below the dealloc instructions. I fixed the test to check the intended behavior.

Tested with 'lit test'.
...
PASS: TRITON :: TritonGPU/reorder-instructions.mlir (12 of 49)
...