### PR TITLE
Virtual classes need a virtual destructor

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -28,6 +28,7 @@ public:
   bool operator==(const Channel &c) {
     return relation == c.relation && operandIdx == c.operandIdx && op == c.op;
   }
+  virtual ~Channel() = default;
 
   Operation *getDstOp() { return op; }
   unsigned getDstOperandIdx() { return operandIdx; }


### PR DESCRIPTION
See https://en.cppreference.com/w/cpp/language/destructor#Virtual_destructors

This can trigger undefined behavior.
