### PR TITLE
[Gluon] Rename memdesc subview ops

### DIFF
--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -206,6 +206,10 @@ class shared_memory_descriptor(base_value):
     def rank(self):
         return len(self.shape)
 
+    @property
+    def layout(self):
+        return self.type.layout
+
     def __str__(self) -> str:
         return str(self.type)
 
@@ -219,31 +223,16 @@ class shared_memory_descriptor(base_value):
         return _semantic.shared_store(self, value)
 
     @builtin
-    def split(self, offset, size, dim=None, layout=None, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
-        if layout is None:
-            layout = self.type.layout
-        if dim is None:
-            dim = 0
-
-        offset = _unwrap_if_constexpr(offset)
-        size = _unwrap_if_constexpr(size)
+    def slice(self, start, length, dim=0, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
+        start = _unwrap_if_constexpr(start)
+        length = _unwrap_if_constexpr(length)
         dim = _unwrap_if_constexpr(dim)
-        layout = _unwrap_if_constexpr(layout)
-
-        return _semantic.memdesc_split(self, offset, size, dim, layout)
+        return _semantic.memdesc_slice(self, start, length, dim)
 
     @builtin
-    def subslice(self, index, shape=None, layout=None, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
-        if layout is None:
-            layout = self.type.layout
-        if shape is None:
-            shape = self.shape[1:]
-
+    def index(self, index, _semantic: GluonSemantic = None) -> shared_memory_descriptor:
         index = _unwrap_if_constexpr(index)
-        shape = [_unwrap_if_constexpr(s) for s in shape]
-        layout = _unwrap_if_constexpr(layout)
-
-        return _semantic.memdesc_slice(self, index, shape, layout)
+        return _semantic.memdesc_index(self, index)
 
     @builtin
     def permute(self, order, _semantic: GluonSemantic) -> shared_memory_descriptor:

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -160,26 +160,25 @@ class GluonSemantic(TritonSemantic[TensorTy]):
     def shared_dealloc(self, mem_desc):
         self.builder.create_local_dealloc(mem_desc.handle)
 
-    def _memdesc_subview(self, mem_desc, offsets, shape, layout):
+    def _memdesc_subview(self, mem_desc, offsets, shape):
+        layout = mem_desc.layout
         ty = ttgl.shared_memory_descriptor_type(mem_desc.dtype, shape, layout, mem_desc.type.alloc_shape)
         builder = self.builder
         handle = builder.create_memdesc_subview(ty.to_ir(builder), mem_desc.handle, offsets)
         return ttgl.shared_memory_descriptor(handle, **ty.__dict__)
 
-    def memdesc_split(self, mem_desc, offset, size, dim, layout):
+    def memdesc_slice(self, mem_desc, start, length, dim):
         offsets = [self.builder.get_int32(0)] * mem_desc.rank
-        offsets[dim] = self.builder.get_int32(offset)
+        offsets[dim] = self.to_tensor(start).handle
         shape = list(mem_desc.shape)
-        shape[dim] = size
-        return self._memdesc_subview(mem_desc, offsets, shape, layout)
+        shape[dim] = length
+        return self._memdesc_subview(mem_desc, offsets, shape)
 
-    def memdesc_slice(self, mem_desc, index, shape, layout):
-        assert mem_desc.rank > len(
-            shape), f"source rank ({mem_desc.rank}) must be greater than result rank ({len(shape)})"
-
+    def memdesc_index(self, mem_desc, index):
+        shape = mem_desc.shape[1:]
         offsets = [self.builder.get_int32(0)] * mem_desc.rank
-        offsets[0] = self._convert_elem_to_ir_value(index, require_i64=False)
-        return self._memdesc_subview(mem_desc, offsets, shape, layout)
+        offsets[0] = self.to_tensor(index).handle
+        return self._memdesc_subview(mem_desc, offsets, shape)
 
     def memdesc_trans(self, mem_desc, order):
         assert len(order) == len(

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple, List, TYPE_CHECKING
 from dataclasses import dataclass
 from triton.experimental.gluon.language import _core as ttgl
 from triton.experimental.gluon.language._core import builtin, base_type, base_value, _unwrap_if_constexpr
+from triton.experimental.gluon.language._semantic import _check
 
 from . import tma
 from ..hopper import mbarrier, fence_async_shared
@@ -108,6 +109,10 @@ class tensor_memory_descriptor(base_value):
     def rank(self):
         return len(self.shape)
 
+    @property
+    def layout(self):
+        return self.type.layout
+
     def __str__(self) -> str:
         return str(self.type)
 
@@ -126,12 +131,12 @@ class tensor_memory_descriptor(base_value):
         _semantic.builder.create_tmem_store(self.handle, value.handle, pred.handle)
 
     @builtin
-    def split(self, start, length, _semantic: GluonSemantic) -> None:
+    def slice(self, start, length, _semantic: GluonSemantic) -> None:
         start = _unwrap_if_constexpr(start)
         length = _unwrap_if_constexpr(length)
-        assert isinstance(start, int)
-        assert isinstance(length, int)
-        shape = [self.shape[0], length]
+        _check(isinstance(start, int), lambda: "start must be a constant int")
+        _check(isinstance(length, int), lambda: "length must be a constant int")
+        shape = self.shape[:-1] + [length]
         layout = self.type.layout
         layout = TensorMemoryLayout((layout.block[0], min(layout.block[1], length)), layout.unpacked,
                                     layout.cta_split_num)
@@ -141,19 +146,13 @@ class tensor_memory_descriptor(base_value):
         return ret
 
     @builtin
-    def subslice(self, index, shape=None, layout=None, _semantic: GluonSemantic = None) -> tensor_memory_descriptor:
-        if layout is None:
-            layout = self.type.layout
-        if shape is None:
-            shape = self.shape[1:]
-
-        index = _semantic._convert_elem_to_ir_value(index, require_i64=False)
-        shape = [_unwrap_if_constexpr(s) for s in shape]
-        layout = _unwrap_if_constexpr(layout)
-
+    def index(self, index, _semantic: GluonSemantic = None) -> tensor_memory_descriptor:
+        index = _semantic.to_tensor(index)
         builder = _semantic.builder
         offsets = [builder.get_int32(0)] * self.rank
-        offsets[0] = index
+        offsets[0] = index.handle
+        shape = self.shape[1:]
+        layout = self.layout
         ret = tensor_memory_descriptor(None, self.dtype, shape, layout, self.type.alloc_shape)
         ret.handle = builder.create_memdesc_subview(ret.type.to_ir(builder), self.handle, offsets)
         return ret


### PR DESCRIPTION
<git-pr-chain>


[Gluon] Rename memdesc subview ops
To be more consistent with pytorch, rename:
- subslice -> index
- split -> slice

Technically the inputs to a slice should be start and end, instead of start
and length. But we need to know the length statically in order to create
the types, so this isn't possible unfortunately.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #7165 👈 **YOU ARE HERE**


</git-pr-chain>
