### PR TITLE
[DEBUG] Add NVPTX_ENABLE_DUMP option to dump PTX after it's generated by LLVM

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -44,6 +44,7 @@ inline const std::set<std::string> ENV_VARS = {
     "MLIR_ENABLE_DIAGNOSTICS",
     "TRITON_ENABLE_LLVM_DEBUG",
     "USE_TTGIR_LOC",
+    "NVPTX_ENABLE_DUMP",
 };
 
 namespace tools {

--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -250,6 +250,9 @@ class CUDABackend(BaseBackend):
         ret = re.sub(r'\.version \d+\.\d+', f'.version {ptx_version}', ret, flags=re.MULTILINE)
         # Remove the debug flag that prevents ptxas from optimizing the code
         ret = re.sub(r",\s*debug|debug,\s*", "", ret)
+        if os.environ.get("NVPTX_ENABLE_DUMP", "0") == "1":
+            print("// -----// NVPTX Dump //----- //")
+            print(ret)
         return ret
 
     @staticmethod


### PR DESCRIPTION
This is just a simple env var in the same vein as MLIR/LLVM_IR_ENABLE_DUMP. It has been helpful to me for reading the 
PTX output directly from the console instead of having to hunt for it in the Triton cache.