### PR TITLE
[release/3.5.x] Revert "[BACKEND] hint to LLVM that we can bound threadIdx.x (#7249)"

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -368,25 +368,22 @@ Value getThreadId(OpBuilder &rewriter, Location loc) {
       rewriter.create<::mlir::gpu::ThreadIdOp>(loc, ::mlir::gpu::Dimension::x);
   tid = rewriter.create<arith::IndexCastOp>(loc, i32_ty, tid);
 
-  Operation *lookupPt = &rewriter.getInsertionBlock()->front();
-  int threadsPerWarp = triton::gpu::lookupThreadsPerWarp(rewriter);
-  int numWarps = triton::gpu::lookupNumWarps(lookupPt);
-  int upperBound = numWarps * threadsPerWarp;
-
-  TritonLLVMOpBuilder b(loc, rewriter);
-
   // If this is being created inside a warp specialize op, compute the relative
   // thread ID within the warp group.
   if (std::optional<int> startId =
           getWarpGroupStartThreadId(rewriter.getInsertionBlock())) {
+    TritonLLVMOpBuilder b(loc, rewriter);
     tid = rewriter.create<arith::SubIOp>(loc, tid, b.i32_val(*startId));
   }
 
-  assert(llvm::isPowerOf2_32(upperBound));
-  // help LLVM's known bits analysis:
-  tid = b.and_(tid, b.i32_val(upperBound - 1));
-
   return tid;
+}
+
+Value getLaneId(OpBuilder &rewriter, Location loc) {
+  TritonLLVMOpBuilder b(loc, rewriter);
+  Value tid = getThreadId(rewriter, loc);
+  int threadsPerWarp = triton::gpu::lookupThreadsPerWarp(rewriter);
+  return b.urem(tid, b.i32_val(threadsPerWarp));
 }
 
 std::pair<Value, Value> getLaneAndWarpId(OpBuilder &rewriter, Location loc) {
@@ -394,24 +391,17 @@ std::pair<Value, Value> getLaneAndWarpId(OpBuilder &rewriter, Location loc) {
   Value tid = getThreadId(rewriter, loc);
   int threadsPerWarp = triton::gpu::lookupThreadsPerWarp(rewriter);
   Value warpSizeVal = b.i32_val(threadsPerWarp);
+  Value laneId = b.urem(tid, warpSizeVal);
 
   // If there is only one warp, the warp ID is always 0.
   Operation *lookupPt = &rewriter.getInsertionBlock()->front();
-  Value laneId;
   Value warpId;
-  if (triton::gpu::lookupNumWarps(lookupPt) == 1) {
-    laneId = tid;
+  if (triton::gpu::lookupNumWarps(lookupPt) == 1)
     warpId = b.i32_val(0);
-  } else {
-    laneId = b.urem(tid, warpSizeVal);
+  else
     warpId = b.udiv(tid, warpSizeVal);
-  }
 
   return {laneId, warpId};
-}
-
-Value getLaneId(OpBuilder &rewriter, Location loc) {
-  return getLaneAndWarpId(rewriter, loc).first;
 }
 
 // Helper function: applies linear layout vectorized over register indices
@@ -460,7 +450,6 @@ applyLinearLayoutVec(Location loc, RewriterBase &rewriter,
   return ret;
 }
 
-// Refactored emitIndices function using applyLinearLayoutVec
 SmallVector<SmallVector<Value>>
 emitIndices(Location loc, RewriterBase &rewriter, const TargetInfoBase &target,
             Attribute layout, RankedTensorType type, bool withCTAOffset) {

--- a/test/Conversion/amd/mfma-shortcut.mlir
+++ b/test/Conversion/amd/mfma-shortcut.mlir
@@ -37,7 +37,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 #dotop0 = #ttg.dot_op<{opIdx = 0, parent = #mfma, kWidth=8}>
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32} {
-  // GFX950-LABEL: mfma_dot_cvt_bf8_mfma32_v4
+// GFX950-LABEL: mfma_dot_cvt_bf8_mfma32_v4
   tt.func public @mfma_dot_cvt_bf8_mfma32_v4(%arg0: tensor<128x32xf8E5M2, #mfma>) {
     // GFX950-NOT: rocdl.ds_bpermute
     // GFX950-COUNT-2: llvm.call_intrinsic "llvm.amdgcn.permlane32.swap"

--- a/test/Conversion/reduce_to_llvm.mlir
+++ b/test/Conversion/reduce_to_llvm.mlir
@@ -25,7 +25,7 @@ tt.func private @reduce_linear_layout(%arg0: tensor<32x16xi32, #linear>) -> tens
   // is not needed.
 
   // Reduce within threads
-  // CHECK: [[SUM0:%.*]] = add i32 [[SRC0]], [[SRC2]]
+  // CHECK-NEXT: [[SUM0:%.*]] = add i32 [[SRC0]], [[SRC2]]
   // CHECK-NEXT: [[SUM1:%.*]] = add i32 [[SRC1]], [[SRC3]]
 
   // Reduce within warp.

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -46,10 +46,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: arrive_barrier
   tt.func @arrive_barrier(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>) {
     // CHECK-NEXT: [[TID:%.*]] = nvvm.read.ptx.sreg.tid.x
-    // CHECK-NEXT: [[C127:%.*]] = llvm.mlir.constant(127 : i32)
-    // CHECK-NEXT: [[RTID:%.*]] = llvm.and [[TID]], [[C127]]
     // CHECK-NEXT: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
-    // CHECK-NEXT: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[RTID]], [[C0]]
+    // CHECK-NEXT: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[TID]], [[C0]]
     // CHECK-NEXT: "@$0 mbarrier.arrive.shared::cta.b64 _, [$1], 2;", "b,r" [[IS_ZERO]], %arg0
     ttng.arrive_barrier %alloc, 2 : !ttg.memdesc<1xi64, #shared0, #smem>
     tt.return
@@ -58,10 +56,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: arrive_barrier_pred
   tt.func @arrive_barrier_pred(%alloc: !ttg.memdesc<1xi64, #shared0, #smem>, %pred: i1) {
     // CHECK-NEXT: [[TID:%.*]] = nvvm.read.ptx.sreg.tid.x
-    // CHECK-NEXT: [[C127:%.*]] = llvm.mlir.constant(127 : i32)
-    // CHECK-NEXT: [[RTID:%.*]] = llvm.and [[TID]], [[C127]]
     // CHECK-NEXT: [[C0:%.*]] = llvm.mlir.constant(0 : i32)
-    // CHECK-NEXT: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[RTID]], [[C0]]
+    // CHECK-NEXT: [[IS_ZERO:%.*]] = llvm.icmp "eq" [[TID]], [[C0]]
     // CHECK-NEXT: [[PRED:%.*]] = llvm.and [[IS_ZERO]], %arg1
     // CHECK-NEXT: "@$0 mbarrier.arrive.shared::cta.b64 _, [$1], 2;", "b,r" [[PRED]], %arg0
     ttng.arrive_barrier %alloc, 2, %pred : !ttg.memdesc<1xi64, #shared0, #smem>


### PR DESCRIPTION
This reverts commit e7cef2e63f79d4802878016bc0dbf3666b912ece.

Motivation: we see regressions in 03-matrix-multiplication.py due to this PR: https://github.com/pytorch/pytorch/issues/159704#issuecomment-3268787789

I believe this is due to the PTXAS bug where extra WARPGROUP.DEPBAR.LE gsb0, 0x0 (i.e. wgmma.wait_group.sync.aligned 1) are incorrectly inserted. I've verified with NCU that there are extra WARPGROUP.DEPBAR.LE gsb0, 0x0 instructions in the SASS.

How (I think) this PR triggers the PTXAS bug: Following this PR, the control flow order changes; I believe this is the reason. In the past, I've observed that this PTXAS bug is triggered by changes in control flow order.