### PR TITLE
[TUTORIAL][softmax] Avoid creating exessive threads for small shapes.

### DIFF
--- a/python/tutorials/02-fused-softmax.py
+++ b/python/tutorials/02-fused-softmax.py
@@ -148,6 +148,8 @@ def softmax(x):
         num_programs = NUM_SM * occupancy
         kernels[BLOCK_SIZE] = (kernel, num_programs)
 
+    num_programs = min(num_programs, n_rows)
+
     # Allocate output
     y = torch.empty_like(x)
 


### PR DESCRIPTION
Smaller shapes only needs up to `n_rows` number of threads.