### PR TITLE
[AMD] [BufferOps] Expose small tensor analysis to Python

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -505,7 +505,7 @@ class amd_knobs(base_knobs):
     # Note: This requires use_buffer_ops be true to have any effect
     use_buffer_atomics: env_bool = env_bool("AMDGCN_USE_BUFFER_ATOMICS", True)
     # Note: This requires use_buffer_ops be true to have any effect
-    use_buffer_small_tensor: env_bool = env_bool("AMDGCN_ANALYZE_SMALL_TENSOR_RANGE", False)
+    buffer_ops_analyze_small_tensor_range: env_bool = env_bool("AMDGCN_ANALYZE_SMALL_TENSOR_RANGE", False)
     dump_amdgcn: env_bool = env_bool("AMDGCN_ENABLE_DUMP")
     libhip_path: env_opt_str = env_opt_str("TRITON_LIBHIP_PATH")
 

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -249,7 +249,7 @@ class HIPBackend(BaseBackend):
                 pm,
                 options.arch,
                 knobs.amd.use_buffer_atomics,
-                knobs.amd.use_buffer_small_tensor,
+                knobs.amd.buffer_ops_analyze_small_tensor_range,
             )
 
         amd.passes.ttgpuir.add_fold_true_cmpi(pm)


### PR DESCRIPTION
I'd like to test both the functionality and effectiveness of the additional small tensor argument to Converting to BufferOps. To enable this testing I added a flag to `add_convert_to_buffer_ops` since I assume there may be some concern about enabling this by default.

My expectation is that long-term this will not be a flag, but this would also be good to have to simplify debugging once we want to enable this analysis by default.   