### PR TITLE
[Frontend] Remove tl._experimental_join and tl._experimental_split.

### DIFF
--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -26,8 +26,6 @@ from .standard import (
 from .core import (
     PropagateNan,
     TRITON_MAX_TENSOR_NUMEL,
-    _experimental_join,
-    _experimental_split,
     _experimental_descriptor_load,
     advance,
     arange,
@@ -121,8 +119,6 @@ from .random import (
 __all__ = [
     "PropagateNan",
     "TRITON_MAX_TENSOR_NUMEL",
-    "_experimental_join",
-    "_experimental_split",
     "_experimental_descriptor_load",
     "abs",
     "advance",

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1360,10 +1360,6 @@ def join(a, b, _builder=None):
     return semantic.join(a, b, _builder)
 
 
-# For temporary backwards compat.
-_experimental_join = join
-
-
 @jit
 def _take_first(a, b):
     return a
@@ -1402,10 +1398,6 @@ def split(a, _builder=None, _generator=None) -> tuple[tensor, tensor]:
         out_rhs = cast(tensor, reduce(out_rhs, None, _take_first, _builder=_builder, _generator=_generator))
 
     return out_lhs, out_rhs
-
-
-# For temporary backwards compat.
-_experimental_split = split
 
 
 @_tensor_member_fn


### PR DESCRIPTION
As promised, these were just for temporary backwards compat.
