### PR TITLE
[AMD] Improve s_xxx instruction placement for fav3 pingpong

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ScheduleLoops.cpp
@@ -390,7 +390,7 @@ buildSchedule(scf::ForOp &forOp, int numStages, const LoadToInfoMap &loadToInfo,
 } // namespace SingleDotSchedule
 
 // Builds a schedule for loops containing chained dots. This schedule aims to
-// better interleave mfams with alu ops which can be co-executed on GFX9. It
+// better interleave mma with alu ops which can be co-executed on GFX9. It
 // works for loops which have 2 dots where the result of the first is
 // transformed and used by the second dot. The dot ops will be scheduled with a
 // distance of one and the ops in between will be spit into 2 parts. The first


### PR DESCRIPTION
This PR improves the placement of s_xxx instructions between clusters in FAv3. It has two benefits:
1. s_xxx instructions are not placed in the memory cluster so they can be co-issued with v_xxx instructions
2. The idle cycles between clusters are reduced, which helps reduce the stall cycles for some v_xxx instructions.

Perf impact on FAv3, with nheads=64 and D=128

causal | batch | N_CTX | this pr | main
-- | -- | -- | -- | --
0 | 32 | 512 | 655 | 649
0 | 16 | 1024 | 824 | 811
0 | 8 | 2048 | 972 | 932
0 | 4 | 4096 | 1046 | 1002
0 | 2 | 8192 | 1048 | 1007
0 | 1 | 16384 | 1064 | 1020
1 | 32 | 512 | 351 | 350
1 | 16 | 1024 | 550 | 541
1 | 8 | 2048 | 728 | 707
1 | 4 | 4096 | 862 | 827
1 | 2 | 8192 | 960 | 914
1 | 1 | 16384 | 895 | 865