### PR TITLE
[Proton] Make `inline static thread_local` variable non-inline.

### DIFF
--- a/third_party/proton/csrc/include/Context/Context.h
+++ b/third_party/proton/csrc/include/Context/Context.h
@@ -38,6 +38,7 @@ public:
 struct Scope : public Context {
   const static size_t DummyScopeId = std::numeric_limits<size_t>::max();
   static std::atomic<size_t> scopeIdCounter;
+
   static size_t getNewScopeId() { return scopeIdCounter++; }
 
   size_t scopeId{};
@@ -122,8 +123,8 @@ protected:
   }
 
 private:
-  inline const static int MAX_CACHE_OBJECTS = 10;
-  inline static thread_local std::map<InternalOpInterface *, bool> opInProgress;
+  inline static const int MAX_CACHE_OBJECTS = 10;
+  static thread_local std::map<InternalOpInterface *, bool> opInProgress;
 };
 
 } // namespace proton

--- a/third_party/proton/csrc/lib/Context/Context.cpp
+++ b/third_party/proton/csrc/lib/Context/Context.cpp
@@ -4,4 +4,7 @@ namespace proton {
 
 std::atomic<size_t> Scope::scopeIdCounter{1};
 
+/*static*/ thread_local std::map<InternalOpInterface *, bool>
+    InternalOpInterface::opInProgress;
+
 } // namespace proton


### PR DESCRIPTION
For some reason this was causing duplicate-definition errors for me when I
built with DEBUG=1 on macos.  Just move the variable to be out-of-line.
