### PR TITLE
[DEBUG] Add TRITON_ALWAYS_COMPILE to force compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ For detailed instructions on how to debug Triton's frontend, please refer to thi
   `DISABLE_LLVM_OPT="disable-lsr"`
   Loop strength reduction is known to cause up to 10% performance changes for
   certain kernels with register pressure.
+- `TRITON_ALWAYS_COMPILE=1` forces to compile kernels regardless of cache hit.
 
 # Changelog
 

--- a/python/triton/compiler/compiler.py
+++ b/python/triton/compiler/compiler.py
@@ -249,7 +249,8 @@ def compile(src, target=None, options=None):
     metadata_filename = f"{src.name}.json"
     metadata_group = fn_cache_manager.get_group(metadata_filename) or {}
     metadata_path = metadata_group.get(metadata_filename)
-    if metadata_path is not None:
+    always_compile = os.environ.get("TRITON_ALWAYS_COMPILE", "0") == "1"
+    if not always_compile and metadata_path is not None:
         # cache hit!
         metadata = json.loads(Path(metadata_path).read_text())
         return CompiledKernel(src, metadata_group, hash)


### PR DESCRIPTION
When you work on the triton compiler itself, you'd want to compile kernels always. So far, we had to remove `$TRITON_CACHE_DIR` or the default triton cache directory. This PR introduces a quick environment variable that forces to kernel compilation always, regardless of cache hit.

```
TRITON_ALWAYS_COMPILE=1 python3 tutorials/01-vector-add.py
```