### PR TITLE
Fix Gluon for Python 3.9

### DIFF
--- a/python/triton/experimental/gluon/_runtime.py
+++ b/python/triton/experimental/gluon/_runtime.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import triton
 from triton.compiler.code_generator import ast_to_ttir
 from triton.compiler.compiler import ASTSource


### PR DESCRIPTION
Fixing `TypeError` with Python 3.9:

```
language/test_frontend.py:3: in <module>
    from triton._filecheck import filecheck_test
/opt/hostedtoolcache/Python/3.9.23/x64/lib/python3.9/site-packages/triton/_filecheck.py:9: in <module>
    from triton.experimental.gluon._runtime import GluonASTSource
/opt/hostedtoolcache/Python/3.9.23/x64/lib/python3.9/site-packages/triton/experimental/gluon/__init__.py:1: in <module>
    from ._runtime import jit
/opt/hostedtoolcache/Python/3.9.23/x64/lib/python3.9/site-packages/triton/experimental/gluon/_runtime.py:58: in <module>
    do_not_specialize: Optional[Iterable[int | str]] = None,
E   TypeError: unsupported operand type(s) for |: 'type' and 'type'
```
