### PR TITLE
[AMD][BACKEND] Return correct shared memory size for gfx1250 from TargetInfo

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -81,8 +81,15 @@ int TargetInfo::getWarpSize() const {
 }
 
 int TargetInfo::getSharedMemorySize() const {
-  int kbytes = getISAFamily() == ISAFamily::CDNA4 ? 160 : 64;
-  return kbytes * 1024;
+  // Should return the maximum capacity in kbyte
+  switch (getISAFamily()) {
+  case ISAFamily::GFX1250:
+    return 320 * 1024;
+  case ISAFamily::CDNA4:
+    return 160 * 1024;
+  default:
+    return 64 * 1024;
+  }
 }
 
 bool TargetInfo::supportMaximumMinimum() const {


### PR DESCRIPTION
Add shared memory capacity for `gfx1250` which is 320 kbyte.