### PR TITLE
[Swizzling] Disallow asymmetric vectorisation within generic swizzling

### DIFF
--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -442,6 +442,7 @@ LinearLayout optimalSwizzlingLdSt(const LinearLayout &src,
   // We fill-up vbasis until it has 32 bits as best we can
   std::optional<bool> srcFillsBank = std::nullopt;
   if ((1 << vbasis.size()) * bitwidth < 32) {
+    auto basesPerBank = llvm::Log2_32(32 / bitwidth);
     auto kWarp = StringAttr::get(ctx, "warp");
     auto warpSrc = removeZeros(flatten(srcFlat, kWarp));
     auto warpDst = removeZeros(flatten(dstFlat, kWarp));
@@ -475,19 +476,15 @@ LinearLayout optimalSwizzlingLdSt(const LinearLayout &src,
       largest = srcFillsBank.value() ? regSrcWarp : regDstWarp;
     }
     vbasis.append(largest.begin(), largest.end());
-    if (vbasis.size() > maxVecBases) {
-      vbasis.resize(maxVecBases);
-    }
-    // We allow vbasis.size > Log2_32(32 / bitwidth) at this point, as it is in
-    // general good, but one should note
-    if (vbasis.size() < llvm::Log2_32(32 / bitwidth)) {
+
+    if (vbasis.size() < basesPerBank) {
       // Pad the vectorisation to 32 bits with warp bases
       auto warpSrcWarp = intersectionBasis(warpSrc, warpDst, dim);
       vbasis.append(warpSrcWarp.begin(), warpSrcWarp.end());
     }
 
     int i = 0;
-    while (vbasis.size() < llvm::Log2_32(32 / bitwidth) &&
+    while (vbasis.size() < basesPerBank &&
            (i < warpSrc.size() || i < warpDst.size())) {
       // If we have not filled up a whole bank, we add more warp bases
       // until we have 32 bits. They will at least avoid bank conflicts in one
@@ -495,25 +492,28 @@ LinearLayout optimalSwizzlingLdSt(const LinearLayout &src,
       if (i < warpSrc.size() && !llvm::is_contained(vbasis, warpSrc[i])) {
         vbasis.push_back(warpSrc[i]);
       }
-      if (vbasis.size() < llvm::Log2_32(32 / bitwidth) && i < warpDst.size() &&
+      if (vbasis.size() < basesPerBank && i < warpDst.size() &&
           !llvm::is_contained(vbasis, warpDst[i])) {
         vbasis.push_back(warpDst[i]);
       }
       ++i;
     }
+
+    // Trim to basesPerBank if we have added more
+    // The idea here is that implementing asymmetric vectorisation without bank
+    // conflicts is a bit tricky. Basically, in this case, you need to use the
+    // vectorisation base in the swizzling pattern. As such, you would not be
+    // able to vectorise all the `ld.shared` instructions that you emit, but
+    // just about half of them (the ones that are not swizzled). We don't
+    // implement this yet
+    if (vbasis.size() > basesPerBank) {
+      vbasis.resize(basesPerBank);
+    }
   }
   auto log2Vec = llvm::Log2_32(
       std::max<int32_t>(1, ((1 << vbasis.size()) * bitwidth) / 32));
-  auto tileSrc = laneSrc;
-  // If the tile is larger than 32 / bitwidth and we had to fill in the bank
-  // we just trim the tile of the value we used to fill the bank
-  if (!srcFillsBank.has_value() || srcFillsBank.value()) {
-    tileSrc.resize(tileSrc.size() - log2Vec);
-  }
-  auto tileDst = laneDst;
-  if (!srcFillsBank.has_value() || !srcFillsBank.value()) {
-    tileDst.resize(tileDst.size() - log2Vec);
-  }
+  auto tileSrc = to_vector(ArrayRef(laneSrc).drop_back(log2Vec));
+  auto tileDst = to_vector(ArrayRef(laneDst).drop_back(log2Vec));
   auto smem = optimalSwizzling(srcFlat, dstFlat, bitwidth, vbasis, tileSrc,
                                tileDst, src.getOutDims());
 

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -107,6 +107,26 @@ TEST_F(SwizzleTest, Test32x16F32Transpose) {
   EXPECT_EQ(r, 0);
   EXPECT_EQ(w, 0);
 }
+
+TEST_F(SwizzleTest, Test128x128F16Transpose) {
+  LinearLayout matrix(
+      {{S("register"), {{1, 0}, {2, 0}, {4, 0}, {0, 32}, {0, 64}}},
+       {S("lane"), {{8, 0}, {16, 0}, {32, 0}, {64, 0}, {0, 1}}},
+       {S("warp"), {{0, 2}, {0, 4}, {0, 8}, {0, 16}}}},
+      {{S("dim0"), 128}, {S("dim1"), 128}},
+      /*requireSurjective=*/true);
+  LinearLayout matrix_t(
+      {{S("register"), {{0, 1}, {0, 2}, {0, 4}, {32, 0}, {64, 0}}},
+       {S("lane"), {{0, 8}, {0, 16}, {0, 32}, {0, 64}, {1, 0}}},
+       {S("warp"), {{2, 0}, {4, 0}, {8, 0}, {16, 0}}}},
+      {{S("dim0"), 128}, {S("dim1"), 128}},
+      /*requireSurjective=*/true);
+  auto smem = optimalSwizzlingLdSt(matrix, matrix_t, /*bitwidth=*/16);
+  auto [r, w] = logBankConflictsLdSt(matrix, matrix_t, smem, /*bitwidth=*/16);
+  EXPECT_EQ(r, 0);
+  EXPECT_EQ(w, 0);
+}
+
 } // namespace
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
Before, we would generate bank conflicts in, say, the load, as we were too
eager to use `st.shared.b32.vn`. Now in these cases, we do not use
vectorisation on the stores, but we do not create bank conflicts on the
load either.

We leave a comment as to how we could do better, but it'd be a bit of
effort for rather modest wins (if any).

Fixes https://github.com/triton-lang/triton/issues/7815
