### PR TITLE
Fixed multiple driver.py compiler warnings/errors

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -432,7 +432,7 @@ static PyObject* data_ptr_str = NULL;
 
 static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
   DevicePtrInfo ptr_info;
-  hipError_t status;
+  hipError_t status = hipSuccess;
   ptr_info.dev_ptr = 0;
   ptr_info.valid = true;
   if (PyLong_Check(obj)) {{


### PR DESCRIPTION
The refactor to driver.py seemed to create multiple conventions that violate our default compiler warning. Here is a description:

```
__triton_launcher.c:170:5: error: no matching function for call to 'PyFloat_Pack2'
  170 |     PyFloat_Pack2(f, (unsigned char*)&result, 1);
  ```

See this definition: https://docs.python.org/3/c-api/float.html. Should be just char*

```
__triton_launcher.c:141:5: error: cannot jump from this goto statement to its label
  141 |     goto cleanup;
      |     ^
__triton_launcher.c:152:14: note: jump bypasses variable initialization
  152 |   hipError_t status = hipSymbolTable.hipPointerGetAttribute(&dev_ptr, HIP_POINTER_ATTRIBUTE_DEVICE_POINTER, ptr_info.dev_ptr);
  ```
  
  Fixed by declaring status at the top of the function.