### PR TITLE
Revert "Enable complete out-of-tree build with TRITON_BUILD_DIR (#7871)"

### DIFF
--- a/python/build_helpers.py
+++ b/python/build_helpers.py
@@ -5,34 +5,18 @@ from pathlib import Path
 
 
 def get_base_dir():
-    return Path(__file__).parent.parent
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
 
-def _get_build_base():
-    build_base = os.getenv("TRITON_BUILD_DIR", default=(get_base_dir() / "build"))
-    return Path(build_base)
-
-
-def _get_dir_common(prefix):
+def _get_cmake_dir():
     plat_name = sysconfig.get_platform()
     python_version = sysconfig.get_python_version()
-    dir_name = f"{prefix}.{plat_name}-{sys.implementation.name}-{python_version}"
-    path = _get_build_base() / dir_name
-    path.mkdir(parents=True, exist_ok=True)
-    return path
+    dir_name = f"cmake.{plat_name}-{sys.implementation.name}-{python_version}"
+    return Path(get_base_dir()) / "build" / dir_name
 
 
 def get_cmake_dir():
-    return _get_dir_common("cmake")
-
-
-def get_build_lib():
-    return _get_dir_common("lib")
-
-
-def get_build_temp():
-    return _get_dir_common("temp")
-
-
-def get_bdist_dir():
-    return _get_dir_common("bdist")
+    cmake_dir = os.getenv("TRITON_BUILD_DIR", default=_get_cmake_dir())
+    cmake_dir = Path(cmake_dir)
+    cmake_dir.mkdir(parents=True, exist_ok=True)
+    return cmake_dir

--- a/setup.py
+++ b/setup.py
@@ -43,13 +43,7 @@ except ImportError:
 
 sys.path.insert(0, os.path.dirname(__file__))
 
-from python.build_helpers import (
-    get_base_dir,
-    get_cmake_dir,
-    get_build_lib,
-    get_build_temp,
-    get_bdist_dir,
-)
+from python.build_helpers import get_base_dir, get_cmake_dir
 
 
 def is_git_repo():
@@ -381,10 +375,6 @@ class CMakeClean(clean):
 
 class CMakeBuildPy(build_py):
 
-    def initialize_options(self):
-        super().initialize_options()
-        self.build_lib = get_build_lib().as_posix()
-
     def run(self) -> None:
         self.run_command('build_ext')
         return super().run()
@@ -406,8 +396,6 @@ class CMakeBuild(build_ext):
     def initialize_options(self):
         build_ext.initialize_options(self)
         self.base_dir = get_base_dir()
-        self.build_lib = get_build_lib()
-        self.build_temp = get_build_temp()
 
     def finalize_options(self):
         build_ext.finalize_options(self)
@@ -707,10 +695,6 @@ def add_links(external_only):
 
 
 class plugin_bdist_wheel(bdist_wheel):
-
-    def initialize_options(self):
-        super().initialize_options()
-        self.bdist_dir = get_bdist_dir()
 
     def run(self):
         add_links(external_only=True)


### PR DESCRIPTION
This reverts commit 1f10206e47c1817100aae90a872fe51a1e00bce8 as it breaks internal workflows (`pip install -v .` no longer copies files into site-packages correctly).