### PR TITLE
[Gluon] Misc fixes split from another PR

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -5,7 +5,7 @@ from triton._internal_testing import is_cuda, is_ampere_or_newer, is_hopper_or_n
 from triton.experimental import gluon
 from triton.experimental.gluon import language as ttgl
 from triton.experimental.gluon.language.nvidia.ampere import async_copy, mbarrier
-from triton.experimental.gluon.language.nvidia.hopper import tma
+from triton.experimental.gluon.language.nvidia.hopper import tma, fence_async_shared
 from triton.experimental.gluon.language.nvidia import hopper
 
 
@@ -121,6 +121,7 @@ def warpgroup_mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttg
     a_shmem = ttgl.allocate_shared_memory(ttgl.float16, [M, K], nvmma_layout, A)
     b_shmem = ttgl.allocate_shared_memory(ttgl.float16, [K, N], nvmma_layout, B)
 
+    fence_async_shared()
     acc = hopper.warpgroup_mma(a_shmem, b_shmem, acc, is_async=ASYNC)
 
     if ASYNC:

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -63,6 +63,7 @@ __all__ = [
 # -------------------------------------
 
 
+@constexpr_function
 def cdiv(x: int, y: int):
     return (x + y - 1) // y
 

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -64,6 +64,7 @@ _IMPORT_FROM_TRITON: List[str] = [
     "maximum",
     "minimum",
     "multiple_of",
+    "num_programs",
     "permute",
     "program_id",
     "reduce",

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -38,6 +38,9 @@ class warpgroup_mma_accumulator_type(_core.base_type):
     def _flatten_ir_types(self, builder: ir.builder, out: List[ir.type]) -> None:
         self.tensor_type._flatten_ir_types(builder, out)
 
+    def __eq__(self, other) -> bool:
+        return type(self) is type(other) and self.tensor_type == other.tensor_type
+
     def mangle(self) -> str:
         return f"FT{self.tensor_type.mangle()}FT"
 


### PR DESCRIPTION
* add `__eq__` to warpgroup_mma_accumulator so it can be used as loop carried vars
* add missing fence_async_shared in unit test
* add `constexpr_function` to `triton.cdiv` so it can be called on constexprs inside kernels
