### PR TITLE
[release 3.4] Revert "[BACKEND] Promote lhs to tmem more aggressively (#7066)"

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -265,13 +265,6 @@ void replaceUsesWithLocalLoad(
     OpBuilder &builder, OpResult old,
     TypedValue<triton::gpu::MemDescType> alloc,
     TypedValue<triton::gpu::AsyncTokenType> token = {});
-
-// Return true if the value comes from a load or a block argument.
-// This will skip convert layouts and memdesc views.
-// This is a helper useful to know if value is likely to come from shared memory
-// after converting loads into async loads.
-bool comesFromLoadOrBlockArg(Value v);
-
 } // namespace mlir::triton
 
 #endif // TRITON_DIALECT_TRITONGPU_TRANSFORMS_UTILITY_H_

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -323,6 +323,29 @@ public:
     if (!(versionMajor >= 1 && versionMajor <= 3))
       return failure();
 
+    // If both of the operands are not loads, we fallback to MMAv2
+    // otherwise the reg-smem roundtrip will tank the MMAv3 performance
+    auto comesFromLoadOrBlockArg = [](Value v) -> bool {
+      // Peel out the original cvt dot_op<..., #blocked>
+      // and any other potential cvt/trans ops
+      while (true) {
+        if (auto cvtOp = v.getDefiningOp<ConvertLayoutOp>()) {
+          v = cvtOp.getSrc();
+          continue;
+        }
+        if (auto transOp = v.getDefiningOp<TransOp>()) {
+          v = transOp.getSrc();
+          continue;
+        }
+        break;
+      }
+      // We also accept block arguments as they appear in many MLIR tests
+      // If this is problematic we can totally drop them
+      return isa<BlockArgument>(v) ||
+             (v.getDefiningOp() &&
+              isa<LoadOp, DescriptorLoadOp>(v.getDefiningOp()));
+    };
+
     bool aFromLoad = comesFromLoadOrBlockArg(dotOp.getA());
     bool bFromLoad = comesFromLoadOrBlockArg(dotOp.getB());
     auto origDotOp = dotOp;

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1556,29 +1556,4 @@ void replaceUsesWithLocalLoad(OpBuilder &builder, OpResult old,
     alloc.erase();
   }
 }
-
-bool comesFromLoadOrBlockArg(Value v) {
-  // Peel out the original cvt dot_op<..., #blocked>
-  // and any other potential cvt/trans ops
-  while (true) {
-    Operation *def = v.getDefiningOp();
-    if (!def)
-      break;
-    if (auto cvtOp = dyn_cast<ttg::ConvertLayoutOp>(def)) {
-      v = cvtOp.getSrc();
-      continue;
-    }
-    if (def->hasTrait<OpTrait::MemDescViewTrait>()) {
-      v = def->getOperand(0);
-      continue;
-    }
-    break;
-  }
-  // We also accept block arguments as they appear in many MLIR tests
-  // If this is problematic we can totally drop them
-  return isa<BlockArgument>(v) ||
-         (v.getDefiningOp() &&
-          isa<LoadOp, DescriptorLoadOp, DescriptorGatherOp>(v.getDefiningOp()));
-}
-
 } // namespace mlir::triton

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
@@ -69,8 +69,7 @@ public:
         isDistributedLayoutTMemCompatible(tcGen5MMAOp, srcType, lhsMemDescType);
     Attribute newLayout = srcLayout;
     if (!layoutTmemCompatible) {
-      if (!comesFromLoadOrBlockArg(src) ||
-          triton::tools::getBoolEnv("ALLOW_LHS_TMEM_LAYOUT_CONVERSION")) {
+      if (triton::tools::getBoolEnv("ALLOW_LHS_TMEM_LAYOUT_CONVERSION")) {
         newLayout = getLHSTMemLayout(tcGen5MMAOp, srcType);
       } else {
         return failure();

--- a/test/TritonGPU/promote-lhs-to-tmem.mlir
+++ b/test/TritonGPU/promote-lhs-to-tmem.mlir
@@ -134,20 +134,4 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     %res_f16 = arith.truncf %res : tensor<128x128xf32, #blocked1> to tensor<128x128xf16, #blocked1>
     tt.return %res_f16 : tensor<128x128xf16, #blocked1>
   }
-
-  // CHECK-LABEL: @promote_lhs_arith
-  tt.func public @promote_lhs_arith(%A_ptr: tensor<128x128x!tt.ptr<f32>, #blocked2>, %B_sh: !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, %arg3: i32) {
-    %true = arith.constant true
-    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked1>
-    // %[[A:.+]] = arith.truncf
-    // %[[C:.+]] = ttg.convert_layout %[[A]]
-    // %[[D:.+]] = ttng.tmem_alloc %[[C]]
-    // ttng.tc_gen5_mma %[[D]]
-    %A = tt.load %A_ptr : tensor<128x128x!tt.ptr<f32>, #blocked2>
-    %A_f16 = arith.truncf %A : tensor<128x128xf32, #blocked2> to tensor<128x128xf16, #blocked2>
-    %A_sh = ttg.local_alloc %A_f16 : (tensor<128x128xf16, #blocked2>) -> !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>
-    %acc_tm = ttng.tmem_alloc %cst : (tensor<128x128xf32, #blocked1>) -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    ttng.tc_gen5_mma %A_sh, %B_sh, %acc_tm, %true, %true : !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf16, #shared, #ttg.shared_memory, mutable>, !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
-    tt.return
-  }
 }


### PR DESCRIPTION
This reverts commit 36f533aae04131c41f5970dbec273b34dff0768d.

Context: failures in https://github.com/pytorch/pytorch/issues/156028 were bisected to this PR. For the release, let's just revert the commit; and we can debug to submit a fix on main later.