### PR TITLE
[Frontend] Print reproducer in case of ptxas error

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -463,6 +463,7 @@ class CUDABackend(BaseBackend):
                          f'Repro command: {" ".join(ptxas_cmd)}\n')
 
                 print(f"""
+
 ================================================================
 {error}
 
@@ -470,7 +471,6 @@ class CUDABackend(BaseBackend):
 ================================================================
 please share the reproducer above with Triton project.
 """)
-                
                 raise PTXASError(error)
 
             with open(fbin, 'rb') as f:


### PR DESCRIPTION
@lezcano and I needed to do this anyway whilst debugging, and having this dump to stdout by default matches what we do when there's an error during an MLIR compilation pass