### PR TITLE
[Do Not Merge][AMD] Quick fix to transposed_load used by dot as a different type.

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -136,18 +136,11 @@ private:
 
     // transposed load can be used only when it's consumed by dot with the
     // loaded data type.
-    int opIdx = 0;
-    triton::gpu::LocalLoadOp lLoad = cast<triton::gpu::LocalLoadOp>(localLoad);
-    if (auto dotEnc = lLoad.getSrc().getType().getEncoding())
-      opIdx = cast<triton::gpu::DotOperandEncodingAttr>(dotEnc).getOpIdx();
-    else
-      return false;
-
     SetVector<Operation *> slice;
     getForwardSlice(localLoad, &slice);
     for (auto op : slice) {
       if (auto dotOp = dyn_cast<triton::DotOp>(op)) {
-        auto inputMat = (opIdx == 0) ? dotOp.getA() : dotOp.getB();
+        auto inputMat = dotOp.getA();
         auto bitwidthMat = inputMat.getType().getElementTypeBitWidth();
         if (bitwidth != bitwidthMat)
           return false;


### PR DESCRIPTION
Don't allow to use transposedLoad when folding convert layout if the tensor is casted into different element type before being used by the dot.
