### PR TITLE
[PROTON] Fix libcuda symbol look up problem on WSL

### DIFF
--- a/third_party/proton/csrc/include/Driver/Dispatch.h
+++ b/third_party/proton/csrc/include/Driver/Dispatch.h
@@ -58,7 +58,12 @@ public:
 
   static void init(const char *name, void **lib) {
     if (*lib == nullptr) {
-      *lib = dlopen(name, RTLD_LAZY);
+      // First reuse the existing handle
+      *lib = dlopen(name, RTLD_NOLOAD);
+    }
+    if (*lib == nullptr) {
+      // If not found, try to load it
+      *lib = dlopen(name, RTLD_LOCAL | RTLD_LAZY);
     }
     if (*lib == nullptr) {
       throw std::runtime_error("Could not find `" + std::string(name) +

--- a/third_party/proton/csrc/lib/Driver/GPU/Cuda.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/Cuda.cpp
@@ -8,8 +8,8 @@ namespace cuda {
 struct ExternLibCuda : public ExternLibBase {
   using RetType = CUresult;
   // https://forums.developer.nvidia.com/t/wsl2-libcuda-so-and-libcuda-so-1-should-be-symlink/236301
-  // "libcuda.so" and "libcuda.so.1" are not linked, so we use "libcuda.so.1"
-  // instead.
+  // On WSL, "libcuda.so" and "libcuda.so.1" may not be linked, so we use
+  // "libcuda.so.1" instead.
   static constexpr const char *name = "libcuda.so.1";
   static constexpr RetType success = CUDA_SUCCESS;
   static void *lib;

--- a/third_party/proton/csrc/lib/Driver/GPU/Cuda.cpp
+++ b/third_party/proton/csrc/lib/Driver/GPU/Cuda.cpp
@@ -7,7 +7,10 @@ namespace cuda {
 
 struct ExternLibCuda : public ExternLibBase {
   using RetType = CUresult;
-  static constexpr const char *name = "libcuda.so";
+  // https://forums.developer.nvidia.com/t/wsl2-libcuda-so-and-libcuda-so-1-should-be-symlink/236301
+  // "libcuda.so" and "libcuda.so.1" are not linked, so we use "libcuda.so.1"
+  // instead.
+  static constexpr const char *name = "libcuda.so.1";
   static constexpr RetType success = CUDA_SUCCESS;
   static void *lib;
 };

--- a/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
@@ -96,7 +96,9 @@ void CuptiProfiler::doStart() {
 
 void CuptiProfiler::doFlush() {
   CUcontext cuContext = nullptr;
-  cuda::ctxGetCurrent<true>(&cuContext);
+  // If the device is not initialized, cuda::ctxGetCurrent will fail.
+  // So we don't throw an error here, but instead just skip the synchronization.
+  cuda::ctxGetCurrent<false>(&cuContext);
   if (cuContext) {
     cuda::ctxSynchronize<true>();
   }

--- a/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
@@ -1,6 +1,7 @@
 #include "Profiler/CuptiProfiler.h"
 #include "Context/Context.h"
 #include "Data/Metric.h"
+#include "Driver/Device.h"
 #include "Driver/GPU/Cuda.h"
 #include "Driver/GPU/Cupti.h"
 
@@ -95,9 +96,9 @@ void CuptiProfiler::doStart() {
 }
 
 void CuptiProfiler::doFlush() {
-  CUcontext cu_context = nullptr;
-  cuda::ctxGetCurrent<false>(&cu_context);
-  if (cu_context) {
+  CUcontext cuContext = nullptr;
+  cuda::ctxGetCurrent<true>(&cuContext);
+  if (cuContext) {
     cuda::ctxSynchronize<true>();
   }
   cupti::activityFlushAll<true>(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED);

--- a/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
@@ -1,7 +1,6 @@
 #include "Profiler/CuptiProfiler.h"
 #include "Context/Context.h"
 #include "Data/Metric.h"
-#include "Driver/Device.h"
 #include "Driver/GPU/Cuda.h"
 #include "Driver/GPU/Cupti.h"
 


### PR DESCRIPTION
https://forums.developer.nvidia.com/t/wsl2-libcuda-so-and-libcuda-so-1-should-be-symlink/236301

On WSL, "libcuda.so" and "libcuda.so.1" may not be linked, so we use "libcuda.so.1" instead.