### PR TITLE
[Release only] Triton release to pypi 

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -90,6 +90,6 @@ jobs:
           path: ./wheelhouse/*.whl
 
       - name: Upload wheels to PyPI
-        if: ${{ matrix.config.arh == 'x86_64' }}
+        if: ${{ matrix.config.arch == 'x86_64' }}
         run: |
           python3 -m twine upload wheelhouse/* -u __token__ -p ${{ secrets.PYPY_API_TOKEN }}


### PR DESCRIPTION
Publish triton release 3.3.0 to pypi
Same as: https://github.com/triton-lang/triton/pull/5618