### PR TITLE
[Build] Remove unused `include(ExternalProject)` from `CMakeLists.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,6 @@ if(POLICY CMP0116)
   cmake_policy(SET CMP0116 OLD)
 endif()
 
-include(ExternalProject)
-
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)


### PR DESCRIPTION
It was added together with `ExternalProject_Add` (for example: https://github.com/triton-lang/triton/commit/2f80a987768ef31f6b3e463b993b18007546eb43#diff-4d128eff7fb511830aeab8bae9f29b1cd34713a492ebde22addb1dd15197b6bd) but `ExternalProject_Add` is no longer used.