### PR TITLE
[triton_kernels][opt_flags] Add function to reset opt_flags

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_ogs_details/opt_flags.py
@@ -321,6 +321,10 @@ def reset_opt_flags_constraints():
     global _opt_flags_constraints
     _opt_flags_constraints = dict()
 
+def reset_opt_flags():
+    global _opt_flags
+    _opt_flags = None
+
 def set_opt_flags(opt_flags: OptFlags):
     global _opt_flags
     assert not _opt_flags_constraints, "setting constraints is incompatible with manual flags override"


### PR DESCRIPTION
Without resetting opt_flags, the following does not work and gives error `AssertionError: opt_flags already set; please reset to None first`:

```
import torch
from triton_kernels.matmul_ogs import matmul_ogs, PrecisionConfig
from triton_kernels.matmul_ogs_details.opt_flags import (
    make_opt_flags,
    set_opt_flags,
)
from triton_kernels.routing import RoutingData

m = 64
n = 128
k = 32
BATCH_SIZE = 1000
dtype = torch.float16

x = torch.randn((BATCH_SIZE, m, k), device="cuda", dtype=dtype)
w = torch.randn((BATCH_SIZE, k, n), device="cuda", dtype=dtype)
bias = None

opt_flags = make_opt_flags(
    dtype,
    dtype,
    dtype,
    PrecisionConfig(),
    m,
    n,
    k,
    RoutingData(None, None, BATCH_SIZE, 1),
    True,
    False,
    False,
)

set_opt_flags(opt_flags)
tri_y = matmul_ogs(x, w, bias)

opt_flags.num_warps = 2
set_opt_flags(opt_flags)
tri_y = matmul_ogs(x, w, bias)
```

After adding `reset_opt_flags()` before the second call of `set_opt_flags` everything works fine.