### PR TITLE
[NVIDIA] Add support for tensor conversion from fp16 to fp32 using ExtFOp 

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -339,8 +339,12 @@ public:
 
 static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
                             Type promotedType) {
-  Type tensorPromotedType = cast<RankedTensorType>(operand.getType())
-                                .cloneWith(std::nullopt, promotedType);
+  RankedTensorType tensor = cast<RankedTensorType>(operand.getType());
+  Type tensorElementType = tensor.getElementType();
+  Type tensorPromotedType = tensor.cloneWith(std::nullopt, promotedType);
+  if (tensorElementType.isF16() && promotedType.isF32()) {
+    return builder.create<arith::ExtFOp>(loc, tensorPromotedType, operand);
+  }
   return builder.create<tt::FpToFpOp>(loc, tensorPromotedType, operand);
 }
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -207,8 +207,12 @@ private:
 
   static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
                               Type promotedType) {
-    Type tensorPromotedType = cast<RankedTensorType>(operand.getType())
-                                  .cloneWith(std::nullopt, promotedType);
+    RankedTensorType tensor = cast<RankedTensorType>(operand.getType());
+    Type tensorElementType = tensor.getElementType();
+    Type tensorPromotedType = tensor.cloneWith(std::nullopt, promotedType);
+    if (tensorElementType.isF16() && promotedType.isF32()) {
+      return builder.create<arith::ExtFOp>(loc, tensorPromotedType, operand);
+    }
     return builder.create<triton::FpToFpOp>(loc, tensorPromotedType, operand);
   }
 };


### PR DESCRIPTION
This PR fixes
`Unsupported conversion from f16 to f16`
`LLVM ERROR: Unsupported rounding mode for conversion.`
on Pascal GPUs.