### PR TITLE
[Backend] support elements width < 16 in transferWithinWarp

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -331,11 +331,11 @@ struct ConvertLayoutOpConversion
     // Pack registers if possible.
     int elemsPerVec = 1 << nPack;
     int bitsPerVecElem = 32 / elemsPerVec;
+    bool packTwo16Bit = bitwidth < bitsPerVecElem && elemsPerVec == 2;
     if (elemsPerVec > 1) {
       SmallVector<Value> packedVals;
       packedVals.reserve(regDim / elemsPerVec);
-      if (bitwidth < bitsPerVecElem) {
-        // Should have bitsPerVecElem == 16 here.
+      if (packTwo16Bit) {
         for (int i = 0; i < regDim; i += elemsPerVec) {
           Value x0 = b.zext(i32_ty, b.bitcast(inVals[i], int_ty(bitwidth)));
           Value x1 = b.zext(i32_ty, b.bitcast(inVals[i + 1], int_ty(bitwidth)));
@@ -343,6 +343,10 @@ struct ConvertLayoutOpConversion
           packedVals.emplace_back(b.or_(x0, x1));
         }
       } else {
+        // For small types, we need to extend the values to i8.
+        if (bitwidth < 8) {
+          llvm::for_each(inVals, [&](Value& v) { v = b.zext(i8_ty, v); });
+        }
         for (int i = 0; i < regDim; i += elemsPerVec) {
           auto slice = ArrayRef<Value>(inVals).slice(i, elemsPerVec);
           Value v = packLLVector(loc, slice, rewriter);
@@ -376,9 +380,21 @@ struct ConvertLayoutOpConversion
     if (elemsPerVec > 1) {
       SmallVector<Value> unpackedVals;
       unpackedVals.reserve(regDim);
-      if (bitwidth >= bitsPerVecElem) {
+      if (packTwo16Bit) {
+        for (auto packedVal : outVals) {
+          Value x0 =
+              b.trunc(int_ty(bitwidth), b.and_(packedVal, b.i32_val(0xFF)));
+          Value x1 =
+              b.trunc(int_ty(bitwidth), b.lshr(packedVal, b.i32_val(16)));
+          unpackedVals.push_back(b.bitcast(x0, elemTy));
+          unpackedVals.push_back(b.bitcast(x1, elemTy));
+        }
+      } else {
         auto packedTy =
             bitwidth < bitsPerVecElem ? int_ty(bitsPerVecElem) : elemTy;
+        if (bitwidth < 8) {
+          packedTy = i8_ty;
+        }
         auto vecTy = vec_ty(packedTy, elemsPerVec);
         auto unpackVal = [&](Value v) {
           v = b.bitcast(v, vecTy);
@@ -388,14 +404,10 @@ struct ConvertLayoutOpConversion
           auto unpacked = unpackVal(v);
           unpackedVals.append(unpacked.begin(), unpacked.end());
         }
-      } else {
-        for (auto packedVal : outVals) {
-          Value x0 =
-              b.trunc(int_ty(bitwidth), b.and_(packedVal, b.i32_val(0xFF)));
-          Value x1 =
-              b.trunc(int_ty(bitwidth), b.lshr(packedVal, b.i32_val(16)));
-          unpackedVals.push_back(b.bitcast(x0, elemTy));
-          unpackedVals.push_back(b.bitcast(x1, elemTy));
+        if (bitwidth < 8) {
+          // Truncate the values to the original bitwidth from i8.
+          llvm::for_each(unpackedVals,
+                         [&](Value& v) { v = b.trunc(elemTy, v); });
         }
       }
       outVals = std::move(unpackedVals);

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -786,8 +786,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #blocked0 = #ttg.blocked<{sizePerThread = [32, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 #blocked1 = #ttg.blocked<{sizePerThread = [16, 2], threadsPerWarp = [2, 16], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
-  //CHECK-LABEL: @convert_layout_blocked_blocked_shuffle_swap
-  tt.func @convert_layout_blocked_blocked_shuffle_swap(%arg0: tensor<32x32xi32, #blocked0>) {
+  //CHECK-LABEL: @convert_layout_blocked_blocked_shuffle_swap_i32
+  tt.func @convert_layout_blocked_blocked_shuffle_swap_i32(%arg0: tensor<32x32xi32, #blocked0>) {
     //CHECK-COUNT-32: llvm.select
     //CHECK-COUNT-32: nvvm.shfl.sync
     //CHECK-COUNT-32: llvm.select
@@ -795,6 +795,23 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
     tt.return
   }
 }
+
+// -----
+
+#blocked0 = #ttg.blocked<{sizePerThread = [32, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [16, 2], threadsPerWarp = [2, 16], warpsPerCTA = [1, 1], order = [1, 0], CTAsPerCGA = [1, 1], CTASplitNum = [1, 1], CTAOrder = [1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
+  //CHECK-LABEL: @convert_layout_blocked_blocked_shuffle_swap_i1
+  tt.func @convert_layout_blocked_blocked_shuffle_swap_i1(%arg0: tensor<32x32xi1, #blocked0>) {
+    //CHECK-COUNT-32: llvm.zext
+    //CHECK-COUNT-8: llvm.select
+    //CHECK-COUNT-8: nvvm.shfl.sync
+    //CHECK-COUNT-8: llvm.select
+    %0 = ttg.convert_layout %arg0 : tensor<32x32xi1, #blocked0> -> tensor<32x32xi1, #blocked1>
+    tt.return
+  }
+}
+
 
 // -----
 


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/7933 assumed we never have elements with width < 16 and dropped handling of widths < 8. Added a test for i1 to avoid backsliding later.