### PR TITLE
fix triton-llvm-opt with O3 option

### DIFF
--- a/bin/triton-llvm-opt.cpp
+++ b/bin/triton-llvm-opt.cpp
@@ -46,6 +46,10 @@ namespace {
 static std::function<Error(Module *)> makeOptimizingPipeline() {
   return [](Module *m) -> Error {
     PipelineTuningOptions tuningOptions;
+    tuningOptions.LoopInterleaving = true;
+    tuningOptions.LoopUnrolling = true;
+    tuningOptions.LoopVectorization = true;
+    tuningOptions.SLPVectorization = true;
     PassBuilder pb(nullptr, tuningOptions);
 
     LoopAnalysisManager lam;
@@ -63,6 +67,7 @@ static std::function<Error(Module *)> makeOptimizingPipeline() {
     if (BreakStructPhiNodes)
       fpm.addPass(BreakStructPhiNodesPass());
     mpm.addPass(createModuleToFunctionPassAdaptor(std::move(fpm)));
+    mpm.addPass(pb.buildPerModuleDefaultPipeline(OptimizationLevel::O3));
     mpm.run(*m, mam);
     return Error::success();
   };


### PR DESCRIPTION
# Description

triton-llvm-opt does not align with python/src/llvm.cc. seems missing some O3 related passes.

# ChangeLog

align triton-llvm-opt with python/src/llvm.cc.