### PR TITLE
[DOC] Clarify lhs_scale and rhs_scale requirements in dot_scaled

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2039,7 +2039,7 @@ def dot_scaled(lhs, lhs_scale, lhs_format, rhs, rhs_scale, rhs_format, acc=None,
 
     :param lhs: The first tensor to be multiplied.
     :type lhs: 2D tensor representing fp4, fp8 or bf16 elements. Fp4 elements are packed into uint8 inputs with the first element in lower bits. Fp8 are stored as uint8 or the corresponding fp8 type.
-    :param lhs_scale: Scale factor for lhs tensor. Shape should be [M, K//group_size] when lhs is [M, K], where group_size is typically 32.
+    :param lhs_scale: Scale factor for lhs tensor. Shape should be [M, K//group_size] when lhs is [M, K], where group_size is 32 if scales type are `e8m0`.
     :type lhs_scale: e8m0 type represented as an uint8 tensor, or None.
     :param lhs_format: format of the lhs tensor. Available formats: {:code:`e2m1`, :code:`e4m3`, :code:`e5m2`, :code:`bf16`, :code:`fp16`}.
     :type lhs_format: str


### PR DESCRIPTION
Addresses confusion in #8431

Update `dot_scaled` docstring to clarify:
- `lhs_scale` shape: `[M, K//group_size]` when lhs is `[M, K]`
- `rhs_scale` shape: `[N, K//group_size]` when rhs is `[K, N]`

The compiler internally handles scale transposition, so scales should remain in their original orientation.

```python
# Correct
acc = tl.dot_scaled(a, None, "bf16", b.T, b_scale, "e4m3", acc=acc)

# Incorrect  
acc = tl.dot_scaled(a, None, "bf16", b.T, b_scale.T, "e4m3", acc=acc)  
```



# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it's a doc change`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
