### PR TITLE
[AMD] Refactor llStore and llLoad to use proper ops (#8036)

### DIFF
--- a/test/Conversion/amd/async-ops-alias-scopes.mlir
+++ b/test/Conversion/amd/async-ops-alias-scopes.mlir
@@ -1,5 +1,5 @@
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 --convert-scf-to-cf --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=COMMON,GFX950
-// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --convert-scf-to-cf --convert-builtin-func-to-llvm | FileCheck %s --check-prefixes=COMMON,GFX942
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 --convert-scf-to-cf | FileCheck %s --check-prefixes=COMMON,GFX950
+// RUN: triton-opt %s -split-input-file --allocate-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx942 --convert-scf-to-cf | FileCheck %s --check-prefixes=COMMON,GFX942
 
 // COMMON: [[$ASYNC_COPY_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.AsyncCopies"
 // COMMON: [[$LOCAL_LOAD_SCOPE:#.*]] = #llvm.alias_scope<id = "amdgpu.LocalLoads"

--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -156,22 +156,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: llvm.cond_br
     // CHECK: rocdl.global.load.lds
     // CHECK-NEXT: llvm.br
-    // CHECK: _predicated_store
+    // CHECK: llvm.cond_br
+    // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
     // CHECK: rocdl.global.load.lds
     // CHECK-NEXT: llvm.br
-    // CHECK: _predicated_store
+    // CHECK: llvm.cond_br
+    // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
     // CHECK: rocdl.global.load.lds
     // CHECK-NEXT: llvm.br
-    // CHECK: _predicated_store
+    // CHECK: llvm.cond_br
+    // CHECK: llvm.store
 
     // CHECK: llvm.cond_br
     // CHECK: rocdl.global.load.lds
     // CHECK-NEXT: llvm.br
-    // CHECK: _predicated_store
+    // CHECK: llvm.cond_br
+    // CHECK: llvm.store
 
     %2 = ttg.async_copy_global_to_local %1, %arg2 mask %67 other %cst_0 : tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     tt.return
@@ -216,28 +220,32 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: llvm.cond_br
     // CHECK: rocdl.global.load.lds
     // CHECK-NEXT: llvm.br
-    // CHECK: _predicated_store
+    // CHECK: llvm.cond_br
+    // CHECK: llvm.store
 
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
     // CHECK: rocdl.global.load.lds
     // CHECK-NEXT: llvm.br
-    // CHECK: _predicated_store
+    // CHECK: llvm.cond_br
+    // CHECK: llvm.store
 
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
     // CHECK: rocdl.global.load.lds
     // CHECK-NEXT: llvm.br
-    // CHECK: _predicated_store
+    // CHECK: llvm.cond_br
+    // CHECK: llvm.store
 
     // CHECK: rocdl.ds_bpermute
     // CHECK: rocdl.ballot
     // CHECK: llvm.cond_br
     // CHECK: rocdl.global.load.lds
     // CHECK-NEXT: llvm.br
-    // CHECK: _predicated_store
+    // CHECK: llvm.cond_br
+    // CHECK: llvm.store
 
     %2 = ttg.async_copy_global_to_local %1, %arg2 mask %67 other %cst_0 : tensor<32x32x!tt.ptr<f32>, #blocked> -> <32x32xf32, #shared, #smem, mutable>
     tt.return

--- a/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
+++ b/test/Conversion/amd/buffer_load_to_local_to_llvm.mlir
@@ -147,19 +147,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // Note that mask/other alignment is 1 so we need 4 conditionals
 
     // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON: _predicated_store
+    // COMMON: llvm.cond_br
+    // COMMON: llvm.store
 
     // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON: _predicated_store
+    // COMMON: llvm.cond_br
+    // COMMON: llvm.store
 
     // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON: _predicated_store
+    // COMMON: llvm.cond_br
+    // COMMON: llvm.store
 
     // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON: _predicated_store
+    // COMMON: llvm.cond_br
+    // COMMON: llvm.store
 
     // COMMON-NOT: rocdl.raw.ptr.buffer.load.lds
     // COMMON-NOT: _predicated_store
+    // COMMON-NOT: llvm.cond_br
+    // COMMON-NOT: llvm.store
 
     amdgpu.buffer_load_to_local %arg1[%arg2] mask=%67 other=%cst_0 into %arg3 : <f32>[tensor<32x32xi32, #blocked>] tensor<32x32xf32, #blocked>  -> <32x32xf32, #shared, #smem, mutable>
     tt.return
@@ -257,22 +263,26 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
     // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON: _predicated_store
+    // COMMON: llvm.cond_br
+    // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
     // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON: _predicated_store
+    // COMMON: llvm.cond_br
+    // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
     // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON: _predicated_store
+    // COMMON: llvm.cond_br
+    // COMMON: llvm.store
 
     // COMMON: rocdl.ds_bpermute
     // COMMON: rocdl.ballot
     // COMMON: rocdl.raw.ptr.buffer.load.lds
-    // COMMON: _predicated_store
+    // COMMON: llvm.cond_br
+    // COMMON: llvm.store
 
     // COMMON-NOT: rocdl.ds_bpermute
     // COMMON-NOT: rocdl.ballot

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -520,6 +520,56 @@ def TTG_UpcastMXFPOp : TT_AMDGPU_Op<"upcast_mxfp", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// MaskedLoadOp
+//===----------------------------------------------------------------------===//
+def MaskedLoadOp : TT_AMDGPU_Op<"masked_load", []> {
+  let summary = "Masked load operation";
+  let description = [{
+    Load operation with masking support. If the mask is true, loads from the given pointer. Works with LLVM types as a utility op for making LLVM conversion easier.
+  }];
+  let arguments = (ins
+    LLVM_AnyPointer:$ptr,
+    I1:$mask,
+    LLVM_Type:$falseVal,
+    DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+    DefaultValuedAttr<BoolAttr, "false">:$forceNoAlias
+  );
+
+  let results = (outs LLVM_Type:$result);
+
+  let assemblyFormat = [{
+    $ptr `,` $mask `,` $falseVal
+    oilist(`cacheModifier` `=` $cache)
+    (`forceNoAlias` $forceNoAlias^)?
+    attr-dict `:` functional-type(operands, results)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// MaskedStoreOp
+//===----------------------------------------------------------------------===//
+def MaskedStoreOp : TT_AMDGPU_Op<"masked_store", []> {
+  let summary = "Masked Store operation";
+  let description = [{
+    Store operation with masking support. If the mask is true, Store from the given pointer. Works with LLVM types as a utility op for making LLVM conversion easier.
+  }];
+  let arguments = (ins
+    LLVM_AnyPointer:$ptr,
+    LLVM_Type:$value,
+    I1:$mask,
+    DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+    DefaultValuedAttr<BoolAttr, "false">:$forceNoAlias
+  );
+
+  let assemblyFormat = [{
+    $ptr `,` $value `,` $mask
+    oilist(`cacheModifier` `=` $cache)
+    (`forceNoAlias` $forceNoAlias^)?
+    attr-dict `:` type(operands)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // InThreadTransposeOp
 //===----------------------------------------------------------------------===//
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/CMakeLists.txt
@@ -5,6 +5,7 @@ add_triton_library(TritonAMDGPUToLLVM
     BufferOpsEmitter.cpp
     ConvertLayoutOpToLLVM.cpp
     MemoryOpToLLVM.cpp
+    MaskedOpsToLLVM.cpp
     DotOpToLLVM/FMA.cpp
     DotOpToLLVM/MFMA.cpp
     DotOpToLLVM/WMMA.cpp

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -531,7 +531,6 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op->getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-
     // original values
     Value ptr = op.getPtr();
     Value mask = op.getMask();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
@@ -1,0 +1,152 @@
+#include "AsyncUtility.h"
+#include "Dialect/TritonAMDGPU/IR/Dialect.h"
+#include "PatternTritonGPUOpToLLVM.h"
+#include "TritonAMDGPUToLLVM/Passes.h"
+#include "Utility.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "triton/Tools/Sys/GetEnv.hpp"
+#include <tuple>
+
+using namespace mlir;
+using namespace mlir::triton::gpu;
+
+namespace {
+
+class ConvertMaskedLoadOp
+    : public OpRewritePattern<triton::amdgpu::MaskedLoadOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::amdgpu::MaskedLoadOp loadOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = loadOp.getLoc();
+    auto elemTy = loadOp.getResult().getType();
+    auto ptr = loadOp.getPtr();
+    auto mask = loadOp.getMask();
+    auto falseVal = loadOp.getFalseVal();
+
+    bool volatileFlag, nonTmpFlag;
+    std::tie(volatileFlag, nonTmpFlag) =
+        mlir::LLVM::AMD::getCacheModifierFlagsForLoadStore(
+            loadOp.getCache(), mlir::LLVM::AMD::MemoryOp::Load);
+
+    auto createLoadWithAttrs = [&](Location loadLoc) -> LLVM::LoadOp {
+      auto load = rewriter.create<LLVM::LoadOp>(
+          loadLoc, elemTy, ptr, /*alignment*/ 0, volatileFlag, nonTmpFlag);
+      if (loadOp.getForceNoAlias()) {
+        AMD::addLocalLoadNoAliasScope(load);
+      }
+      return load;
+    };
+
+    bool useDirectLoad = mlir::matchPattern(mask, mlir::m_One());
+
+    if (useDirectLoad) {
+      auto llvmLoadOp = createLoadWithAttrs(loc);
+      rewriter.replaceOp(loadOp, llvmLoadOp.getResult());
+      return success();
+    }
+
+    Block *currentBlock = rewriter.getInsertionBlock();
+    Block *afterLoad =
+        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+    afterLoad->addArgument({elemTy}, {loc});
+
+    Block *trueBlock = rewriter.createBlock(afterLoad);
+
+    rewriter.setInsertionPointToEnd(currentBlock);
+    rewriter.create<LLVM::CondBrOp>(loc, mask, trueBlock, ValueRange{},
+                                    afterLoad, ValueRange{falseVal});
+    rewriter.setInsertionPointToStart(trueBlock);
+    //              | vialatile | non-tmp | gcn instr gfx94
+    // LLVM::LoadOp | 0         | 0       | (ca) global load
+    //              | 0/1       | 1       | (cg) global load nt
+    //              | 1         | 0       | (cv) flat load sc0 sc1
+    auto llvmLoadOp = createLoadWithAttrs(loc);
+    rewriter.create<LLVM::BrOp>(loc, ValueRange{llvmLoadOp->getResult(0)},
+                                afterLoad);
+
+    rewriter.replaceOp(loadOp, afterLoad->getArgument(0));
+
+    return success();
+  }
+};
+
+class ConvertMaskedStoreOp
+    : public OpRewritePattern<triton::amdgpu::MaskedStoreOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(triton::amdgpu::MaskedStoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+
+    auto loc = storeOp.getLoc();
+    auto val = storeOp.getValue();
+    auto elemTy = storeOp.getValue().getType();
+    auto ptr = storeOp.getPtr();
+    auto mask = storeOp.getMask();
+
+    bool volatileFlag, nonTmpFlag;
+    std::tie(volatileFlag, nonTmpFlag) =
+        mlir::LLVM::AMD::getCacheModifierFlagsForLoadStore(
+            storeOp.getCache(), mlir::LLVM::AMD::MemoryOp::Store);
+
+    int alignment = 0;
+    if (auto vecTy = dyn_cast<VectorType>(elemTy)) {
+      auto vecElemTy = vecTy.getElementType();
+      auto elemSizeInBytes = vecElemTy.getIntOrFloatBitWidth() / 8;
+      alignment = elemSizeInBytes * vecTy.getNumElements();
+    }
+
+    auto createStoreWithAttrs = [&](Location storeLoc) -> LLVM::StoreOp {
+      auto store = rewriter.create<LLVM::StoreOp>(storeLoc, val, ptr, alignment,
+                                                  volatileFlag, nonTmpFlag);
+      if (storeOp.getForceNoAlias()) {
+        AMD::addLocalLoadNoAliasScope(store);
+      }
+      return store;
+    };
+
+    bool useDirectStore = mlir::matchPattern(mask, mlir::m_One());
+
+    if (useDirectStore) {
+      auto llvmStoreOp = createStoreWithAttrs(loc);
+      rewriter.eraseOp(storeOp);
+      return success();
+    }
+
+    Block *currentBlock = rewriter.getInsertionBlock();
+    Block *afterStore =
+        rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
+    Block *trueBlock = rewriter.createBlock(afterStore);
+    rewriter.setInsertionPointToEnd(currentBlock);
+    rewriter.create<LLVM::CondBrOp>(loc, mask, trueBlock, afterStore);
+    rewriter.setInsertionPointToStart(trueBlock);
+    //               | vialatile | non-tmp | gcn instr gfx94
+    // LLVM::StoreOp | 0         | 0       | (cg) global store
+    //               | 0         | 1       | (cs) global store nt
+    //               | 1         | 0/1     | (wt) global store sc0 sc1
+    auto llvmStoreOp = createStoreWithAttrs(loc);
+    rewriter.create<LLVM::BrOp>(loc, afterStore);
+    rewriter.setInsertionPointToStart(afterStore);
+    rewriter.eraseOp(storeOp);
+    return success();
+  }
+};
+
+} // namespace
+
+namespace mlir::triton::AMD {
+
+void populateMaskedOpsToLLVMPatterns(RewritePatternSet &patterns) {
+  patterns.add<ConvertMaskedLoadOp>(patterns.getContext());
+  patterns.add<ConvertMaskedStoreOp>(patterns.getContext());
+}
+} // namespace mlir::triton::AMD
+
+// namespace mlir::triton

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -47,6 +47,8 @@ void populateFp4ToFpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                    RewritePatternSet &patterns,
                                    PatternBenefit benefit);
 
+void populateMaskedOpsToLLVMPatterns(RewritePatternSet &patterns);
+
 } // namespace mlir::triton::AMD
 
 #endif // TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTOLLVM_PATTERNTRITONGPUOPTOLLVM_H_

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -175,6 +175,8 @@ struct ConvertTritonAMDGPUToLLVM
                                              targetInfo, AMDBenefit);
     AMD::populateLoadStoreOpToLLVMPatterns(typeConverter, targetInfo, patterns,
                                            axisInfoAnalysis, AMDBenefit);
+    AMD::populateMaskedOpsToLLVMPatterns(patterns);
+
     populatePatterns7(mlir::triton::populateReduceOpToLLVMPatterns,
                       commonBenefit);
     populatePatterns7(mlir::triton::populateScanOpToLLVMPatterns,
@@ -206,7 +208,6 @@ struct ConvertTritonAMDGPUToLLVM
                                                         targetInfo, AMDBenefit);
     mlir::triton::AMD::populateFp4ToFpToLLVMPatterns(typeConverter, patterns,
                                                      AMDBenefit);
-
     // TODO(thomas): this should probably be done in a separate step to not
     // interfere with our own lowering of arith ops. Add arith/math's patterns
     // to help convert scalar expression to LLVM.

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -1,4 +1,5 @@
 #include "Utility.h"
+#include "AsyncUtility.h"
 #include "Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "TritonAMDGPUToLLVM/GCNAsmFormat.h"
 #include "TritonAMDGPUToLLVM/TargetUtils.h"
@@ -8,7 +9,6 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
-
 namespace tt = mlir::triton;
 using mlir::triton::ModuleAxisInfoAnalysis;
 using mlir::triton::AMD::DppCtrl;
@@ -301,106 +301,6 @@ Value permute(Location loc, RewriterBase &rewriter, Value x, Value y,
   return op.getResult(0);
 }
 
-Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
-               ProgramIDDim axis) {
-  Value blockId =
-      rewriter.create<::mlir::gpu::BlockIdOp>(loc, mlir::gpu::Dimension(axis));
-  return rewriter.create<arith::IndexCastOp>(loc, i32_ty, blockId);
-}
-
-Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
-             Value pred, Value falseVal, triton::CacheModifier cm,
-             bool forceNoAliasAsyncLoads) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-  Type funcType = getFunctionType(elemTy, ValueRange({ptr, pred, falseVal}));
-  auto parent = ptr.getParentRegion()->getParentOfType<LLVM::LLVMFuncOp>();
-  auto getLoadNameRaw = [](triton::CacheModifier cm) {
-    switch (cm) {
-    case triton::CacheModifier::CA:
-      return predicatedLoadCA;
-    case triton::CacheModifier::CG:
-      return predicatedLoadCG;
-    case triton::CacheModifier::CV:
-      return predicatedLoadCV;
-    default:
-      // Do not fail in compile time in the case of unsupported modifier.
-      // Just apply default config.
-      return predicatedLoad;
-    }
-  };
-  std::string funcName = getLoadNameRaw(cm);
-  if (forceNoAliasAsyncLoads)
-    funcName += noAliasAsyncLoads;
-
-  auto mangledName = mangleFunc(funcName, funcType);
-  LLVM::LLVMFuncOp funcOp =
-      appendOrGetExternFuncOp(rewriter, parent, mangledName, funcType);
-  return LLVM::createLLVMCallOp(rewriter, loc, funcOp,
-                                ValueRange({ptr, pred, falseVal}))
-      .getResult();
-}
-
-void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
-             Value pred, triton::CacheModifier cm,
-             bool forceNoAliasAsyncLoads) {
-  auto b = TritonLLVMOpBuilder(loc, rewriter);
-
-  auto ctx = ptr.getContext();
-  Type funcType = getFunctionType(void_ty(ctx), ValueRange({ptr, val, pred}));
-  auto parent = ptr.getParentRegion()->getParentOfType<LLVM::LLVMFuncOp>();
-
-  auto getStoreNameWithCacheMod = [](triton::CacheModifier cm) {
-    switch (cm) {
-    case triton::CacheModifier::WT:
-      return predicatedStoreWT;
-    case triton::CacheModifier::CG:
-      return predicatedStoreCG;
-    case triton::CacheModifier::CS:
-      return predicatedStoreCS;
-    default:
-      // Do not fail in compile time in the case of unsupported modifier.
-      // Just apply default config.
-      return predicatedStore;
-    }
-  };
-  std::string funcName = getStoreNameWithCacheMod(cm);
-  if (forceNoAliasAsyncLoads)
-    funcName += noAliasAsyncLoads;
-
-  auto mangledName = mangleFunc(funcName, funcType);
-  LLVM::LLVMFuncOp funcOp =
-      appendOrGetExternFuncOp(rewriter, parent, mangledName, funcType);
-  LLVM::createLLVMCallOp(rewriter, loc, funcOp, ValueRange({ptr, val, pred}));
-}
-
-static bool isPredicatedLoadCA(LLVM::CallOp callOp) {
-  return callOp.getCallee().value().contains(mlir::LLVM::AMD::predicatedLoadCA);
-}
-
-static bool isPredicatedLoadCG(LLVM::CallOp callOp) {
-  return callOp.getCallee().value().contains(mlir::LLVM::AMD::predicatedLoadCG);
-}
-
-static bool isPredicatedLoadCV(LLVM::CallOp callOp) {
-  return callOp.getCallee().value().contains(mlir::LLVM::AMD::predicatedLoadCV);
-}
-
-static bool isPredicatedStoreCS(LLVM::CallOp callOp) {
-  return callOp.getCallee().value().contains(
-      mlir::LLVM::AMD::predicatedStoreCS);
-}
-
-static bool isPredicatedStoreCG(LLVM::CallOp callOp) {
-  return callOp.getCallee().value().contains(
-      mlir::LLVM::AMD::predicatedStoreCG);
-}
-
-static bool isPredicatedStoreWT(LLVM::CallOp callOp) {
-  return callOp.getCallee().value().contains(
-      mlir::LLVM::AMD::predicatedStoreWT);
-}
-
 // Utility function that returns flags <volatile, nontemporal> for a predicated
 // Load or Store
 // ---------------------------------
@@ -417,22 +317,60 @@ static bool isPredicatedStoreWT(LLVM::CallOp callOp) {
 //      | .wt |   T      | X
 // -----+-----+----------+---------
 std::pair<bool, bool>
-getCacheModifierFlagsForPredicatedCall(LLVM::CallOp callOp) {
-  if (isPredicatedLoadCA(callOp))
-    return std::make_pair(false, false);
-  if (isPredicatedLoadCG(callOp))
-    return std::make_pair(false, true);
-  if (isPredicatedLoadCV(callOp))
-    return std::make_pair(true, true);
-
-  if (isPredicatedStoreCG(callOp))
-    return std::make_pair(false, false);
-  if (isPredicatedStoreCS(callOp))
-    return std::make_pair(false, true);
-  if (isPredicatedStoreWT(callOp))
-    return std::make_pair(true, true);
-  // unsupported modifier
+getCacheModifierFlagsForLoadStore(const triton::CacheModifier &cm,
+                                  MemoryOp op) {
+  switch (op) {
+  case MemoryOp::Load: {
+    switch (cm) {
+    case triton::CacheModifier::CA:
+      return std::make_pair(false, false);
+    case triton::CacheModifier::CG:
+      return std::make_pair(false, true);
+    case triton::CacheModifier::CS:
+      return std::make_pair(false, true);
+    case triton::CacheModifier::CV:
+      return std::make_pair(true, true);
+    default:
+      return std::make_pair(false, false);
+    }
+  }
+  case MemoryOp::Store: {
+    switch (cm) {
+    case triton::CacheModifier::CG:
+      return std::make_pair(false, false);
+    case triton::CacheModifier::CS:
+      return std::make_pair(false, true);
+    case triton::CacheModifier::WT:
+      return std::make_pair(true, true);
+    default:
+      return std::make_pair(false, false);
+    }
+  }
+  }
   return std::make_pair(false, false);
+}
+
+Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
+               ProgramIDDim axis) {
+  Value blockId =
+      rewriter.create<::mlir::gpu::BlockIdOp>(loc, mlir::gpu::Dimension(axis));
+  return rewriter.create<arith::IndexCastOp>(loc, i32_ty, blockId);
+}
+
+Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
+             Value pred, Value falseVal, triton::CacheModifier cm,
+             bool forceNoAliasAsyncLoads) {
+  return rewriter
+      .create<triton::amdgpu::MaskedLoadOp>(loc, elemTy, ptr, pred, falseVal,
+                                            cm, forceNoAliasAsyncLoads)
+      .getResult();
+}
+
+void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
+             Value pred, triton::CacheModifier cm,
+             bool forceNoAliasAsyncLoads) {
+  rewriter.create<triton::amdgpu::MaskedStoreOp>(loc, ptr, val, pred, cm,
+                                                 forceNoAliasAsyncLoads);
 }
 
 // Create the auxiliary/cachepolicy value of ROCDL::RawPtrBufferLoad/StoreOp

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -14,15 +14,7 @@
 
 namespace mlir::LLVM::AMD {
 
-const char predicatedLoad[] = "__triton_hip_predicated_load";
-const char predicatedLoadCA[] = "__triton_hip_predicated_load_CA";
-const char predicatedLoadCG[] = "__triton_hip_predicated_load_CG";
-const char predicatedLoadCV[] = "__triton_hip_predicated_load_CV";
-const char predicatedStore[] = "__triton_hip_predicated_store";
-const char predicatedStoreCG[] = "__triton_hip_predicated_store_CG";
-const char predicatedStoreCS[] = "__triton_hip_predicated_store_CS";
-const char predicatedStoreWT[] = "__triton_hip_predicated_store_WT";
-const char noAliasAsyncLoads[] = "__no_alias_async_loads";
+enum class MemoryOp { Load, Store };
 
 Value shuffleXor(Location loc, RewriterBase &rewriter, Value val, int i,
                  mlir::triton::AMD::ISAFamily isaFamily =
@@ -42,6 +34,9 @@ Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
 
 Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
                ProgramIDDim axis);
+
+std::pair<bool, bool>
+getCacheModifierFlagsForLoadStore(const triton::CacheModifier &cm, MemoryOp op);
 
 // Loads from shared or global memory with predication.
 // `otherElems` is used to mask out the elements that are not loaded
@@ -63,7 +58,7 @@ void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
 
 // Get cache modifier information for creating load or store instruction
 // Get flags <volatile, nontemporal> for a predicated Load or Store
-std::pair<bool, bool> getCacheModifierFlagsForPredicatedCall(LLVM::CallOp);
+std::pair<bool, bool> getCacheModifierFlagsForLoadStore(LLVM::CallOp);
 // Get the cachepolicy value for a cache modifier
 int32_t
 getCtrlBitsForCacheModifierOnTarget(triton::CacheModifier, bool,

--- a/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/Passes.td
+++ b/third_party/proton/Dialect/include/Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/Passes.td
@@ -15,9 +15,10 @@ def ConvertProtonAMDGPUToLLVM : Pass<"convert-proton-amd-gpu-to-llvm", "mlir::Mo
                              "mlir::gpu::GPUDialect",
                              "mlir::scf::SCFDialect",
                              "mlir::LLVM::LLVMDialect",
-      						 "mlir::ROCDL::ROCDLDialect",
+                             "mlir::ROCDL::ROCDLDialect",
                              "mlir::triton::TritonDialect",
                              "mlir::triton::gpu::TritonGPUDialect",
+                             "mlir::triton::amdgpu::TritonAMDGPUDialect",
                              "mlir::triton::proton::ProtonDialect",
                              "mlir::triton::proton::gpu::ProtonGPUDialect"];
 

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/ConvertProtonGPUToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/ConvertProtonGPUToLLVM.cpp
@@ -3,13 +3,15 @@
 #include "Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/Passes.h"
 #include "Conversion/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.h"
 #include "Dialect/ProtonGPU/IR/Dialect.h"
+#include "amd/include/Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/GPUToROCDL/GPUToROCDLPass.h"
 #include "mlir/Dialect/AMDGPU/Utils/Chipset.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/ROCDLDialect.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
 
 using namespace mlir;
@@ -56,6 +58,7 @@ struct ConvertProtonAMDGPUToLLVM
         typeConverter, patterns, protonTargetInfo, 1);
     mlir::triton::proton::gpu::AMD::populateProtonGPUOpAMDPatterns(
         typeConverter, patterns, protonTargetInfo, 1);
+    mlir::triton::AMD::populateMaskedOpsToLLVMPatterns(patterns);
     mlir::arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
 
     FailureOr<mlir::amdgpu::Chipset> maybeChipset =


### PR DESCRIPTION
Required for release branch to resolve severe hang as reported by @davidberard98 in https://github.com/triton-lang/triton/pull/7355

Refactor `llLoad` and `llStore` to no longer use strings that get replaced in built in to LLVM pass, now they have their own AMDGPU ops. `builtin-func-to-llvm` is no longer responsible for these operations, so code there was removed.

---------



(cherry picked from commit 3d8b0be75d5f548767602323e0c52b95517771ec)

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
