### PR TITLE
Revert "[AMD] Hint the compiler to preload kernel arguments (#3632)"

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -192,10 +192,6 @@ class HIPBackend(BaseBackend):
         kernels[0].add_fn_attr("amdgpu-waves-per-eu", f"{options.waves_per_eu}")
         denormal_mode = "preserve-sign" if options.allow_flush_denorm else "ieee"
         kernels[0].add_fn_attr("denormal-fp-math-f32", denormal_mode)
-        # Hint the compiler that we'd like the firmware to set the kernel arguments
-        # to user SGPRs so that the kernel does not need to s_load its arguments
-        # from memory.
-        amd.set_all_fn_arg_inreg(kernels[0])
 
         if options.extern_libs:
             paths = [path for (name, path) in options.extern_libs if amd.need_extern_lib(llvm_mod, name)]

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -204,15 +204,6 @@ void init_triton_amd(py::module &&m) {
       },
       py::return_value_policy::take_ownership);
 
-  m.def("set_all_fn_arg_inreg", [](llvm::Function *fn) {
-    for (llvm::Argument &arg : fn->args()) {
-      // Check for incompatible attributes.
-      if (arg.hasByRefAttr() || arg.hasNestAttr())
-        continue;
-      arg.addAttr(llvm::Attribute::InReg);
-    }
-  });
-
   m.def("need_extern_lib", [](llvm::Module *module, const std::string &lib) {
     for (llvm::Function &f : module->functions()) {
       if (f.hasExternalLinkage() && f.hasName() && !f.hasExactDefinition()) {


### PR DESCRIPTION
This reverts commit ebb065f2e54d55a1f7ef80e1e0dababed8991f67.

On MI300, test_dot(32, 32, 128, 16, False, True, 'none', 'ieee', 'float32', 'float32', 1, 1, 'cuda') failed due to this commit. We'll re-enable InReg attribute after we figured out the reason for the failure.

Some observations
- It passes if we change num_warps from 16 to 8
- It passes if we change K from 128 to 64
- It passes if we only add `InReg` to 4 kernel args. (5 will fail) 