### PR TITLE
Remove constexprs from params in `jit.py`

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -735,7 +735,6 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # TODO(jlebar): Remove uses of these fields outside this file, then
         # remove the fields here.
         self.arg_names = [p.name for p in self.params]
-        self.constexprs = [p.num for p in self.params if p.is_constexpr]
 
         # Hooks that will be called prior to executing "run"
         self.pre_run_hooks = []


### PR DESCRIPTION
The `constexprs` field is never used outside `jit.py` and can be computed on-demand from `self.params`. This addresses part of the TODO(jlebar) at line 735.
