### PR TITLE
[AMD] Avoid selecting MFMA with small K than problem size

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -352,8 +352,6 @@ def test_op(m, n, k, split_k, do_gather, do_scatter, fused_scatter, inner_expt_o
             pytest.skip("NYI: Persistent kernel not supported on AMD GPU")
         if split_k is not None and split_k > 1:
             pytest.skip("splitK hasn't been fully tested on AMD GPU.")
-        if inner_expt_opt is not None and is_hip_cdna4():
-            pytest.skip("Currently triggers a compiler bug.")
 
     if "float8_e4m3fnuz" in (weight_dtype_str, act_dtype_str) and not is_hip_cdna3():
         pytest.skip("float8_e4m3fnuz only tested on AMD CDNA3 Platform")

--- a/test/TritonGPU/amd/accelerate-amd-matmul-mfma.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-mfma.mlir
@@ -83,7 +83,7 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
 // -----
 
 // MFMA0-NOT: amd_mfma
-// MFMA16: amd_mfma
+// MFMA16-NOT: amd_mfma
 #blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [2, 4], order = [1, 0]}>
 // CHECK-LABEL: mfma_dot_small_k
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -199,9 +199,8 @@ chooseMfmaInstruction(Location loc, int mfmaVersion, RankedTensorType cType,
   assert(kDim != 0);
   assert(enforcedNonKDim != 0 || (M % mDim == 0 && N % nDim == 0));
   // If inputKSize % kDim != 0 (including the case where inputKSize < kDim),
-  // this layout will introduce data duplication. We will not use MFMA layout
-  // in this case, except MFMA layout is enforced.
-  if (enforcedNonKDim == 0 && inputKSize % kDim != 0)
+  // this layout will introduce data duplication.
+  if (inputKSize % kDim != 0)
     return failure();
   return maybeMfmaIntrinsic;
 }


### PR DESCRIPTION
We need to make sure not breaking even if explictly requested
to use a specific MFMA variant. In general we need to phase
out the selection of MFMA variant gradually anyway.