### PR TITLE
[BACKEND][PIPELINE] Do not add root users of loads that we won't pipeline to the coarse schedule.

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MatmulLoopPipeline.cpp
@@ -712,6 +712,8 @@ scheduleLoads(scf::ForOp forOp, CoarseSchedule &schedule,
   CoarseSchedule::Cluster rootUsersCluster = schedule.clusters.newAtFront();
   // Put the root uses of the loads in the last stage.
   for (auto &[loadOp, dist, use] : loadOpToIndLevelAndUse) {
+    if (loadToInfo.count(loadOp) == 0)
+      continue;
     // Non-LoadOp(s) are the root uses of all LoadOp(s) and should be
     // always present in the opInfo
     if (!isa<tt::LoadOp>(use)) {


### PR DESCRIPTION
`IfOp` pipelining PR changed the logic around selecting which ops to pipeline to separate `LoadOp` discovery and selecting which of them to pipeline. What I have missed in that PR is that now we need to make sure that we don't leave root users of `loads` that don't make the cut in the coarse schedule, as this may result in incorrect schedule.