### PR TITLE
[NVIDIA]  Add ptx60 feature when compiling for Pascal GPUs

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -235,7 +235,8 @@ class CUDABackend(BaseBackend):
     @staticmethod
     def make_ptx(src, metadata, opt, capability):
         proc = 'sm_90a' if capability == 90 else f'sm_{capability}'
-        ret = llvm.translate_to_asm(src, 'nvptx64-nvidia-cuda', proc, '', ['nvptx-short-ptr'], opt.enable_fp_fusion,
+        features = '+ptx60' if capability == 60 or capability == 61 else ''
+        ret = llvm.translate_to_asm(src, 'nvptx64-nvidia-cuda', proc, features, ['nvptx-short-ptr'], opt.enable_fp_fusion,
                                     False)
         # Find kernel names (there should only be one)
         names = re.findall(r".visible .entry ([a-zA-Z_][a-zA-Z0-9_]*)", ret)


### PR DESCRIPTION
Follow-up to #3874

This PR fixes:
`LLVM ERROR: Cannot select: intrinsic %llvm.nvvm.shfl.sync.bfly.i32`

After merging #3874 and this PR `triton` will work with Pascal GPUs.