### PR TITLE
[AMD] knob for within_2gb check for specialization

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -599,13 +599,17 @@ def test_hooks(device, fresh_triton_cache) -> None:
 @pytest.mark.skipif(reason="within_2g is a HIP specific optimization", condition=not is_hip())
 def test_within_2gb(device, fresh_triton_cache) -> None:
     default_buffer_ops = os.environ.get("AMDGCN_USE_BUFFER_OPS", "0")
+    default_do_check_is_within_2gb = os.environ.get("AMDGCN_DO_CHECK_IS_WITHIN_2GB", "0")
     try:
         use_buffer_ops_opts = ["1", "0"]
+        do_check_is_within_2gb = ["1", "0"]
         # The ranges should only be available when buffer ops are enabled
         pointer_ranges = [[(0, )], []]
-        for use_buffer_ops, pointer_range in zip(use_buffer_ops_opts, pointer_ranges):
+        for use_buffer_ops, pointer_range, check_is_within_2gb in zip(use_buffer_ops_opts, pointer_ranges,
+                                                                      do_check_is_within_2gb):
             # Set AMDGCN_USE_BUFFER_OPS
             os.environ["AMDGCN_USE_BUFFER_OPS"] = use_buffer_ops
+            os.environ["AMDGCN_DO_CHECK_IS_WITHIN_2GB"] = check_is_within_2gb
 
             @triton.jit
             def kernel_add(a):
@@ -632,6 +636,7 @@ def test_within_2gb(device, fresh_triton_cache) -> None:
             assert pointer_range_32 == pointer_range
     finally:
         os.environ["AMDGCN_USE_BUFFER_OPS"] = default_buffer_ops
+        os.environ["AMDGCN_DO_CHECK_IS_WITHIN_2GB"] = default_do_check_is_within_2gb
 
 
 def test_function_arguments(device):

--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -439,6 +439,7 @@ class nvidia_knobs(base_knobs):
 
 class amd_knobs(base_knobs):
     use_buffer_ops: env_bool = env_bool("AMDGCN_USE_BUFFER_OPS", True)
+    do_check_is_within_2gb: env_bool = env_bool("AMDGCN_DO_CHECK_IS_WITHIN_2GB", True)
     # Note: This requires use_buffer_ops be true to have any effect
     use_buffer_atomics: env_bool = env_bool("AMDGCN_USE_BUFFER_ATOMICS", True)
     dump_amdgcn: env_bool = env_bool("AMDGCN_ENABLE_DUMP")

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -172,8 +172,9 @@ class HIPBackend(BaseBackend):
         ret = BaseBackend.get_arg_specialization(arg, ty, **kwargs)
         # Only attempt to do buffer ops specialization if buffer ops are enabled.
         # Otherwise the is_within_2gb check is unnecessary overhead.
-        if knobs.amd.use_buffer_ops and ty == "tensor" and HIPBackend.is_within_2gb(arg):
-            ret += "S"
+        if knobs.amd.use_buffer_ops and ty == "tensor":
+            if not knobs.amd.do_check_is_within_2gb or HIPBackend.is_within_2gb(arg):
+                ret += "S"
         return ret
 
     @staticmethod


### PR DESCRIPTION
This PR puts the `within_2gb` behind a knob (on by default). The purpose is to save on the overhead of the check when the user is certain the check will pass.


See https://github.com/triton-lang/triton/pull/6655 for more info.