### PR TITLE
fix binary released version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You can install the latest stable release of Triton from pip:
 ```bash
 pip install triton
 ```
-Binary wheels are available for CPython 3.8-3.12 and PyPy 3.8-3.9.
+Binary wheels are available for CPython 3.8-3.12 and PyPi 3.8-3.10.
 
 And the latest nightly release:
 


### PR DESCRIPTION
This PR:
1. fixes a typo `s/Pypy/PyPi`
2. raises the max version to 3.10 - not sure if there is even higher, but 3.10 is definitely there:
```
pip install triton -U
Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com
Requirement already satisfied: triton in /mnt/nvme0/anaconda3/envs/py310-pt22/lib/python3.10/site-packages (2.2.0)
Collecting triton
  Downloading triton-2.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (1.4 kB)
Requirement already satisfied: filelock in /mnt/nvme0/anaconda3/envs/py310-pt22/lib/python3.10/site-packages (from triton) (3.13.1)
Downloading triton-2.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (168.1 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 168.1/168.1 MB 2.3 MB/s eta 0:00:00
Installing collected packages: triton
  Attempting uninstall: triton
    Found existing installation: triton 2.2.0
    Uninstalling triton-2.2.0:
      Successfully uninstalled triton-2.2.0
Successfully installed triton-2.3.0
```