### PR TITLE
Don't use the default value for `device` fixture as this will break it.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6515,7 +6515,7 @@ shared_layouts = [
 
 @pytest.mark.parametrize("M, N, M_tile_size, N_tile_size",
                          [[128, 128, 64, 64], [128, 128, 64, 32], [128, 64, 64, 32], [256, 128, 64, 64]])
-def test_split_subview(M, N, M_tile_size, N_tile_size, device='cuda'):
+def test_split_subview(M, N, M_tile_size, N_tile_size, device):
     num_rows_per_warp = THREADS_PER_WARP // 4
     num_repeats_M = triton.cdiv(M, M_tile_size)
     num_repeats_N = triton.cdiv(N, N_tile_size)


### PR DESCRIPTION
Example for XPU backend:
```bash
=========================================================================== short test summary info ============================================================================
FAILED python/test/unit/language/test_core.py::test_split_subview[128-128-64-64] - AssertionError: Torch not compiled with CUDA enabled
FAILED python/test/unit/language/test_core.py::test_split_subview[128-128-64-32] - AssertionError: Torch not compiled with CUDA enabled
FAILED python/test/unit/language/test_core.py::test_split_subview[128-64-64-32] - AssertionError: Torch not compiled with CUDA enabled
FAILED python/test/unit/language/test_core.py::test_split_subview[256-128-64-64] - AssertionError: Torch not compiled with CUDA enabled
============================================================================== 4 failed in 4.99s ===================================================
```