### PR TITLE
[Gluon] Add numel and nbytes properties

### DIFF
--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import math
 from typing import TypeVar, List, TYPE_CHECKING, Tuple
 from functools import wraps
 
@@ -215,6 +216,10 @@ class shared_memory_descriptor(base_value):
     @property
     def rank(self):
         return len(self.shape)
+
+    @property
+    def numel(self) -> int:
+        return math.prod(self.shape)
 
     @property
     def layout(self):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from warnings import warn
 from contextlib import contextmanager
 from enum import Enum
@@ -752,6 +753,10 @@ class block_type(dtype):
     def scalar(self):
         return self.element_ty
 
+    @property
+    def nbytes(self):
+        return self.numel * (self.element_ty.primitive_bitwidth // 8)
+
     def mangle(self) -> str:
         elt = self.scalar.mangle()
         shape = '_'.join(map(str, self.shape))
@@ -878,10 +883,7 @@ class tensor(base_value):
         self.handle = handle
         # Block shape
         self.shape = type.shape if type.is_block() else ()
-        self.numel = 1
-        for s in self.shape:
-            self.numel *= s
-        self.numel = constexpr(self.numel)
+        self.numel = constexpr(math.prod(self.shape))
         self.type = type  # Tensor type (can be block_type)
         # Following the practice in pytorch, dtype is scalar type
         self.dtype = type.scalar

--- a/python/tutorials/gluon/01-attention-forward.py
+++ b/python/tutorials/gluon/01-attention-forward.py
@@ -233,18 +233,9 @@ def get_desc_channel(desc, num_buffers: gl.constexpr, num_consumers: gl.constexp
     return SharedMemoryChannel.alloc(shape, desc.dtype, layout, num_buffers, num_consumers)
 
 
-@tl.constexpr_function
-def get_load_size_bytes(desc):
-    size = desc.dtype.primitive_bitwidth // 8
-    for dim in desc.block_type.shape:
-        size *= dim
-    return size
-
-
 @gluon.jit
 def issue_async_tma_load(smem, bar, desc, offset):
-    size: gl.constexpr = get_load_size_bytes(desc)
-    mbarrier.expect(bar, size)
+    mbarrier.expect(bar, desc.block_type.nbytes)
     tma.async_copy_global_to_shared(desc, [offset, 0], bar, smem)
 
 


### PR DESCRIPTION
<git-pr-chain>


[Gluon] Add numel and nbytes properties

This adds new properties:
- shared_memory_descriptor.numel
- block_type.numel
- block_type.nbytes

And I update the attention tutorial to use
`tensor_descriptor.block_type.nbytes` when calling `mbarrier.expect`.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #7507 👈 **YOU ARE HERE**


</git-pr-chain>
