### PR TITLE
[triton_kernels] cacheable sets __name__ and __module__ on JITFunction

### DIFF
--- a/python/triton_kernels/triton_kernels/specialize.py
+++ b/python/triton_kernels/triton_kernels/specialize.py
@@ -19,6 +19,9 @@ def cacheable(f):
     g.fn.__name__ = f.__name__
     g.fn.__module__ = f.__module__
     g.fn.__qualname__ = f.__qualname__
+    g.__name__ = f.__name__
+    g.__module__ = f.__module__
+    g.__qualname__ = f.__qualname__
     g._fn_name = f"{f.__module__}.{f.__qualname__}"
     return g
 


### PR DESCRIPTION
Currently `kernel.__module__` points to the fake module created by `specialize` which means you can't import it programmatically.