### PR TITLE
[AMD][gfx12] Support WMMAv2 dot instruction generation

### DIFF
--- a/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_wmma_dot_to_llvm.mlir
@@ -24,8 +24,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     tt.return
   }
 
-  //  CHECK-LABEL: wmma_dot
-  tt.func @wmma_dot(%arg0: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg2: tensor<16x16xf16, #mma1>) {
+  //  CHECK-LABEL: wmma1_dot
+  tt.func @wmma1_dot(%arg0: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg2: tensor<16x16xf16, #mma1>) {
     // CHECK-COUNT-32: llvm.extractvalue %{{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16, f16)>
     // CHECK-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
     // CHECK: llvm.mlir.undef : vector<16xf16>
@@ -38,8 +38,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     tt.return
   }
 
-  //  CHECK-LABEL: wmma_dot_bf16
-  tt.func @wmma_dot_bf16(%arg0: tensor<16x16xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<16x16xbf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg2: tensor<16x16xbf16, #mma1>) {
+  //  CHECK-LABEL: wmma1_dot_bf16
+  tt.func @wmma1_dot_bf16(%arg0: tensor<16x16xbf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<16x16xbf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg2: tensor<16x16xbf16, #mma1>) {
     // CHECK-COUNT-16: llvm.extractvalue %{{.*}} : !llvm.struct<(bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16)>
     // CHECK: llvm.bitcast %{{.*}} : vector<16xbf16> to vector<16xi16>
     // CHECK-COUNT-16: llvm.extractvalue %{{.*}} : !llvm.struct<(bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16, bf16)>
@@ -52,8 +52,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     tt.return
   }
 
-  //  CHECK-LABEL: wmma_dot_int8_32
-  tt.func @wmma_dot_int8_32(%arg0: tensor<16x16xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<16x16xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg2: tensor<16x16xi32, #mma1>) {
+  //  CHECK-LABEL: wmma1_dot_int8_32
+  tt.func @wmma1_dot_int8_32(%arg0: tensor<16x16xi8, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<16x16xi8, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg2: tensor<16x16xi32, #mma1>) {
     // CHECK-COUNT-16: llvm.extractvalue %{{.*}} : !llvm.struct<(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8)>
     // CHECK-COUNT-16: llvm.insertelement {{.*}} : vector<16xi8>
     // CHECK: llvm.bitcast %{{.*}} : vector<16xi8> to vector<4xi32>
@@ -67,8 +67,8 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     tt.return
   }
 
-  //  CHECK-LABEL: wmma_dot_int4_32
-  tt.func @wmma_dot_int4_32(%arg0: tensor<16x16xi4, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<16x16xi4, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg2: tensor<16x16xi32, #mma1>) {
+  //  CHECK-LABEL: wmma1_dot_int4_32
+  tt.func @wmma1_dot_int4_32(%arg0: tensor<16x16xi4, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>>, %arg1: tensor<16x16xi4, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>>, %arg2: tensor<16x16xi32, #mma1>) {
     // CHECK-COUNT-16: llvm.extractvalue %{{.*}} : !llvm.struct<(i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4, i4)>
     // CHECK-COUNT-16: llvm.insertelement {{.*}} : vector<16xi4>
     // CHECK: llvm.bitcast %{{.*}} : vector<16xi4> to vector<2xi32>
@@ -79,6 +79,22 @@ module attributes {"triton_gpu.num-ctas" = 1 : i32, "triton_gpu.num-warps" = 4 :
     // CHECK: rocdl.wmma.i32.16x16x16.iu4 {{.*}} : (i1, vector<2xi32>, i1, vector<2xi32>, vector<8xi32>, i1) -> vector<8xi32>
     %0 = tt.dot %arg0, %arg1, %arg2 {inputPrecision = 2 : i32, maxNumImpreciseAcc = 0 : i32} : tensor<16x16xi4, #triton_gpu.dot_op<{opIdx = 0, parent = #mma1, kWidth = 16}>> * tensor<16x16xi4, #triton_gpu.dot_op<{opIdx = 1, parent = #mma1, kWidth = 16}>> -> tensor<16x16xi32, #mma1>
     // CHECK-COUNT-8: llvm.insertvalue {{.*}} : !llvm.struct<(i32, i32, i32, i32, i32, i32, i32, i32)>
+    tt.return
+  }
+
+  //  CHECK-LABEL: wmma2_dot
+  tt.func @wmma2_dot(%arg0: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma2, kWidth = 8}>>, %arg1: tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma2, kWidth = 8}>>, %arg2: tensor<16x16xf16, #mma2>) {
+    // CHECK-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK-COUNT-8: llvm.extractvalue %{{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
+    // CHECK: llvm.mlir.undef : vector<8xf16>
+    // CHECK: llvm.call_intrinsic "llvm.amdgcn.wmma.f16.16x16x16.f16.v8f16.v8f16"{{.*}} : (vector<8xf16>, vector<8xf16>, vector<8xf16>, i1) -> vector<8xf16>
+    %0 = tt.dot %arg0, %arg1, %arg2, inputPrecision = ieee : tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 0, parent = #mma2, kWidth = 8}>> * tensor<16x16xf16, #triton_gpu.dot_op<{opIdx = 1, parent = #mma2, kWidth = 8}>> -> tensor<16x16xf16, #mma2>
+    // CHECK-COUNT-8: llvm.extractelement {{.*}} : vector<8xf16>
+    // CHECK: llvm.mlir.undef : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
+    // CHECK-COUNT-8: llvm.insertvalue {{.*}} : !llvm.struct<(f16, f16, f16, f16, f16, f16, f16, f16)>
     tt.return
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -40,8 +40,8 @@ enum class WMMAInstrType : uint8_t {
   FP32_BF16,
   FP16_FP16,
   BF16_BF16,
-  INT32_IU8,
-  INT32_IU4,
+  I32_I8,
+  I32_I4,
   NOT_APPLICABLE,
 };
 
@@ -109,16 +109,16 @@ static WMMAInstrType getWMMAInstrTypeFromDot(DotOp op) {
   if (dElemTy.isBF16() && aElemTy.isBF16())
     return WMMAInstrType::BF16_BF16;
   if (dElemTy.isInteger(32) && aElemTy.isInteger(8))
-    return WMMAInstrType::INT32_IU8;
+    return WMMAInstrType::I32_I8;
   if (dElemTy.isInteger(32) && aElemTy.isInteger(4))
-    return WMMAInstrType::INT32_IU4;
+    return WMMAInstrType::I32_I4;
 
   return WMMAInstrType::NOT_APPLICABLE;
 }
 
-Value generateWMMAOp(ConversionPatternRewriter &rewriter, Location loc,
-                     WMMAInstrType wmmaType, Value valA, Value valB, Value valC,
-                     Type aElType, Type bElType) {
+Value generateROCDLOp(ConversionPatternRewriter &rewriter, Location loc,
+                      WMMAInstrType wmmaType, Value valA, Value valB,
+                      Value valC, Type aElType, Type bElType) {
   auto resType = valC.getType();
   Value falseFlag = int_val(1, false);
   switch (wmmaType) {
@@ -134,13 +134,13 @@ Value generateWMMAOp(ConversionPatternRewriter &rewriter, Location loc,
   case WMMAInstrType::BF16_BF16:
     return rewriter.create<ROCDL::wmma_bf16_16x16x16_bf16>(
         loc, TypeRange{resType}, ValueRange{valA, valB, valC, falseFlag});
-  case WMMAInstrType::INT32_IU8:
+  case WMMAInstrType::I32_I8:
     return rewriter.create<ROCDL::wmma_i32_16x16x16_iu8>(
         loc, TypeRange{resType},
         ValueRange{int_val(1, !aElType.isUnsignedInteger()), valA,
                    int_val(1, !bElType.isUnsignedInteger()), valB, valC,
                    falseFlag});
-  case WMMAInstrType::INT32_IU4:
+  case WMMAInstrType::I32_I4:
     return rewriter.create<ROCDL::wmma_i32_16x16x16_iu4>(
         loc, TypeRange{resType},
         ValueRange{int_val(1, !aElType.isUnsignedInteger()), valA,
@@ -152,14 +152,98 @@ Value generateWMMAOp(ConversionPatternRewriter &rewriter, Location loc,
   return Value();
 }
 
+std::string getTypeStr(Type ty) {
+  std::string scalarName;
+  if (ty.isF32()) {
+    scalarName = "f32";
+  } else if (ty.isF16()) {
+    scalarName = "f16";
+  } else if (ty.isBF16()) {
+    scalarName = "bf16";
+  } else if (ty.isInteger(32)) {
+    scalarName = "i32";
+  } else if (ty.isInteger(8)) {
+    scalarName = "iu8";
+  } else if (ty.isInteger(4)) {
+    scalarName = "iu4";
+  } else if (auto vecTy = dyn_cast<VectorType>(ty)) {
+    auto elemType = vecTy.getElementType();
+    auto numElems = vecTy.getNumElements();
+    scalarName = "v" + std::to_string(numElems) + getTypeStr(elemType);
+  } else {
+    llvm::report_fatal_error("WMMA data type not supported");
+  }
+  return scalarName;
+}
+
+StringRef getWmmaIntrinsicName(Type aElTy, Type bElTy, Type dElTy, Type valATy,
+                               Type valCTy) {
+  static llvm::SmallDenseMap<llvm::hash_code, std::string> intrinsics;
+  using MapInfo = llvm::DenseMapInfo<Type>;
+  llvm::hash_code h = llvm::hash_combine(
+      MapInfo::getHashValue(aElTy), MapInfo::getHashValue(bElTy),
+      MapInfo::getHashValue(dElTy), MapInfo::getHashValue(valATy),
+      MapInfo::getHashValue(valCTy));
+  if (!intrinsics.contains(h)) {
+    std::string name = "llvm.amdgcn.wmma.";
+    name += getTypeStr(dElTy);
+    name += ".16x16x16."; // TODO support 16x16x32 for i4 operands
+    name += getTypeStr(aElTy);
+    if (isa<FloatType>(aElTy) && aElTy.getIntOrFloatBitWidth() == 8)
+      name += '.' + getTypeStr(bElTy);
+    name += '.' + getTypeStr(valCTy) + "." + getTypeStr(valATy);
+    intrinsics[h] = name;
+  }
+  return intrinsics[h];
+}
+
+Value generateWMMAIntrinsic(ConversionPatternRewriter &rewriter, Location loc,
+                            WMMAInstrType wmmaType, Value valA, Value valB,
+                            Value valC, Type aElType, Type bElType,
+                            Type dElType) {
+  auto name = getWmmaIntrinsicName(aElType, bElType, dElType, valA.getType(),
+                                   valC.getType());
+  LLVM::FastmathFlagsAttr defaultFlags{};
+  SmallVector<Value> operands;
+  if (aElType.isInteger())
+    operands.push_back(int_val(1, !aElType.isUnsignedInteger()));
+  operands.push_back(valA);
+  if (bElType.isInteger())
+    operands.push_back(int_val(1, !bElType.isUnsignedInteger()));
+  operands.push_back(valB);
+  operands.push_back(valC);
+  // Flag for using low bits in registers. Result could be already packed to
+  // int32. Set low bits by default for now.
+  if (32 / dElType.getIntOrFloatBitWidth() > 1 || dElType.isInteger(32)) {
+    operands.push_back(int_val(1, false));
+  }
+  auto wmmaIntrinsic = rewriter.create<mlir::LLVM::CallIntrinsicOp>(
+      loc, TypeRange{valC.getType()}, StringAttr::get(loc.getContext(), name),
+      operands, defaultFlags);
+
+  return wmmaIntrinsic.getResult(0);
+}
+
+Value generateWMMAOp(ConversionPatternRewriter &rewriter, Location loc,
+                     WMMAInstrType wmmaType, Value valA, Value valB, Value valC,
+                     Type aElType, Type bElType, Type dElType, int version) {
+  if (version == 1) {
+    return generateROCDLOp(rewriter, loc, wmmaType, valA, valB, valC, aElType,
+                           bElType);
+  } else {
+    assert(version == 2);
+    return generateWMMAIntrinsic(rewriter, loc, wmmaType, valA, valB, valC,
+                                 aElType, bElType, dElType);
+  }
+}
+
 // Conduct the Dot conversion.
 LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
                          ConversionPatternRewriter &rewriter,
                          const LLVMTypeConverter *typeConverter) {
   auto wmmaLayout = cast<AMDWmmaEncodingAttr>(
       cast<RankedTensorType>(op.getResult().getType()).getEncoding());
-  // TODO: support 2nd gen of WMMA
-  assert(wmmaLayout.getVersion() == 1);
+  int wmmaVer = wmmaLayout.getVersion();
   auto warpsPerCTA = wmmaLayout.getWarpsPerCTA();
   auto mnkDim = AMDWmmaEncodingAttr::getMNKDimPerInstr();
   auto wmmaInstrType = getWMMAInstrTypeFromDot(op);
@@ -204,7 +288,7 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   unsigned warpSize = triton::gpu::getWarpSize(wmmaLayout);
   constexpr unsigned vgprElemBitWidth = 32;
   unsigned paddedOutputElemSize =
-      vgprElemBitWidth / dstElemTy.getIntOrFloatBitWidth();
+      wmmaVer == 1 ? vgprElemBitWidth / dstElemTy.getIntOrFloatBitWidth() : 1;
   // compute number of output elements that each thread holds for one WMMA
   // instruction.
   auto elemsPerVec = mnkDim[0] * mnkDim[1] * paddedOutputElemSize / warpSize;
@@ -226,7 +310,7 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
         for (size_t k = 0; k < numRepK; k++) {
           acc = generateWMMAOp(rewriter, loc, wmmaInstrType, ha[{b, m, k}],
                                hb[{b, n, k}], acc, aTensorTy.getElementType(),
-                               bTensorTy.getElementType());
+                               bTensorTy.getElementType(), dstElemTy, wmmaVer);
         }
         for (unsigned v = 0; v < dElemsToStorePerThread; ++v) {
           fc[fcThreadOffIdx + v] = extract_element(


### PR DESCRIPTION
- Added intrinsic generation according to the operands type, cache them to avoid repetitive calculations
- Fixed parameters dependent on the version in the main logic of WMMA operation generator
- Added a lit test to verify number of llvm instructions