### PR TITLE
Re-enable linear layouts.

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -1177,10 +1177,7 @@ emitIndicesUsingLinearLayouts(Location loc, RewriterBase &rewriter,
 inline SmallVector<SmallVector<Value>>
 emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
             Attribute layout, RankedTensorType type, bool withCTAOffset,
-            bool allowLL = false) {
-  // TODO(jlebar): LLs are disabled for now due to bugs found on AMD and A100
-  // GPUs.  Enable again wth allowLL = true above.
-
+            bool allowLL = true) {
   // Eventually the LinearLayout path will be the only one.  For now we allow
   // both paths so we can test that they produce the same results.
   if (allowLL) {

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -80,11 +80,13 @@ LinearLayout blockedToLinearLayout(ArrayRef<int64_t> shape,
       layoutForDim(kBlock, blocked.getCTASplitNum(), blocked.getCTAOrder(),
                    /*extraZeros=*/ctgDupes);
 
-  // Split the shape among the register+lane+warp.
-  LinearLayout ctaLayout =
-      layoutForDim(kRegister, blocked.getSizePerThread(), blocked.getOrder()) *
-      layoutForDim(kLane, blocked.getThreadsPerWarp(), blocked.getOrder()) *
+  LinearLayout registerLayout =
+      layoutForDim(kRegister, blocked.getSizePerThread(), blocked.getOrder());
+  LinearLayout laneLayout =
+      layoutForDim(kLane, blocked.getThreadsPerWarp(), blocked.getOrder());
+  LinearLayout warpLayout =
       layoutForDim(kWarp, blocked.getWarpsPerCTA(), blocked.getOrder());
+  LinearLayout ctaLayout = registerLayout * laneLayout * warpLayout;
 
   // If the shape per CTA is larger than the layout, we repeat the layout by
   // having each lane hold multiple elements, i.e. adding to the register

--- a/test/Conversion/dedup-by-constancy.mlir
+++ b/test/Conversion/dedup-by-constancy.mlir
@@ -1,7 +1,7 @@
 // RUN: triton-opt %s -split-input-file --convert-triton-gpu-to-llvm --llvm-optimize-for-nvvm-target | FileCheck %s
 
 // CHECK-LABEL: dedup_by_constancy_full
-// CHECK-COUNT-5: llvm.add
+// CHECK-COUNT-2: llvm.add
 // CHECK-NOT: llvm.add
 // CHECK: llvm.icmp "slt"
 // CHECK-NOT: llvm.icmp "slt"
@@ -36,7 +36,7 @@ module attributes {"triton_gpu.target" = "cuda:80", "triton_gpu.num-ctas" = 1 : 
 // -----
 
 // CHECK-LABEL: dedup_by_constancy_partial
-// CHECK-COUNT-8: llvm.add
+// CHECK-COUNT-4: llvm.add
 // CHECK-NOT: llvm.add
 // CHECK: llvm.icmp "slt"
 // CHECK-NOT: llvm.icmp "slt"


### PR DESCRIPTION
Revert "Disable linear layouts. (#3867)"

This reverts commit 987dd045c0af345d26f98dcd451189ef47646030, with a fix for
the breakage (which was caused by the fact that order of argument evaluation in
C++ is undefined).