### PR TITLE
[BACKEND] Invalidate mbarrier after their last use.

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -123,6 +123,22 @@ def TTNG_InitBarrierOp : TTNG_Op<"init_barrier", [MemoryEffects<[MemWrite<Shared
     let assemblyFormat = "$alloc `,` $count attr-dict `:` type($alloc)";
 }
 
+def TTNG_InvalBarrierOp : TTNG_Op<"inval_barrier", [MemoryEffects<[MemWrite<SharedMemory>]>]> {
+    let summary = "Invalidate a barrier allocation.";
+
+    let description = [{
+      Invalidate a barrier allocation so that it can be re-used. According to PTX
+      spec this has to be done before any re-use of the memory used by mbarrier.
+
+      https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-inval
+    }];
+
+    let hasVerifier = 1;
+    let arguments = (ins TT_MemDescType:$alloc);
+    let assemblyFormat = "$alloc attr-dict `:` type($alloc)";
+}
+
+
 def TTNG_WaitBarrierOp : TTNG_Op<"wait_barrier", []> {
     let summary = "wait until the mbarrier phase completes.";
 

--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -83,6 +83,13 @@ LogicalResult InitBarrierOp::verify() {
   return success();
 }
 
+// -- InvalBarrierOp --
+LogicalResult InvalBarrierOp::verify() {
+  if (failed(verifyBarrierType(*this, getAlloc().getType())))
+    return failure();
+  return success();
+}
+
 // -- WaitBarrierOp --
 LogicalResult WaitBarrierOp::verify() {
   if (failed(verifyBarrierType(*this, getAlloc().getType())))

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TMALowering.cpp
@@ -53,6 +53,7 @@ public:
         loc, op.getDescPtr(), op.getIndices(), barrierAlloc, alloc, pred);
     Value phase = rewriter.create<arith::ConstantIntOp>(loc, 0, 32);
     rewriter.create<WaitBarrierOp>(loc, barrierAlloc, phase);
+    rewriter.create<InvalBarrierOp>(loc, barrierAlloc);
     rewriter.replaceOpWithNewOp<LocalLoadOp>(op, op.getType(), alloc);
     return success();
   }

--- a/python/test/unit/hopper/test_experimental_tma.py
+++ b/python/test/unit/hopper/test_experimental_tma.py
@@ -118,7 +118,7 @@ def test_experimental_tma_matmul(num_stages):
     desc_b = torch.tensor(desc_b, device=device)
     desc_c = torch.tensor(desc_c, device=device)
     matmul_kernel_tma[(triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N), 1, 1)](desc_a, desc_b, desc_c, M, N, K,
-                                                                                 BLOCK_M, BLOCK_N, BLOCK_K, num_warps=4,
+                                                                                 BLOCK_M, BLOCK_N, BLOCK_K, num_warps=8,
                                                                                  num_stages=num_stages)
     ref_out = torch.matmul(A.to(torch.float32), B.to(torch.float32))
     torch.testing.assert_close(ref_out, C, rtol=1e-3, atol=1e-3)

--- a/test/TritonNvidiaGPU/tma_lowering.mlir
+++ b/test/TritonNvidiaGPU/tma_lowering.mlir
@@ -1,5 +1,22 @@
 // RUN: triton-opt %s -split-input-file --triton-nvidia-tma-lowering | FileCheck %s
 
+#blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {
+// CHECK-LABEL: tma_load
+// CHECK: triton_gpu.local_alloc  : ()
+// CHECK: triton_gpu.local_alloc  : ()
+// CHECK: triton_nvidia_gpu.init_barrier
+// CHECK: triton_nvidia_gpu.async_tma_copy_global_to_local
+// CHECK: triton_nvidia_gpu.wait_barrier
+// CHECK: triton_nvidia_gpu.inval_barrier
+// CHECK: triton_gpu.local_load
+  tt.func public @tma_load(%arg0: !tt.ptr<i8>, %arg1: i32) -> tensor<128x64xf16, #blocked> {
+    %l = tt.experimental_descriptor_load %arg0[%arg1, %arg1] : !tt.ptr<i8> -> tensor<128x64xf16, #blocked>
+    tt.return %l : tensor<128x64xf16, #blocked>
+  }
+}
+
+// -----
 
 #blocked = #triton_gpu.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
 module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 : i32, triton_gpu.target = "cuda:90", "triton_gpu.threads-per-warp" = 32 : i32} {

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -99,6 +99,34 @@ struct InitBarrierOpConversion
   }
 };
 
+struct InvalBarrierOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::InvalBarrierOp> {
+  using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(triton::nvidia_gpu::InvalBarrierOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op->getLoc();
+    auto smemObj = LLVM::getSharedMemoryObjectFromStruct(
+        loc, adaptor.getAlloc(),
+        typeConverter->convertType(op.getAlloc().getType().getElementType()),
+        rewriter);
+
+    auto id = getThreadId(rewriter, loc);
+    Value pred = icmp_eq(id, i32_val(0));
+    ::mlir::triton::PTXBuilder ptxBuilder;
+    const std::string ptx = "@$0 mbarrier.inval.shared::cta.b64 [$1];";
+    auto &barSyncOp = *ptxBuilder.create<>(ptx);
+    barSyncOp({ptxBuilder.newOperand(pred, "b"),
+               ptxBuilder.newOperand(smemObj.getBase(), "r")},
+              /*onlyAttachMLIRArgs=*/true);
+    auto voidTy = void_ty(op->getContext());
+    ptxBuilder.launch(rewriter, loc, voidTy);
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 struct WaitBarrierOpConversion
     : public ConvertOpToLLVMPattern<triton::nvidia_gpu::WaitBarrierOp> {
   using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;
@@ -137,6 +165,7 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
     PatternBenefit benefit) {
   patterns.add<BarrierOpConversion>(typeConverter, benefit);
   patterns.add<FenceAsyncSharedOpConversion>(typeConverter, benefit);
-  patterns.add<InitBarrierOpConversion>(typeConverter, benefit);
+  patterns.add<InitBarrierOpConversion, InvalBarrierOpConversion>(typeConverter,
+                                                                  benefit);
   patterns.add<WaitBarrierOpConversion>(typeConverter, benefit);
 }


### PR DESCRIPTION
According to PTX spec this is needed before the shared memory can be re-used. This is suspected to be causing sporadic memory corruptions.