### PR TITLE
[BACKEND] Support stmatrix for swizzle distributed to shared

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -39,7 +39,8 @@ public:
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
       SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
       ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
-      ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const = 0;
+      ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
+      int swizzleByteWidth = 0) const = 0;
 
   virtual std::string getMulhiFuncName(Type resultElementTy) const = 0;
   // Emits LLVM code with |rewriter| to print a message following the given

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -120,7 +120,8 @@ bool TargetInfo::processReplicaUsingStMatrix(
     ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
     SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
     ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
-    ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const {
+    ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
+    int swizzleByteWidth) const {
   return false;
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -47,7 +47,8 @@ public:
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
       SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
       ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
-      ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const override;
+      ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
+      int swizzleByteWidth) const override;
 
   std::string getMulhiFuncName(Type resultElementTy) const override;
 

--- a/third_party/nvidia/backend/driver.c
+++ b/third_party/nvidia/backend/driver.c
@@ -352,7 +352,7 @@ static PyObject *fill2DTMADescriptor(PyObject *self, PyObject *args) {
   CUresult result = cuTensorMapEncodeTiled(
       (CUtensorMap *)desc, type, rank, (void *)global_address, dims,
       globalStrides, tensorDims, elementStrides, CU_TENSOR_MAP_INTERLEAVE_NONE,
-      CU_TENSOR_MAP_SWIZZLE_128B, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
+      swizzle, CU_TENSOR_MAP_L2_PROMOTION_L2_128B,
       CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
   assert(result == CUDA_SUCCESS);
   return Py_None;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -45,6 +45,10 @@ Value convertLayout(int opIdx, ConversionPatternRewriter &rewriter,
 
 namespace {
 
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+
 struct LocalLoadOpConversion
     : public ConvertOpToLLVMPattern<triton::gpu::LocalLoadOp> {
 public:
@@ -751,12 +755,86 @@ private:
 private:
   const NVIDIA::TargetInfo &targetInfo;
 };
+
+struct LocalAllocOpConversion
+    : public ConvertOpToLLVMPattern<triton::gpu::LocalAllocOp> {
+  LocalAllocOpConversion(const LLVMTypeConverter &converter,
+                         const NVIDIA::TargetInfo &targetInfo,
+                         PatternBenefit benefit = 1)
+      : ConvertOpToLLVMPattern<triton::gpu::LocalAllocOp>(converter, benefit),
+        targetInfo(targetInfo) {}
+
+  LogicalResult
+  matchAndRewrite(triton::gpu::LocalAllocOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!op.getSrc())
+      return failure();
+    auto mmaEncoding = dyn_cast<triton::gpu::NvidiaMmaEncodingAttr>(
+        op.getSrc().getType().getEncoding());
+    if (!mmaEncoding)
+      return failure();
+    auto sharedLayout =
+        cast<triton::gpu::SharedEncodingAttr>(op.getType().getEncoding());
+    if (!sharedLayout.getHasLeadingOffset())
+      return failure();
+    int swizzleByteSize = 0;
+    if (sharedLayout.getPerPhase() == 4 && sharedLayout.getMaxPhase() == 2)
+      swizzleByteSize = 32;
+    else if (sharedLayout.getPerPhase() == 2 && sharedLayout.getMaxPhase() == 4)
+      swizzleByteSize = 64;
+    else if (sharedLayout.getPerPhase() == 1 && sharedLayout.getMaxPhase() == 8)
+      swizzleByteSize = 128;
+    else
+      return failure();
+
+    Location loc = op->getLoc();
+    RankedTensorType srcTy = op.getSrc().getType();
+    Value smemBase =
+        LLVM::getSharedMemoryBase(loc, rewriter, op.getOperation());
+    auto srcs = unpackLLElements(loc, adaptor.getSrc(), rewriter);
+    SmallVector<unsigned> shape;
+    for (int64_t dim : srcTy.getShape())
+      shape.push_back(dim);
+    bool loweredToStMatrix = targetInfo.processReplicaUsingStMatrix(
+        rewriter, loc, smemBase, srcs, srcTy,
+        getTypeConverter()->convertType(srcTy.getElementType()), shape, shape,
+        sharedLayout.getOrder(), 1, swizzleByteSize);
+    if (!loweredToStMatrix)
+      return failure();
+
+    auto resultTy = cast<MemDescType>(op.getType());
+    // Workaround for 3D tensors
+    // TODO: we need to modify the pipeline pass to give a proper shared
+    // encoding to 3D tensors
+    auto order = sharedLayout.getOrder();
+    SmallVector<unsigned> newOrder;
+    if (resultTy.getShape().size() != order.size()) {
+      for (auto i = 0; i < order.size(); ++i)
+        newOrder.push_back(order[i] + 1);
+      newOrder.push_back(0);
+    } else {
+      newOrder = SmallVector<unsigned>(order.begin(), order.end());
+    }
+    auto llvmElemTy = typeConverter->convertType(resultTy.getElementType());
+    auto shapePerCTA = getShapePerCTA(sharedLayout, resultTy.getShape());
+    auto smemObj = SharedMemoryObject(smemBase, llvmElemTy, shapePerCTA,
+                                      newOrder, loc, rewriter);
+    auto retVal = getStructFromSharedMemoryObject(loc, smemObj, rewriter);
+    rewriter.replaceOp(op, retVal);
+    return success();
+  }
+
+private:
+  const NVIDIA::TargetInfo &targetInfo;
+};
+
 } // namespace
 
 void mlir::triton::NVIDIA::populateConvertLayoutOpToLLVMOptimizedPatterns(
     LLVMTypeConverter &typeConverter, const TargetInfo &targetInfo,
     RewritePatternSet &patterns, PatternBenefit benefit) {
   patterns.add<ConvertLayoutOpOptimizedConversion>(typeConverter, benefit);
+  patterns.add<LocalAllocOpConversion>(typeConverter, targetInfo, benefit);
 }
 
 void mlir::triton::NVIDIA::populateConvertLayoutOpToLLVMPatterns(

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -789,8 +789,7 @@ struct LocalAllocOpConversion
 
     Location loc = op->getLoc();
     RankedTensorType srcTy = op.getSrc().getType();
-    Value smemBase =
-        LLVM::getSharedMemoryBase(loc, rewriter, op.getOperation());
+    Value smemBase = LLVM::getSharedMemoryBase(loc, rewriter, op);
     auto srcs = unpackLLElements(loc, adaptor.getSrc(), rewriter);
     SmallVector<unsigned> shape;
     for (int64_t dim : srcTy.getShape())

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -14,7 +14,8 @@ using ::mlir::triton::gpu::getShapePerCTA;
 using ::mlir::triton::gpu::getShapePerCTATile;
 namespace {
 Value computeStMatrixAddr(Value laneId, int matStride, Location loc,
-                          ConversionPatternRewriter &rewriter) {
+                          ConversionPatternRewriter &rewriter,
+                          int swizzleByteWidth) {
   Value rowInMat = urem(laneId, i32_val(8)); // row in the 8x8 matrix
   // linear index of the matrix in the 2x2 matrices
   // Decompose matIndex => s_0, s_1, that is the coordinate in 2x2 matrices in
@@ -22,6 +23,8 @@ Value computeStMatrixAddr(Value laneId, int matStride, Location loc,
   Value matIndex = udiv(laneId, i32_val(8));
   Value s0 = urem(matIndex, i32_val(2));
   Value s1 = udiv(matIndex, i32_val(2));
+  if (swizzleByteWidth >= 32)
+    s1 = xor_(s1, and_(laneId, i32_val(1)));
   Value mIndex = add(rowInMat, mul(s0, i32_val(8)));
   int m8n8Stride = 8;
   Value offset =
@@ -51,7 +54,7 @@ void storeDistributedToSharedWithStMatrix(
     RankedTensorType tensorTy, Type elemTy, SmallVector<Value> &inVals,
     Value smemBase, ArrayRef<unsigned> paddedRepShape,
     ArrayRef<unsigned> origRepShape, Location loc,
-    ConversionPatternRewriter &rewriter) {
+    ConversionPatternRewriter &rewriter, int swizzlingByteWidth) {
   auto shapePerCTA = getShapePerCTA(tensorTy);
   auto mmaLayout = mlir::cast<NvidiaMmaEncodingAttr>(tensorTy.getEncoding());
   auto order = triton::gpu::getOrder(mmaLayout);
@@ -64,7 +67,14 @@ void storeDistributedToSharedWithStMatrix(
   int instrM = mmaShape[0] * warpsPerCTA[0];
   std::array<int, 2> numRep = {ceil((int)origRepShape[0], instrM),
                                ceil((int)origRepShape[1], instrN)};
-
+  int numBoxes = 1;
+  if (swizzlingByteWidth == 128) {
+    int contigDimSizeInByte =
+        origRepShape[1] * elemTy.getIntOrFloatBitWidth() / 8;
+    numBoxes = ceil<int>(contigDimSizeInByte, 128);
+  }
+  SmallVector<unsigned> boxShape = {paddedRepShape[0], paddedRepShape[1]};
+  boxShape[1] = boxShape[1] / numBoxes;
   Value thread = getThreadId(rewriter, loc);
   Value warp = udiv(thread, i32_val(32));
   Value lane = urem(thread, i32_val(32));
@@ -74,38 +84,57 @@ void storeDistributedToSharedWithStMatrix(
 
   // Compute the relative offset for each lane.
   Value stMatrixLaneOffset =
-      computeStMatrixAddr(lane, paddedRepShape[1], loc, rewriter);
+      computeStMatrixAddr(lane, boxShape[1], loc, rewriter, swizzlingByteWidth);
   multiDimWarpId[0] = mul(multiDimWarpId[0], i32_val(mmaShape[0]));
   multiDimWarpId[1] = mul(multiDimWarpId[1], i32_val(mmaShape[1]));
-  SmallVector<Value> multiDimOffsetWrapped =
-      getWrappedMultiDimOffset(rewriter, loc, multiDimWarpId, origRepShape,
-                               shapePerCTATile, shapePerCTA);
+  SmallVector<Value> multiDimOffsetWrapped = getWrappedMultiDimOffset(
+      rewriter, loc, multiDimWarpId, boxShape, shapePerCTATile, shapePerCTA);
   Value relativeOffset =
-      linearize(rewriter, loc, multiDimOffsetWrapped, paddedRepShape, order);
+      linearize(rewriter, loc, multiDimOffsetWrapped, boxShape, order);
   relativeOffset = add(relativeOffset, stMatrixLaneOffset);
   int indexOffset = 0;
   int m8n8x4Stride = 16;
   int numNChunk = mmaShape[1] / m8n8x4Stride;
+  unsigned totalNumElements = product(origRepShape);
+  numNChunk = numNChunk / numBoxes;
   for (int m = 0; m < numRep[0]; m++) {
     for (int n = 0; n < numRep[1]; n++) {
-      for (int k = 0; k < numNChunk; k++) {
-        Value addr =
-            add(relativeOffset, i32_val(k * m8n8x4Stride + n * instrN +
-                                        m * instrM * paddedRepShape[1]));
-        stMatrixm8n8x4(addr, inVals, indexOffset, smemBase, elemTy, loc,
-                       rewriter);
-        indexOffset += 8;
+      for (int box = 0; box < numBoxes; box++) {
+        for (int k = 0; k < numNChunk; k++) {
+          Value kOffset;
+          if (swizzlingByteWidth >= 64) {
+            int swizzleBits = swizzlingByteWidth == 128 ? 6 : 2;
+            Value o = lshr(and_(lane, i32_val(swizzleBits)), i32_val(1));
+            Value kV = xor_(o, i32_val(k));
+            kOffset = mul(kV, i32_val(m8n8x4Stride));
+          } else {
+            kOffset = i32_val(k * m8n8x4Stride);
+          }
+          Value addr = add(relativeOffset,
+                           i32_val(n * instrN + m * instrM * boxShape[1] +
+                                   box * (totalNumElements / numBoxes)));
+          addr = add(addr, kOffset);
+
+          stMatrixm8n8x4(addr, inVals, indexOffset, smemBase, elemTy, loc,
+                         rewriter);
+          indexOffset += 8;
+        }
       }
     }
   }
 }
 
-bool isStMatrixCompatible(RankedTensorType tensorTy) {
+bool isStMatrixCompatible(RankedTensorType tensorTy, int swizzlingByteWidth) {
   auto mmaLayout =
       mlir::dyn_cast<NvidiaMmaEncodingAttr>(tensorTy.getEncoding());
   if (!mmaLayout || !mmaLayout.isHopper())
     return false;
   if (tensorTy.getElementType().getIntOrFloatBitWidth() != 16)
+    return false;
+  if (swizzlingByteWidth > 0 && mmaLayout.getInstrShape()[1] < 64)
+    return false;
+  if (swizzlingByteWidth != 0 && swizzlingByteWidth != 32 &&
+      swizzlingByteWidth != 64 && swizzlingByteWidth != 128)
     return false;
   return true;
 }
@@ -335,12 +364,13 @@ bool TargetInfo::processReplicaUsingStMatrix(
     ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
     SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
     ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
-    ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const {
-  if (isStMatrixCompatible(srcTy) && accumNumReplicates == 1 &&
-      outOrd[0] == 1 && paddedRepShape[1] % 8 == 0) {
+    ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
+    int swizzlingByteWidth) const {
+  if (isStMatrixCompatible(srcTy, swizzlingByteWidth) &&
+      accumNumReplicates == 1 && outOrd[0] == 1 && paddedRepShape[1] % 8 == 0) {
     storeDistributedToSharedWithStMatrix(srcTy, elemTy, vals, smemBase,
                                          paddedRepShape, origRepShape, loc,
-                                         rewriter);
+                                         rewriter, swizzlingByteWidth);
     return true;
   }
   return false;

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -42,7 +42,8 @@ public:
       ConversionPatternRewriter &rewriter, Location loc, Value smemBase,
       SmallVector<Value> &vals, RankedTensorType srcTy, Type elemTy,
       ArrayRef<unsigned> paddedRepShape, ArrayRef<unsigned> origRepShape,
-      ArrayRef<unsigned> outOrd, unsigned accumNumReplicates) const override;
+      ArrayRef<unsigned> outOrd, unsigned accumNumReplicates,
+      int swizzleByteWidth) const override;
 
   std::string getMulhiFuncName(Type resultElementTy) const override;
 


### PR DESCRIPTION
When copying from mma layout to swizzled shared layout we can use stmatrix to avoid bank conflicts and reduce the number of instructions.