### PR TITLE
Decouple the Triton lowering code for out of tree backends to reuse.

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -12,6 +12,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
+#include "triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Tools/LinearLayout.h"
 #include "triton/Tools/StrUtil.h"
@@ -1101,6 +1102,11 @@ emitBaseIndexForLayoutImpl(Location loc, RewriterBase &rewriter,
     result.erase(result.begin() + sliceLayout.getDim());
     // CTAOffset has been added in emitBaseIndexForLayout of parentLayout
     return result;
+  } else if (auto distributedLayout =
+                 mlir::dyn_cast<triton::gpu::DistributedEncodingTrait>(
+                     layout)) {
+    result =
+        distributedLayout.emitBaseIndexWithinCTAForLayout(loc, rewriter, type);
   } else {
     llvm_unreachable("unsupported emitBaseIndexForLayout");
   }
@@ -1163,6 +1169,9 @@ emitOffsetForLayout(Attribute layout, RankedTensorType type) {
   }
   if (auto sliceLayout = mlir::dyn_cast<SliceEncodingAttr>(layout))
     return emitOffsetForSliceLayout(sliceLayout, type);
+  if (auto distributedLayout =
+          mlir::dyn_cast<triton::gpu::DistributedEncodingTrait>(layout))
+    return distributedLayout.emitOffsetForLayout(type);
   llvm_unreachable("unsupported emitOffsetForLayout");
 }
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -526,6 +526,32 @@ For the Threads Per Warp and Values Per Thread level, the linear id distribution
     InterfaceMethod<"Gets the number of contiguous elements per thread.",
                     "SmallVector<unsigned>",
                     "getContigPerThread">,
+
+    InterfaceMethod<[{
+                      Emit base index of the values owned by the thread with in the CTA.
+                      The base index should have the same rank as the tensor's shape.
+                    }],
+                    "SmallVector<Value>",
+                    "emitBaseIndexWithinCTAForLayout",
+                     (ins "Location":$loc,
+                          "OpBuilder&":$rewriter,
+                          "RankedTensorType":$type),
+                     /*methodBody=*/[{}],
+                     /*defaultImplementation=*/[{
+                       llvm_unreachable("unsupported emitBaseIndexWithinCTAForLayout");
+                     }]>,
+
+    InterfaceMethod<[{
+                      Get the offsets to the thread base index of each value owned by the threads.
+                      The offset should have the same rank as the tensor's shape.
+                    }],
+                    "SmallVector<SmallVector<unsigned>>",
+                    "emitOffsetForLayout",
+                     (ins "RankedTensorType":$type),
+                     /*methodBody=*/[{}],
+                     /*defaultImplementation=*/[{
+                       llvm_unreachable("unsupported emitOffsetForLayout");
+                     }]>,
   ];
 }
 

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h
@@ -1,6 +1,8 @@
 #ifndef TRITON_GPU_DIALECT_INTERFACES_H
 #define TRITON_GPU_DIALECT_INTERFACES_H
 
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "triton/Dialect/TritonGPU/IR/TritonGPUAttrInterfaces.h.inc"
 
 #endif // TRITON_GPU_DIALECT_INTERFACES_H


### PR DESCRIPTION
Issue
===
The Triton lowering code is coupled with the in tree backends' definition. Like: The function defined [here](https://github.com/openai/triton/blob/161f7a48d33275917372c3113aa70949c5bee9a8/include/triton/Conversion/TritonGPUToLLVM/Utility.h#L1072). 
It is hard for the out of tree backends to reuse the lowering code in Triton.

Decouple Proposal
===
This PR is going to add new interfaces to the `DistributedEncodingTraits` to support the third party to reuse the lowering logic in TritonGPUToLLVM.

The out of tree backend can inherit the `DistributedEncoding` and implement the two new interfaces:
`emitBaseIndexWithinCTAForLayout`: Emit base index of the values owned by the thread with in the CTA.
`emitOffsetForLayout`: Get the offsets to the thread base index of each value owned by the threads.

The in tree Triton lowering code can uses the new interfaces to generate the LLVM code in general.