### PR TITLE
[Backend] Fix function attributes after tensor descriptor fallback

### DIFF
--- a/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
+++ b/test/Triton/rewrite-tensor-descriptor-to-pointer.mlir
@@ -138,3 +138,14 @@ module {
 // CHECK-DAG: %[[c256:.*]] = arith.constant 256 : i64
 // CHECK: %{{.*}}:6 = tt.call @callee(%[[PTR]], %[[c256]], %[[c256]], %[[c256]], %[[c1]], %false)
 // CHECK-SAME -> (!tt.ptr<f32>, i64, i64, i64, i64, i1)
+
+// -----
+
+module {
+  tt.func public @arg_attr(%arg0: !tt.tensordesc<tensor<128x128xf32>>, %arg1: i32 {tt.divisibility = 16 : i32}) {
+    tt.return
+  }
+}
+
+// CHECK-LABEL: @arg_attr
+// CHECK-SAME: %arg6: i32 {tt.divisibility = 16 : i32}) {


### PR DESCRIPTION
The tensor descriptor rewriting pass uses 1-to-n type conversion, which will expand a tensordesc argument into multiple new pointer and int arguments. However, the upstream function conversion in mlir doesn't remap the attributes to the corresponding new argument index, which means we may make incorrect assumptions about arguments and miscompile.