### PR TITLE
Update MIN_PYTHON version to 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -779,7 +779,7 @@ def get_git_version_suffix():
 TRITON_VERSION = "3.5.0" + get_git_version_suffix() + os.environ.get("TRITON_WHEEL_VERSION_SUFFIX", "")
 
 # Dynamically define supported Python versions and classifiers
-MIN_PYTHON = (3, 9)
+MIN_PYTHON = (3, 10)
 MAX_PYTHON = (3, 14)
 
 PYTHON_REQUIRES = f">={MIN_PYTHON[0]}.{MIN_PYTHON[1]},<{MAX_PYTHON[0]}.{MAX_PYTHON[1] + 1}"


### PR DESCRIPTION
Python 3.9 EOL is October 2025. Hence creating this PR to move min supported version to 3.10.

Associated PyTorch issue: https://github.com/pytorch/pytorch/issues/161167