### PR TITLE
[PROTON] Remove cupti/cuda header files in CuptiProfiler.h

### DIFF
--- a/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
@@ -2,7 +2,7 @@
 #define PROTON_PROFILER_CUPTI_PROFILER_H_
 
 #include "Context/Context.h"
-#include "Driver/GPU/Cupti.h"
+#include "Driver/GPU/Cuda.h"
 #include "Profiler.h"
 
 #include <atomic>
@@ -34,53 +34,12 @@ private:
                           size_t *maxNumRecords);
   static void completeBuffer(CUcontext context, uint32_t streamId,
                              uint8_t *buffer, size_t size, size_t validSize);
-  static void processActivity(std::map<uint32_t, size_t> &correlation,
-                              std::set<Data *> &dataSet,
-                              CUpti_Activity *activity);
-  static void callback(void *userData, CUpti_CallbackDomain domain,
-                       CUpti_CallbackId cbId, const void *cbData);
 
   const inline static size_t AlignSize = 8;
   const inline static size_t BufferSize = 64 * 1024 * 1024;
 
   std::map<uint32_t, size_t> correlation;
-  CUpti_SubscriberHandle subscriber{};
-  struct CuptiState {
-    CuptiProfiler &profiler;
-    std::set<Data *> dataSet;
-    size_t level{0};
-    bool isRecording{false};
-    Scope scope{};
-
-    CuptiState(CuptiProfiler &profiler) : profiler(profiler) {}
-
-    void record(const Scope &scope, const std::set<Data *> &dataSet) {
-      this->scope = scope;
-      this->dataSet.insert(dataSet.begin(), dataSet.end());
-    }
-
-    void reset() {
-      dataSet.clear();
-      level = 0;
-      scope = Scope();
-    }
-
-    void enterOp() {
-      profiler.enterOp(scope);
-      for (auto data : dataSet) {
-        data->enterOp(scope);
-      }
-    }
-
-    void exitOp() {
-      profiler.exitOp(scope);
-      for (auto data : dataSet) {
-        data->exitOp(this->scope);
-      }
-    }
-  };
-
-  static inline thread_local CuptiState cuptiState{CuptiProfiler::instance()};
+  void *subscriber{};
 };
 
 } // namespace proton

--- a/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
@@ -7,16 +7,14 @@
 #include <atomic>
 #include <map>
 
-struct CUctx_st;
-
 namespace proton {
 
 class CuptiProfiler : public Profiler,
                       public OpInterface,
                       public Singleton<CuptiProfiler> {
 public:
-  CuptiProfiler() = default;
-  virtual ~CuptiProfiler() = default;
+  CuptiProfiler();
+  virtual ~CuptiProfiler();
 
 protected:
   // OpInterface
@@ -31,16 +29,9 @@ protected:
   void doStop() override;
 
 private:
-  static void allocBuffer(uint8_t **buffer, size_t *bufferSize,
-                          size_t *maxNumRecords);
-  static void completeBuffer(struct CUctx_st *context, uint32_t streamId,
-                             uint8_t *buffer, size_t size, size_t validSize);
-
-  const inline static size_t AlignSize = 8;
-  const inline static size_t BufferSize = 64 * 1024 * 1024;
-
-  std::map<uint32_t, size_t> correlation;
-  void *subscriber{};
+  // pimpl-idiom to hide the implementation details
+  struct CuptiCallback;
+  std::unique_ptr<CuptiCallback> cuptiCallback;
 };
 
 } // namespace proton

--- a/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
@@ -29,7 +29,7 @@ protected:
   void doStop() override;
 
 private:
-  // pimpl-idiom to hide the implementation details
+  // Use the pimpl idiom to hide the implementation details.  This lets us avoid including the cupti header from this header.  The cupti header and the equivalent header from AMD define conflicting macros, so we want to use those headers only within cc files.
   struct CuptiCallback;
   std::unique_ptr<CuptiCallback> cuptiCallback;
 };

--- a/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
@@ -2,11 +2,12 @@
 #define PROTON_PROFILER_CUPTI_PROFILER_H_
 
 #include "Context/Context.h"
-#include "Driver/GPU/Cuda.h"
 #include "Profiler.h"
 
 #include <atomic>
 #include <map>
+
+struct CUctx_st;
 
 namespace proton {
 
@@ -32,7 +33,7 @@ protected:
 private:
   static void allocBuffer(uint8_t **buffer, size_t *bufferSize,
                           size_t *maxNumRecords);
-  static void completeBuffer(CUcontext context, uint32_t streamId,
+  static void completeBuffer(struct CUctx_st *context, uint32_t streamId,
                              uint8_t *buffer, size_t size, size_t validSize);
 
   const inline static size_t AlignSize = 8;

--- a/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
+++ b/third_party/proton/csrc/include/Profiler/CuptiProfiler.h
@@ -29,9 +29,12 @@ protected:
   void doStop() override;
 
 private:
-  // Use the pimpl idiom to hide the implementation details.  This lets us avoid including the cupti header from this header.  The cupti header and the equivalent header from AMD define conflicting macros, so we want to use those headers only within cc files.
-  struct CuptiCallback;
-  std::unique_ptr<CuptiCallback> cuptiCallback;
+  // Use the pimpl idiom to hide the implementation details. This lets us avoid
+  // including the cupti header from this header. The cupti header and the
+  // equivalent header from AMD define conflicting macros, so we want to use
+  // those headers only within cc files.
+  struct CuptiProfilerPimpl;
+  std::unique_ptr<CuptiProfilerPimpl> pImpl;
 };
 
 } // namespace proton

--- a/third_party/proton/csrc/include/Profiler/Profiler.h
+++ b/third_party/proton/csrc/include/Profiler/Profiler.h
@@ -67,21 +67,16 @@ public:
     return this;
   }
 
-  /// Get the number of data objects registered to the profiler.
-  size_t getDataCount() const {
+  /// Get the set of data objects registered to the profiler.
+  std::set<Data *> getDataSet() const {
     std::shared_lock<std::shared_mutex> lock(mutex);
-    return dataSet.size();
+    return dataSet;
   }
 
 protected:
   virtual void doStart() = 0;
   virtual void doFlush() = 0;
   virtual void doStop() = 0;
-
-  std::set<Data *> getDataSetSnapshot() const {
-    std::shared_lock<std::shared_mutex> lock(mutex);
-    return dataSet;
-  }
 
   mutable std::shared_mutex mutex;
   std::set<Data *> dataSet;

--- a/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
@@ -301,6 +301,11 @@ void CuptiProfiler::CuptiProfilerPimpl::doStop() {
   cupti::finalize<true>();
 }
 
+CuptiProfiler::CuptiProfiler()
+    : pImpl(std::make_unique<CuptiProfilerPimpl>()) {}
+
+CuptiProfiler::~CuptiProfiler() = default;
+
 void CuptiProfiler::startOp(const Scope &scope) { pImpl->startOp(scope); }
 
 void CuptiProfiler::stopOp(const Scope &scope) { pImpl->stopOp(scope); }

--- a/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
+++ b/third_party/proton/csrc/lib/Profiler/CuptiProfiler.cpp
@@ -46,7 +46,7 @@ struct CuptiState {
   }
 };
 
-static inline thread_local CuptiState cuptiState;
+static thread_local CuptiState cuptiState;
 
 std::shared_ptr<Metric> convertActivityToMetric(CUpti_Activity *activity) {
   std::shared_ptr<Metric> metric;


### PR DESCRIPTION
`CuptiProfiler.h` needs to be included in `Session.cpp`, which will also include `RocTracerProfiler.h`, mixing `cupti.h` and `roctracer_hip.h` will cause problems because some variables in hip and cuda have the same name.

Thus, `CuptiProfiler.h` shouldn't include anything specific to nvidia, and `RocTracerProfiler.h` shouldn't include anything specific to amd. 