### PR TITLE
[AMD] Remove getShapePerCTATile from extract_slice and concat verifiers

### DIFF
--- a/test/Conversion/amd/invalid_concat_op.mlir
+++ b/test/Conversion/amd/invalid_concat_op.mlir
@@ -82,7 +82,7 @@ module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32,
     %arg6: tensor<32x64xf32, #blocked>,
     %arg7: tensor<32x64xf32, #blocked>) {
 
-    // expected-error @+1 {{Lane and warp dim basis must match between source and destination layout.}}
+    // expected-error @+1 {{No source register holds the element for destination index [16, 0]}}
     %1 = amdg.concat %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7:
     tensor<32x64xf32, #blocked>,tensor<32x64xf32, #blocked>, tensor<32x64xf32, #blocked>, tensor<32x64xf32, #blocked>, tensor<32x64xf32, #blocked>, tensor<32x64xf32, #blocked>, tensor<32x64xf32, #blocked>, tensor<32x64xf32, #blocked> -> tensor<128x128xf32, #blocked1>
     tt.return

--- a/test/Conversion/amd/invalid_extractslice_to_llvm.mlir
+++ b/test/Conversion/amd/invalid_extractslice_to_llvm.mlir
@@ -2,30 +2,35 @@
 
 // Invalid size
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-tt.func @invalid_size_input(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
-  // expected-error @+1 {{Lane and warp dim basis must match between source and destination layout.}}
-  %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x2xi32, #blocked1>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_size_input(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{Lane and warp dim basis must match between source and destination layout.}}
+    %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x2xi32, #blocked1>
+    tt.return
+  }
 }
 
 // -----
 
 // Invalid offset, not multiple of shapePerTile
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-tt.func @invalid_offset_input(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
-  // expected-error @+1 {{No source register holds the element for destination index [0, 5]}}
-  %1 = amdg.extract_slice %arg0 [0,5] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked1>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_offset_input(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{No source register holds the element for destination index [0, 5]}}
+    %1 = amdg.extract_slice %arg0 [0,5] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked1>
+    tt.return
+  }
 }
-
 // -----
 
 // Invalid offset, out of bounds for dimension
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-tt.func @invalid_offset_input(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
-  // expected-error @+1 {{invalid offset at dimension 1}}
-  %1 = amdg.extract_slice %arg0 [0,128] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked1>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_offset_input(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{invalid offset at dimension 1}}
+    %1 = amdg.extract_slice %arg0 [0,128] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked1>
+    tt.return
+  }
 }
 
 // -----
@@ -33,50 +38,61 @@ tt.func @invalid_offset_input(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibi
 // Invalid result layout
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
 #blocked2 = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-tt.func @invalid_result_layout(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
-  // expected-error @+1 {{No source register holds the element for destination index [128, 0]}}
-  %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked2>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_result_layout(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{No source register holds the element for destination index [128, 0]}}
+    %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked2>
+    tt.return
+  }
 }
+
 // -----
 
 // Invalid result element type
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-tt.func @invalid_result_element_type(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
-  // expected-error @+1 {{result element type must match source element type}}
-  %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x16xi64, #blocked1>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_result_element_type(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{result element type must match source element type}}
+    %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x16xi64, #blocked1>
+    tt.return
+  }
 }
 
 // -----
 
 // Invalid result rank
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-tt.func @invalid_result_rank(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
-  // expected-error @+1 {{result rank must be equal to source rank}}
-  %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x16x2xi32, #blocked1>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_result_rank(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{result rank must be equal to source rank}}
+    %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x16x2xi32, #blocked1>
+    tt.return
+  }
 }
 
 // -----
 
 // Invalid result shape
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-tt.func @invalid_result_rank(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
-  // expected-error @+1 {{result shape cannot exceed source shape at dimension 1}}
-  %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x256xi32, #blocked1>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_result_rank(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{result shape cannot exceed source shape at dimension 1}}
+    %1 = amdg.extract_slice %arg0 [0,0] : tensor<256x128xi32, #blocked1> to tensor<256x256xi32, #blocked1>
+    tt.return
+  }
 }
 
 // -----
 
 // Invalid non static offset
 #blocked1 = #ttg.blocked<{sizePerThread = [8, 1], threadsPerWarp = [4, 16], warpsPerCTA = [8, 1], order = [1, 0]}>
-tt.func @invalid_non_static_offset(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}, %arg1: i32) {
-  // expected-error @+2 {{expected ']'}}
-  // expected-error @+1 {{expected integer value}}
-  %2 = amdg.extract_slice %arg0 [%arg1, 0] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked1>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_non_static_offset(%arg0: tensor<256x128xi32, #blocked1> {tt.divisibility = 16 : i32}, %arg1: i32) {
+    // expected-error @+2 {{expected ']'}}
+    // expected-error @+1 {{expected integer value}}
+    %2 = amdg.extract_slice %arg0 [%arg1, 0] : tensor<256x128xi32, #blocked1> to tensor<256x16xi32, #blocked1>
+    tt.return
+  }
 }
 
 // -----
@@ -84,10 +100,12 @@ tt.func @invalid_non_static_offset(%arg0: tensor<256x128xi32, #blocked1> {tt.div
 // Invalid layout 1
 #dst_layout = #ttg.linear<{register=[[0, 1], [0, 2], [0, 8], [0, 16], [0, 64], [64, 0]], lane=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4]], warp=[[0, 32], [32, 0]], block=[]}>
 #src_layout = #ttg.linear<{register=[[0, 1], [0, 2], [0, 8], [0, 16], [0, 64], [0, 128], [64, 0], [128, 0]], lane=[[1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 0]], warp=[[0, 32], [32, 0]], block=[]}>
-tt.func @invalid_lane_warp_basis(%arg0: tensor<256x256xi32, #src_layout> {tt.divisibility = 16 : i32}) {
-  // expected-error @+1 {{Lane and warp dim basis must match between source and destination layout}}
-  %2 = amdg.extract_slice %arg0 [0, 0] : tensor<256x256xi32, #src_layout> to tensor<128x128xi32, #dst_layout>
-  tt.return
+module attributes {"ttg.compute-capability" = 0 : i32, "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @invalid_lane_warp_basis(%arg0: tensor<256x256xi32, #src_layout> {tt.divisibility = 16 : i32}) {
+    // expected-error @+1 {{Lane and warp dim basis must match between source and destination layout}}
+    %2 = amdg.extract_slice %arg0 [0, 0] : tensor<256x256xi32, #src_layout> to tensor<128x128xi32, #dst_layout>
+    tt.return
+  }
 }
 
 // -----

--- a/third_party/amd/include/Dialect/TritonAMDGPU/Utility/CommonUtils.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/Utility/CommonUtils.h
@@ -3,13 +3,26 @@
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Tools/LinearLayout.h"
 
 namespace mlir::triton::AMD {
+using ElemLocationKey = SmallVector<std::pair<StringAttr, int32_t>>;
 
 SmallVector<scf::ForOp> getLeafForOps(triton::FuncOp funcOp);
 
 // [FIXME LL] Kill this function
 SmallVector<unsigned> getShapePerCTATile(RankedTensorType tensorTy);
+
+// Build element coordinates for a given register ID.
+// All other hardware dimensions (lane, warp, block) are set to 0.
+ElemLocationKey getElemCoordinatesFromRegisters(LinearLayout ll, unsigned regId,
+                                                MLIRContext *ctx);
+
+// Extract register ID from element coordinates.
+// Returns std::nullopt if non-register dimensions are non-zero.
+std::optional<int> getRegFromCoordinates(LinearLayout ll,
+                                         ElemLocationKey coordinates,
+                                         MLIRContext *ctx);
 
 } // namespace mlir::triton::AMD
 

--- a/third_party/amd/lib/Dialect/TritonAMDGPU/Utility/CommonUtils.cpp
+++ b/third_party/amd/lib/Dialect/TritonAMDGPU/Utility/CommonUtils.cpp
@@ -29,4 +29,34 @@ SmallVector<unsigned> getShapePerCTATile(RankedTensorType tensorTy) {
   return shape;
 }
 
+ElemLocationKey getElemCoordinatesFromRegisters(triton::LinearLayout ll,
+                                                unsigned regId,
+                                                MLIRContext *ctx) {
+  StringAttr kReg = StringAttr::get(ctx, "register");
+  StringAttr kLane = StringAttr::get(ctx, "lane");
+  StringAttr kWarp = StringAttr::get(ctx, "warp");
+  StringAttr kBlock = StringAttr::get(ctx, "block");
+
+  SmallVector<std::pair<StringAttr, int32_t>> hardwareLocation = {
+      {kReg, static_cast<int32_t>(regId)},
+      {kLane, 0},
+      {kWarp, 0},
+      {kBlock, 0},
+  };
+
+  return ll.apply(hardwareLocation);
+}
+
+std::optional<int> getRegFromCoordinates(triton::LinearLayout ll,
+                                         ElemLocationKey coordinates,
+                                         MLIRContext *ctx) {
+  auto dims = ll.pseudoinvert().apply(coordinates);
+  StringAttr kReg = StringAttr::get(ctx, "register");
+  assert(dims[0].first == kReg && "First dimension must be 'register'");
+
+  int regId = dims[0].second; // "register"
+  if (dims[1].second != 0 || dims[2].second != 0 || dims[3].second != 0)
+    return std::nullopt;
+  return regId;
+}
 } // namespace mlir::triton::AMD

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/CMakeLists.txt
@@ -3,7 +3,6 @@ add_triton_library(TritonAMDGPUDialectToLLVM
     ExtractSliceOpToLLVM.cpp
     InThreadTransposeOpToTTG.cpp
     ConcatOpToLLVM.cpp
-    Utility.cpp
     ScaledUpcastToLLVM.cpp
 
     DEPENDS

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/Utility.cpp
@@ -5,8 +5,9 @@ using namespace mlir;
 
 namespace mlir::LLVM::AMD {
 
-ElemLocationKey getElemCoordsFromReg(tt::LinearLayout ll, unsigned regId,
-                                     MLIRContext *ctx) {
+ElemLocationKey getElemCoordinatesFromRegisters(tt::LinearLayout ll,
+                                                unsigned regId,
+                                                MLIRContext *ctx) {
   StringAttr kReg = StringAttr::get(ctx, "register");
   SmallVector<std::pair<StringAttr, int32_t>> hardwareLocation;
   for (auto dimName : ll.getInDimNames()) {
@@ -18,15 +19,18 @@ ElemLocationKey getElemCoordsFromReg(tt::LinearLayout ll, unsigned regId,
   return ll.apply(hardwareLocation);
 }
 
-llvm::MapVector<ElemLocationKey, unsigned>
-mapRegToCoordinates(tt::LinearLayout ll, MLIRContext *ctx) {
+std::optional<int> getRegFromCoordinates(tt::LinearLayout ll,
+                                         ElemLocationKey coordinates,
+                                         MLIRContext *ctx) {
+  auto hardwareLocation = ll.pseudoinvert().apply(coordinates);
   llvm::MapVector<ElemLocationKey, unsigned> elemToReg;
   StringAttr kReg = StringAttr::get(ctx, "register");
-  auto regBases = ll.getBases().lookup(kReg);
-  int regNum = 1 << regBases.size();
-  for (int regId = 0; regId < regNum; ++regId) {
-    elemToReg[getElemCoordsFromReg(ll, regId, ctx)] = regId;
+  for (auto location : hardwareLocation) {
+    if (location.first == kReg)
+      return location.second;
   }
-  return elemToReg;
+
+  return {};
 } // namespace mlir::triton
+
 } // namespace mlir::LLVM::AMD

--- a/third_party/amd/lib/TritonAMDGPUDialectToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUDialectToLLVM/Utility.h
@@ -8,11 +8,13 @@ namespace tt = mlir::triton;
 namespace mlir::LLVM::AMD {
 using ElemLocationKey = SmallVector<std::pair<StringAttr, int32_t>>;
 
-ElemLocationKey getElemCoordsFromReg(tt::LinearLayout ll, unsigned regId,
-                                     MLIRContext *ctx);
+ElemLocationKey getElemCoordinatesFromRegisters(tt::LinearLayout ll,
+                                                unsigned regId,
+                                                MLIRContext *ctx);
 
-llvm::MapVector<ElemLocationKey, unsigned>
-mapRegToCoordinates(tt::LinearLayout ll, MLIRContext *ctx);
+std::optional<int> getRegFromCoordinates(tt::LinearLayout ll,
+                                         ElemLocationKey coordinates,
+                                         MLIRContext *ctx);
 
 } // namespace mlir::LLVM::AMD
 #endif // TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUDIALECTTOLLVM_UTILITY_H_


### PR DESCRIPTION
TODO: Remove getShapePerCTATile  from AMD specific LDS allocation