### PR TITLE
[PROTON-DEV] Take out the stack (thread-local) memory related code

### DIFF
--- a/test/Proton/nvidia/protongpu_to_llvm.mlir
+++ b/test/Proton/nvidia/protongpu_to_llvm.mlir
@@ -51,19 +51,6 @@ module attributes {"ttg.num-warps" = 8 : i32} {
 // -----
 
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
- module attributes {"ttg.num-warps" = 8 : i32} {
-   // CHECK-LABEL: convert_stack_segment_setup
-   tt.func @convert_stack_segment_setup() -> !proton_gpu.segment<384, #proton_gpu.stack_memory, warp> {
-     // CHECK-DAG: llvm.mlir.undef : !llvm.struct<(ptr, i32)>
-     %0 = proton_gpu.stack_alloc : !ttg.memdesc<96xi32, #shared, #proton_gpu.stack_memory, mutable>
-     %3 = proton_gpu.segment_alloc %0 : !ttg.memdesc<96xi32, #shared, #proton_gpu.stack_memory, mutable> -> !proton_gpu.segment<384, #proton_gpu.stack_memory, warp>
-     tt.return %3 : !proton_gpu.segment<384, #proton_gpu.stack_memory, warp>
-   }
- }
-
-// -----
-
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: convert_circular_smem_store_nested
@@ -178,26 +165,6 @@ module attributes {"ttg.num-warps" = 8 : i32, ttg.profile_scratch_memory_alignme
     llvm.return
   }
 }
-
-// -----
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-module attributes {"ttg.num-warps" = 8 : i32} {
-   tt.func @convert_stack_alloc_invalid(){
-     // expected-error @+1 {{'proton_gpu.stack_alloc' op proton stack size must be positive and non-zero}}
-     %1 = proton_gpu.stack_alloc : !ttg.memdesc<0xi32, #shared, #proton_gpu.stack_memory, mutable>
-     tt.return
-   }
- }
-
-// -----
-#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
-module attributes {"ttg.num-warps" = 8 : i32} {
-   tt.func @convert_stack_alloc_invalid2(){
-     // expected-error @+1 {{'proton_gpu.stack_alloc' op proton stack buffer element type must be int 32}}
-     %1 = proton_gpu.stack_alloc : !ttg.memdesc<96xi8, #shared, #proton_gpu.stack_memory, mutable>
-     tt.return
-   }
- }
 
 // -----
 

--- a/test/Proton/ops.mlir
+++ b/test/Proton/ops.mlir
@@ -20,11 +20,9 @@ module attributes {"ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: protongpu_ops
   tt.func @protongpu_ops() {
     // CHECK: ttg.local_alloc
-    // CHECK-NEXT: proton_gpu.stack_alloc
     // CHECK-NEXT: proton_gpu.global_scratch_alloc
     // CHECK-NEXT: proton_gpu.segment_alloc
     // CHECK-NEXT: proton_gpu.init_ctx
-    // CHECK-NEXT: proton_gpu.segment_alloc
     // CHECK-NEXT: proton_gpu.read_counter
     // CHECK-NEXT: proton_gpu.circular_store start
     // CHECK-NEXT: gpu.barrier
@@ -32,11 +30,9 @@ module attributes {"ttg.num-warps" = 8 : i32} {
     // CHECK-NEXT: proton_gpu.finalize
     // CHECK-NEXT: tt.return
     %0 = ttg.local_alloc : () -> !ttg.memdesc<64xi32, #shared, #smem, mutable>
-    %stack = proton_gpu.stack_alloc : !ttg.memdesc<64xi32, #shared, #proton_gpu.stack_memory, mutable>
     %1 = proton_gpu.global_scratch_alloc {alignment = 128 : i32, nbytes = 384 : i32} : !tt.ptr<i32>
     %seg = proton_gpu.segment_alloc %0 : !ttg.memdesc<64xi32, #shared, #smem, mutable> -> !proton_gpu.segment<256, #shared, warp>
     proton_gpu.init_ctx %1 : !tt.ptr<i32>
-    %seg_stack = proton_gpu.segment_alloc %stack : !ttg.memdesc<64xi32, #shared, #proton_gpu.stack_memory, mutable> -> !proton_gpu.segment<256, #proton_gpu.stack_memory, warp>
     %3 = proton_gpu.read_counter : i32
     proton_gpu.circular_store start %seg, %3 {scopeId = 0 : i32} : !proton_gpu.segment<256, #shared, warp>, i32
     gpu.barrier

--- a/third_party/proton/dialect/include/Conversion/ProtonToProtonGPU/Passes.td
+++ b/third_party/proton/dialect/include/Conversion/ProtonToProtonGPU/Passes.td
@@ -55,9 +55,8 @@ def ConvertProtonToProtonGPU: Pass<"convert-proton-to-protongpu", "mlir::ModuleO
                     clEnumValN(gpu::BufferStrategy::FLUSH, "flush", "Flush Buffer")
               )}]>,
        Option<"bufferType", "buffer-type", "gpu::BufferType", /*default*/"gpu::BufferType::SHARED",
-              "Internal buffer type (STACK, SHARED, GLOBAL) that stores the profiling data",
+              "Internal buffer type (SHARED, GLOBAL) that stores the profiling data",
               /*parser*/[{::llvm::cl::values(
-                    clEnumValN(gpu::BufferType::STACK, "stack", "Stack Memory"),
                     clEnumValN(gpu::BufferType::SHARED, "shared", "Shared Memory"),
                     clEnumValN(gpu::BufferType::GLOBAL, "global", "Global Memory")
               )}]>,

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUAttrDefs.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUAttrDefs.td
@@ -49,25 +49,14 @@ def BufferStrategyAttr : I32EnumAttr<
 def BufferTypeAttr : I32EnumAttr<
   "BufferType", "The type of internal buffer to be used",
   [
-    I32EnumAttrCase<"STACK", 0, "stack">,
     I32EnumAttrCase<"SHARED", 1, "shared">,
     I32EnumAttrCase<"GLOBAL", 2, "global">,
   ]> {
   let cppNamespace = "::mlir::triton::proton::gpu";
   let description = [{
     The following buffer types are supported:
-    - STACK: Thread-private stack buffer type.
     - SHARED: Shared memory buffer type.
     - GLOBAL: Profiling data get stored directly in global memory, but may be cached in L2/L1.
-  }];
-}
-
-
-def PTG_StackMemorySpace : AttrDef<ProtonGPU_Dialect, "StackMemorySpace"> {
-  let cppNamespace = "::mlir::triton::proton::gpu";
-  let mnemonic = "stack_memory";
-  let description = [{
-    Attribute to indicate that the memory descriptor points to stack memory.
   }];
 }
 

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUOps.td
@@ -146,23 +146,6 @@ def PTG_SegmentAllocOp : PTG_Op<"segment_alloc", [Pure]> {
   let assemblyFormat = "$buffer attr-dict `:` qualified(type($buffer)) `->` type($segment)";
 }
 
-def PTG_StackAllocOp : PTG_Op<"stack_alloc", [
-    MemoryEffects<[MemAlloc<GlobalMemory>]>
-]> {
-  let summary = "Allocate a proton buffer in stack memory";
-
-  let description = [{
-    This operation allocates a proton buffer in device stack memory.
-  }];
-
-  let arguments = (ins);
-
-  let hasVerifier = 1;
-
-  let results = (outs TTG_MemDescType:$buffer);
-
-  let assemblyFormat = "attr-dict `:` qualified(type($buffer))";
-}
 
 def PTG_InitCtxOp : PTG_Op<"init_ctx", [
     MemoryEffects<[MemWrite<GlobalMemory>]>

--- a/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUTypes.td
+++ b/third_party/proton/dialect/include/Dialect/ProtonGPU/IR/ProtonGPUTypes.td
@@ -25,7 +25,7 @@ def PTG_SegmentType : PTG_TypeDef<"Segment", "segment", []> {
     - `segmentBase`: pointer to each segment's start in the internal buffer
     - `indexPtr`: pointer to the current index within the segment
 
-    The segment can reside in global memory, shared memory, or stack memory depending on the `memorySpace` attribute.
+    The segment can reside in global memory or shared memory depending on the `memorySpace` attribute.
   }];
 
   let parameters = (ins

--- a/third_party/proton/dialect/lib/Dialect/ProtonGPU/IR/Ops.cpp
+++ b/third_party/proton/dialect/lib/Dialect/ProtonGPU/IR/Ops.cpp
@@ -18,26 +18,6 @@ namespace triton {
 namespace proton {
 namespace gpu {
 
-// -- StackAllocOp --
-LogicalResult StackAllocOp::verify() {
-  auto bufferTy = mlir::cast<triton::gpu::MemDescType>(getBuffer().getType());
-  auto elemTy = bufferTy.getElementType();
-  auto rank = bufferTy.getRank();
-
-  if (!isa<IntegerType>(elemTy) || elemTy.getIntOrFloatBitWidth() != 32)
-    return emitOpError("proton stack buffer element type must be int 32");
-
-  if (rank > 1)
-    return emitOpError("proton stack currently only supports 1-D shapes");
-
-  int stackAllocationSize =
-      mlir::ShapedType::getNumElements(bufferTy.getShape());
-  if (stackAllocationSize <= 0)
-    return emitOpError("proton stack size must be positive and non-zero");
-
-  return success();
-}
-
 // -- CircularRecordOp --
 LogicalResult CircularStoreOp::verify() {
   auto scopeId = getScopeId();

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AMDPatternProtonGPUOpToLLVM.cpp
@@ -35,7 +35,8 @@ struct CircularStoreOpConversion
     uint32_t addrSpace = dataPack.addrSpace;
     if (addrSpace == 1) {
       // TODO(crobeck): see what buffer ops performance looks like here for
-      // stack mem (address space 1) compared to predicated ops to shared memory
+      // global mem (address space 1) compared to predicated ops to shared
+      // memory
       llvm::report_fatal_error("unimplemented");
     } else if (addrSpace == 3) {
       // Setting predicate always true has bank conflicts but it is

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
@@ -122,13 +122,11 @@ int TargetInfo::getAddressSpace(Attribute addressSpace) const {
   int spaceId = 0;
   if (mlir::isa<triton::gpu::SharedMemorySpaceAttr>(addressSpace)) {
     spaceId = 3;
-  } else if (mlir::isa<proton::gpu::StackMemorySpaceAttr>(addressSpace)) {
-    spaceId = 1;
   } else if (mlir::isa<proton::gpu::GlobalMemorySpaceAttr>(addressSpace)) {
     spaceId = 1;
   } else {
     llvm::report_fatal_error("Only support SharedMemorySpace, "
-                             "StackMemorySpace, and GlobalMemorySpace for now");
+                             "and GlobalMemorySpace for now");
   }
   return spaceId;
 }

--- a/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
@@ -46,13 +46,11 @@ int TargetInfo::getAddressSpace(Attribute addressSpace) const {
   int spaceId = 0;
   if (mlir::isa<triton::gpu::SharedMemorySpaceAttr>(addressSpace)) {
     spaceId = 3;
-  } else if (mlir::isa<proton::gpu::StackMemorySpaceAttr>(addressSpace)) {
-    spaceId = 1;
   } else if (mlir::isa<proton::gpu::GlobalMemorySpaceAttr>(addressSpace)) {
     spaceId = 1;
   } else {
     llvm::report_fatal_error("Only support SharedMemorySpace, "
-                             "StackMemorySpace, and GlobalMemorySpace for now");
+                             "and GlobalMemorySpace for now");
   }
   return spaceId;
 }

--- a/third_party/proton/dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -281,13 +281,6 @@ public:
           {allocBufferSize / 4}, builder.getI32Type(), encoding,
           sharedMemorySpace, /*mutable_memory=*/true);
       buffer = builder.create<triton::gpu::LocalAllocOp>(loc, sharedBufferType);
-    } else if (bufferType == gpu::BufferType::STACK) {
-      Attribute stackMemorySpace =
-          mlir::triton::proton::gpu::StackMemorySpaceAttr::get(context);
-      auto stackBufferType = triton::gpu::MemDescType::get(
-          {allocBufferSize / 4}, builder.getI32Type(), encoding,
-          stackMemorySpace, /*mutable_memory=*/true);
-      buffer = builder.create<gpu::StackAllocOp>(loc, stackBufferType);
     } else if (bufferType == gpu::BufferType::GLOBAL) {
       mlir::emitError(loc, "not implemented yet");
       return failure();

--- a/third_party/proton/dialect/triton_proton.cc
+++ b/third_party/proton/dialect/triton_proton.cc
@@ -50,7 +50,6 @@ void init_triton_proton(py::module &&m) {
       .export_values();
 
   py::enum_<proton::gpu::BufferType>(m, "BUFFER_TYPE", py::module_local())
-      .value("STACK", proton::gpu::BufferType::STACK)
       .value("SHARED", proton::gpu::BufferType::SHARED)
       .value("GLOBAL", proton::gpu::BufferType::GLOBAL)
       .export_values();

--- a/third_party/proton/proton/mode.py
+++ b/third_party/proton/proton/mode.py
@@ -13,7 +13,6 @@ buffer_strategies = {
 buffer_types = {
     "shared": triton_proton.BUFFER_TYPE.SHARED,
     "global": triton_proton.BUFFER_TYPE.GLOBAL,
-    "stack": triton_proton.BUFFER_TYPE.STACK,
 }
 
 sampling_strategies = {


### PR DESCRIPTION
This PR takes out stack memory (thread-local memory) related attribute, operator and conversion pass before we have a concrete use case.
