### PR TITLE
[Blackwell] Fix barrierSlice typing bug

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -754,17 +754,19 @@ void createBarrierAndWaitOps(scf::ForOp forOp, CoarseSchedule &schedule,
   Value barrierAlloc = createBarrierAlloc(forOp, numStages);
   Value vTrue = builder.create<arith::ConstantIntOp>(1, 1);
   Value phase = forOp.getRegionIterArg(phaseArgIdx);
-  Value barrierIdx = forOp.getRegionIterArg(barrierIdxArgIdx);
   Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
+  Value barrierIdx;
+  if (numStages > 1) {
+    barrierIdx = forOp.getRegionIterArg(barrierIdxArgIdx);
+  } else {
+    barrierIdx = zero;
+  }
   Value one = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 1, 32);
   Value numStagesVal =
       builder.create<arith::ConstantIntOp>(forOp.getLoc(), numStages, 32);
 
-  Value barrierSlice = barrierAlloc;
-  if (numStages > 1) {
-    barrierSlice =
-        triton::createSingleBufferView(builder, barrierAlloc, barrierIdx);
-  }
+  Value barrierSlice =
+      triton::createSingleBufferView(builder, barrierAlloc, barrierIdx);
   mma.addCompletionBarrier(barrierSlice, vTrue);
   mma.setIsAsync(true);
 


### PR DESCRIPTION
`createBarrierAlloc` always returns a [num_stages x 1] memory allocations for barriers. When num_stages=1 we still need to call `triton::createSingleBufferView` to match the type assumptions for the underlying barrier.