### PR TITLE
[frontend][typing] Adding typing & small fix for autotuner.py

### DIFF
--- a/python/triton/runtime/autotuner.py
+++ b/python/triton/runtime/autotuner.py
@@ -221,7 +221,6 @@ class Autotuner(KernelInterface):
                 top_k = int(len(self.configs) * top_k)
             elif not isinstance(top_k, int):
                 # Slice index must be an integer
-                # if top_k is a float > 1.0, raise an exception
                 raise TypeError(f"Error while pruning configs, top_k must be either 1) a float <= 1.0 or 2) an int")
 
             if len(pruned_configs) > top_k:


### PR DESCRIPTION
Hello everyone!

# Context

I've been working on improving the compatibility of torch.compile with user-defined Triton kernels and recently ran into a type checking (and potential correctness) issue [here](https://github.com/pytorch/pytorch/pull/142207/files#diff-f5fa7d0e418e91c63fa56d577a92a294c87e19318a3c8b3736ac4254eaa51db9R1054).

This doesn't type the entire file, but it fixes several typing issues in autotuner.py. There is a plan to revisit this file and other user-facing portions of the API---but since this catches a potential bug I thought it would be worth filing this sooner rather than later.

# Testing 

I ran the pre-commit hooks and `python3 -m python/test/unit`. 

I ran mypy with the following command:
```bash
mypy python/triton/runtime/autotuner.py | grep autotune
```
and the python unit tests.


=====================================================================================
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ x] This PR does not need a test because: This PR only adds typing hints and one very small change to the frontend

- Select one of the following.
  - [ x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
