### PR TITLE
Add pipelining support to TMAs

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -162,13 +162,14 @@ def TTNG_AsyncTMACopyGlobalToLocalOp : TTNG_Op<"async_tma_copy_global_to_local",
     Variadic<I32>:$coord,
     TT_MemDescType:$barrier,
     TT_MemDescType:$result,
+    I1:$pred,
     DefaultValuedAttr<TT_CacheModifierAttr, "triton::CacheModifier::NONE">:$cache,
     DefaultValuedAttr<TT_EvictionPolicyAttr, "triton::EvictionPolicy::NORMAL">:$evict,
     DefaultValuedAttr<BoolAttr, "false">:$isVolatile
   );
 
   let assemblyFormat = [{
-    $desc_ptr `[` $coord `]` $result `,` $barrier
+    $desc_ptr `[` $coord `]` $result `,` $barrier `,` $pred
     oilist(`cacheModifier` `=` $cache | `evictionPolicy` `=` $evict)
     attr-dict `:` type($desc_ptr) `,` type($barrier) `->` type($result)
   }];

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -212,7 +212,7 @@ static void createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
                             Value insertIdx, Value extractIdx,
                             CoarseSchedule &schedule,
                             CoarseSchedule::Cluster prefetchCluster,
-                            llvm::MapVector<tt::LoadOp, LoadInfo> &loadToInfo,
+                            llvm::MapVector<Operation *, LoadInfo> &loadToInfo,
                             int numStages) {
   OpBuilder builder(forOp);
   Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
@@ -308,6 +308,76 @@ static void createAsyncCopy(scf::ForOp &forOp, tt::LoadOp loadOp, Value alloc,
   loadOp.erase();
 }
 
+static void createTMAAsyncCopy(
+    scf::ForOp &forOp, tt::ExperimentalDescriptorLoadOp loadOp, Value alloc,
+    Value insertIdx, Value extractIdx, Value barrier, Value phase,
+    CoarseSchedule &schedule, CoarseSchedule::Cluster prefetchCluster,
+    llvm::MapVector<Operation *, LoadInfo> &loadToInfo, int numStages) {
+  assert(phase && "Phase value is required for TMA async copy.");
+  OpBuilder builder(forOp);
+  Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
+  builder.setInsertionPoint(loadOp);
+  // TODO merge subview part with async cp.
+  Location loc = loadOp.getLoc();
+  tt::MemDescType allocTy = cast<tt::MemDescType>(alloc.getType());
+  SmallVector<Value> copyOffsets(allocTy.getRank(), zero);
+  copyOffsets[0] = insertIdx;
+  tt::MemDescType subviewTy = tt::MemDescType::get(
+      allocTy.getShape().drop_front(), allocTy.getElementType(),
+      allocTy.getEncoding(), /*mutableMemory=*/true);
+  auto view =
+      builder.create<ttg::MemDescSubviewOp>(loc, subviewTy, alloc, copyOffsets);
+
+  tt::MemDescType barrierTy = tt::MemDescType::get(
+      {1}, builder.getI64Type(),
+      barrier.getType().cast<tt::MemDescType>().getEncoding(),
+      /*mutableMemory=*/true);
+  Value barrierViewCopy = builder.create<ttg::MemDescSubviewOp>(
+      loc, barrierTy, barrier, ArrayRef<Value>({insertIdx}));
+  Value pred = builder.create<arith::ConstantIntOp>(loc, 1, 1);
+  Operation *copy = builder.create<ttng::AsyncTMACopyGlobalToLocalOp>(
+      loc, loadOp.getDescPtr(), loadOp.getIndices(), barrierViewCopy, view,
+      pred);
+
+  Value barrierViewWait = builder.create<ttg::MemDescSubviewOp>(
+      loc, barrierTy, barrier, ArrayRef<Value>({extractIdx}));
+  Operation *wait =
+      builder.create<ttng::WaitBarrierOp>(loc, barrierViewWait, phase);
+
+  bool isMMV3Load = loadToInfo[loadOp].loadIsMMAV3;
+  auto [stage, cluster] = schedule[loadOp];
+  schedule.erase(loadOp);
+  schedule.insert(copy, stage, cluster);
+
+  // Extract part.
+  SmallVector<Value> loadOffsets(allocTy.getRank(), zero);
+  loadOffsets[0] = extractIdx;
+  auto viewLoad =
+      builder.create<ttg::MemDescSubviewOp>(loc, subviewTy, alloc, loadOffsets);
+  if (isMMV3Load) {
+    auto alloc = cast<ttg::LocalAllocOp>((*loadOp->getUsers().begin()));
+    alloc.replaceAllUsesWith(viewLoad.getResult());
+    alloc.erase();
+  } else {
+    SmallVector<ttg::LocalAllocOp> allocsToErase;
+    for (Operation *user : loadOp->getUsers()) {
+      if (auto alloc = dyn_cast<ttg::LocalAllocOp>(user)) {
+        alloc.replaceAllUsesWith(viewLoad.getResult());
+        allocsToErase.push_back(alloc);
+      }
+    }
+    for (auto alloc : allocsToErase) {
+      alloc.erase();
+    }
+
+    auto sharedLoad = builder.create<ttg::LocalLoadOp>(
+        loc, loadOp.getType(), viewLoad /*,wait->getResult(0)*/);
+    auto result = sharedLoad->getResults();
+    loadOp->replaceAllUsesWith(result);
+  }
+  loadOp.erase();
+}
+
 // If all the transitive uses of the given value have are used by a convert to
 // the same dot operand encoding, return true and get the shared encoding that
 // needs to be used to be compatible with users' layouts.
@@ -373,8 +443,8 @@ getBlockedEncoding(tt::LoadOp loadOp, tt::ModuleAxisInfoAnalysis &axisInfo) {
 }
 
 static std::optional<ttg::SharedEncodingAttr>
-getSharedEncoding(tt::LoadOp loadOp, bool isMMAV3) {
-  auto ty = cast<RankedTensorType>(loadOp.getType());
+getSharedEncoding(Operation *loadOp, bool isMMAV3) {
+  auto ty = cast<RankedTensorType>(loadOp->getResultTypes()[0]);
   auto ctaLayout = ttg::getCTALayout(ty.getEncoding());
   auto blockedOrder = ttg::getOrder(ty.getEncoding());
   SmallVector<unsigned> order;
@@ -424,9 +494,9 @@ getSharedEncoding(tt::LoadOp loadOp, bool isMMAV3) {
 // final use of the load op (another load op, or a dot op).
 // Indirection level is "0" for the load op directly used by the dot op,
 // "1" for the load op used by the load op used by the dot op, and so on.
-static llvm::SmallVector<std::tuple<tt::LoadOp, int, Operation *>>
+static llvm::SmallVector<std::tuple<Operation *, int, Operation *>>
 loadOpsToIndirectionLevelAndUse(scf::ForOp forOp) {
-  llvm::SmallVector<std::tuple<tt::LoadOp, int, Operation *>>
+  llvm::SmallVector<std::tuple<Operation *, int, Operation *>>
       loadOpToIndLevelAndUse;
   DenseSet<Operation *> seen;
 
@@ -434,10 +504,9 @@ loadOpsToIndirectionLevelAndUse(scf::ForOp forOp) {
       [&](Operation *op, int distance, Operation *use) {
         if (!seen.insert(op).second)
           return;
-        if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
+        if (isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp>(op)) {
           // TODO: What if there are multiple uses at different distances?
-          loadOpToIndLevelAndUse.push_back(
-              std::make_tuple(loadOp, distance, use));
+          loadOpToIndLevelAndUse.push_back(std::make_tuple(op, distance, use));
           use = op;
           distance++;
         }
@@ -461,7 +530,7 @@ loadOpsToIndirectionLevelAndUse(scf::ForOp forOp) {
   // that are not directly used by dot ops.
   if (forOp->hasAttr(tt::kNumStagesAttrName)) {
     for (Operation &op : forOp.getBody()->without_terminator()) {
-      if (!isa<tt::LoadOp>(op))
+      if (!isa<tt::LoadOp, tt::ExperimentalDescriptorLoadOp>(op))
         dfs(&op, 0, &op);
     }
   }
@@ -469,7 +538,7 @@ loadOpsToIndirectionLevelAndUse(scf::ForOp forOp) {
   return loadOpToIndLevelAndUse;
 }
 
-static bool loadIsMMAv3(tt::LoadOp loadOp) {
+static bool loadIsMMAv3(Operation *loadOp) {
   if (!loadOp->hasOneUse())
     return false;
   auto alloc = dyn_cast<ttg::LocalAllocOp>(*loadOp->getUsers().begin());
@@ -482,7 +551,7 @@ static bool loadIsMMAv3(tt::LoadOp loadOp) {
 
   // MMA V3 case.
   auto newOrder = sharedEnc.getOrder();
-  auto ty = cast<RankedTensorType>(loadOp.getType());
+  auto ty = cast<RankedTensorType>(loadOp->getResultTypes()[0]);
   auto oldOrder = ttg::getOrder(ty.getEncoding());
 
   // The operand of MMAv3 is in SharedEncoding and its order should not
@@ -492,52 +561,52 @@ static bool loadIsMMAv3(tt::LoadOp loadOp) {
   return oldOrder == newOrder;
 }
 
-static llvm::MapVector<tt::LoadOp, LoadInfo>
-assignMemoryLayouts(llvm::SmallVector<std::tuple<tt::LoadOp, int, Operation *>>
+static llvm::MapVector<Operation *, LoadInfo>
+assignMemoryLayouts(llvm::SmallVector<std::tuple<Operation *, int, Operation *>>
                         &loadOpToIndLevelAndUse,
                     tt::ModuleAxisInfoAnalysis &axisInfoAnalysis) {
-  llvm::MapVector<tt::LoadOp, LoadInfo> loadToInfo;
+  llvm::MapVector<Operation *, LoadInfo> loadToInfo;
 
-  for (auto &[loadOp, dist, use] : loadOpToIndLevelAndUse) {
-    assert(!isLoadFromTensorPtr(loadOp) &&
-           "Block ptr should have been lowered before this pass.");
-
-    if (loadToInfo.count(loadOp))
+  for (auto &[op, dist, use] : loadOpToIndLevelAndUse) {
+    if (loadToInfo.count(op))
       // TODO pawel: err, we'd need to verify that the distance is the same
       continue;
-
     LoadInfo loadInfo;
-    auto ptr = loadOp.getPtr();
-    unsigned vec = axisInfoAnalysis.getPtrContiguity(ptr);
-    if (auto mask = loadOp.getMask())
-      vec = std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));
 
-    auto tensorTy = ptr.getType().dyn_cast<RankedTensorType>();
-    if (!tensorTy)
-      continue;
-    auto ty =
-        tensorTy.getElementType().cast<tt::PointerType>().getPointeeType();
-    unsigned width = vec * ty.getIntOrFloatBitWidth();
+    if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
+      assert(!isLoadFromTensorPtr(loadOp) &&
+             "Block ptr should have been lowered before this pass.");
+      auto ptr = loadOp.getPtr();
+      unsigned vec = axisInfoAnalysis.getPtrContiguity(ptr);
+      if (auto mask = loadOp.getMask())
+        vec = std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));
 
-    // We do not pipeline all loads for the following reasons:
-    // 1. On nvidia GPUs, cp.async's cp-size can only be 4, 8, or 16.
-    // 2. It's likely that pipling small loads won't offer much performance
-    //    improvement and may even hurt performance by increasing register
-    //    pressure.
-    LDBG("Load " << *loadOp << " has width " << width);
-    if (width < 32)
-      continue;
+      auto tensorTy = ptr.getType().dyn_cast<RankedTensorType>();
+      if (!tensorTy)
+        continue;
+      auto ty =
+          tensorTy.getElementType().cast<tt::PointerType>().getPointeeType();
+      unsigned width = vec * ty.getIntOrFloatBitWidth();
+
+      // We do not pipeline all loads for the following reasons:
+      // 1. On nvidia GPUs, cp.async's cp-size can only be 4, 8, or 16.
+      // 2. It's likely that pipling small loads won't offer much performance
+      //    improvement and may even hurt performance by increasing register
+      //    pressure.
+      LDBG("Load " << *loadOp << " has width " << width);
+      if (width < 32)
+        continue;
+    }
 
     if (auto dot = dyn_cast<tt::DotOp>(use)) {
       loadInfo.usedByDot = true;
-      if (loadIsMMAv3(loadOp)) {
+      if (loadIsMMAv3(op)) {
         loadInfo.loadIsMMAV3 = true;
         loadInfo.sharedEncoding =
-            getSharedEncoding(loadOp, /*loadIsMMAv3=*/true).value_or(nullptr);
+            getSharedEncoding(op, /*loadIsMMAv3=*/true).value_or(nullptr);
       } else {
         loadInfo.sharedEncoding =
-            getSharedEncIfAllUsersAreDotEnc(loadOp.getResult())
-                .value_or(nullptr);
+            getSharedEncIfAllUsersAreDotEnc(op->getResult(0)).value_or(nullptr);
 
         // HACK: Triton LLVM codegen has a bug where local_loads from #shared to
         // #mma layout can lead to invalid code if the loaded shape is smaller
@@ -553,7 +622,7 @@ assignMemoryLayouts(llvm::SmallVector<std::tuple<tt::LoadOp, int, Operation *>>
                                 .getType()
                                 .getEncoding()
                                 .dyn_cast<ttg::NvidiaMmaEncodingAttr>()) {
-            auto loadTy = loadOp.getType().cast<RankedTensorType>();
+            auto loadTy = op->getResultTypes()[0].cast<RankedTensorType>();
             auto mmaInstrShape = dotEnc.getInstrShape();
             if (loadTy.getRank() < mmaInstrShape.size())
               continue;
@@ -589,22 +658,24 @@ assignMemoryLayouts(llvm::SmallVector<std::tuple<tt::LoadOp, int, Operation *>>
     // encoding.
     if (!loadInfo.sharedEncoding && !isMMAv3Dot(use)) {
       loadInfo.sharedEncoding =
-          getSharedEncoding(loadOp, /*isMMAV3=*/loadInfo.loadIsMMAV3)
+          getSharedEncoding(op, /*isMMAV3=*/loadInfo.loadIsMMAV3)
               .value_or(nullptr);
-      loadInfo.blockedEncoding = getBlockedEncoding(loadOp, axisInfoAnalysis);
+      if (auto loadOp = dyn_cast<tt::LoadOp>(op)) {
+        loadInfo.blockedEncoding = getBlockedEncoding(loadOp, axisInfoAnalysis);
+      }
     }
 
     // If that still didn't work, bail on pipelining this load.
     if (!loadInfo.sharedEncoding) {
       continue;
     }
-    loadToInfo[loadOp] = loadInfo;
+    loadToInfo[op] = loadInfo;
   }
 
   return loadToInfo;
 }
 
-static llvm::MapVector<tt::LoadOp, LoadInfo>
+static llvm::MapVector<Operation *, LoadInfo>
 scheduleLoads(scf::ForOp forOp, CoarseSchedule &schedule,
               DenseSet<Operation *> &rootUsers, int numStages) {
   ModuleOp moduleOp = forOp->getParentOfType<ModuleOp>();
@@ -612,7 +683,7 @@ scheduleLoads(scf::ForOp forOp, CoarseSchedule &schedule,
 
   // Get all loads that are (transitively) used by dot ops and their distance
   // to the dot op.
-  llvm::SmallVector<std::tuple<tt::LoadOp, int, Operation *>>
+  llvm::SmallVector<std::tuple<Operation *, int, Operation *>>
       loadOpToIndLevelAndUse = loadOpsToIndirectionLevelAndUse(forOp);
   LLVM_DEBUG({
     LDBG("Found " << loadOpToIndLevelAndUse.size() << " loads to pipeline:");
@@ -627,7 +698,7 @@ scheduleLoads(scf::ForOp forOp, CoarseSchedule &schedule,
 
   // Check which loads are good for pipelining, and assign them
   // memory layouts.
-  llvm::MapVector<tt::LoadOp, LoadInfo> loadToInfo =
+  llvm::MapVector<Operation *, LoadInfo> loadToInfo =
       assignMemoryLayouts(loadOpToIndLevelAndUse, axisInfoAnalysis);
 
   if (loadToInfo.empty())
@@ -801,29 +872,56 @@ static void scheduleDistanceOneDependencies(scf::ForOp forOp,
 }
 
 // Create an allocation that can hold distance number of loadOp shapes.
-static Value createAlloc(scf::ForOp &forOp, tt::LoadOp loadOp,
+static Value createAlloc(scf::ForOp &forOp, Operation *loadOp,
                          ttg::SharedEncodingAttr sharedEnc, unsigned distance) {
   OpBuilder builder(forOp);
-  auto ty = cast<RankedTensorType>(loadOp.getType());
+  auto ty = cast<RankedTensorType>(loadOp->getResultTypes()[0]);
   SmallVector<int64_t> bufferShape(ty.getShape().begin(), ty.getShape().end());
   bufferShape.insert(bufferShape.begin(), distance);
   Type memdescType = mlir::triton::MemDescType::get(
       bufferShape, ty.getElementType(), sharedEnc, /*mutableMemory*/ true);
   Value alloc = builder.create<mlir::triton::gpu::LocalAllocOp>(
-      loadOp.getLoc(), memdescType, Value());
+      loadOp->getLoc(), memdescType, Value());
   return alloc;
+}
+
+// Create an allocation to hold the mbarriers.
+static Value createBarrierAlloc(scf::ForOp &forOp, unsigned distance) {
+  OpBuilder builder(forOp);
+  Location loc = forOp.getLoc();
+  auto context = forOp.getContext();
+  auto barrierCTALayout =
+      ttg::CTALayoutAttr::get(context, /*CTAsPerCGA=*/{1},
+                              /*CTASplitNum=*/{1}, /*CTAOrder=*/{0});
+  auto barrierEncoding =
+      ttg::SharedEncodingAttr::get(context, 1, 1, 1, {0}, barrierCTALayout);
+  Type barrierMemDescType =
+      tt::MemDescType::get({distance}, builder.getI64Type(), barrierEncoding,
+                           /*mutableMemory=*/true);
+  Type singleBarrierMemDescType = tt::MemDescType::get(
+      {1}, builder.getI64Type(), barrierEncoding, /*mutableMemory=*/true);
+  Value barrierAlloc = builder.create<mlir::triton::gpu::LocalAllocOp>(
+      loc, barrierMemDescType, Value());
+  for (unsigned i = 0; i < distance; i++) {
+    Value idx = builder.create<arith::ConstantIntOp>(loc, i, 32);
+    Value barrierView = builder.create<ttg::MemDescSubviewOp>(
+        loc, singleBarrierMemDescType, barrierAlloc, idx);
+    builder.create<ttng::InitBarrierOp>(forOp->getLoc(), barrierView, 1);
+  }
+  return barrierAlloc;
 }
 
 // Convert load ops into their asyn version and apply multi-buffering based on
 // the required number of buffers.
 static SmallVector<Value>
 createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
-               llvm::MapVector<tt::LoadOp, LoadInfo> &loadToInfo,
+               llvm::MapVector<Operation *, LoadInfo> &loadToInfo,
                int numStages) {
   struct AsyncLoad {
-    AsyncLoad(tt::LoadOp loadOp, Value alloc) : loadOp(loadOp), alloc(alloc) {}
-    tt::LoadOp loadOp;
+    AsyncLoad(Operation *loadOp, Value alloc) : loadOp(loadOp), alloc(alloc) {}
+    Operation *loadOp;
     Value alloc;
+    Value barrier;
   };
   // Calculate the number of buffers needed for each load.
   // TODO pawel: we could do more fine-grained allocation here and
@@ -844,12 +942,17 @@ createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
 
   SmallVector<AsyncLoad> asyncLoads;
   SmallVector<Value> allocs;
+  bool hasTMALoad = false;
   for (auto &[loadOp, info] : loadToInfo) {
     assert(info.sharedEncoding && "LoadOp shared encoding not defined.");
     Value alloc = createAlloc(forOp, loadOp, info.sharedEncoding, numBuffers);
     assert(alloc && "Failed to create alloc for the async load.");
     allocs.push_back(alloc);
     asyncLoads.emplace_back(loadOp, alloc);
+    if (isa<tt::ExperimentalDescriptorLoadOp>(loadOp)) {
+      hasTMALoad = true;
+      asyncLoads.back().barrier = createBarrierAlloc(forOp, numBuffers);
+    }
   }
 
   IRRewriter builder(forOp.getContext());
@@ -862,12 +965,16 @@ createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
   Value one = builder.create<arith::ConstantIntOp>(loc, 1, 32);
   Value insertIdx = minusOne;
   Value extractIdx = minusOne;
+  Value phase = Value();
   Value numBuffersVal =
       builder.create<arith::ConstantIntOp>(loc, numBuffers, 32);
   SmallVector<Value> newOperands;
   newOperands.push_back(insertIdx);
   newOperands.push_back(extractIdx);
-  Value phase;
+  if (hasTMALoad) {
+    phase = builder.create<arith::ConstantIntOp>(loc, 0, 32);
+    newOperands.push_back(phase);
+  }
   unsigned newOperandIndex = forOp.getBody()->getNumArguments();
   // Patch the loop to add the new loop carried dependencies.
   scf::ForOp newForOp =
@@ -876,6 +983,9 @@ createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
   forOp = newForOp;
   insertIdx = newForOp.getBody()->getArgument(newOperandIndex);
   extractIdx = newForOp.getBody()->getArgument(newOperandIndex + 1);
+  if (phase) {
+    phase = newForOp.getBody()->getArgument(newOperandIndex + 2);
+  }
 
   // Create two counters for the insert and extract indices to avoid creating
   // long liverange.
@@ -889,17 +999,29 @@ createAsyncOps(scf::ForOp &forOp, CoarseSchedule &schedule,
   Value cndExt = builder.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
                                                extractIdx, numBuffersVal);
   extractIdx = builder.create<arith::SelectOp>(loc, cndExt, extractIdx, zero);
+  if (phase) {
+    Value nextPhase = builder.create<arith::XOrIOp>(loc, phase, one);
+    phase = builder.create<arith::SelectOp>(loc, cndExt, phase, nextPhase);
+  }
 
   // Create a cluster for the prefetches. It may end up being empty, but this
   // is OK.
   CoarseSchedule::Cluster prefetchCluster = schedule.clusters.newAtBack();
 
   for (AsyncLoad &asyncLoad : asyncLoads) {
-    createAsyncCopy(forOp, asyncLoad.loadOp, asyncLoad.alloc, insertIdx,
-                    extractIdx, schedule, prefetchCluster, loadToInfo,
-                    numStages);
+    if (auto loadOp = dyn_cast<tt::LoadOp>(asyncLoad.loadOp)) {
+      createAsyncCopy(forOp, loadOp, asyncLoad.alloc, insertIdx, extractIdx,
+                      schedule, prefetchCluster, loadToInfo, numStages);
+    } else {
+      auto descLoad = cast<tt::ExperimentalDescriptorLoadOp>(asyncLoad.loadOp);
+      createTMAAsyncCopy(forOp, descLoad, asyncLoad.alloc, insertIdx,
+                         extractIdx, asyncLoad.barrier, phase, schedule,
+                         prefetchCluster, loadToInfo, numStages);
+    }
   }
   SmallVector<Value> newYieldOperands = {insertIdx, extractIdx};
+  if (phase)
+    newYieldOperands.push_back(phase);
   // Patch the yield with the updated counters.
   appendToYield(forOp, newYieldOperands);
 
@@ -912,7 +1034,7 @@ bool mlir::triton::preProcessLoopAndGetSchedule(
   // a scaffold for the final schedule.
   DenseSet<Operation *> rootUsers;
   CoarseSchedule coarseSchedule(numStages);
-  llvm::MapVector<tt::LoadOp, LoadInfo> loadToInfo =
+  llvm::MapVector<Operation *, LoadInfo> loadToInfo =
       scheduleLoads(forOp, coarseSchedule, rootUsers, numStages);
   if (loadToInfo.empty())
     return false;

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -52,6 +52,13 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
     loadOp.getMaskMutable().assign(mask);
     return op;
   }
+  if (auto copyOp = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    rewriter.setInsertionPoint(copyOp);
+    Value mask = getPredMask(rewriter, copyOp.getPred().getType(),
+                             copyOp.getPred(), pred);
+    copyOp.getPredMutable().assign(mask);
+    return op;
+  }
 
   assert("don't know how to predicate this op" && false);
   return op;

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -31,12 +31,11 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
 #shared1 = #triton_gpu.shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32} {
   // CHECK-LABEL: tma_copy
-  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr<1>, i32, i32, !llvm.ptr<3>) -> !llvm.void
-  // CHECK: nvvm.barrier0
   // CHECK: "@$0 mbarrier.arrive.expect_tx.shared.b64 _, [$1], 65536;", "b,r" %{{.*}}, %{{.*}} : (i1, !llvm.ptr<3>) -> !llvm.void
-
-  tt.func @tma_copy(%tma: !tt.ptr<i64>, %alloc: !tt.memdesc<128x128xf32, #shared1>, %x: i32, %barrier: !tt.memdesc<1xi64, #shared0>, %phase: i32) {
-    triton_nvidia_gpu.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier : !tt.ptr<i64>, !tt.memdesc<1xi64, #shared0> -> !tt.memdesc<128x128xf32, #shared1>
+  // CHECK: nvvm.barrier0
+  // CHECK: "@$0 cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {$3, $4}], [$5];", "b,r,l,r,r,r" {{.*}} : (i1, !llvm.ptr<3>, !llvm.ptr<1>, i32, i32, !llvm.ptr<3>) -> !llvm.void
+  tt.func @tma_copy(%tma: !tt.ptr<i64>, %alloc: !tt.memdesc<128x128xf32, #shared1>, %x: i32, %barrier: !tt.memdesc<1xi64, #shared0>, %phase: i32, %pred: i1) {
+    triton_nvidia_gpu.async_tma_copy_global_to_local %tma[%x, %x] %alloc, %barrier, %pred : !tt.ptr<i64>, !tt.memdesc<1xi64, #shared0> -> !tt.memdesc<128x128xf32, #shared1>
     tt.return
   }
 }

--- a/test/TritonGPU/loop-pipeline.mlir
+++ b/test/TritonGPU/loop-pipeline.mlir
@@ -1489,3 +1489,42 @@ module attributes {"triton_gpu.target" = "cuda:90", "triton_gpu.num-ctas" = 1 : 
     tt.return
   }
 }
+
+
+// -----
+
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
+#blocked1 = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#mma = #triton_gpu.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 16]}>
+#shared = #triton_gpu.shared<{vec = 8, perPhase = 1, maxPhase = 8, order = [1, 0], hasLeadingOffset = true}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+//   CHECK-LABEL: @matmul_tma
+//     CHECK-DAG:   triton_gpu.local_alloc  : () -> !tt.memdesc<3x128x64xf16, #{{.+}}, mutable>
+//     CHECK-DAG:   triton_gpu.local_alloc  : () -> !tt.memdesc<3xi64, #{{.+}}, mutable>
+//         CHECK:   triton_nvidia_gpu.init_barrier
+//     CHECK-DAG:   triton_gpu.local_alloc  : () -> !tt.memdesc<3x64x256xf16, #{{.+}}, mutable>
+//     CHECK-DAG:   triton_gpu.local_alloc  : () -> !tt.memdesc<3xi64, #{{.+}}, mutable>
+// CHECK-COUNT-3:   triton_nvidia_gpu.init_barrier
+// CHECK-COUNT-4:   triton_nvidia_gpu.async_tma_copy_global_to_local
+//         CHECK:   scf.for
+// CHECK-COUNT-2:     triton_nvidia_gpu.wait_barrier
+// CHECK-COUNT-2:     triton_nvidia_gpu.async_tma_copy_global_to_local
+//         CHECK:     scf.yield
+  tt.func public @matmul_tma(%arg0: !tt.ptr<i8> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<i8> {tt.divisibility = 16 : i32}) -> tensor<128x256xf32, #mma> {
+    %c256_i32 = arith.constant 256 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x256xf32, #mma>
+    %0:2 = scf.for %arg3 = %c0_i32 to %c256_i32 step %c1_i32 iter_args(%arg4 = %cst, %arg5 = %c0_i32) -> (tensor<128x256xf32, #mma>, i32)  : i32 {
+      %1 = tt.experimental_descriptor_load %arg0[%c0_i32, %arg5] : !tt.ptr<i8> -> tensor<128x64xf16, #blocked>
+      %2 = triton_gpu.local_alloc %1 : (tensor<128x64xf16, #blocked>) -> !tt.memdesc<128x64xf16, #shared>
+      %3 = tt.experimental_descriptor_load %arg1[%arg5, %c0_i32] : !tt.ptr<i8> -> tensor<64x256xf16, #blocked1>
+      %4 = triton_gpu.local_alloc %3 : (tensor<64x256xf16, #blocked1>) -> !tt.memdesc<64x256xf16, #shared>
+      %5 = tt.dot %2, %4, %arg4, inputPrecision = tf32 : !tt.memdesc<128x64xf16, #shared> * !tt.memdesc<64x256xf16, #shared> -> tensor<128x256xf32, #mma>
+      %6 = arith.addi %arg5, %c64_i32 : i32
+      scf.yield %5, %6 : tensor<128x256xf32, #mma>, i32
+    }
+    tt.return %0#0 : tensor<128x256xf32, #mma>
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -914,47 +914,22 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     assert(op.getEvict() == triton::EvictionPolicy::NORMAL &&
            "eviction policy not supported yet.");
     auto loc = op.getLoc();
+    Type llvmElemTy =
+        typeConverter->convertType(op.getResult().getType().getElementType());
     auto barrierMemObj = LLVM::getSharedMemoryObjectFromStruct(
         loc, adaptor.getBarrier(),
         typeConverter->convertType(op.getBarrier().getType().getElementType()),
         rewriter);
     auto dstMemObj = LLVM::getSharedMemoryObjectFromStruct(
-        loc, adaptor.getResult(),
-        typeConverter->convertType(op.getResult().getType().getElementType()),
-        rewriter);
+        loc, adaptor.getResult(), llvmElemTy, rewriter);
     auto voidTy = void_ty(op->getContext());
     auto id = getThreadId(rewriter, loc);
-    auto pred = icmp_eq(id, i32_val(0));
-
-    int rank = op.getCoord().size();
-    ::mlir::triton::PTXBuilder ptxBuilderTMA;
-    SmallVector<PTXBuilder::Operand *> operands = {
-        ptxBuilderTMA.newOperand(pred, "b"),
-        ptxBuilderTMA.newOperand(dstMemObj.getBase(), "r"),
-        ptxBuilderTMA.newOperand(adaptor.getDescPtr(), "l")};
-    std::string tmaInst =
-        "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
-        "d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {";
-    int operandIdx = 3;
-    for (int i = 0; i < rank; i++) {
-      operands.push_back(
-          ptxBuilderTMA.newOperand(adaptor.getCoord()[rank - i - 1], "r"));
-      tmaInst += "$" + std::to_string(operandIdx++);
-      if (i != rank - 1)
-        tmaInst += ", ";
-    }
-    operands.push_back(ptxBuilderTMA.newOperand(barrierMemObj.getBase(), "r"));
-    tmaInst += "}], [$" + std::to_string(operandIdx++) + "];";
-    auto &tma = *ptxBuilderTMA.create<>(tmaInst);
-    tma(operands, /*onlyAttachMLIRArgs=*/true);
-    ptxBuilderTMA.launch(rewriter, loc, voidTy);
-
-    barrier();
-
-    int64_t size =
-        (product(op.getResult().getType().getShape()) *
-         op.getResult().getType().getElementType().getIntOrFloatBitWidth()) /
-        8;
+    Value pred = icmp_eq(id, i32_val(0));
+    pred = and_(pred, adaptor.getPred());
+    int elementSizeInBytes =
+        op.getResult().getType().getElementType().getIntOrFloatBitWidth() / 8;
+    int totalNumElements = product(op.getResult().getType().getShape());
+    int64_t size = totalNumElements * elementSizeInBytes;
     ::mlir::triton::PTXBuilder ptxBuilder;
     auto &arrive = *ptxBuilder.create<>(
         "@$0 mbarrier.arrive.expect_tx.shared.b64 _, [$1], " +
@@ -964,6 +939,51 @@ struct AsyncTMACopyGlobalToLocalOpConversion
            /*onlyAttachMLIRArgs=*/true);
     ptxBuilder.launch(rewriter, loc, voidTy);
 
+    barrier();
+
+    int innerBlockSize = op.getResult().getType().getShape().back();
+    int contigDimSizeInByte = innerBlockSize * elementSizeInBytes;
+    int numCopies = 1;
+    int rank = op.getCoord().size();
+    if (rank > 1)
+      numCopies = ceil<int>(contigDimSizeInByte, 128);
+
+    // The bounding box inner dimension must be less than or equal to the
+    // swizzle size.
+    // https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html#group__CUDA__TENSOR__MEMORY_1ga7c7d2aaac9e49294304e755e6f341d7
+    // We clamp the block size and the codegen will emit multiple copy
+    // operations.
+    for (int copyIdx = 0; copyIdx < numCopies; copyIdx++) {
+      ::mlir::triton::PTXBuilder ptxBuilderTMA;
+      Type elemPtrTy = ptr_ty(rewriter.getContext(), 3);
+      Value shMemPtr = gep(elemPtrTy, llvmElemTy, dstMemObj.getBase(),
+                           i32_val(copyIdx * (totalNumElements / numCopies)));
+      SmallVector<PTXBuilder::Operand *> operands = {
+          ptxBuilderTMA.newOperand(pred, "b"),
+          ptxBuilderTMA.newOperand(shMemPtr, "r"),
+          ptxBuilderTMA.newOperand(adaptor.getDescPtr(), "l")};
+      std::string tmaInst =
+          "@$0 cp.async.bulk.tensor." + std::to_string(rank) +
+          "d.shared::cluster.global.mbarrier::complete_tx::bytes [$1], [$2, {";
+      int operandIdx = 3;
+      for (int i = 0; i < rank; i++) {
+        Value coord = adaptor.getCoord()[rank - i - 1];
+        if (i == 0) {
+          int offset = copyIdx * (128 / elementSizeInBytes);
+          coord = add(coord, i32_val(offset));
+        }
+        operands.push_back(ptxBuilderTMA.newOperand(coord, "r"));
+        tmaInst += "$" + std::to_string(operandIdx++);
+        if (i != rank - 1)
+          tmaInst += ", ";
+      }
+      operands.push_back(
+          ptxBuilderTMA.newOperand(barrierMemObj.getBase(), "r"));
+      tmaInst += "}], [$" + std::to_string(operandIdx++) + "];";
+      auto &tma = *ptxBuilderTMA.create<>(tmaInst);
+      tma(operands, /*onlyAttachMLIRArgs=*/true);
+      ptxBuilderTMA.launch(rewriter, loc, voidTy);
+    }
     rewriter.eraseOp(op);
     return success();
   }


### PR DESCRIPTION
Allow pipelining the TMA loads and add some conventions for the swizzling parameters.
Having a convention for swizzling is fragile but this is currently the only way to have things working efficiently at the moment.