### PR TITLE
Use libstdc++ from system toolchain for AlmaLinux

### DIFF
--- a/.github/workflows/llvm-build/almalinux.Dockerfile
+++ b/.github/workflows/llvm-build/almalinux.Dockerfile
@@ -25,7 +25,8 @@ RUN cmake -GNinja -Bbuild \
   -DCMAKE_ASM_COMPILER=clang \
   -DCMAKE_C_COMPILER_LAUNCHER=sccache \
   -DCMAKE_CXX_COMPILER_LAUNCHER=sccache \
-  -DCMAKE_CXX_FLAGS="-Wno-everything" \
+  -DCMAKE_C_FLAGS="--gcc-install-dir=/usr/lib/gcc/$(gcc -dumpmachine)/8" \
+  -DCMAKE_CXX_FLAGS="--gcc-install-dir=/usr/lib/gcc/$(gcc -dumpmachine)/8 -Wno-everything" \
   -DCMAKE_LINKER=lld \
   -DCMAKE_INSTALL_PREFIX="/install" \
   -DPython3_EXECUTABLE="/usr/bin/python3.8" \


### PR DESCRIPTION
The AlmaLinux build currently builds against libstdc++ from GCC 14,
because installing clang also pulls in GCC 14, and clang automatically
picks the newest libstdc++ on the system.

Instead, pointing clang to the system GCC installation should link
against the corresponding libstdc++. This improves the portability of
the generated binaries. The AlmaLinux binaries should now be compatible
with a superset of the systems that the Ubuntu binaries are compatible
with.

We can then separately evaluate removing the Ubuntu build if this works
for all users.
(I assume these have to be separate changes anyway for CI)

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is a CI change.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
