### PR TITLE
Using elect to make ptx realize TMA copies are uniform

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -926,6 +926,10 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto id = getThreadId(rewriter, loc);
     Value pred = icmp_eq(id, i32_val(0));
     pred = and_(pred, adaptor.getPred());
+    // Select just one thread for the TMA copy. This also helps the compiler to
+    // figure out that the op is uniform.
+    pred = and_(pred, LLVM::NVIDIA::createElectPredicate(loc, rewriter));
+
     int elementSizeInBytes =
         op.getResult().getType().getElementType().getIntOrFloatBitWidth() / 8;
     int totalNumElements = product(op.getResult().getType().getShape());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -190,6 +190,14 @@ void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
   createStoreDSmem(loc, rewriter, addr, ctaId, values, pred);
 }
 
+/// Create a predicate with just single active thread.
+Value createElectPredicate(Location loc, PatternRewriter &rewriter) {
+  PTXBuilder ptxBuilder;
+  auto &elect = *ptxBuilder.create<>("elect.sync _|$0, 0xffffffff;");
+  elect({ptxBuilder.newOperand("=b")}, /*onlyAttachMLIRArgs=*/true);
+  return ptxBuilder.launch(rewriter, loc, i1_ty);
+}
+
 } // namespace NVIDIA
 } // namespace LLVM
 } // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -77,6 +77,9 @@ void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
 void createStoreDSmem(Location loc, PatternRewriter &rewriter, Value addr,
                       Value ctaId, ArrayRef<Value> values);
 
+/// Create a predicate with just single active thread.
+Value createElectPredicate(Location loc, PatternRewriter &rewriter);
+
 } // namespace NVIDIA
 } // namespace LLVM
 


### PR DESCRIPTION
Even though we are using 1D blocks so our threadId.x is uniform, ptxas emits a loop around `cp.async.bulk.tensor` predicated with `threadId.x == 0` as it fails to recognize that predicate will be uniform. To avoid that, we `and` the predicate with a result of an `elect.sync` instruction that returns single active channel, and forces the instruction to be recognized as uniform. 