### PR TITLE
Remove remaining calls to `isa/cast/dyn_cast/...` member functions.

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -3,6 +3,7 @@
 
 #include "mlir/Analysis/DataFlowFramework.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 

--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -3,6 +3,7 @@
 
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
@@ -86,8 +87,8 @@ public:
     if (!encoding)
       // encoding not available
       return resultVals;
-    if (!encoding.dyn_cast<BlockedEncodingAttr>() &&
-        !encoding.dyn_cast<SliceEncodingAttr>()) {
+    if (!dyn_cast<BlockedEncodingAttr>(encoding) &&
+        !dyn_cast<SliceEncodingAttr>(encoding)) {
       // TODO: constraining the ecndoing type here is necessary for avoiding
       // crashes in the getElemsPerThread call below happening in the
       // test_core::test_fp8_dot_acc

--- a/include/triton/Dialect/Triton/IR/TritonTypes.td
+++ b/include/triton/Dialect/Triton/IR/TritonTypes.td
@@ -42,10 +42,10 @@ def TT_I64Like : AnyTypeOf<[I64, I64Tensor]>;
 // Pointer Type in TableGen
 class TT_PtrOf<list<Type> pointeeTypes> :
     DialectType<Triton_Dialect,
-                And<[CPred<"$_self.isa<::mlir::triton::PointerType>()">,
+                And<[CPred<"::mlir::isa<::mlir::triton::PointerType>($_self)">,
                      Concat<"[](::mlir::Type pointeeType) { return ",
                             SubstLeaves<"$_self", "pointeeType", AnyTypeOf<pointeeTypes>.predicate>,
-                                        "; }($_self.cast<::mlir::triton::PointerType>().getPointeeType())">]>,
+                                        "; }(::mlir::cast<::mlir::triton::PointerType>($_self).getPointeeType())">]>,
                 "ptr", "::mlir::triton::PointerType">;
 
 // Pointer Type in C++ (corresponding to `TT_PtrOf`)

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -280,7 +280,7 @@ compared to 1*64 when the hasLeadingOffset is false.
                      "bool":$needTrans), [{
 
         // ---- begin GFX908/GFX90A ----
-        if (auto mfmaEnc = dotOpEnc.getParent().dyn_cast<AMDMfmaEncodingAttr>()) {
+        if (auto mfmaEnc = mlir::dyn_cast<AMDMfmaEncodingAttr>(dotOpEnc.getParent())) {
           int kDimNum = dotOpEnc.getOpIdx() == 0 ? 1 : 0;
           if (needTrans)
             kDimNum = 1 - kDimNum;
@@ -312,7 +312,7 @@ compared to 1*64 when the hasLeadingOffset is false.
         }
 
         // ---- begin GFX11 ----
-        if (dotOpEnc.getParent().isa<AMDWmmaEncodingAttr>()) {
+        if (mlir::isa<AMDWmmaEncodingAttr>(dotOpEnc.getParent())) {
           if (dotOpEnc.getOpIdx() == 0) {
             const int numBanks = 32;
             const int bankBitWidth = 32;
@@ -334,7 +334,7 @@ compared to 1*64 when the hasLeadingOffset is false.
         }
 
 
-        auto mmaEnc = dotOpEnc.getParent().dyn_cast<NvidiaMmaEncodingAttr>();
+        auto mmaEnc = mlir::dyn_cast<NvidiaMmaEncodingAttr>(dotOpEnc.getParent());
 
         if(!mmaEnc)
           return get(context, 1, 1, 1, order, CTALayout);
@@ -1207,7 +1207,7 @@ def SliceEncodingAttr : DistributedEncoding<"SliceEncoding", "slice_encoding"> {
     SmallVector<T> paddedShape(ArrayRef<T> shape) const;
 
     SmallVector<unsigned> getContigPerThread() {
-      auto parentLayout = getParent().cast<DistributedEncodingTrait>();
+      auto parentLayout = mlir::cast<DistributedEncodingTrait>(getParent());
       return parentLayout.getContigPerThread();
     };
   }];
@@ -1245,7 +1245,7 @@ section 9.7.13.4.1 for more details.
     AttrBuilder<(ins "unsigned":$opIdx,
                      "Attribute":$parent,
                      "Type":$eltTy), [{
-      NvidiaMmaEncodingAttr parentAttr = parent.dyn_cast<NvidiaMmaEncodingAttr>();
+      NvidiaMmaEncodingAttr parentAttr = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent);
       if (!parentAttr || !parentAttr.isAmpere())
         return $_get(context, opIdx, parent, 0);
       unsigned bitwidth = eltTy.getIntOrFloatBitWidth();

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUDialect.td
@@ -26,12 +26,12 @@ def TritonGPU_Dialect : Dialect {
       if (!mod->hasAttr("triton_gpu.num-warps"))
         llvm::report_fatal_error(
             "TritonGPU module should contain a triton_gpu.num-warps attribute");
-      return mod->getAttr("triton_gpu.num-warps").cast<IntegerAttr>().getInt();
+      return cast<IntegerAttr>(mod->getAttr("triton_gpu.num-warps")).getInt();
     }
     static int getNumCTAs(ModuleOp mod) {
       if (!mod->hasAttr("triton_gpu.num-ctas"))
         return 1;
-      return mod->getAttr("triton_gpu.num-ctas").cast<IntegerAttr>().getInt();
+      return cast<IntegerAttr>(mod->getAttr("triton_gpu.num-ctas")).getInt();
     }
     void registerTypes();
 
@@ -42,7 +42,7 @@ def TritonGPU_Dialect : Dialect {
       if(!threadsPerWarp) {
         return 32;
       }
-      return threadsPerWarp.cast<IntegerAttr>().getInt();
+      return cast<IntegerAttr>(threadsPerWarp).getInt();
     }
   }];
 

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUDialect.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUDialect.td
@@ -48,13 +48,13 @@ def TritonNvidiaGPU_Dialect : Dialect {
       if(!mod->hasAttr("triton_gpu.num-warps"))
         llvm::report_fatal_error(
             "TritonGPU module should contain a triton_gpu.num-warps attribute");
-      return mod->getAttr("triton_gpu.num-warps").cast<IntegerAttr>().getInt();
+      return cast<IntegerAttr>(mod->getAttr("triton_gpu.num-warps")).getInt();
     }
     static int getNumCTAs(ModuleOp mod) {
       if(!mod->hasAttr("triton_gpu.num-ctas"))
         llvm::report_fatal_error(
             "TritonGPU module should contain a triton_gpu.num-ctas attribute");
-      return mod->getAttr("triton_gpu.num-ctas").cast<IntegerAttr>().getInt();
+      return cast<IntegerAttr>(mod->getAttr("triton_gpu.num-ctas")).getInt();
     }
     void registerTypes();
   }];

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -1,5 +1,7 @@
 #include "triton/Analysis/Alias.h"
+
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1,4 +1,7 @@
 #include "triton/Analysis/Utility.h"
+
+#include <deque>
+
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
@@ -6,12 +9,12 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/Matchers.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
-#include <deque>
 
 namespace mlir {
 namespace {
@@ -20,7 +23,7 @@ using namespace triton;
 using namespace triton::gpu;
 
 int getParentAxis(Attribute layout, int axis) {
-  if (auto sliceEncoding = layout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceEncoding = dyn_cast<SliceEncodingAttr>(layout)) {
     axis = axis < sliceEncoding.getDim() ? axis : axis + 1;
     return getParentAxis(sliceEncoding.getParent(), axis);
   }
@@ -28,7 +31,7 @@ int getParentAxis(Attribute layout, int axis) {
 }
 
 SmallVector<unsigned> getParentOrder(Attribute layout) {
-  if (auto sliceEncoding = layout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceEncoding = mlir::dyn_cast<SliceEncodingAttr>(layout)) {
     return getParentOrder(sliceEncoding.getParent());
   }
   return getOrder(layout);
@@ -64,7 +67,7 @@ unsigned ReduceOpHelper::getThreadOffsetOnReductionAxis() {
   }
 
   unsigned threadOffset = 1;
-  if (auto sliceLayout = srcLayout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(srcLayout)) {
     auto parentLayout = sliceLayout.getParent();
     auto threadsPerWarp = getThreadsPerWarp(parentLayout);
     threadOffset = threadsPerWarp[sliceLayout.getDim()];
@@ -97,7 +100,7 @@ bool shouldUseDistSmem(Attribute srcLayout, Attribute dstLayout) {
 
   // Case where CTAsPerCGA of srcLayout in the sliced dim is not 1 is not
   // implemented yet
-  if (auto sliceLayout = srcLayout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(srcLayout)) {
     auto dim = sliceLayout.getDim();
     auto CTAsPerCGA = getCTAsPerCGA(sliceLayout.getParent());
     if (CTAsPerCGA[dim] != 1)
@@ -105,7 +108,7 @@ bool shouldUseDistSmem(Attribute srcLayout, Attribute dstLayout) {
   }
 
   // Case where CTAsPerCGA of dstLayout in the sliced dim is not 1 is supported
-  if (auto sliceLayout = dstLayout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(dstLayout)) {
     auto dim = sliceLayout.getDim();
     auto CTAsPerCGA = getCTAsPerCGA(sliceLayout.getParent());
     if (CTAsPerCGA[dim] != 1)
@@ -206,13 +209,13 @@ bool ReduceOpHelper::isSupportedLayout() {
   }
 
   auto srcLayout = getSrcLayout();
-  if (srcLayout.isa<BlockedEncodingAttr>()) {
+  if (isa<BlockedEncodingAttr>(srcLayout)) {
     return true;
   }
-  if (auto mmaLayout = srcLayout.dyn_cast<MmaEncodingTrait>()) {
+  if (auto mmaLayout = dyn_cast<MmaEncodingTrait>(srcLayout)) {
     return mmaLayout.supportReduction();
   }
-  if (auto sliceLayout = srcLayout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceLayout = dyn_cast<SliceEncodingAttr>(srcLayout)) {
     return true;
   }
   return false;
@@ -355,7 +358,7 @@ getReshapeDecomposition(ArrayRef<int64_t> srcShape,
 }
 
 BlockedEncodingAttr ScanLoweringHelper::getEncoding() {
-  return srcEncoding.cast<BlockedEncodingAttr>();
+  return cast<BlockedEncodingAttr>(srcEncoding);
 }
 
 unsigned ScanLoweringHelper::getAxisElementStride() {
@@ -577,8 +580,8 @@ bool supportMMA(Value value, int version) {
 bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
   auto srcLayout = srcTy.getEncoding();
   auto dstLayout = dstTy.getEncoding();
-  auto mfmaLayout = srcLayout.cast<AMDMfmaEncodingAttr>();
-  auto dotOperandLayout = dstLayout.cast<DotOperandEncodingAttr>();
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(srcLayout);
+  auto dotOperandLayout = cast<DotOperandEncodingAttr>(dstLayout);
   // TODO: Remove the restriction on the warpsPerCTA once chain dot testing is
   // improved. In addition, we can enable this shortcut for regular MFMA
   // layout when opIdx == 1.
@@ -591,8 +594,8 @@ bool isMfmaToDotShortcut(RankedTensorType &srcTy, RankedTensorType &dstTy) {
 }
 
 static bool isMmaToMmaShortcut(Attribute srcEncoding, Attribute dstEncoding) {
-  auto src = srcEncoding.dyn_cast<NvidiaMmaEncodingAttr>();
-  auto dst = dstEncoding.dyn_cast<NvidiaMmaEncodingAttr>();
+  auto src = dyn_cast<NvidiaMmaEncodingAttr>(srcEncoding);
+  auto dst = dyn_cast<NvidiaMmaEncodingAttr>(dstEncoding);
   if (!src || !dst)
     return false;
   // when #mma = MmaEncoding<version=3, warpsPerCTA=[..., 1]>
@@ -610,8 +613,8 @@ bool matchMmaV3AndDotOperandLayout(RankedTensorType srcTy,
                                    RankedTensorType dstTy) {
   auto srcLayout = srcTy.getEncoding();
   auto dstLayout = dstTy.getEncoding();
-  auto mmaLayout = srcLayout.cast<NvidiaMmaEncodingAttr>();
-  auto dotOperandLayout = dstLayout.cast<DotOperandEncodingAttr>();
+  auto mmaLayout = cast<NvidiaMmaEncodingAttr>(srcLayout);
+  auto dotOperandLayout = cast<DotOperandEncodingAttr>(dstLayout);
   int elementTypeSize = srcTy.getElementType().getIntOrFloatBitWidth();
   auto ans = mmaLayout.getVersionMajor() == 3 &&
              dotOperandLayout.getOpIdx() == 0 &&
@@ -627,8 +630,8 @@ bool isMmaToDotShortcut(RankedTensorType srcTy, RankedTensorType dstTy) {
   // when #mma = MmaEncoding<version=2, warpsPerCTA=[..., 1]>
   auto srcLayout = srcTy.getEncoding();
   auto dstLayout = dstTy.getEncoding();
-  auto mmaLayout = srcLayout.cast<NvidiaMmaEncodingAttr>();
-  auto dotOperandLayout = dstLayout.cast<DotOperandEncodingAttr>();
+  auto mmaLayout = mlir::cast<NvidiaMmaEncodingAttr>(srcLayout);
+  auto dotOperandLayout = mlir::cast<DotOperandEncodingAttr>(dstLayout);
   return mmaLayout.getVersionMajor() == 2 &&
          mmaLayout.getWarpsPerCTA()[1] == 1 &&
          dotOperandLayout.getOpIdx() == 0 &&
@@ -866,7 +869,7 @@ static MakeTensorPtrOp getMakeTensorPtrOpImpl(Operation *op, Value v) {
   }
 
   if (auto branch = dyn_cast<RegionBranchOpInterface>(op)) {
-    auto idx = v.cast<OpResult>().getResultNumber();
+    auto idx = cast<OpResult>(v).getResultNumber();
     llvm::SmallVector<scf::YieldOp> yieldOps;
     op->walk([&](Operation *op) {
       if (auto yieldOp = dyn_cast<scf::YieldOp>(op))
@@ -904,7 +907,7 @@ MakeTensorPtrOp getMakeTensorPtrOp(Value v) {
     return getMakeTensorPtrOpImpl(definingOp, v);
 
   // If there is no defining op, v must be a BlockArgument.
-  BlockArgument arg = v.cast<BlockArgument>();
+  BlockArgument arg = cast<BlockArgument>(v);
   unsigned argNum = arg.getArgNumber();
   Operation *argOwner = arg.getOwner()->getParentOp();
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -41,15 +41,13 @@ public:
     Attribute srcLayout = srcTy.getEncoding();
     Attribute dstLayout = dstTy.getEncoding();
     // TODO: do we need to check if src is shared ?
-    if (srcLayout.isa<SharedEncodingAttr>() &&
-        isaDistributedLayout(dstLayout)) {
+    if (isa<SharedEncodingAttr>(srcLayout) && isaDistributedLayout(dstLayout)) {
       return lowerSharedToDistributed(op, adaptor, getTypeConverter(),
                                       rewriter);
     }
-    if (dstLayout.isa<DotOperandEncodingAttr>() &&
-        dstLayout.cast<DotOperandEncodingAttr>()
-            .getParent()
-            .isa<BlockedEncodingAttr>()) {
+    if (isa<DotOperandEncodingAttr>(dstLayout) &&
+        isa<BlockedEncodingAttr>(
+            cast<DotOperandEncodingAttr>(dstLayout).getParent())) {
       return lowerSharedToDotOpFMA(op, adaptor, getTypeConverter(), rewriter);
     }
     return failure();
@@ -64,10 +62,9 @@ private:
     auto loc = op.getLoc();
     RankedTensorType dstTy = op.getType();
     Attribute dstLayout = dstTy.getEncoding();
-    auto dotLayout = dstLayout.cast<DotOperandEncodingAttr>();
-    auto blockedLayout = dstLayout.cast<DotOperandEncodingAttr>()
-                             .getParent()
-                             .cast<BlockedEncodingAttr>();
+    auto dotLayout = cast<DotOperandEncodingAttr>(dstLayout);
+    auto blockedLayout = cast<BlockedEncodingAttr>(
+        cast<DotOperandEncodingAttr>(dstLayout).getParent());
     auto thread = getThreadId(rewriter, loc);
     Value res = SharedToDotOperandFMA::convertLayout(
         dotLayout.getOpIdx(), op.getSrc(), adaptor.getSrc(), blockedLayout,
@@ -86,7 +83,7 @@ private:
     auto dstShape = dstTy.getShape();
     assert(dstShape.size() <= 2 &&
            "Unexpected rank of ConvertLayout(shared->blocked)");
-    auto srcSharedLayout = srcTy.getEncoding().cast<SharedEncodingAttr>();
+    auto srcSharedLayout = cast<SharedEncodingAttr>(srcTy.getEncoding());
     auto dstLayout = dstTy.getEncoding();
     auto inOrd = getOrder(srcSharedLayout);
 

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandFMA.cpp
@@ -1,3 +1,4 @@
+#include "mlir/Support/LLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
 using ValueTable = std::map<std::pair<int, int>, Value>;
@@ -92,7 +93,7 @@ Value loadAFMA(Value A, Value llA, BlockedEncodingAttr dLayout, Value thread,
                Location loc, const LLVMTypeConverter *typeConverter,
                ConversionPatternRewriter &rewriter) {
   auto aTensorTy = cast<MemDescType>(A.getType());
-  auto aLayout = aTensorTy.getEncoding().cast<SharedEncodingAttr>();
+  auto aLayout = cast<SharedEncodingAttr>(aTensorTy.getEncoding());
   auto aShapePerCTA = getShapePerCTA(aTensorTy);
 
   auto aOrder = aLayout.getOrder();
@@ -158,7 +159,7 @@ Value loadBFMA(Value B, Value llB, BlockedEncodingAttr dLayout, Value thread,
                Location loc, const LLVMTypeConverter *typeConverter,
                ConversionPatternRewriter &rewriter) {
   auto bTensorTy = cast<MemDescType>(B.getType());
-  auto bLayout = bTensorTy.getEncoding().cast<SharedEncodingAttr>();
+  auto bLayout = cast<SharedEncodingAttr>(bTensorTy.getEncoding());
   auto bShapePerCTA = getShapePerCTA(bTensorTy);
 
   auto bOrder = bLayout.getOrder();

--- a/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DecomposeUnsupportedConversions.cpp
@@ -23,9 +23,9 @@ void decomposeSplatOpToSharedLayoutConversion(ModuleOp module) {
   int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(module);
   int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(module);
   module.walk([&](triton::SplatOp splatOp) -> void {
-    auto dstType = splatOp.getType().cast<RankedTensorType>();
+    auto dstType = cast<RankedTensorType>(splatOp.getType());
     auto shared =
-        dstType.getEncoding().dyn_cast<triton::gpu::SharedEncodingAttr>();
+        dyn_cast<triton::gpu::SharedEncodingAttr>(dstType.getEncoding());
     if (shared) {
       OpBuilder builder(splatOp);
       SmallVector<unsigned, 4> sizePerThread(dstType.getRank(), 1);
@@ -53,11 +53,11 @@ void decomposeTensorCoreToDotLayoutConversion(ModuleOp module,
 
   module.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
     OpBuilder builder(cvtOp);
-    auto srcType = cvtOp.getSrc().getType().cast<RankedTensorType>();
-    auto dstType = cvtOp.getType().cast<RankedTensorType>();
-    auto srcMma = srcType.getEncoding().dyn_cast<TensorCoreEncodingAttr>();
+    auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
+    auto dstType = cast<RankedTensorType>(cvtOp.getType());
+    auto srcMma = dyn_cast<TensorCoreEncodingAttr>(srcType.getEncoding());
     auto dstDotOp =
-        dstType.getEncoding().dyn_cast<triton::gpu::DotOperandEncodingAttr>();
+        dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
     if (srcMma && dstDotOp && !shortcutFn(srcType, dstType)) {
       auto tmpType = RankedTensorType::get(
           dstType.getShape(), dstType.getElementType(),
@@ -88,12 +88,12 @@ void decomposeBlockedToDotLayoutConversion(ModuleOp module) {
   int threadsPerWarp = triton::gpu::TritonGPUDialect::getThreadsPerWarp(module);
   module.walk([&](triton::gpu::ConvertLayoutOp cvtOp) -> void {
     OpBuilder builder(cvtOp);
-    auto srcType = cvtOp.getSrc().getType().cast<RankedTensorType>();
-    auto dstType = cvtOp.getType().cast<RankedTensorType>();
+    auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
+    auto dstType = cast<RankedTensorType>(cvtOp.getType());
     auto srcBlocked =
-        srcType.getEncoding().dyn_cast<triton::gpu::BlockedEncodingAttr>();
+        dyn_cast<triton::gpu::BlockedEncodingAttr>(srcType.getEncoding());
     auto dstDotOp =
-        dstType.getEncoding().dyn_cast<triton::gpu::DotOperandEncodingAttr>();
+        dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
     if (srcBlocked && dstDotOp) {
       auto tmpType = MemDescType::get(
           dstType.getShape(), dstType.getElementType(),

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -1,3 +1,4 @@
+#include "mlir/Support/LLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
 using namespace mlir;
@@ -45,7 +46,7 @@ LogicalResult convertFMADot(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   auto bShapePerCTA = getShapePerCTA(bTensorTy);
 
   BlockedEncodingAttr dLayout =
-      dTensorTy.getEncoding().cast<BlockedEncodingAttr>();
+      cast<BlockedEncodingAttr>(dTensorTy.getEncoding());
   auto order = dLayout.getOrder();
   auto cc = unpackLLElements(loc, adaptor.getC(), rewriter);
 

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -24,7 +24,7 @@ void lowerDistributedToShared(LocalAllocOp op, LocalAllocOpAdaptor adaptor,
   auto dstTy = op.getType();
   auto dstShapePerCTA = triton::gpu::getShapePerCTA(dstTy);
   auto srcLayout = srcTy.getEncoding();
-  auto outOrd = dstTy.getEncoding().cast<SharedEncodingAttr>().getOrder();
+  auto outOrd = mlir::cast<SharedEncodingAttr>(dstTy.getEncoding()).getOrder();
   assert(srcTy.getShape().size() == 2 ||
          (srcTy.getShape().size() <= 3 && outOrd[2] == 0) &&
              "Unexpected rank of ConvertLayout(blocked->shared)");
@@ -57,7 +57,7 @@ struct LocalAllocOpConversion
     auto resultTy = cast<MemDescType>(op.getType());
     auto typeConverter = getTypeConverter();
     auto sharedLayout =
-        resultTy.getEncoding().cast<triton::gpu::SharedEncodingAttr>();
+        cast<triton::gpu::SharedEncodingAttr>(resultTy.getEncoding());
     auto order = sharedLayout.getOrder();
     // Workaround for 3D tensors
     // TODO: we need to modify the pipeline pass to give a proper shared

--- a/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/PrintOpToLLVM.cpp
@@ -57,7 +57,7 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
       SmallVector<int, 8> dimWidths;
       SmallVector<SmallVector<Value>> indices;
       if (auto rankedTy =
-              op.getOperand(i).getType().dyn_cast<RankedTensorType>()) {
+              dyn_cast<RankedTensorType>(op.getOperand(i).getType())) {
         indices = emitIndices(loc, rewriter, targetInfo, rankedTy.getEncoding(),
                               rankedTy, true);
         for (int64_t dim : rankedTy.getShape()) {
@@ -171,7 +171,7 @@ struct PrintOpConversion : public ConvertOpToLLVMPattern<triton::PrintOp> {
   std::string getFormatSubstr(Value value, bool hex = false,
                               std::optional<int> width = std::nullopt) const {
     Type type = value.getType();
-    if (type.isa<LLVM::LLVMPointerType>()) {
+    if (isa<LLVM::LLVMPointerType>(type)) {
       return "%p";
     }
     // Hex is "0x%0nx" or "0x%0nllx", where n is the number of hex digits in the

--- a/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ScanOpToLLVM.cpp
@@ -1,12 +1,12 @@
+#include <iterator>
+
 #include "ReduceScanCommon.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
-
 #include "llvm/ADT/STLExtras.h"
-
-#include <iterator>
 
 using namespace mlir;
 using namespace mlir::triton;

--- a/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/TypeConverter.cpp
@@ -1,5 +1,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
+
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Conversion/MLIRTypes.h"
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 
@@ -74,10 +76,11 @@ Type TritonGPUToLLVMTypeConverter::getElementTypeForStruct(
   auto ctx = type.getContext();
   Attribute layout = type.getEncoding();
   Type elemTy = convertType(type.getElementType());
-  auto dotOpLayout = layout.dyn_cast<DotOperandEncodingAttr>();
+  auto dotOpLayout = mlir::dyn_cast<DotOperandEncodingAttr>(layout);
   if (!dotOpLayout)
     return elemTy;
-  auto mmaParent = dotOpLayout.getParent().dyn_cast<NvidiaMmaEncodingAttr>();
+  auto mmaParent =
+      mlir::dyn_cast<NvidiaMmaEncodingAttr>(dotOpLayout.getParent());
   if (!mmaParent || mmaParent.isHopper())
     return elemTy;
   int bitwidth = elemTy.getIntOrFloatBitWidth();
@@ -92,7 +95,7 @@ Type TritonGPUToLLVMTypeConverter::convertTritonTensorType(
   SmallVector<int64_t> shape(type.getShape().begin(), type.getShape().end());
   Type eltType = getElementTypeForStruct(cast<TensorOrMemDesc>(type));
 
-  if (auto shared_layout = layout.dyn_cast<SharedEncodingAttr>()) {
+  if (auto shared_layout = mlir::dyn_cast<SharedEncodingAttr>(layout)) {
     SmallVector<Type, 4> types;
     // base ptr
     auto ptrType = LLVM::LLVMPointerType::get(ctx, 3);

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -1,10 +1,13 @@
 #include "triton/Dialect/TritonGPU/Transforms/TritonGPUConversion.h"
+
+#include <algorithm>
+#include <numeric>
+
 #include "mlir/IR/IRMapping.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
-#include <algorithm>
-#include <numeric>
 
 using namespace mlir;
 using namespace mlir::triton::gpu;
@@ -112,8 +115,8 @@ TritonGPUConversionTarget::TritonGPUConversionTarget(
         cast<RankedTensorType>(dotOp.getA().getType()).getEncoding();
     Attribute bEncoding =
         cast<RankedTensorType>(dotOp.getB().getType()).getEncoding();
-    if (aEncoding && aEncoding.isa<triton::gpu::DotOperandEncodingAttr>() &&
-        bEncoding && bEncoding.isa<triton::gpu::DotOperandEncodingAttr>())
+    if (aEncoding && isa<triton::gpu::DotOperandEncodingAttr>(aEncoding) &&
+        bEncoding && isa<triton::gpu::DotOperandEncodingAttr>(bEncoding))
       return true;
     return false;
   });

--- a/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.cpp
@@ -58,7 +58,7 @@ public:
                   ConversionPatternRewriter &rewriter) const override {
     Type retType = getTypeConverter()->convertType(op.getType());
     auto retShapedType = cast<ShapedType>(retType);
-    auto value = adaptor.getValue().dyn_cast<DenseElementsAttr>();
+    auto value = dyn_cast<DenseElementsAttr>(adaptor.getValue());
     if (dyn_cast<RankedTensorType>(retShapedType)) {
       assert(value);
       if (value.getElementType().isInteger(1) && value.isSplat())
@@ -151,7 +151,7 @@ struct TritonExpandDimsPattern
     Attribute _argEncoding = argType.getEncoding();
     if (!_argEncoding)
       return failure();
-    auto argEncoding = _argEncoding.cast<triton::gpu::BlockedEncodingAttr>();
+    auto argEncoding = cast<triton::gpu::BlockedEncodingAttr>(_argEncoding);
     // return shape
     auto retShape = argType.getShape().vec();
     retShape.insert(retShape.begin() + op.getAxis(), 1);
@@ -255,14 +255,14 @@ struct TritonDotPattern : public OpConversionPattern<triton::DotOp> {
     Value a = adaptor.getA();
     Value b = adaptor.getB();
     Value c = adaptor.getC();
-    if (!aEncoding.isa<triton::gpu::DotOperandEncodingAttr>()) {
+    if (!mlir::isa<triton::gpu::DotOperandEncodingAttr>(aEncoding)) {
       Attribute encoding = triton::gpu::DotOperandEncodingAttr::get(
           getContext(), 0, dEncoding, aEltType);
       auto dstType =
           RankedTensorType::get(aType.getShape(), aEltType, encoding);
       a = rewriter.create<triton::gpu::ConvertLayoutOp>(a.getLoc(), dstType, a);
     }
-    if (!bEncoding.isa<triton::gpu::DotOperandEncodingAttr>()) {
+    if (!mlir::isa<triton::gpu::DotOperandEncodingAttr>(bEncoding)) {
       Attribute encoding = triton::gpu::DotOperandEncodingAttr::get(
           getContext(), 1, dEncoding, bEltType);
       auto dstType =
@@ -294,7 +294,7 @@ struct TritonCatPattern : public OpConversionPattern<triton::CatOp> {
     auto retType = cast<RankedTensorType>(
         this->getTypeConverter()->convertType(op.getType()));
     auto retEncoding =
-        retType.getEncoding().cast<triton::gpu::BlockedEncodingAttr>();
+        cast<triton::gpu::BlockedEncodingAttr>(retType.getEncoding());
     auto lhsType = adaptor.getLhs().getType();
     auto rhsType = adaptor.getRhs().getType();
     auto lhsTotalElemsPerThread = triton::gpu::getTotalElemsPerThread(lhsType);
@@ -348,7 +348,7 @@ struct TritonSplitOpPattern : public OpConversionPattern<triton::SplitOp> {
                                 ConversionPatternRewriter &rewriter) const {
     auto src = adaptor.getSrc();
     auto srcTy = cast<RankedTensorType>(src.getType());
-    auto srcEnc = srcTy.getEncoding().dyn_cast<BlockedEncodingAttr>();
+    auto srcEnc = dyn_cast<BlockedEncodingAttr>(srcTy.getEncoding());
     int rank = srcEnc.getOrder().size();
     auto typeConverter = getTypeConverter<TritonGPUTypeConverter>();
 

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -4,6 +4,7 @@
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/IR/Types.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
@@ -95,7 +96,7 @@ struct CanonicalizeMaskedLoadPattern : public OpRewritePattern<LoadOp> {
     if (!constantMask)
       return failure();
 
-    auto splatMask = constantMask.getValue().dyn_cast<SplatElementsAttr>();
+    auto splatMask = mlir::dyn_cast<SplatElementsAttr>(constantMask.getValue());
     if (!splatMask)
       return failure();
 
@@ -163,7 +164,7 @@ struct CanonicalizeMaskedStorePattern : public OpRewritePattern<StoreOp> {
     if (!constantMask)
       return failure();
 
-    auto splatMask = constantMask.getValue().dyn_cast<SplatElementsAttr>();
+    auto splatMask = mlir::dyn_cast<SplatElementsAttr>(constantMask.getValue());
     if (!splatMask)
       return failure();
 
@@ -631,7 +632,7 @@ static OpFoldResult foldViewLikeOp(ViewLikeOp op, Attribute value) {
     return {};
 
   auto shapedType = cast<ShapedType>(op.getType());
-  if (auto denseElemsAttr = value.dyn_cast<DenseElementsAttr>()) {
+  if (auto denseElemsAttr = dyn_cast<DenseElementsAttr>(value)) {
     if (denseElemsAttr.isSplat()) {
       return denseElemsAttr.resizeSplat(shapedType);
     } else {
@@ -748,7 +749,7 @@ OpFoldResult BroadcastOp::fold(FoldAdaptor adaptor) {
   if (!value)
     return {};
 
-  if (auto denseElemsAttr = value.dyn_cast<SplatElementsAttr>()) {
+  if (auto denseElemsAttr = dyn_cast<SplatElementsAttr>(value)) {
     auto shapedType = cast<ShapedType>(getType());
     return denseElemsAttr.resizeSplat(shapedType);
   }

--- a/lib/Dialect/Triton/IR/Traits.cpp
+++ b/lib/Dialect/Triton/IR/Traits.cpp
@@ -66,7 +66,7 @@ LogicalResult OpTrait::impl::verifySameOperandsAndResultEncoding(
 
 LogicalResult OpTrait::impl::verifyTensorSize(Operation *op) {
   for (auto opType : op->getOperandTypes()) {
-    if (auto tensorType = opType.dyn_cast<RankedTensorType>()) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(opType)) {
       int64_t numElements = 1;
       for (int64_t s : tensorType.getShape())
         numElements *= s;
@@ -81,7 +81,7 @@ LogicalResult OpTrait::impl::verifyTensorSize(Operation *op) {
     }
   }
   for (auto opType : op->getResultTypes()) {
-    if (auto tensorType = opType.dyn_cast<RankedTensorType>()) {
+    if (auto tensorType = dyn_cast<RankedTensorType>(opType)) {
       int64_t numElements = 1;
       for (int64_t s : tensorType.getShape())
         numElements *= s;
@@ -110,7 +110,7 @@ LogicalResult OpTrait::impl::verifyTensorLayouts(Operation *op) {
   auto module = op->getParentOfType<ModuleOp>();
   auto checkLayout = [&](Value val, auto makeErr) -> LogicalResult {
     // Only ranked tensors can have layouts.
-    auto rankedTy = val.getType().dyn_cast<RankedTensorType>();
+    auto rankedTy = dyn_cast<RankedTensorType>(val.getType());
     if (!rankedTy)
       return success();
 
@@ -124,7 +124,7 @@ LogicalResult OpTrait::impl::verifyTensorLayouts(Operation *op) {
     // layouts also have invariants!
 
     // TODO(jlebar): Handle the case when the encoding is nested within tt.ptr.
-    if (auto blocked = layout.dyn_cast<ttg::BlockedEncodingAttr>()) {
+    if (auto blocked = dyn_cast<ttg::BlockedEncodingAttr>(layout)) {
       // A different verifier should have checked that the layout itself is
       // valid, including that threads-per-warp has the same rank as
       // warps-per-block etc.
@@ -205,9 +205,9 @@ LogicalResult OpTrait::impl::verifyTensorLayouts(Operation *op) {
 }
 
 static ArrayRef<int64_t> getTypeShape(Type type) {
-  auto rankedType = type.dyn_cast<RankedTensorType>();
-  if (auto ptrType = type.dyn_cast<triton::PointerType>())
-    rankedType = ptrType.getPointeeType().dyn_cast<RankedTensorType>();
+  auto rankedType = dyn_cast<RankedTensorType>(type);
+  if (auto ptrType = dyn_cast<triton::PointerType>(type))
+    rankedType = dyn_cast<RankedTensorType>(ptrType.getPointeeType());
   return rankedType ? rankedType.getShape() : ArrayRef<int64_t>();
 }
 

--- a/lib/Dialect/Triton/IR/Types.cpp
+++ b/lib/Dialect/Triton/IR/Types.cpp
@@ -1,5 +1,7 @@
 #include "triton/Dialect/Triton/IR/Types.h"
+
 #include "mlir/IR/DialectImplementation.h" // required by `Types.cpp.inc`
+#include "mlir/Support/LLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "llvm/ADT/TypeSwitch.h" // required by `Types.cpp.inc`
 

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -1,15 +1,15 @@
+#include <memory>
+
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
-
-#include <memory>
 
 #define GEN_PASS_CLASSES
 #include "triton/Dialect/Triton/Transforms/Passes.h.inc"
@@ -30,17 +30,17 @@ bool isZero(Value val) {
 }
 
 bool isBroadcastConstantCombinable(Attribute value) {
-  if (auto denseValue = value.dyn_cast<DenseElementsAttr>()) {
+  if (auto denseValue = dyn_cast<DenseElementsAttr>(value)) {
     return denseValue.isSplat();
   }
-  return value.isa<FloatAttr, IntegerAttr>();
+  return isa<FloatAttr, IntegerAttr>(value);
 }
 
 DenseElementsAttr getConstantValue(Builder &builder, Attribute value,
                                    Value bcast_res) {
   auto resType = cast<ShapedType>(bcast_res.getType());
   DenseElementsAttr res;
-  if (auto denseValue = value.dyn_cast<DenseElementsAttr>()) {
+  if (auto denseValue = dyn_cast<DenseElementsAttr>(value)) {
     res =
         DenseElementsAttr::get(resType, denseValue.getSplatValue<Attribute>());
   } else {

--- a/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
+++ b/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
@@ -1,14 +1,14 @@
+#include <memory>
+
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
-
-#include <memory>
 
 // TODO(jlebar): Move this and all other generatede code into namespace
 // mlir::triton.

--- a/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorPointer.cpp
@@ -1,11 +1,12 @@
+#include <memory>
+#include <stack>
+
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"
-
-#include <memory>
-#include <stack>
 
 using namespace mlir;
 
@@ -172,14 +173,14 @@ public:
     // Set zero padding value
     TypedAttr attr =
         elementType.isIntOrIndex()
-            ? builder.getIntegerAttr(elementType, 0).cast<TypedAttr>()
-            : builder.getFloatAttr(elementType, 0).cast<TypedAttr>();
+            ? cast<TypedAttr>(builder.getIntegerAttr(elementType, 0))
+            : cast<TypedAttr>(builder.getFloatAttr(elementType, 0));
 
     // Float NaN padding case
     if (padding.value() == triton::PaddingOption::PAD_NAN) {
       assert(!elementType.isIntOrIndex());
       auto apNaN = llvm::APFloat::getNaN(
-          attr.cast<FloatAttr>().getValue().getSemantics());
+          cast<FloatAttr>(attr).getValue().getSemantics());
       attr = builder.getFloatAttr(elementType, apNaN);
     }
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -4,6 +4,7 @@
 
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Analysis/Utility.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.cpp.inc"
@@ -42,7 +43,7 @@ namespace gpu {
 
 unsigned getTotalElemsPerThread(Attribute layout, ArrayRef<int64_t> shape,
                                 Type eltTy) {
-  if (auto tritonGPUAttr = layout.dyn_cast<TritonGPU_AttrTrait>()) {
+  if (auto tritonGPUAttr = mlir::dyn_cast<TritonGPU_AttrTrait>(layout)) {
     return tritonGPUAttr.getTotalElemsPerThread(shape, eltTy);
   } else {
     llvm::report_fatal_error("getTotalElemsPerThread not implemented");
@@ -52,7 +53,7 @@ unsigned getTotalElemsPerThread(Attribute layout, ArrayRef<int64_t> shape,
 
 SmallVector<unsigned> getElemsPerThread(Attribute layout,
                                         ArrayRef<int64_t> shape, Type eltTy) {
-  if (auto tritonGPUAttr = layout.dyn_cast<TritonGPU_AttrTrait>()) {
+  if (auto tritonGPUAttr = mlir::dyn_cast<TritonGPU_AttrTrait>(layout)) {
     return tritonGPUAttr.getElemsPerThread(shape, eltTy);
   } else {
     llvm::report_fatal_error("getElemsPerThread not implemented");
@@ -77,7 +78,7 @@ unsigned getTotalElemsPerThread(Type type) {
 }
 
 SmallVector<unsigned> getThreadsPerWarp(Attribute layout) {
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
+  if (auto distributedLayout = dyn_cast<DistributedEncodingTrait>(layout)) {
     return distributedLayout.getThreadsPerWarp();
   } else {
     llvm::report_fatal_error("getThreadsPerWarp not implemented");
@@ -97,7 +98,7 @@ unsigned getWarpSize(Attribute layout) {
 SmallVector<unsigned>
 getThreadsPerWarpWithUniqueData(Attribute layout,
                                 ArrayRef<int64_t> tensorShape) {
-  if (auto sliceLayout = layout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(layout)) {
     auto parentLayout = sliceLayout.getParent();
     auto parentShape = sliceLayout.paddedShape(tensorShape);
     auto parentThreadsPerWarp =
@@ -117,7 +118,8 @@ getThreadsPerWarpWithUniqueData(Attribute layout,
 }
 
 SmallVector<unsigned> getWarpsPerCTA(Attribute layout) {
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
+  if (auto distributedLayout =
+          mlir::dyn_cast<DistributedEncodingTrait>(layout)) {
     return distributedLayout.getWarpsPerCTA();
   }
 
@@ -127,7 +129,7 @@ SmallVector<unsigned> getWarpsPerCTA(Attribute layout) {
 
 SmallVector<unsigned>
 getWarpsPerCTAWithUniqueData(Attribute layout, ArrayRef<int64_t> tensorShape) {
-  if (auto sliceLayout = layout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(layout)) {
     auto parentLayout = sliceLayout.getParent();
     auto parentShape = sliceLayout.paddedShape(tensorShape);
     auto parentWarpsPerCTA =
@@ -150,7 +152,8 @@ getWarpsPerCTAWithUniqueData(Attribute layout, ArrayRef<int64_t> tensorShape) {
 }
 
 SmallVector<unsigned> getSizePerThread(Attribute layout) {
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
+  if (auto distributedLayout =
+          mlir::dyn_cast<DistributedEncodingTrait>(layout)) {
     return distributedLayout.getSizePerThread();
   } else {
     llvm::report_fatal_error("getSizePerThread not implemented");
@@ -159,7 +162,7 @@ SmallVector<unsigned> getSizePerThread(Attribute layout) {
 }
 
 SmallVector<unsigned> getContigPerThread(Attribute layout) {
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
+  if (auto distributedLayout = dyn_cast<DistributedEncodingTrait>(layout)) {
     return distributedLayout.getContigPerThread();
   } else {
     llvm::report_fatal_error("getContigPerThread not implemented");
@@ -171,7 +174,7 @@ SmallVector<unsigned> getUniqueContigPerThread(Attribute layout,
                                                ArrayRef<int64_t> shape) {
   // If slice layout, call recursively on parent layout, and drop
   // sliced dim
-  if (auto sliceLayout = layout.dyn_cast<SliceEncodingAttr>()) {
+  if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(layout)) {
     auto parentLayout = sliceLayout.getParent();
     auto parentShape = sliceLayout.paddedShape(shape);
     auto parentUniqueContigPerThread =
@@ -193,7 +196,8 @@ SmallVector<unsigned> getUniqueContigPerThread(Attribute layout,
 
 SmallVector<unsigned> getShapePerCTATile(Attribute layout,
                                          ArrayRef<int64_t> tensorShape) {
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
+  if (auto distributedLayout =
+          mlir::dyn_cast<DistributedEncodingTrait>(layout)) {
     return distributedLayout.getShapePerCTATile(tensorShape);
   } else {
     llvm::report_fatal_error("getShapePerCTATile not implemented");
@@ -224,28 +228,28 @@ static SmallVector<unsigned> eraseOrder(ArrayRef<unsigned> order,
 }
 
 SmallVector<unsigned> getOrder(Attribute layout) {
-  if (auto blockedLayout = layout.dyn_cast<BlockedEncodingAttr>()) {
+  if (auto blockedLayout = dyn_cast<BlockedEncodingAttr>(layout)) {
     return SmallVector<unsigned>(blockedLayout.getOrder().begin(),
                                  blockedLayout.getOrder().end());
-  } else if (auto mmaLayout = layout.dyn_cast<MmaEncodingTrait>()) {
-    auto distributedLayout = layout.cast<DistributedEncodingTrait>();
+  } else if (auto mmaLayout = dyn_cast<MmaEncodingTrait>(layout)) {
+    auto distributedLayout = cast<DistributedEncodingTrait>(layout);
     auto rank = distributedLayout.getWarpsPerCTA().size();
     SmallVector<unsigned> order(rank);
     for (auto i = 0; i < rank; ++i)
       order[i] = rank - 1 - i;
-    if (auto mfmaLayout = layout.dyn_cast<AMDMfmaEncodingAttr>()) {
+    if (auto mfmaLayout = dyn_cast<AMDMfmaEncodingAttr>(layout)) {
       if (mfmaLayout.getIsTransposed()) {
         std::swap(order[rank - 2], order[rank - 1]);
       }
     }
     return order;
-  } else if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>()) {
+  } else if (auto dotLayout = dyn_cast<DotOperandEncodingAttr>(layout)) {
     auto rank = getWarpsPerCTA(dotLayout.getParent()).size();
     SmallVector<unsigned> order(rank);
     for (auto i = 0; i < rank; ++i)
       order[i] = rank - 1 - i;
     return order;
-  } else if (auto sliceLayout = layout.dyn_cast<SliceEncodingAttr>()) {
+  } else if (auto sliceLayout = dyn_cast<SliceEncodingAttr>(layout)) {
     SmallVector<unsigned> parentOrder = getOrder(sliceLayout.getParent());
     unsigned dim = sliceLayout.getDim();
     SmallVector<unsigned> order;
@@ -258,7 +262,7 @@ SmallVector<unsigned> getOrder(Attribute layout) {
         order.push_back(d);
     }
     return order;
-  } else if (auto sharedLayout = layout.dyn_cast<SharedEncodingAttr>()) {
+  } else if (auto sharedLayout = mlir::dyn_cast<SharedEncodingAttr>(layout)) {
     return SmallVector<unsigned>(sharedLayout.getOrder().begin(),
                                  sharedLayout.getOrder().end());
   } else {
@@ -268,11 +272,12 @@ SmallVector<unsigned> getOrder(Attribute layout) {
 };
 
 CTALayoutAttr getCTALayout(Attribute layout) {
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
+  if (auto distributedLayout =
+          mlir::dyn_cast<DistributedEncodingTrait>(layout)) {
     return CTALayoutAttr::get(
         layout.getContext(), getCTAsPerCGA(distributedLayout),
         getCTASplitNum(distributedLayout), getCTAOrder(distributedLayout));
-  } else if (auto sharedLayout = layout.dyn_cast<SharedEncodingAttr>())
+  } else if (auto sharedLayout = mlir::dyn_cast<SharedEncodingAttr>(layout))
     return sharedLayout.getCTALayout();
   else
     llvm::report_fatal_error("Unimplemented usage of getCTALayout");
@@ -281,11 +286,11 @@ CTALayoutAttr getCTALayout(Attribute layout) {
 
 SmallVector<unsigned> getCTAsPerCGA(Attribute layout) {
   ArrayRef<unsigned> ref;
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>())
+  if (auto distributedLayout = mlir::dyn_cast<DistributedEncodingTrait>(layout))
     return distributedLayout.getCTAsPerCGA();
-  else if (layout.isa<AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>())
+  else if (mlir::isa<AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>(layout))
     return {1, 1};
-  else if (auto sharedLayout = layout.dyn_cast<SharedEncodingAttr>())
+  else if (auto sharedLayout = mlir::dyn_cast<SharedEncodingAttr>(layout))
     ref = sharedLayout.getCTALayout().getCTAsPerCGA();
   else
     llvm::report_fatal_error("Unimplemented usage of getCTAsPerCGA");
@@ -294,12 +299,13 @@ SmallVector<unsigned> getCTAsPerCGA(Attribute layout) {
 
 SmallVector<unsigned> getCTASplitNum(Attribute layout) {
   SmallVector<unsigned> res;
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
+  if (auto distributedLayout =
+          mlir::dyn_cast<DistributedEncodingTrait>(layout)) {
     return distributedLayout.getCTASplitNum();
-  } else if (layout.isa<AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>()) {
+  } else if (mlir::isa<AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>(layout)) {
     res.resize(2);
     res[0] = res[1] = 1;
-  } else if (auto sharedLayout = layout.dyn_cast<SharedEncodingAttr>()) {
+  } else if (auto sharedLayout = mlir::dyn_cast<SharedEncodingAttr>(layout)) {
     res.assign(sharedLayout.getCTALayout().getCTASplitNum().begin(),
                sharedLayout.getCTALayout().getCTASplitNum().end());
   } else {
@@ -310,11 +316,12 @@ SmallVector<unsigned> getCTASplitNum(Attribute layout) {
 
 SmallVector<unsigned> getCTAOrder(Attribute layout) {
   SmallVector<unsigned> res;
-  if (auto distributedLayout = layout.dyn_cast<DistributedEncodingTrait>()) {
+  if (auto distributedLayout =
+          mlir::dyn_cast<DistributedEncodingTrait>(layout)) {
     res = distributedLayout.getCTAOrder();
-  } else if (layout.isa<AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>()) {
+  } else if (mlir::isa<AMDMfmaEncodingAttr, AMDWmmaEncodingAttr>(layout)) {
     return {0, 1};
-  } else if (auto sharedLayout = layout.dyn_cast<SharedEncodingAttr>()) {
+  } else if (auto sharedLayout = mlir::dyn_cast<SharedEncodingAttr>(layout)) {
     res = SmallVector<unsigned>(sharedLayout.getCTALayout().getCTAOrder());
   } else {
     llvm::report_fatal_error("Unimplemented usage of getCTAOrder");
@@ -335,7 +342,7 @@ SmallVector<int64_t> getShapePerCTA(ArrayRef<unsigned> CTASplitNum,
 }
 
 SmallVector<int64_t> getShapePerCTA(Attribute layout, ArrayRef<int64_t> shape) {
-  if (auto sharedLayout = layout.dyn_cast<SharedEncodingAttr>()) {
+  if (auto sharedLayout = mlir::dyn_cast<SharedEncodingAttr>(layout)) {
     // Special logic for pipeline pass, where shape is 3D and CTALayout is 2D.
     // The first dim of shape is numStages. This is a work around, otherwise too
     // many places would have to be modified in pipeline pass. Maybe we need to
@@ -357,21 +364,21 @@ SmallVector<int64_t> getShapePerCTA(Type type) {
 
 unsigned getNumWarpsPerCTA(Attribute layout) {
   SmallVector<unsigned> warpsPerCTA;
-  if (auto blockedLayout = layout.dyn_cast<BlockedEncodingAttr>())
+  if (auto blockedLayout = dyn_cast<BlockedEncodingAttr>(layout))
     warpsPerCTA = blockedLayout.getWarpsPerCTA();
-  else if (auto sliceLayout = layout.dyn_cast<SliceEncodingAttr>())
+  else if (auto sliceLayout = dyn_cast<SliceEncodingAttr>(layout))
     return getNumWarpsPerCTA(sliceLayout.getParent());
-  else if (auto mmaLayout = layout.dyn_cast<MmaEncodingTrait>()) {
+  else if (auto mmaLayout = dyn_cast<MmaEncodingTrait>(layout)) {
     // Use the distributed layout interface to get the number of warps per CTA.
-    auto distributedLayout = layout.cast<DistributedEncodingTrait>();
+    auto distributedLayout = cast<DistributedEncodingTrait>(layout);
     warpsPerCTA = distributedLayout.getWarpsPerCTA();
-  } else if (auto mfmaLayout = layout.dyn_cast<AMDMfmaEncodingAttr>())
+  } else if (auto mfmaLayout = dyn_cast<AMDMfmaEncodingAttr>(layout))
     warpsPerCTA = mfmaLayout.getWarpsPerCTA();
-  else if (auto wmmaLayout = layout.dyn_cast<AMDWmmaEncodingAttr>())
+  else if (auto wmmaLayout = dyn_cast<AMDWmmaEncodingAttr>(layout))
     warpsPerCTA = wmmaLayout.getWarpsPerCTA();
-  else if (auto dotLayout = layout.dyn_cast<DotOperandEncodingAttr>())
+  else if (auto dotLayout = dyn_cast<DotOperandEncodingAttr>(layout))
     return getNumWarpsPerCTA(dotLayout.getParent());
-  else if (auto sharedLayout = layout.dyn_cast<SharedEncodingAttr>())
+  else if (auto sharedLayout = dyn_cast<SharedEncodingAttr>(layout))
     llvm::report_fatal_error("Cannot get numWarps from SharedEncodingAttr");
   else
     llvm::report_fatal_error("Unimplemented usage of getNumWarpsPerCTA");
@@ -383,15 +390,14 @@ unsigned getNumCTAs(Attribute layout) {
 }
 
 bool isaDistributedLayout(Attribute layout) {
-  return layout.isa<BlockedEncodingAttr>() || layout.isa<MmaEncodingTrait>() ||
-         layout.isa<SliceEncodingAttr>();
+  return isa<BlockedEncodingAttr, MmaEncodingTrait, SliceEncodingAttr>(layout);
 }
 
 template <typename T> bool hasEncoding(Value value) {
   auto type = value.getType();
   if (auto tensorType = dyn_cast<TensorOrMemDesc>(type)) {
     auto encoding = tensorType.getEncoding();
-    return encoding && encoding.isa<T>();
+    return encoding && isa<T>(encoding);
   }
   return false;
 }
@@ -482,7 +488,7 @@ getDefaultBlockedEncoding(MLIRContext *context, ArrayRef<int64_t> shape,
 
 static LogicalResult parseIntAttrValue(AsmParser &parser, Attribute attr,
                                        unsigned &value, StringRef desc) {
-  auto intAttr = attr.dyn_cast<IntegerAttr>();
+  auto intAttr = mlir::dyn_cast<IntegerAttr>(attr);
   if (!intAttr) {
     parser.emitError(parser.getNameLoc(), "expected an integer type in ")
         << desc;
@@ -514,7 +520,7 @@ static LogicalResult parseIntAttrValue(AsmParser &parser, Attribute attr,
 
 static LogicalResult parseBoolAttrValue(AsmParser &parser, Attribute attr,
                                         bool &value, StringRef desc) {
-  auto boolAttr = attr.dyn_cast<BoolAttr>();
+  auto boolAttr = mlir::dyn_cast<BoolAttr>(attr);
   if (!boolAttr) {
     parser.emitError(parser.getNameLoc(), "expected an bool type in ") << desc;
     return failure();
@@ -528,7 +534,7 @@ static LogicalResult parseIntArrayAttr(AsmParser &parser,
                                        const NamedAttribute &attr,
                                        SmallVector<unsigned> &res,
                                        StringRef desc) {
-  auto arrayAttr = attr.getValue().dyn_cast<ArrayAttr>();
+  auto arrayAttr = mlir::dyn_cast<ArrayAttr>(attr.getValue());
   if (!arrayAttr) {
     parser.emitError(parser.getNameLoc(), "expected an array for ") << desc;
     return failure();
@@ -912,11 +918,11 @@ DotOperandEncodingAttr::getElemsPerThread(ArrayRef<int64_t> shape,
 
 unsigned DotOperandEncodingAttr::getTotalElemsPerThread(ArrayRef<int64_t> shape,
                                                         Type eltTy) const {
-  if (auto mmaParent = getParent().dyn_cast<MmaEncodingTrait>()) {
+  if (auto mmaParent = mlir::dyn_cast<MmaEncodingTrait>(getParent())) {
     return mmaParent.getTotalElemsPerThreadForOperands(shape, eltTy,
                                                        getKWidth(), getOpIdx());
   }
-  if (auto blockedLayout = getParent().dyn_cast<BlockedEncodingAttr>()) {
+  if (auto blockedLayout = mlir::dyn_cast<BlockedEncodingAttr>(getParent())) {
     auto shapePerCTA = getShapePerCTA(*this, shape);
     auto shapePerCTATile = ::getShapePerCTATile(blockedLayout);
     auto order = blockedLayout.getOrder();
@@ -963,7 +969,7 @@ SmallVector<unsigned> DotOperandEncodingAttr::getWarpsPerCTA() const {
   auto parentLayout = getParent();
   assert(parentLayout && "DotOperandEncodingAttr must have a parent");
   if (auto distributedLayout =
-          parentLayout.dyn_cast<DistributedEncodingTrait>()) {
+          mlir::dyn_cast<DistributedEncodingTrait>(parentLayout)) {
     return distributedLayout.getWarpsPerCTA();
   } else {
     llvm::report_fatal_error(
@@ -981,7 +987,7 @@ SmallVector<unsigned> DotOperandEncodingAttr::getShapePerCTATile(
     ArrayRef<int64_t> tensorShape) const {
   auto parentLayout = getParent();
   assert(parentLayout && "DotOperandEncodingAttr must have a parent");
-  if (auto parentMmaLayout = parentLayout.dyn_cast<MmaEncodingTrait>()) {
+  if (auto parentMmaLayout = mlir::dyn_cast<MmaEncodingTrait>(parentLayout)) {
     return parentMmaLayout.getShapePerCTATileForDotOperands(tensorShape,
                                                             getOpIdx());
   } else {
@@ -1319,7 +1325,7 @@ Attribute SliceEncodingAttr::parse(AsmParser &parser, Type type) {
     return {};
   if (parser.parseGreater().failed())
     return {};
-  unsigned dim = attrs.get("dim").cast<IntegerAttr>().getInt();
+  unsigned dim = mlir::cast<IntegerAttr>(attrs.get("dim")).getInt();
   Attribute parent = attrs.get("parent");
   return parser.getChecked<SliceEncodingAttr>(parser.getContext(), dim, parent);
 }
@@ -1968,7 +1974,7 @@ SmallVector<unsigned> DotOperandEncodingAttr::getThreadsPerWarp() const {
 SmallVector<unsigned> DotOperandEncodingAttr::getSizePerThread() const {
   auto parentLayout = getParent();
   assert(parentLayout && "DotOperandEncodingAttr must have a parent");
-  if (auto parentMmaLayout = parentLayout.dyn_cast<MmaEncodingTrait>()) {
+  if (auto parentMmaLayout = mlir::dyn_cast<MmaEncodingTrait>(parentLayout)) {
     return parentMmaLayout.getSizePerThreadForOperands(getOpIdx());
   } else {
     llvm::report_fatal_error(
@@ -1986,9 +1992,9 @@ Attribute DotOperandEncodingAttr::parse(AsmParser &parser, Type type) {
     return {};
   if (parser.parseGreater().failed())
     return {};
-  unsigned opIdx = attrs.get("opIdx").cast<IntegerAttr>().getInt();
+  unsigned opIdx = mlir::cast<IntegerAttr>(attrs.get("opIdx")).getInt();
   Attribute parent = attrs.get("parent");
-  auto mmaParent = parent.dyn_cast<NvidiaMmaEncodingAttr>();
+  auto mmaParent = mlir::dyn_cast<NvidiaMmaEncodingAttr>(parent);
   unsigned kWidth = 0;
   Attribute _kWidth = attrs.get("kWidth");
   if (_kWidth) {
@@ -1997,9 +2003,9 @@ Attribute DotOperandEncodingAttr::parse(AsmParser &parser, Type type) {
       parser.emitError(loc, "kWidth only supported for MMAv2+ parent");
       return Attribute();
     }
-    kWidth = _kWidth.cast<IntegerAttr>().getInt();
+    kWidth = mlir::cast<IntegerAttr>(_kWidth).getInt();
   }
-  if (parent.isa<AMDWmmaEncodingAttr>()) {
+  if (mlir::isa<AMDWmmaEncodingAttr>(parent)) {
     kWidth = AMDWmmaEncodingAttr::getMNKDimPerWMMAInstr()[2];
   }
   return parser.getChecked<DotOperandEncodingAttr>(parser.getContext(), opIdx,
@@ -2007,7 +2013,7 @@ Attribute DotOperandEncodingAttr::parse(AsmParser &parser, Type type) {
 }
 
 void DotOperandEncodingAttr::print(mlir::AsmPrinter &printer) const {
-  auto mmaParent = getParent().dyn_cast<NvidiaMmaEncodingAttr>();
+  auto mmaParent = mlir::dyn_cast<NvidiaMmaEncodingAttr>(getParent());
   printer << "<{"
           << "opIdx = " << getOpIdx() << ", parent = " << getParent();
   if (mmaParent && mmaParent.isAmpere())
@@ -2024,16 +2030,16 @@ public:
   using OpAsmDialectInterface::OpAsmDialectInterface;
 
   AliasResult getAlias(Attribute attr, raw_ostream &os) const override {
-    if (auto mmaAttr = attr.dyn_cast<MmaEncodingTrait>()) {
+    if (auto mmaAttr = mlir::dyn_cast<MmaEncodingTrait>(attr)) {
       os << "mma";
       return AliasResult::FinalAlias;
-    } else if (auto sharedAttr = attr.dyn_cast<SharedEncodingAttr>()) {
+    } else if (auto sharedAttr = mlir::dyn_cast<SharedEncodingAttr>(attr)) {
       os << "shared";
       return AliasResult::FinalAlias;
-    } else if (auto blockedAttr = attr.dyn_cast<BlockedEncodingAttr>()) {
+    } else if (auto blockedAttr = mlir::dyn_cast<BlockedEncodingAttr>(attr)) {
       os << "blocked";
       return AliasResult::FinalAlias;
-    } /* else if (auto sliceAttr = attr.dyn_cast<SliceEncodingAttr>()) {
+    } /* else if (auto sliceAttr = dyn_cast<SliceEncodingAttr>(attr)) {
       os << "slice";
       return AliasResult::FinalAlias;
     } */
@@ -2113,7 +2119,7 @@ struct TritonGPUInferLayoutInterface
           applyPermutation(invOrderUnsigned, layout.getCTAOrder()));
     };
 
-    if (auto enc = operandEncoding.dyn_cast<SharedEncodingAttr>()) {
+    if (auto enc = mlir::dyn_cast<SharedEncodingAttr>(operandEncoding)) {
       if (enc.getOrder().size() != order.size()) {
         return failure();
       }
@@ -2128,7 +2134,7 @@ struct TritonGPUInferLayoutInterface
       return success();
     }
 
-    if (auto enc = operandEncoding.dyn_cast<BlockedEncodingAttr>()) {
+    if (auto enc = mlir::dyn_cast<BlockedEncodingAttr>(operandEncoding)) {
       auto n = order.size();
       if (enc.getSizePerThread().size() != n ||
           enc.getThreadsPerWarp().size() != n ||
@@ -2155,7 +2161,7 @@ struct TritonGPUInferLayoutInterface
   inferExpandDimsOpEncoding(Attribute operandEncoding, unsigned axis,
                             Attribute &resultEncoding,
                             std::optional<Location> location) const override {
-    auto sliceEncoding = operandEncoding.dyn_cast<SliceEncodingAttr>();
+    auto sliceEncoding = mlir::dyn_cast<SliceEncodingAttr>(operandEncoding);
     if (!sliceEncoding)
       return emitOptionalError(
           location, "ExpandDimsOp operand encoding must be SliceEncodingAttr");
@@ -2170,17 +2176,17 @@ struct TritonGPUInferLayoutInterface
   inferDotOpEncoding(Attribute operandEncoding, unsigned opIdx,
                      Attribute retEncoding,
                      std::optional<Location> location) const override {
-    auto mmaRetEncoding = retEncoding.dyn_cast<NvidiaMmaEncodingAttr>();
+    auto mmaRetEncoding = mlir::dyn_cast<NvidiaMmaEncodingAttr>(retEncoding);
     if (mmaRetEncoding && mmaRetEncoding.isHopper()) {
-      auto dotOpEnc = operandEncoding.dyn_cast<DotOperandEncodingAttr>();
-      if (!operandEncoding.isa<SharedEncodingAttr>() &&
+      auto dotOpEnc = mlir::dyn_cast<DotOperandEncodingAttr>(operandEncoding);
+      if (!mlir::isa<SharedEncodingAttr>(operandEncoding) &&
           !(opIdx == 0 && dotOpEnc && dotOpEnc.getOpIdx() == 0 &&
-            dotOpEnc.getParent().isa<NvidiaMmaEncodingAttr>())) {
+            mlir::isa<NvidiaMmaEncodingAttr>(dotOpEnc.getParent()))) {
         return emitOptionalError(
             location, "unexpected operand layout for NvidiaMmaEncodingAttr v3");
       }
     } else if (auto dotOpEnc =
-                   operandEncoding.dyn_cast<DotOperandEncodingAttr>()) {
+                   mlir::dyn_cast<DotOperandEncodingAttr>(operandEncoding)) {
       if (opIdx != dotOpEnc.getOpIdx())
         return emitOptionalError(location, "Wrong opIdx");
       if (retEncoding != dotOpEnc.getParent())
@@ -2195,13 +2201,13 @@ struct TritonGPUInferLayoutInterface
   verifyDotOpEncodingCompatibility(Operation *op, Attribute operandEncodingA,
                                    Attribute operandEncodingB) const override {
     auto aEncoding =
-        operandEncodingA.dyn_cast<triton::gpu::DotOperandEncodingAttr>();
+        mlir::dyn_cast<triton::gpu::DotOperandEncodingAttr>(operandEncodingA);
     auto bEncoding =
-        operandEncodingB.dyn_cast<triton::gpu::DotOperandEncodingAttr>();
+        mlir::dyn_cast<triton::gpu::DotOperandEncodingAttr>(operandEncodingB);
     if (!aEncoding && !bEncoding)
       return mlir::success();
     auto mmaAEncoding =
-        aEncoding.getParent().dyn_cast_or_null<NvidiaMmaEncodingAttr>();
+        mlir::dyn_cast_or_null<NvidiaMmaEncodingAttr>(aEncoding.getParent());
     if (mmaAEncoding && mmaAEncoding.isHopper())
       return success();
     // Verify that the encodings are valid.
@@ -2239,7 +2245,7 @@ struct TritonGPUInferLayoutInterface
   inferReshapeOpNoReorderEncoding(ArrayRef<int64_t> srcShape, Attribute srcEnc,
                                   ArrayRef<int64_t> dstShape, Attribute &dstEnc,
                                   std::optional<Location> loc) const override {
-    auto src = srcEnc.dyn_cast<BlockedEncodingAttr>();
+    auto src = mlir::dyn_cast<BlockedEncodingAttr>(srcEnc);
     if (!src) {
       return emitOptionalError(
           loc, "Non-reordering reshape only supports BlockedEncoding");
@@ -2486,7 +2492,7 @@ struct TritonGPUInferLayoutInterface
   LogicalResult
   inferJoinOpEncoding(Attribute srcEnc, Attribute &dstEnc,
                       std::optional<Location> loc) const override {
-    auto enc = srcEnc.dyn_cast<BlockedEncodingAttr>();
+    auto enc = mlir::dyn_cast<BlockedEncodingAttr>(srcEnc);
     if (!enc) {
       return emitOptionalError(loc,
                                "JoinOp can only operate on BlockedEncoding");
@@ -2521,7 +2527,7 @@ struct TritonGPUInferLayoutInterface
   LogicalResult
   inferSplitOpEncoding(Attribute srcEnc, Attribute &dstEnc,
                        std::optional<Location> loc) const override {
-    auto enc = srcEnc.dyn_cast<BlockedEncodingAttr>();
+    auto enc = mlir::dyn_cast<BlockedEncodingAttr>(srcEnc);
     if (!enc) {
       return emitOptionalError(loc,
                                "SplitOp can only operate on BlockedEncoding");
@@ -2645,13 +2651,13 @@ struct CanonicalizeConvertFromConvert
     // heuristic to accommodate fused attention.
     auto srcType = op.getSrc().getType();
     auto dstType = op.getType();
-    if (dstType.getEncoding().isa<DotOperandEncodingAttr>() &&
-        srcType.getEncoding().isa<NvidiaMmaEncodingAttr>())
+    if (mlir::isa<DotOperandEncodingAttr>(dstType.getEncoding()) &&
+        mlir::isa<NvidiaMmaEncodingAttr>(srcType.getEncoding()))
       return failure();
 
     // for hopper MMAv3
-    if (dstType.getEncoding().isa<SharedEncodingAttr>() &&
-        srcType.getEncoding().isa<NvidiaMmaEncodingAttr>() &&
+    if (mlir::isa<SharedEncodingAttr>(dstType.getEncoding()) &&
+        mlir::isa<NvidiaMmaEncodingAttr>(srcType.getEncoding()) &&
         llvm::any_of(op.getResult().getUsers(),
                      [](Operation *dot) { return isa<DotOp>(dot); })) {
       return failure();
@@ -2736,7 +2742,7 @@ struct CanonicalizeConvertFromConvert
 
     // cvt(type, constant) -> constant
     if (auto cst = llvm::dyn_cast<arith::ConstantOp>(arg))
-      if (auto ret = cst.getValue().dyn_cast<SplatElementsAttr>()) {
+      if (auto ret = dyn_cast<SplatElementsAttr>(cst.getValue())) {
         auto ty = cast<ShapedType>(op->getResultTypes().front());
         auto newRet =
             SplatElementsAttr::get(ty, ret.getSplatValue<Attribute>());

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -1,4 +1,7 @@
+#include <memory>
+
 #include "mlir/IR/TypeUtilities.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Analysis/Utility.h"
@@ -7,7 +10,6 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/Support/Debug.h"
-#include <memory>
 
 using namespace mlir;
 namespace tt = mlir::triton;
@@ -63,7 +65,7 @@ warpsPerTileV2(tt::DotOp dotOp, const ArrayRef<int64_t> shape, int numWarps) {
         continue;
       }
       if (auto mmaEncoding =
-              resTy.getEncoding().dyn_cast<NvidiaMmaEncodingAttr>()) {
+              dyn_cast<NvidiaMmaEncodingAttr>(resTy.getEncoding())) {
         return ttg::getWarpsPerCTA(mmaEncoding);
       }
       hasChainedDot = true;
@@ -231,7 +233,7 @@ public:
     // TODO: Check data-types and SM compatibility
     RankedTensorType oldRetType = dotOp.getType();
     if (!oldRetType.getEncoding() ||
-        oldRetType.getEncoding().isa<ttg::NvidiaMmaEncodingAttr>())
+        mlir::isa<ttg::NvidiaMmaEncodingAttr>(oldRetType.getEncoding()))
       return failure();
 
     // get MMA encoding for the given number of warps
@@ -263,11 +265,8 @@ public:
       getBackwardSlice(b, &bBwdSlices, opt);
       // get the source of the first conversion found in slices
       auto getCvtArgOrder = [](Operation *op) {
-        return cast<ConvertLayoutOp>(op)
-            .getSrc()
-            .getType()
-            .getEncoding()
-            .cast<BlockedEncodingAttr>()
+        return mlir::cast<BlockedEncodingAttr>(
+                   cast<ConvertLayoutOp>(op).getSrc().getType().getEncoding())
             .getOrder();
       };
       bool isARow = true;
@@ -354,7 +353,7 @@ static void decomposeMixedModeDotOp(ModuleOp mod, int computeCapability) {
     Type AElType = dotOp.getA().getType().getElementType();
     Type promoteType;
     NvidiaMmaEncodingAttr mmaLayout =
-        D.getType().getEncoding().dyn_cast<NvidiaMmaEncodingAttr>();
+        dyn_cast<NvidiaMmaEncodingAttr>(D.getType().getEncoding());
     if (mmaLayout) {
       bool isNativeFP8 = AElType.isFloat8E5M2() || AElType.isFloat8E4M3FNUZ();
       // promote operands for sm < 89 since fp8 mma is not natively supported

--- a/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Coalesce.cpp
@@ -1,12 +1,14 @@
+#include <iterator>
+#include <numeric>
+
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "llvm/Support/Debug.h"
-#include <iterator>
-#include <numeric>
 
 #define DEBUG_TYPE "tritongpu-coalesce"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
@@ -117,7 +119,7 @@ struct CoalescePass : public TritonGPUCoalesceBase<CoalescePass> {
     for (auto operand : op->getOperands()) {
       auto tensorType = dyn_cast<RankedTensorType>(operand.getType());
       if (tensorType &&
-          !tensorType.getEncoding().isa<triton::gpu::SharedEncodingAttr>()) {
+          !isa<triton::gpu::SharedEncodingAttr>(tensorType.getEncoding())) {
         Type newType = getNewType(tensorType, encoding);
         newArgs.push_back(builder.create<triton::gpu::ConvertLayoutOp>(
             op->getLoc(), newType, operand));

--- a/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/F32DotTC.cpp
@@ -27,10 +27,7 @@ public:
                                 PatternRewriter &rewriter) const override {
 
     auto isF32 = [](Value operand) {
-      return operand.getType()
-          .cast<RankedTensorType>()
-          .getElementType()
-          .isF32();
+      return cast<RankedTensorType>(operand.getType()).getElementType().isF32();
     };
 
     if (!(dotOp.getInputPrecision() == tt::InputPrecision::TF32x3 &&

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -1,7 +1,9 @@
 #include "PipeliningUtility.h"
+
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
@@ -74,7 +76,7 @@ void mlir::triton::addDep(Operation *op, DenseSet<Operation *> &deps,
   for (Value operand : op->getOperands()) {
     Value v = operand;
     llvm::SmallDenseSet<Value> seen;
-    while (auto arg = v.dyn_cast<BlockArgument>()) {
+    while (auto arg = mlir::dyn_cast<BlockArgument>(v)) {
       if (!includeArg)
         break;
       if (!seen.insert(v).second)

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -5,6 +5,7 @@
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Analysis/Utility.h"
@@ -106,8 +107,8 @@ struct PipelinePass : public TritonGPUPipelineBase<PipelinePass> {
     // global control.
     if (!forOp->hasAttr(mlir::triton::kNumStagesAttrName))
       return numStages;
-    return forOp->getAttr(mlir::triton::kNumStagesAttrName)
-        .cast<IntegerAttr>()
+    return mlir::cast<IntegerAttr>(
+               forOp->getAttr(mlir::triton::kNumStagesAttrName))
         .getInt();
   }
 

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -8,6 +8,7 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -34,14 +35,14 @@ public:
       auto srcType = cast<RankedTensorType>(cvtOp.getSrc().getType());
       auto dstType = cast<RankedTensorType>(cvtOp.getType());
       auto srcEncoding = srcType.getEncoding();
-      if (srcEncoding.isa<triton::gpu::SharedEncodingAttr>())
+      if (isa<triton::gpu::SharedEncodingAttr>(srcEncoding))
         return;
       auto dstDotOp =
-          dstType.getEncoding().dyn_cast<triton::gpu::DotOperandEncodingAttr>();
+          dyn_cast<triton::gpu::DotOperandEncodingAttr>(dstType.getEncoding());
       if (!dstDotOp)
         return;
       if (auto srcMmaEncoding =
-              srcEncoding.dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>()) {
+              dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(srcEncoding)) {
 
         if (srcMmaEncoding.getVersionMajor() != 2 ||
             (srcMmaEncoding.getWarpsPerCTA()[1] == 1 &&
@@ -49,7 +50,7 @@ public:
           return;
       }
       if (auto srcMfmaEncoding =
-              srcEncoding.dyn_cast<triton::gpu::AMDMfmaEncodingAttr>()) {
+              dyn_cast<triton::gpu::AMDMfmaEncodingAttr>(srcEncoding)) {
 
         if (srcMfmaEncoding.getWarpsPerCTA()[1] == 1 &&
             srcMfmaEncoding.getIsTransposed() &&

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -212,11 +214,11 @@ bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
       // This is to avoid stepping into the known bug.
       if (isa<mlir::triton::ReduceOp>(op)) {
         auto tensorType =
-            op->getOperand(0).getType().dyn_cast<RankedTensorType>();
+            dyn_cast<RankedTensorType>(op->getOperand(0).getType());
         if (tensorType &&
-            tensorType.getEncoding().isa<NvidiaMmaEncodingAttr>()) {
+            isa<NvidiaMmaEncodingAttr>(tensorType.getEncoding())) {
           auto mmaInstrShape =
-              encoding.cast<NvidiaMmaEncodingAttr>().getInstrShape();
+              cast<NvidiaMmaEncodingAttr>(encoding).getInstrShape();
           if (tensorType.getShape()[tensorType.getRank() - 2] <
                   mmaInstrShape[0] ||
               tensorType.getShape()[tensorType.getRank() - 1] <
@@ -228,25 +230,25 @@ bool hasConvertToMMATransisitiveUse(Operation *op, Attribute encoding) {
 
       if (auto convertOp = dyn_cast<ConvertLayoutOp>(op)) {
         Attribute dstEncoding = convertOp.getType().getEncoding();
-        if (auto mmaLayout = dstEncoding.dyn_cast<NvidiaMmaEncodingAttr>())
+        if (auto mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(dstEncoding))
           return (mmaLayout.getVersionMajor() > 1) ? true
                                                    : mmaLayout == encoding;
-        if (dstEncoding.isa<triton::gpu::AMDMfmaEncodingAttr,
-                            triton::gpu::AMDWmmaEncodingAttr>())
+        if (isa<triton::gpu::AMDMfmaEncodingAttr,
+                triton::gpu::AMDWmmaEncodingAttr>(dstEncoding))
           return true;
-        if (dstEncoding.isa<triton::gpu::DotOperandEncodingAttr>()) {
-          if (auto mmaLayout = encoding.dyn_cast<NvidiaMmaEncodingAttr>()) {
+        if (isa<triton::gpu::DotOperandEncodingAttr>(dstEncoding)) {
+          if (auto mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(encoding)) {
             return mmaLayout.getVersionMajor() > 1;
           } else {
-            assert(encoding.isa<triton::gpu::AMDMfmaEncodingAttr>() ||
-                   encoding.isa<triton::gpu::AMDWmmaEncodingAttr>());
+            assert((mlir::isa<triton::gpu::AMDMfmaEncodingAttr,
+                              triton::gpu::AMDWmmaEncodingAttr>(encoding)));
             return true;
           }
         }
       }
       bool isMMAV3 =
-          encoding.isa<NvidiaMmaEncodingAttr>() &&
-          encoding.cast<NvidiaMmaEncodingAttr>().getVersionMajor() == 3;
+          isa<NvidiaMmaEncodingAttr>(encoding) &&
+          cast<NvidiaMmaEncodingAttr>(encoding).getVersionMajor() == 3;
       if (isMMAV3 && isa<LocalAllocOp>(op))
         return true;
       auto yield = dyn_cast<scf::YieldOp>(op);
@@ -301,7 +303,7 @@ void LayoutPropagation::initAnchorLayout() {
       // back to mma further down to avoid generating reduction with MMA
       // layout that may have lower performance.
       // This can be improved with more aggressive backward propagation.
-      if (tensorType.getEncoding().isa<MmaEncodingTrait>() &&
+      if (isa<MmaEncodingTrait>(tensorType.getEncoding()) &&
           v.getDefiningOp() &&
           !hasConvertToMMATransisitiveUse(v.getDefiningOp(),
                                           tensorType.getEncoding())) {
@@ -439,8 +441,8 @@ void LayoutPropagation::resolveConflicts() {
     bool isLoadOrStore =
         op && isa<LoadOp, StoreOp, AtomicRMWOp, AtomicCASOp>(op);
     for (Attribute e : info.encodings) {
-      if ((isLoadOrStore && e.isa<BlockedEncodingAttr>()) ||
-          (!isLoadOrStore && e.isa<MmaEncodingTrait>())) {
+      if ((isLoadOrStore && isa<BlockedEncodingAttr>(e)) ||
+          (!isLoadOrStore && isa<MmaEncodingTrait>(e))) {
         encoding = e;
         break;
       }
@@ -886,14 +888,14 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
     if (v.getDefiningOp()) {
       opsToRewrite.insert(v.getDefiningOp());
       if (auto ifOp = v.getDefiningOp<scf::IfOp>()) {
-        unsigned operandIdx = v.cast<OpResult>().getResultNumber();
+        unsigned operandIdx = cast<OpResult>(v).getResultNumber();
         opsToRewrite.insert(ifOp.thenYield().getOperation());
         yieldOperandsMap[ifOp.thenYield()].push_back(operandIdx);
         opsToRewrite.insert(ifOp.elseYield().getOperation());
         yieldOperandsMap[ifOp.elseYield()].push_back(operandIdx);
       }
     } else {
-      BlockArgument blockArg = v.cast<BlockArgument>();
+      BlockArgument blockArg = cast<BlockArgument>(v);
       Operation *parentOp = blockArg.getOwner()->getParentOp();
       if (auto loopOp = cast<LoopLikeOpInterface>(parentOp)) {
         opsToRewrite.insert(loopOp.getOperation());
@@ -1083,7 +1085,7 @@ void LayoutRematerialization::backwardRematerialization(
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristic to accommodate fused attention
   RankedTensorType targetType = convertOp.getType();
-  if (targetType.getEncoding().isa<DotOperandEncodingAttr>())
+  if (isa<DotOperandEncodingAttr>(targetType.getEncoding()))
     return;
   Value oldV = convertOp->getOperand(0);
   LDBG("check backward remat with source " << oldV << " encoding "
@@ -1126,7 +1128,7 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   // we don't handle conversions to DotOperandEncodingAttr
   // this is a heuristics to accommodate fused attention
   RankedTensorType targetType = convertOp.getType();
-  if (targetType.getEncoding().isa<DotOperandEncodingAttr>())
+  if (mlir::isa<DotOperandEncodingAttr>(targetType.getEncoding()))
     return;
 
   auto isExtOrBroadcastOp = [](Operation *op) {

--- a/lib/Dialect/TritonGPU/Transforms/ReorderInstructions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReorderInstructions.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
@@ -29,7 +30,8 @@ static bool willIncreaseRegisterPressure(Operation *op) {
   auto cvt = dyn_cast<triton::gpu::ConvertLayoutOp>(op);
   if (!cvt)
     return false;
-  if (cvt.getType().getEncoding().isa<triton::gpu::DotOperandEncodingAttr>())
+  if (mlir::isa<triton::gpu::DotOperandEncodingAttr>(
+          cvt.getType().getEncoding()))
     return true;
   return false;
 }
@@ -104,9 +106,8 @@ public:
     // Move `dot` operand so that conversions to opIdx=1 happens after
     // conversions to opIdx=0
     m.walk([&](triton::gpu::LocalLoadOp op) {
-      auto dstEncoding = op.getType()
-                             .getEncoding()
-                             .dyn_cast<triton::gpu::DotOperandEncodingAttr>();
+      auto dstEncoding = mlir::dyn_cast<triton::gpu::DotOperandEncodingAttr>(
+          op.getType().getEncoding());
       if (!dstEncoding)
         return;
       int opIdx = dstEncoding.getOpIdx();

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1,7 +1,11 @@
 #include "triton/Analysis/Utility.h"
+
+#include <fstream>
+
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/Support/LLVM.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -10,8 +14,6 @@
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "llvm/Support/Debug.h"
-
-#include <fstream>
 #define DEBUG_TYPE "ttg-utility"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
@@ -235,7 +237,7 @@ std::string GraphDumper::emitValueNode(Value value) const {
   NodeInfo info = onValue(value);
   if (info.find("label") == info.end()) {
     std::string shapeStr = getShapeStr(value.getType());
-    if (auto arg = value.dyn_cast<BlockArgument>())
+    if (auto arg = mlir::dyn_cast<BlockArgument>(value))
       info["label"] =
           "BlockArg" + std::to_string(arg.getArgNumber()) + " " + shapeStr;
     else
@@ -263,15 +265,15 @@ GraphDumper::NodeInfo GraphLayoutMarker::onValue(Value value) const {
 std::string GraphLayoutMarker::getColor(const Type &type) const {
   if (auto tensorTy = dyn_cast<RankedTensorType>(type)) {
     auto layout = tensorTy.getEncoding();
-    if (layout.isa<triton::gpu::BlockedEncodingAttr>())
+    if (isa<triton::gpu::BlockedEncodingAttr>(layout))
       return "green";
-    else if (layout.isa<triton::gpu::SliceEncodingAttr>())
+    else if (isa<triton::gpu::SliceEncodingAttr>(layout))
       return "yellow";
-    else if (layout.isa<triton::gpu::NvidiaMmaEncodingAttr>())
+    else if (isa<triton::gpu::NvidiaMmaEncodingAttr>(layout))
       return "lightslateblue";
-    else if (layout.isa<triton::gpu::DotOperandEncodingAttr>())
+    else if (isa<triton::gpu::DotOperandEncodingAttr>(layout))
       return "orange";
-    else if (layout.isa<triton::gpu::SharedEncodingAttr>())
+    else if (isa<triton::gpu::SharedEncodingAttr>(layout))
       return "orangered";
     else {
       llvm::report_fatal_error("Unrecognized layout");
@@ -291,7 +293,7 @@ static std::optional<Attribute> inferDstEncoding(triton::ReduceOp op,
 
 static std::optional<Attribute> inferDstEncoding(triton::ExpandDimsOp op,
                                                  Attribute encoding) {
-  auto sliceEncoding = encoding.dyn_cast<triton::gpu::SliceEncodingAttr>();
+  auto sliceEncoding = mlir::dyn_cast<triton::gpu::SliceEncodingAttr>(encoding);
   if (!sliceEncoding)
     return std::nullopt;
   if (op.getAxis() != sliceEncoding.getDim())
@@ -325,7 +327,7 @@ static std::optional<Attribute> inferDstEncoding(SplitOp op, Attribute srcEnc) {
 
 static std::optional<Attribute> inferSrcEncoding(triton::ReduceOp op,
                                                  Attribute encoding) {
-  auto sliceEncoding = encoding.dyn_cast<triton::gpu::SliceEncodingAttr>();
+  auto sliceEncoding = mlir::dyn_cast<triton::gpu::SliceEncodingAttr>(encoding);
   if (!sliceEncoding)
     return std::nullopt;
   if (op.getAxis() != sliceEncoding.getDim())
@@ -541,7 +543,7 @@ bool canFoldIntoConversion(Operation *op, Attribute targetEncoding) {
     return !triton::gpu::isExpensiveCat(cast<triton::CatOp>(op),
                                         targetEncoding);
   if (auto convert = dyn_cast<triton::gpu::ConvertLayoutOp>(op)) {
-    if (targetEncoding.isa<triton::gpu::NvidiaMmaEncodingAttr>()) {
+    if (mlir::isa<triton::gpu::NvidiaMmaEncodingAttr>(targetEncoding)) {
       auto srcEncoding = convert.getSrc().getType().getEncoding();
       if (targetEncoding != srcEncoding)
         return false;
@@ -695,7 +697,7 @@ getConvertBackwardSlice(Value root, SetVector<Value> &slice,
 
     if (auto ifOp = currentValue.getDefiningOp<scf::IfOp>()) {
       auto results = ifOp.getResults();
-      unsigned argIdx = currentValue.cast<OpResult>().getResultNumber();
+      unsigned argIdx = mlir::cast<OpResult>(currentValue).getResultNumber();
 
       auto thenValue = ifOp.thenYield().getOperand(argIdx);
       auto elseValue = ifOp.elseYield().getOperand(argIdx);
@@ -859,7 +861,7 @@ struct ForOpDeadArgElimination : public OpRewritePattern<scf::ForOp> {
     while (!queue.empty()) {
       Value value = queue.pop_back_val();
       if (auto nestedFor = value.getDefiningOp<scf::ForOp>()) {
-        auto result = value.cast<OpResult>();
+        auto result = mlir::cast<OpResult>(value);
         OpOperand &forOperand = *nestedFor.getTiedLoopInit(result);
         markLive(forOperand.get());
         auto nestedYieldOp =
@@ -870,7 +872,7 @@ struct ForOpDeadArgElimination : public OpRewritePattern<scf::ForOp> {
         continue;
       }
       if (auto nestedIf = value.getDefiningOp<scf::IfOp>()) {
-        auto result = value.cast<OpResult>();
+        auto result = mlir::cast<OpResult>(value);
         for (scf::YieldOp nestedYieldOp :
              {nestedIf.thenYield(), nestedIf.elseYield()}) {
           Value nestedYieldOperand =
@@ -889,7 +891,7 @@ struct ForOpDeadArgElimination : public OpRewritePattern<scf::ForOp> {
       }
       // If an argument block is live then the associated yield operand and
       // forOp operand are live.
-      auto arg = value.cast<BlockArgument>();
+      auto arg = mlir::cast<BlockArgument>(value);
       if (auto forOwner = dyn_cast<scf::ForOp>(arg.getOwner()->getParentOp())) {
         if (arg.getArgNumber() < forOwner.getNumInductionVars())
           continue;

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "mlir/IR/Builders.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 
 #define GET_OP_CLASSES

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -49,9 +49,8 @@ public:
       OpBuilder builder(op);
       auto a = op->getOperand(0);
       auto b = op->getOperand(1);
-      auto mmaEncoding = cast<RankedTensorType>(op->getResult(0).getType())
-                             .getEncoding()
-                             .dyn_cast<ttg::NvidiaMmaEncodingAttr>();
+      auto mmaEncoding = dyn_cast<ttg::NvidiaMmaEncodingAttr>(
+          cast<RankedTensorType>(op->getResult(0).getType()).getEncoding());
       if (!mmaEncoding || !mmaEncoding.isHopper())
         return WalkResult::advance();
       bool aDependsOnShared = dependOnSharedEncOperand(a);

--- a/lib/Target/LLVMIR/LLVMDIScope.cpp
+++ b/lib/Target/LLVMIR/LLVMDIScope.cpp
@@ -1,8 +1,8 @@
-#include "triton/Target/LLVMIR/Passes.h"
-
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
+#include "triton/Target/LLVMIR/Passes.h"
 #include "llvm/BinaryFormat/Dwarf.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Path.h"
@@ -120,8 +120,8 @@ struct LLVMDIScopePass : public LLVMDIScopeBase<LLVMDIScopePass> {
     auto lexicalBlockFileAttr = LLVM::DILexicalBlockFileAttr::get(
         context, scopeAttr, calleeFileAttr, /*discriminator=*/0);
     Location loc = calleeLoc;
-    if (calleeLoc.isa<CallSiteLoc>()) {
-      auto nestedLoc = calleeLoc.cast<CallSiteLoc>().getCallee();
+    if (mlir::isa<CallSiteLoc>(calleeLoc)) {
+      auto nestedLoc = mlir::cast<CallSiteLoc>(calleeLoc).getCallee();
       loc = getNestedLoc(op, lexicalBlockFileAttr, nestedLoc);
     }
     return FusedLoc::get(context, {loc}, lexicalBlockFileAttr);
@@ -136,8 +136,8 @@ struct LLVMDIScopePass : public LLVMDIScopeBase<LLVMDIScopePass> {
       // We assemble the full inline stack so the parent of this loc must be a
       // function
       auto funcOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-      auto funcOpLoc = funcOp.getLoc().cast<FusedLoc>();
-      scopeAttr = funcOpLoc.getMetadata().cast<LLVM::DISubprogramAttr>();
+      auto funcOpLoc = mlir::cast<FusedLoc>(funcOp.getLoc());
+      scopeAttr = mlir::cast<LLVM::DISubprogramAttr>(funcOpLoc.getMetadata());
       auto loc =
           CallSiteLoc::get(getNestedLoc(op, scopeAttr, calleeLoc), callerLoc);
       op->setLoc(loc);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandMFMA.cpp
@@ -199,20 +199,20 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
                     const SharedMemoryObject &smemObj,
                     const LLVMTypeConverter *typeConverter, Value thread) {
   assert((opIdx == 0 || opIdx == 1) && "unexpected operand idx");
-  auto aTensorTy = tensor.getType().cast<MemDescType>();
+  auto aTensorTy = cast<MemDescType>(tensor.getType());
   ArrayRef<int64_t> shape = aTensorTy.getShape();
   auto rank = shape.size();
   int kDimIdx = opIdx == 0 ? rank - 1 : rank - 2;
   int nonKDimIdx = opIdx == 0 ? rank - 2 : rank - 1;
 
-  auto mfmaLayout = encoding.getParent().cast<AMDMfmaEncodingAttr>();
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(encoding.getParent());
   auto mDim = mfmaLayout.getMDim();
   auto nDim = mfmaLayout.getNDim();
   assert((mDim == nDim && (mDim == 32 || mDim == 16 || mDim == 4)) ||
          (mDim == 64 && nDim == 4) || (mDim == 4 && nDim == 64));
   auto warpsPerCTA = mfmaLayout.getWarpsPerCTA();
 
-  auto sharedLayout = aTensorTy.getEncoding().cast<SharedEncodingAttr>();
+  auto sharedLayout = cast<SharedEncodingAttr>(aTensorTy.getEncoding());
   auto order = sharedLayout.getOrder();
 
   auto elemTy = aTensorTy.getElementType();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM/SharedToDotOperandWMMA.cpp
@@ -112,14 +112,14 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
   int kDimIdx = opIdx == 0 ? 1 : 0;
   int nonKDimIdx = opIdx == 0 ? 0 : 1;
 
-  auto wmmaLayout = encoding.getParent().cast<AMDWmmaEncodingAttr>();
+  auto wmmaLayout = cast<AMDWmmaEncodingAttr>(encoding.getParent());
   auto nonKDim = wmmaLayout.getMNKDimPerWMMAInstr()[nonKDimIdx];
   assert(nonKDim == 16);
   auto warpsPerCTA = wmmaLayout.getWarpsPerCTA();
 
-  auto aTensorTy = tensor.getType().cast<MemDescType>();
+  auto aTensorTy = cast<MemDescType>(tensor.getType());
   ArrayRef<int64_t> shape = aTensorTy.getShape();
-  auto sharedLayout = aTensorTy.getEncoding().cast<SharedEncodingAttr>();
+  auto sharedLayout = cast<SharedEncodingAttr>(aTensorTy.getEncoding());
   auto order = sharedLayout.getOrder();
 
   auto elemTy = aTensorTy.getElementType();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM.cpp
@@ -35,19 +35,17 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
     bool isOuter = K == 1;
 
     if (!isOuter) {
-      auto dEncoding = D.getType().cast<RankedTensorType>().getEncoding();
-      if (dEncoding.isa<AMDMfmaEncodingAttr>() && supportMFMA(op)) {
+      auto dEncoding = cast<RankedTensorType>(D.getType()).getEncoding();
+      if (isa<AMDMfmaEncodingAttr>(dEncoding) && supportMFMA(op)) {
         return AMD::convertMFMA(op, adaptor, getTypeConverter(), rewriter);
       }
-      if (dEncoding.isa<AMDWmmaEncodingAttr>()) {
+      if (isa<AMDWmmaEncodingAttr>(dEncoding)) {
         return AMD::convertWMMA(op, adaptor, getTypeConverter(), rewriter);
       }
     }
 
-    if (D.getType()
-            .cast<RankedTensorType>()
-            .getEncoding()
-            .isa<BlockedEncodingAttr>())
+    if (isa<BlockedEncodingAttr>(
+            cast<RankedTensorType>(D.getType()).getEncoding()))
       return convertFMADot(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -176,9 +176,9 @@ struct DotOpMFMAConversionHelper {
     Value a = op.getA();
     Value b = op.getB();
     Value d = op.getD();
-    auto aTensorTy = a.getType().cast<RankedTensorType>();
-    auto bTensorTy = b.getType().cast<RankedTensorType>();
-    auto dTensorTy = d.getType().cast<RankedTensorType>();
+    auto aTensorTy = cast<RankedTensorType>(a.getType());
+    auto bTensorTy = cast<RankedTensorType>(b.getType());
+    auto dTensorTy = cast<RankedTensorType>(d.getType());
     auto elemTyA = aTensorTy.getElementType();
     auto elemTyB = bTensorTy.getElementType();
 
@@ -191,8 +191,8 @@ struct DotOpMFMAConversionHelper {
     mfmaInsnName = maybeMfmaInsn->getInsnName();
     unsigned kBase = maybeMfmaInsn->getKBase();
 
-    auto aEncoding = aTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
-    auto bEncoding = bTensorTy.getEncoding().cast<DotOperandEncodingAttr>();
+    auto aEncoding = cast<DotOperandEncodingAttr>(aTensorTy.getEncoding());
+    auto bEncoding = cast<DotOperandEncodingAttr>(bTensorTy.getEncoding());
     int kWidth = aEncoding.getKWidth();
     auto rank = aTensorTy.getShape().size();
 
@@ -354,16 +354,16 @@ LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
                           const LLVMTypeConverter *typeConverter,
                           ConversionPatternRewriter &rewriter) {
   auto rankedTType = [](Value tensor) {
-    return tensor.getType().cast<RankedTensorType>();
+    return cast<RankedTensorType>(tensor.getType());
   };
 
-  assert(rankedTType(op.getA()).getEncoding().isa<DotOperandEncodingAttr>() &&
-         rankedTType(op.getB()).getEncoding().isa<DotOperandEncodingAttr>() &&
+  assert(isa<DotOperandEncodingAttr>(rankedTType(op.getA()).getEncoding()) &&
+         isa<DotOperandEncodingAttr>(rankedTType(op.getB()).getEncoding()) &&
          "Both $a and %b should be DotOperand layout.");
 
   auto cTensorTy = rankedTType(op.getC());
   auto dTensorTy = rankedTType(op.getD());
-  assert(cTensorTy.getEncoding().isa<AMDMfmaEncodingAttr>() &&
+  assert(isa<AMDMfmaEncodingAttr>(cTensorTy.getEncoding()) &&
          "Currently, we only support $c with a mfma layout.");
 
   assert(cTensorTy.getShape()[0] == dTensorTy.getShape()[0] &&
@@ -371,11 +371,8 @@ LogicalResult convertMFMA(triton::DotOp op, triton::DotOp::Adaptor adaptor,
          "DotOp's $c operand should pass the same number of values as $d");
 
   auto loc = op.getLoc();
-  auto mfmaLayout = op.getResult()
-                        .getType()
-                        .cast<RankedTensorType>()
-                        .getEncoding()
-                        .cast<AMDMfmaEncodingAttr>();
+  auto mfmaLayout = cast<AMDMfmaEncodingAttr>(
+      cast<RankedTensorType>(op.getResult().getType()).getEncoding());
 
   DotOpMFMAConversionHelper helper(mfmaLayout, rewriter, typeConverter, loc);
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -17,7 +17,7 @@ namespace {
 // Used to mask out the redundant data accessed by threads.
 Value redundantDataMask(Type valueTy, ConversionPatternRewriter &rewriter,
                         Location loc, const AMD::TargetInfo &targetInfo) {
-  auto tensorTy = valueTy.dyn_cast<RankedTensorType>();
+  auto tensorTy = dyn_cast<RankedTensorType>(valueTy);
   Value mask = int_val(1, 1);
   auto tid = tid_val();
   auto clusterCTAId = targetInfo.getClusterCTAId(rewriter, loc);
@@ -93,14 +93,14 @@ struct LoadStoreConversionBase {
       : targetInfo(targetInfo), axisAnalysisPass(axisAnalysisPass) {}
 
   unsigned getContiguity(Value ptr) const {
-    auto tensorTy = ptr.getType().dyn_cast<RankedTensorType>();
+    auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
     if (!tensorTy)
       return 1;
     return axisAnalysisPass.getPtrContiguity(ptr);
   }
 
   unsigned getVectorSize(Value ptr) const {
-    auto tensorTy = ptr.getType().dyn_cast<RankedTensorType>();
+    auto tensorTy = dyn_cast<RankedTensorType>(ptr.getType());
     if (!tensorTy)
       return 1;
     auto contiguity = getContiguity(ptr);
@@ -173,9 +173,9 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
     bool otherIsSplatConstInt = false;
     DenseElementsAttr constAttr;
     int64_t splatVal = 0;
-    if (other && valueElemTy.isa<IntegerType>() &&
+    if (other && isa<IntegerType>(valueElemTy) &&
         matchPattern(other, m_Constant(&constAttr)) && constAttr.isSplat() &&
-        constAttr.getElementType().isa<IntegerType>()) {
+        isa<IntegerType>(constAttr.getElementType())) {
       otherIsSplatConstInt = true;
       splatVal = constAttr.getSplatValue<APInt>().getSExtValue();
     }
@@ -208,7 +208,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
 
       mlir::Attribute zeroAttr = rewriter.getZeroAttr(valueElemTy);
       auto denseValue =
-          DenseElementsAttr::get(vecTy.cast<mlir::ShapedType>(), zeroAttr);
+          DenseElementsAttr::get(cast<mlir::ShapedType>(vecTy), zeroAttr);
       Value zeroVal = rewriter.create<LLVM::ConstantOp>(loc, vecTy, denseValue);
 
       Value falseVal = zeroVal;
@@ -392,7 +392,7 @@ struct AtomicCASOpConversion
 
     // deal with tensor or scalar
     auto valueTy = op.getResult().getType();
-    auto TensorTy = valueTy.dyn_cast<RankedTensorType>();
+    auto TensorTy = dyn_cast<RankedTensorType>(valueTy);
     Type valueElemTy =
         TensorTy ? getTypeConverter()->convertType(TensorTy.getElementType())
                  : valueTy;
@@ -402,7 +402,7 @@ struct AtomicCASOpConversion
     auto vec = getVectorSize(op.getPtr());
     // tensor
     if (TensorTy) {
-      auto valTy = op.getVal().getType().cast<RankedTensorType>();
+      auto valTy = cast<RankedTensorType>(op.getVal().getType());
       vec = std::min<unsigned>(vec, valTy.getElementType().isF16() ? 2 : 1);
     }
 
@@ -556,7 +556,7 @@ struct AtomicRMWOpConversion
       maskElements = unpackLLElements(loc, llMask, rewriter);
 
     Value opResult = op.getResult();
-    auto tensorTy = opResult.getType().dyn_cast<RankedTensorType>();
+    auto tensorTy = dyn_cast<RankedTensorType>(opResult.getType());
     Type valueElemTy =
         tensorTy ? getTypeConverter()->convertType(tensorTy.getElementType())
                  : opResult.getType();
@@ -567,7 +567,7 @@ struct AtomicRMWOpConversion
     int numElems = 1;
     // tensor
     if (tensorTy) {
-      auto valTy = val.getType().cast<RankedTensorType>();
+      auto valTy = cast<RankedTensorType>(val.getType());
       vec = std::min<unsigned>(vec, valTy.getElementType().isF16() ? 2 : 1);
       // mask
       numElems = tensorTy.getNumElements();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -96,7 +96,7 @@ struct ConvertTritonAMDGPUToLLVM
     // in a way that isn't reflected in triton_gpu.num-warps.  If so, we have to
     // respect that here.
     if (Attribute attr = mod->getAttr("triton_gpu.num-warp-groups-per-cta")) {
-      numWarps *= attr.cast<IntegerAttr>().getInt();
+      numWarps *= cast<IntegerAttr>(attr).getInt();
     }
 
     // Allocate shared memory and set barrier

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -24,7 +24,7 @@ std::string getTypeString(Type ty) {
 }
 
 std::string mangleFunc(std::string name, Type type) {
-  auto funcType = type.dyn_cast<LLVM::LLVMFunctionType>();
+  auto funcType = dyn_cast<LLVM::LLVMFunctionType>(type);
   assert(funcType && "Expecting an LLVMFunctionType");
   std::string mangled = name + "_";
   auto retTy = funcType.getReturnType();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -134,7 +134,7 @@ Value convertAndCastTensor(mlir::PatternRewriter &rewriter, Value value,
   assert(newElemType.isIntOrFloat());
 
   auto loc = value.getLoc();
-  auto oldType = value.getType().cast<RankedTensorType>();
+  auto oldType = cast<RankedTensorType>(value.getType());
   auto oldElemType = oldType.getElementType();
 
   assert(oldElemType.isIntOrFloat());
@@ -234,12 +234,12 @@ public:
   chooseMfmaDimensions(tt::DotOp dot) const {
     // number of matrix elements along k dim per one MFMA intruction
     unsigned kDim = 0;
-    auto opType = dot.getA().getType().cast<RankedTensorType>();
+    auto opType = cast<RankedTensorType>(dot.getA().getType());
     auto dataTypeA = opType.getElementType();
     auto dataTypeB =
-        dot.getB().getType().cast<RankedTensorType>().getElementType();
+        cast<RankedTensorType>(dot.getB().getType()).getElementType();
 
-    auto resType = dot.getD().getType().cast<RankedTensorType>();
+    auto resType = cast<RankedTensorType>(dot.getD().getType());
     auto resShape = resType.getShape();
     auto rank = resShape.size();
     auto M = resShape[rank - 2];
@@ -299,7 +299,7 @@ public:
 
     RankedTensorType oldRetType = dotOp.getType();
     if (!oldRetType.getEncoding() ||
-        !oldRetType.getEncoding().isa<ttg::BlockedEncodingAttr>())
+        !isa<ttg::BlockedEncodingAttr>(oldRetType.getEncoding()))
       return failure();
 
     if (!supportMFMA(dotOp))
@@ -315,8 +315,8 @@ public:
     // operands
     Value a = dotOp.getA();
     Value b = dotOp.getB();
-    auto oldAType = a.getType().cast<RankedTensorType>();
-    auto oldBType = b.getType().cast<RankedTensorType>();
+    auto oldAType = cast<RankedTensorType>(a.getType());
+    auto oldBType = cast<RankedTensorType>(b.getType());
     auto ctx = oldAType.getContext();
 
     ttg::AMDMfmaEncodingAttr mfmaEnc;
@@ -405,9 +405,8 @@ public:
 };
 static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
                             Type promotedType) {
-  Type tensorPromotedType =
-      operand.getType().cast<RankedTensorType>().cloneWith(std::nullopt,
-                                                           promotedType);
+  Type tensorPromotedType = cast<RankedTensorType>(operand.getType())
+                                .cloneWith(std::nullopt, promotedType);
   return builder.create<triton::FpToFpOp>(loc, tensorPromotedType, operand);
 }
 
@@ -419,7 +418,7 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
     OpBuilder builder(dotOp);
     Type AElType = dotOp.getA().getType().getElementType();
     Type promoteType;
-    if (D.getType().getEncoding().isa<AMDMfmaEncodingAttr>()) {
+    if (isa<AMDMfmaEncodingAttr>(D.getType().getEncoding())) {
       Type BElType = dotOp.getB().getType().getElementType();
 
       auto maxBitWidth = std::max(AElType.getIntOrFloatBitWidth(),
@@ -436,7 +435,7 @@ static void decomposeMixedModeDotOp(ModuleOp mod) {
         promoteType = builder.getF16Type();
       else if (maxBitWidth <= 32)
         promoteType = builder.getF32Type();
-    } else if (D.getType().getEncoding().isa<AMDWmmaEncodingAttr>()) {
+    } else if (isa<AMDWmmaEncodingAttr>(D.getType().getEncoding())) {
       Type BElType = dotOp.getB().getType().getElementType();
 
       if (AElType == BElType)
@@ -473,9 +472,9 @@ public:
                   mlir::PatternRewriter &rewriter) const override {
     auto dotOp = cast<tt::DotOp>(op);
 
-    auto oldRetType = dotOp.getResult().getType().cast<RankedTensorType>();
+    auto oldRetType = cast<RankedTensorType>(dotOp.getResult().getType());
     if (!oldRetType.getEncoding() ||
-        !oldRetType.getEncoding().isa<ttg::BlockedEncodingAttr>())
+        !isa<ttg::BlockedEncodingAttr>(oldRetType.getEncoding()))
       return failure();
 
     // TODO: Support different operand types
@@ -490,8 +489,8 @@ public:
     // operands
     Value a = dotOp.getA();
     Value b = dotOp.getB();
-    auto oldAType = a.getType().cast<RankedTensorType>();
-    auto oldBType = b.getType().cast<RankedTensorType>();
+    auto oldAType = cast<RankedTensorType>(a.getType());
+    auto oldBType = cast<RankedTensorType>(b.getType());
     auto ctx = oldAType.getContext();
 
     AMDWmmaEncodingAttr wmmaEnc;
@@ -511,7 +510,7 @@ public:
     auto aElemType = oldAType.getElementType();
     if (oldRetElemType.isIntOrIndex())
       wmmaAccType = rewriter.getIntegerType(32);
-    else if (oldRetElemType.isa<mlir::Float16Type, mlir::BFloat16Type>() &&
+    else if (isa<mlir::Float16Type, mlir::BFloat16Type>(oldRetElemType) &&
              aElemType == oldRetElemType)
       wmmaAccType = oldRetElemType;
     else

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -29,7 +29,7 @@ static bool willIncreaseRegisterPressure(Operation *op) {
   auto cvt = dyn_cast<triton::gpu::ConvertLayoutOp>(op);
   if (!cvt)
     return false;
-  if (cvt.getType().getEncoding().isa<triton::gpu::DotOperandEncodingAttr>())
+  if (isa<triton::gpu::DotOperandEncodingAttr>(cvt.getType().getEncoding()))
     return true;
   return false;
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -50,9 +50,8 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
     unsigned K = AShapePerCTA[reduceAxis];
     bool isOuter = K == 1;
 
-    NvidiaMmaEncodingAttr mmaLayout = cast<RankedTensorType>(D.getType())
-                                          .getEncoding()
-                                          .dyn_cast<NvidiaMmaEncodingAttr>();
+    NvidiaMmaEncodingAttr mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(
+        cast<RankedTensorType>(D.getType()).getEncoding());
     if (!isOuter && mmaLayout && supportMMA(op, mmaLayout.getVersionMajor())) {
       if (mmaLayout.isVolta())
         return convertMMA884(op, adaptor, getTypeConverter(), rewriter);
@@ -68,9 +67,8 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
           "Unsupported MMA kind found when converting DotOp to LLVM.");
     }
 
-    if (cast<RankedTensorType>(D.getType())
-            .getEncoding()
-            .isa<BlockedEncodingAttr>())
+    if (isa<BlockedEncodingAttr>(
+            cast<RankedTensorType>(D.getType()).getEncoding()))
       return convertFMADot(op, adaptor, getTypeConverter(), rewriter);
 
     llvm::report_fatal_error(
@@ -97,9 +95,8 @@ struct DotAsyncOpConversion
     unsigned K = AShapePerCTA[reduceAxis];
     bool isOuter = K == 1;
 
-    NvidiaMmaEncodingAttr mmaLayout = cast<RankedTensorType>(D.getType())
-                                          .getEncoding()
-                                          .dyn_cast<NvidiaMmaEncodingAttr>();
+    NvidiaMmaEncodingAttr mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(
+        cast<RankedTensorType>(D.getType()).getEncoding());
     if (!isOuter && mmaLayout &&
         supportMMA(op.getOperand(0), mmaLayout.getVersionMajor())) {
       if (mmaLayout.isHopper()) {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv1.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv1.cpp
@@ -45,15 +45,12 @@ LogicalResult convertMMA884(triton::DotOp op, triton::DotOp::Adaptor adaptor,
   Value A = op.getA();
   Value B = op.getB();
   Value D = op.getResult();
-  auto mmaLayout = cast<RankedTensorType>(D.getType())
-                       .getEncoding()
-                       .cast<NvidiaMmaEncodingAttr>();
-  auto ALayout = cast<RankedTensorType>(A.getType())
-                     .getEncoding()
-                     .cast<DotOperandEncodingAttr>();
-  auto BLayout = cast<RankedTensorType>(B.getType())
-                     .getEncoding()
-                     .cast<DotOperandEncodingAttr>();
+  auto mmaLayout = cast<NvidiaMmaEncodingAttr>(
+      cast<RankedTensorType>(D.getType()).getEncoding());
+  auto ALayout = cast<DotOperandEncodingAttr>(
+      cast<RankedTensorType>(A.getType()).getEncoding());
+  auto BLayout = cast<DotOperandEncodingAttr>(
+      cast<RankedTensorType>(B.getType()).getEncoding());
 
   auto ATensorTy = cast<RankedTensorType>(A.getType());
   auto BTensorTy = cast<RankedTensorType>(B.getType());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -1,9 +1,8 @@
-#include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
-
 #include "PatternTritonGPUOpToLLVM.h"
-#include "Utility.h"
-
 #include "TargetInfo.h"
+#include "TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
+#include "Utility.h"
+#include "mlir/Support/LLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 
@@ -798,8 +797,8 @@ struct ClampFOpConversion
 
     auto getSplatInitializer = [](Value v) -> std::optional<double> {
       if (auto constOp = v.getDefiningOp<arith::ConstantOp>()) {
-        if (auto attr =
-                constOp.getValueAttr().dyn_cast<DenseIntOrFPElementsAttr>()) {
+        if (auto attr = mlir::dyn_cast<DenseIntOrFPElementsAttr>(
+                constOp.getValueAttr())) {
           if (attr.isSplat()) {
             return attr.getSplatValue<APFloat>().convertToDouble();
           }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -778,9 +778,9 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto dstTy = op.getResult().getType();
     auto resElemTy = getTypeConverter()->convertType(dstTy.getElementType());
     auto srcLayout = srcTy.getEncoding();
-    assert((srcLayout.isa<BlockedEncodingAttr, SliceEncodingAttr>() &&
+    assert((isa<BlockedEncodingAttr, SliceEncodingAttr>(srcLayout) &&
             "Unexpected srcLayout in AsyncCopyGlobalToLocalOpConversion"));
-    auto resSharedLayout = dstTy.getEncoding().cast<SharedEncodingAttr>();
+    auto resSharedLayout = cast<SharedEncodingAttr>(dstTy.getEncoding());
     auto srcShape = srcTy.getShape();
     assert((srcShape.size() <= 3) &&
            "insert_slice_async: Unexpected rank of %src");

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -53,7 +53,7 @@ void storeDistributedToSharedWithStMatrix(
     ArrayRef<unsigned> origRepShape, Location loc,
     ConversionPatternRewriter &rewriter) {
   auto shapePerCTA = getShapePerCTA(tensorTy);
-  auto mmaLayout = tensorTy.getEncoding().cast<NvidiaMmaEncodingAttr>();
+  auto mmaLayout = mlir::cast<NvidiaMmaEncodingAttr>(tensorTy.getEncoding());
   auto order = triton::gpu::getOrder(mmaLayout);
   auto warpsPerCTA = mmaLayout.getWarpsPerCTA();
   auto shapePerCTATile = getShapePerCTATile(mmaLayout);
@@ -101,7 +101,8 @@ void storeDistributedToSharedWithStMatrix(
 }
 
 bool isStMatrixCompatible(RankedTensorType tensorTy) {
-  auto mmaLayout = tensorTy.getEncoding().dyn_cast<NvidiaMmaEncodingAttr>();
+  auto mmaLayout =
+      mlir::dyn_cast<NvidiaMmaEncodingAttr>(tensorTy.getEncoding());
   if (!mmaLayout || !mmaLayout.isHopper())
     return false;
   if (tensorTy.getElementType().getIntOrFloatBitWidth() != 16)

--- a/unittest/Conversion/TritonGPUToLLVM/DumpLayout.cpp
+++ b/unittest/Conversion/TritonGPUToLLVM/DumpLayout.cpp
@@ -164,7 +164,7 @@ int eval(Value value, int ctaid, int tid) {
   assert(op && "Unrecognized source value in the index expression");
   if (auto constantOp = llvm::dyn_cast<mlir::LLVM::ConstantOp>(op)) {
     auto attr = constantOp.getValue();
-    return attr.cast<mlir::IntegerAttr>().getInt();
+    return mlir::cast<mlir::IntegerAttr>(attr).getInt();
   } else if (auto addOp = llvm::dyn_cast<mlir::LLVM::AddOp>(op)) {
     return eval(addOp.getLhs(), ctaid, tid) + eval(addOp.getRhs(), ctaid, tid);
   } else if (auto mulOp = llvm::dyn_cast<mlir::LLVM::MulOp>(op)) {
@@ -323,7 +323,7 @@ std::string dumpSharedLayout(Attribute layout, llvm::ArrayRef<int64_t> shape,
   if (!multiCTA)
     assert(numCTAs == 1 && "numCTAs must be 1 when multiCTA is false");
 
-  auto sharedLayout = layout.cast<SharedEncodingAttr>();
+  auto sharedLayout = mlir::cast<SharedEncodingAttr>(layout);
   auto blockedLayout = BlockedEncodingAttr::get(
       /*context=*/layout.getContext(), /*shape=*/shape,
       /*sizePerThread=*/{1, 1}, /*order=*/sharedLayout.getOrder(),

--- a/unittest/Dialect/TritonGPU/DialectTest.cpp
+++ b/unittest/Dialect/TritonGPU/DialectTest.cpp
@@ -299,11 +299,11 @@ void testReshape(RankedTensorType srcTy, RankedTensorType dstTy,
 
   std::vector<std::unique_ptr<MultiIdx>> srcMultiIdxs =
       getMultiIdxs(SmallVector<unsigned>(srcTy.getShape()),
-                   srcTy.getEncoding().cast<BlockedEncodingAttr>());
+                   mlir::cast<BlockedEncodingAttr>(srcTy.getEncoding()));
 
   std::vector<std::unique_ptr<MultiIdx>> dstMultiIdxs =
       getMultiIdxs(SmallVector<unsigned>(dstTy.getShape()),
-                   inferredEnc.cast<BlockedEncodingAttr>());
+                   mlir::cast<BlockedEncodingAttr>(inferredEnc));
 
   if (srcMultiIdxs.size() != dstMultiIdxs.size() ||
       !llvm::all_of(llvm::zip_equal(srcMultiIdxs, dstMultiIdxs),
@@ -346,7 +346,7 @@ TEST_P(InferReshapeOpNoReorderEncodingTest, DoIt) {
 
   std::optional<BlockedEncodingAttr> expectedDstEnc;
   if (auto dstEnc = cast<RankedTensorType>(dst).getEncoding()) {
-    expectedDstEnc = dstEnc.cast<BlockedEncodingAttr>();
+    expectedDstEnc = cast<BlockedEncodingAttr>(dstEnc);
   }
 
   testReshape(cast<RankedTensorType>(src), cast<RankedTensorType>(dst),


### PR DESCRIPTION
Removes calls to `isa/cast/dyn_cast/...` member functions which have been deprecated in https://github.com/llvm/llvm-project/commit/7ac1fb01e9b70d09e6c4f39414bcd7c93787ef91 as per this [discussion](https://discourse.llvm.org/t/preferred-casting-style-going-forward/68443).