### PR TITLE
[AMD]Enable Transposed Mfma Layout For Fp8

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -451,17 +451,12 @@ public:
         warpsPerTileMFMA(dotOp, retShape, numWarps, {mDim, nDim});
 
     // Use transposed mfma layout to enable larger vectorization for global
-    // store instructions, except for fp8 matmul kernels due to regression
-    // TODO (lixun): investigate the regression and enable this feature again
+    // store instructions.
     auto aElemTy = mfmaInstr->aElementType;
-    bool isFP8 = llvm::isa<Float8E5M2FNUZType, Float8E4M3FNUZType,
-                           Float8E4M3FNType, Float8E5M2Type>(aElemTy);
-    bool isTransposed =
-        isChainDotHead(dotOp) || isChainDotTail(dotOp) || !isFP8;
     ttg::AMDMfmaEncodingAttr mfmaEnc = ttg::AMDMfmaEncodingAttr::get(
         oldRetType.getContext(),
         /*version*/ mfmaVersion, warpsPerTile,
-        /*instrShape*/ mDim, nDim, isTransposed, CTALayout);
+        /*instrShape*/ mDim, nDim, /*isTransposed=*/true, CTALayout);
 
     Type mfmaAccType;
     if (oldRetType.getElementType().isIntOrIndex())


### PR DESCRIPTION
Fixed https://github.com/ROCm/triton-internal/issues/918

The transposed mfma layout for fp8/bf8 was disabled due to [regression](https://github.com/ROCm/triton-internal/issues/431). But current report shows that non-transposed mfma layout generates extra `convert_layout` ops before `split`, which exceeds the LDS limits.

Experiment shows the regression has gone. So it's fine to enable it back.
