### PR TITLE
Use Docker for Ubuntu x64 job

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -23,13 +23,14 @@ jobs:
   build:
     name: Build on ${{ matrix.config.runner }}
     runs-on: ${{ matrix.config.runs_on }}
+    container: ${{ matrix.config.container }}
     timeout-minutes: 240  # 4 hours
 
     strategy:
       fail-fast: true
       matrix:
         config:
-        - {runner: 'Ubuntu 22.04', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'x64'}
+        - {runner: 'Ubuntu 22.04', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'x64', container: 'ubuntu:22.04'}
         - {runner: 'Ubuntu 22.04 ARM64', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'arm64'}
         - {runner: 'CentOS 7', runs_on: ['self-hosted', 'CPU'], target-os: 'centos', arch: 'x64'}
         - {runner: 'AlmaLinux 8', runs_on: ['self-hosted', 'CPU'], target-os: 'almalinux', arch: 'x64'}
@@ -91,6 +92,11 @@ jobs:
         path: ${{ env.SCCACHE_DIR }}
         key: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-${{ env.short_llvm_commit_hash }}
         restore-keys: ${{ matrix.config.target-os }}-${{ matrix.config.arch }}-
+
+    - name: Install dependencies for Ubuntu Docker container
+      if: matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu'
+      run: |
+        apt update && apt install -y build-essential clang python3 pip cmake ninja-build
 
     - name: Configure, Build, Test, and Install LLVM (Ubuntu and macOS x64)
       if: matrix.config.arch == 'x64' && (matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'macos')


### PR DESCRIPTION
We currently use GitHub's runners to build LLVM binaries, which are subject to the toolchains that GitHub preinstalls on them and the GitHub's deprecation schedule. This causes problems when we want to build binaries for distribution, because we cannot maintain close control of binary compatibility.

For example, bumping from GitHub's 20.04 runner to the 22.04 runner also bumped the minimum required libstdc++ version, breaking binary compatibility on systems with older toolchains. This is made trickier by the fact that the runners come with multiple versions of GCC (including GCC 12 in this case) and Clang always picks the newest libstdc++ available on the host.

Docker allows us to maintain fine control over the environment in which binaries are produced. We can continue running old versions of containers indefinitely and pin the exact toolchain version that is used to build.

LLVM maintains compatibility with much older compilers, so we could pick even older images than 22.04 and potentially eliminate the need to maintain multiple binary distributions for Linux. But this seems like a good first step.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is a CI change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
