### PR TITLE
[BACKEND] Prefer simpler smem instructions

### DIFF
--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -667,12 +667,12 @@ optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
       if (a0 > b0)
         return false;
 
-      // minimise number of rounds to move the data:
+      // maximise number of rounds to move the data:
       int a1 = std::get<1>(a).getInDimSize(kReps);
       int b1 = std::get<1>(b).getInDimSize(kReps);
-      if (a1 < b1)
-        return true;
       if (a1 > b1)
+        return true;
+      if (a1 < b1)
         return false;
 
       // prefer {ld,st}.shared > {ld,st}matrix > {ld,st}matrix.trans:

--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -217,6 +217,34 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 2, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 8]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
+  // There are x4 the ldmatrix as there is broadcasting at a warp level
+  // CHECK-LABEL: convert_blocked_to_dot_rhs
+  tt.func @convert_blocked_to_dot_rhs(%a: tensor<64x64xf16, #blocked>) {
+    // CHECK-COUNT-1: llvm.store
+    //          CHECK: nvvm.barrier0
+    // CHECK-COUNT-4: nvgpu.ldmatrix
+    //          CHECK: nvvm.barrier0
+    // CHECK-COUNT-1: llvm.store
+    //          CHECK: nvvm.barrier0
+    // CHECK-COUNT-4: nvgpu.ldmatrix
+    //          CHECK: nvvm.barrier0
+    // CHECK-COUNT-1: llvm.store
+    //          CHECK: nvvm.barrier0
+    // CHECK-COUNT-4: nvgpu.ldmatrix
+    //          CHECK: nvvm.barrier0
+    // CHECK-COUNT-1: llvm.store
+    //          CHECK: nvvm.barrier0
+    // CHECK-COUNT-4: nvgpu.ldmatrix
+    %b = ttg.convert_layout %a  : tensor<64x64xf16, #blocked> -> tensor<64x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 2}>>
+    tt.return
+  }
+}
+
+// -----
+
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0], instrShape = [16, 64, 16]}>
 #shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {


### PR DESCRIPTION
If there is not an explicit advantage to using {ld,st}matrix, then use {ld,st}.shared instead. These instructions are local to a single thread so are easier for downstream compilers to reason about and optimise. Also, this may simplify address computations.