### PR TITLE
Disable linear layouts.

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -1177,7 +1177,10 @@ emitIndicesUsingLinearLayouts(Location loc, RewriterBase &rewriter,
 inline SmallVector<SmallVector<Value>>
 emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
             Attribute layout, RankedTensorType type, bool withCTAOffset,
-            bool allowLL = true) {
+            bool allowLL = false) {
+  // TODO(jlebar): LLs are disabled for now due to bugs found on AMD and A100
+  // GPUs.  Enable again wth allowLL = true above.
+
   // Eventually the LinearLayout path will be the only one.  For now we allow
   // both paths so we can test that they produce the same results.
   if (allowLL) {

--- a/test/Conversion/dedup-by-constancy.mlir
+++ b/test/Conversion/dedup-by-constancy.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm --llvm-optimize-for-nvvm-target | FileCheck %s
 
 // CHECK-LABEL: dedup_by_constancy_full
-// CHECK-COUNT-2: llvm.add
+// CHECK-COUNT-5: llvm.add
 // CHECK-NOT: llvm.add
 // CHECK: llvm.icmp "slt"
 // CHECK-NOT: llvm.icmp "slt"
@@ -36,7 +36,7 @@ module attributes {"triton_gpu.target" = "cuda:80", "triton_gpu.num-ctas" = 1 : 
 // -----
 
 // CHECK-LABEL: dedup_by_constancy_partial
-// CHECK-COUNT-4: llvm.add
+// CHECK-COUNT-8: llvm.add
 // CHECK-NOT: llvm.add
 // CHECK: llvm.icmp "slt"
 // CHECK-NOT: llvm.icmp "slt"


### PR DESCRIPTION
We've encountered issues on AMDGPU and A100 GPUs not raised in CI.
