### PR TITLE
[PROTON] Support setting scope/op properties

### DIFF
--- a/third_party/proton/csrc/Proton.cpp
+++ b/third_party/proton/csrc/Proton.cpp
@@ -63,14 +63,14 @@ void initProton(pybind11::module &&m) {
         [](size_t scopeId,
            const std::map<std::string, MetricValueType> &metrics) {
           SessionManager::instance().addMetrics(scopeId, metrics,
-                                                /*aggregatable=*/true);
+                                                /*aggregable=*/true);
         });
 
   m.def("set_properties",
         [](size_t scopeId,
            const std::map<std::string, MetricValueType> &metrics) {
           SessionManager::instance().addMetrics(scopeId, metrics,
-                                                /*aggregatable=*/false);
+                                                /*aggregable=*/false);
         });
 
   m.def("device_info", [](int device_id) {

--- a/third_party/proton/csrc/Proton.cpp
+++ b/third_party/proton/csrc/Proton.cpp
@@ -62,7 +62,15 @@ void initProton(pybind11::module &&m) {
   m.def("add_metrics",
         [](size_t scopeId,
            const std::map<std::string, MetricValueType> &metrics) {
-          SessionManager::instance().addMetrics(scopeId, metrics);
+          SessionManager::instance().addMetrics(scopeId, metrics,
+                                                /*aggregatable=*/true);
+        });
+
+  m.def("set_properties",
+        [](size_t scopeId,
+           const std::map<std::string, MetricValueType> &metrics) {
+          SessionManager::instance().addMetrics(scopeId, metrics,
+                                                /*aggregatable=*/false);
         });
 
   m.def("device_info", [](int device_id) {

--- a/third_party/proton/csrc/include/Data/Data.h
+++ b/third_party/proton/csrc/include/Data/Data.h
@@ -24,9 +24,9 @@ public:
 
   /// Add multiple metrics to the data.
   /// [MT] The implementation must be thread-safe.
-  virtual void
-  addMetrics(size_t scopeId,
-             const std::map<std::string, MetricValueType> &metrics) = 0;
+  virtual void addMetrics(size_t scopeId,
+                          const std::map<std::string, MetricValueType> &metrics,
+                          bool aggregatable) = 0;
 
   /// Dump the data to the given output format.
   /// [MT] Thread-safe.

--- a/third_party/proton/csrc/include/Data/Data.h
+++ b/third_party/proton/csrc/include/Data/Data.h
@@ -26,7 +26,7 @@ public:
   /// [MT] The implementation must be thread-safe.
   virtual void addMetrics(size_t scopeId,
                           const std::map<std::string, MetricValueType> &metrics,
-                          bool aggregatable) = 0;
+                          bool aggregable) = 0;
 
   /// Dump the data to the given output format.
   /// [MT] Thread-safe.

--- a/third_party/proton/csrc/include/Data/TraceData.h
+++ b/third_party/proton/csrc/include/Data/TraceData.h
@@ -11,9 +11,9 @@ public:
 
   void addMetric(size_t scopeId, std::shared_ptr<Metric> metric) override;
 
-  void
-  addMetrics(size_t scopeId,
-             const std::map<std::string, MetricValueType> &metrics) override;
+  void addMetrics(size_t scopeId,
+                  const std::map<std::string, MetricValueType> &metrics,
+                  bool aggregatable) override;
 
 protected:
   void startOp(const Scope &scope) override final;

--- a/third_party/proton/csrc/include/Data/TraceData.h
+++ b/third_party/proton/csrc/include/Data/TraceData.h
@@ -13,7 +13,7 @@ public:
 
   void addMetrics(size_t scopeId,
                   const std::map<std::string, MetricValueType> &metrics,
-                  bool aggregatable) override;
+                  bool aggregable) override;
 
 protected:
   void startOp(const Scope &scope) override final;

--- a/third_party/proton/csrc/include/Data/TreeData.h
+++ b/third_party/proton/csrc/include/Data/TreeData.h
@@ -20,7 +20,7 @@ public:
 
   void addMetrics(size_t scopeId,
                   const std::map<std::string, MetricValueType> &metrics,
-                  bool aggregatable) override;
+                  bool aggregable) override;
 
 protected:
   // OpInterface

--- a/third_party/proton/csrc/include/Data/TreeData.h
+++ b/third_party/proton/csrc/include/Data/TreeData.h
@@ -18,9 +18,9 @@ public:
 
   void addMetric(size_t scopeId, std::shared_ptr<Metric> metric) override;
 
-  void
-  addMetrics(size_t scopeId,
-             const std::map<std::string, MetricValueType> &metrics) override;
+  void addMetrics(size_t scopeId,
+                  const std::map<std::string, MetricValueType> &metrics,
+                  bool aggregatable) override;
 
 protected:
   // OpInterface

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -89,7 +89,7 @@ public:
 
   void addMetrics(size_t scopeId,
                   const std::map<std::string, MetricValueType> &metrics,
-                  bool aggregatable);
+                  bool aggregable);
 
 private:
   std::unique_ptr<Session> makeSession(size_t id, const std::string &path,

--- a/third_party/proton/csrc/include/Session/Session.h
+++ b/third_party/proton/csrc/include/Session/Session.h
@@ -88,7 +88,8 @@ public:
   void exitOp(const Scope &scope);
 
   void addMetrics(size_t scopeId,
-                  const std::map<std::string, MetricValueType> &metrics);
+                  const std::map<std::string, MetricValueType> &metrics,
+                  bool aggregatable);
 
 private:
   std::unique_ptr<Session> makeSession(size_t id, const std::string &path,

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -15,7 +15,7 @@ void TraceData::addMetric(size_t scopeId, std::shared_ptr<Metric> metric) {
 
 void TraceData::addMetrics(
     size_t scopeId, const std::map<std::string, MetricValueType> &metrics,
-    bool aggregatable) {
+    bool aggregable) {
   throw NotImplemented();
 }
 

--- a/third_party/proton/csrc/lib/Data/TraceData.cpp
+++ b/third_party/proton/csrc/lib/Data/TraceData.cpp
@@ -14,7 +14,8 @@ void TraceData::addMetric(size_t scopeId, std::shared_ptr<Metric> metric) {
 }
 
 void TraceData::addMetrics(
-    size_t scopeId, const std::map<std::string, MetricValueType> &metrics) {
+    size_t scopeId, const std::map<std::string, MetricValueType> &metrics,
+    bool aggregatable) {
   throw NotImplemented();
 }
 

--- a/third_party/proton/csrc/lib/Data/TreeData.cpp
+++ b/third_party/proton/csrc/lib/Data/TreeData.cpp
@@ -44,7 +44,7 @@ void TreeData::addMetric(size_t scopeId, std::shared_ptr<Metric> metric) {
 
 void TreeData::addMetrics(size_t scopeId,
                           const std::map<std::string, MetricValueType> &metrics,
-                          bool aggregatable) {
+                          bool aggregable) {
   std::unique_lock<std::shared_mutex> lock(mutex);
   auto scopeIdIt = scopeIdToContextId.find(scopeId);
   auto contextId = Tree::TreeNode::DummyId;
@@ -61,7 +61,7 @@ void TreeData::addMetrics(size_t scopeId,
   for (auto [metricName, metricValue] : metrics) {
     if (node.flexibleMetrics.find(metricName) == node.flexibleMetrics.end())
       node.flexibleMetrics.emplace(
-          metricName, FlexibleMetric(metricName, metricValue, aggregatable));
+          metricName, FlexibleMetric(metricName, metricValue, aggregable));
     else {
       node.flexibleMetrics.at(metricName).updateValue(metricValue);
     }

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -182,11 +182,11 @@ void SessionManager::exitOp(const Scope &scope) {
 
 void SessionManager::addMetrics(
     size_t scopeId, const std::map<std::string, MetricValueType> &metrics,
-    bool aggregatable) {
+    bool aggregable) {
   std::shared_lock<std::shared_mutex> lock(mutex);
   for (auto [sessionId, active] : activeSessions) {
     if (active) {
-      sessions[sessionId]->data->addMetrics(scopeId, metrics, aggregatable);
+      sessions[sessionId]->data->addMetrics(scopeId, metrics, aggregable);
     }
   }
 }

--- a/third_party/proton/csrc/lib/Session/Session.cpp
+++ b/third_party/proton/csrc/lib/Session/Session.cpp
@@ -181,11 +181,12 @@ void SessionManager::exitOp(const Scope &scope) {
 }
 
 void SessionManager::addMetrics(
-    size_t scopeId, const std::map<std::string, MetricValueType> &metrics) {
+    size_t scopeId, const std::map<std::string, MetricValueType> &metrics,
+    bool aggregatable) {
   std::shared_lock<std::shared_mutex> lock(mutex);
   for (auto [sessionId, active] : activeSessions) {
     if (active) {
-      sessions[sessionId]->data->addMetrics(scopeId, metrics);
+      sessions[sessionId]->data->addMetrics(scopeId, metrics, aggregatable);
     }
   }
 }


### PR DESCRIPTION
Different from "metrics" that can be aggregated, "properties" in proton cannot.

This is particularly useful for fine-grained IR analysis for GPU kernels. We need to know the file path of each kernel to get the path to IR files. Using the existing approach, a file path has to be appended to a scope name, which is not something that the user wants to know. Instead, by setting a `file_path` property, the path will be hidden from users. Given that each triton kernel corresponds to a unique file path, the solution should work.