### PR TITLE
[Backend] Fix ptxas workaround

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -410,16 +410,16 @@ struct ConvertLayoutOpConversion
         if (bitsPerVecElem == 8) {
           for (auto packedVal : outVals) {
             Value x0 =
-                b.trunc(int_ty(bitwidth), b.and_(packedVal, b.i32_val(0xF)));
+                b.trunc(int_ty(bitwidth), b.and_(packedVal, b.i32_val(0xFF)));
             Value x1 = b.trunc(
                 int_ty(bitwidth),
-                b.and_(b.lshr(packedVal, b.i32_val(8)), b.i32_val(0xF)));
+                b.and_(b.lshr(packedVal, b.i32_val(8)), b.i32_val(0xFF)));
             Value x2 = b.trunc(
                 int_ty(bitwidth),
-                b.and_(b.lshr(packedVal, b.i32_val(16)), b.i32_val(0xF)));
+                b.and_(b.lshr(packedVal, b.i32_val(16)), b.i32_val(0xFF)));
             Value x3 = b.trunc(
                 int_ty(bitwidth),
-                b.and_(b.lshr(packedVal, b.i32_val(24)), b.i32_val(0xF)));
+                b.and_(b.lshr(packedVal, b.i32_val(24)), b.i32_val(0xFF)));
             unpackedVals.push_back(b.bitcast(x0, elemTy));
             unpackedVals.push_back(b.bitcast(x1, elemTy));
             unpackedVals.push_back(b.bitcast(x2, elemTy));
@@ -428,7 +428,7 @@ struct ConvertLayoutOpConversion
         } else {
           for (auto packedVal : outVals) {
             Value x0 =
-                b.trunc(int_ty(bitwidth), b.and_(packedVal, b.i32_val(0xFF)));
+                b.trunc(int_ty(bitwidth), b.and_(packedVal, b.i32_val(0xFFFF)));
             Value x1 =
                 b.trunc(int_ty(bitwidth), b.lshr(packedVal, b.i32_val(16)));
             unpackedVals.push_back(b.bitcast(x0, elemTy));


### PR DESCRIPTION
I found this convert layout that crashes with the current workaround introduced in https://github.com/triton-lang/triton/pull/7933:
```
#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [16, 2], warpsPerCTA = [2, 1], order = [1, 0]}>
#mma1 = #ttg.amd_wmma<{version = 1, isTranspose = true, warpsPerCTA = [2, 1]}>
module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "hip:gfx1100", "ttg.threads-per-warp" = 32 : i32} {
  tt.func public @fix_workaround(%arg0: tensor<32x16xi1, #blocked>) {
    %1 = ttg.convert_layout %arg0 : tensor<32x16xi1, #blocked> -> tensor<32x16xi1, #mma1>
    tt.return
  }
}
```
`triton-opt --convert-triton-amdgpu-to-llvm=arch=gfx1100`
The problem seems to be that in this case bitwidth = 1 and bitsPerVecElem = 8, not 16 as the workaround currently seems to expect. I'm not sure if this approach still works correctly with the ptxas bug on nvidia?
@ThomasRaoux @antiagainst 