### PR TITLE
[AMD]: reimplement fast_tanhf() to avoid overflow

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/BuiltinFuncToLLVM.cpp
@@ -113,12 +113,12 @@ private:
       // This avoids overflow when e^(2x) becomes infinity for large x
 
       // Get absolute value of x
-      auto absX = rewriter.create<LLVM::FAbsOp>(loc, rewriter.getF32Type(),
-                                                operands[0]);
+      auto absX = LLVM::FAbsOp::create(rewriter, loc, rewriter.getF32Type(),
+                                       operands[0]);
 
       // Calculate 2*|x|
-      auto twoAbsX = rewriter.create<LLVM::FMulOp>(
-          loc, rewriter.getF32Type(), absX,
+      auto twoAbsX = LLVM::FMulOp::create(
+          rewriter, loc, rewriter.getF32Type(), absX,
           LLVM::createConstantF32(loc, rewriter, 2.0), defaultFlags);
 
       // Calculate e^(2*|x|)
@@ -126,20 +126,21 @@ private:
                                      rewriter.getF32Type(), ftz);
 
       // Calculate e^(2*|x|) + 1
-      auto exp2AbsXPlus1 = rewriter.create<LLVM::FAddOp>(
-          loc, rewriter.getF32Type(), exp2AbsX->getResult(0),
+      auto exp2AbsXPlus1 = LLVM::FAddOp::create(
+          rewriter, loc, rewriter.getF32Type(), exp2AbsX->getResult(0),
           LLVM::createConstantF32(loc, rewriter, 1.0), defaultFlags);
 
       // Calculate 2 / (e^(2*|x|) + 1)
       auto two = LLVM::createConstantF32(loc, rewriter, 2.0);
-      auto ratio = rewriter.create<LLVM::FDivOp>(
-          loc, rewriter.getF32Type(), two, exp2AbsXPlus1->getResult(0),
-          defaultFlags);
+      auto ratio =
+          LLVM::FDivOp::create(rewriter, loc, rewriter.getF32Type(), two,
+                               exp2AbsXPlus1->getResult(0), defaultFlags);
 
       // Calculate 1 - 2/(e^(2*|x|) + 1)
       auto one = LLVM::createConstantF32(loc, rewriter, 1.0);
-      auto posResult = rewriter.create<LLVM::FSubOp>(
-          loc, rewriter.getF32Type(), one, ratio->getResult(0), defaultFlags);
+      auto posResult =
+          LLVM::FSubOp::create(rewriter, loc, rewriter.getF32Type(), one,
+                               ratio->getResult(0), defaultFlags);
 
       // Apply the sign of the original input using copysign
       // tanh(x) = sign(x) * (1 - 2/(e^(2*|x|) + 1))


### PR DESCRIPTION
### The Problem with the Original Formula
The original formula is:
```
tanh(x) = (e^(2x) - 1) / (e^(2x) + 1)
```
- Issue with large positive x:
   - When x = 20: e^(40) ≈ 2.4 × 10^17 → manageable
   - When x = 50: e^(100) ≈ 2.7 × 10^43 → overflow to infinity
   - Result: (∞ - 1)/(∞ + 1) = NaN x
- For negative x: The formula actually works fine because e^(2x) → 0, giving (-1)/(1) = -1  

### The Numerically Stable Solution
- For Positive x: Reformulation
```
tanh(x) = (e^(2x) - 1) / (e^(2x) + 1) = (e^(2x) + 1 - 2) / (e^(2x) + 1) = 1 - 2/(e^(2x) + 1)
```
-  For Negative x: Using Symmetry
```
tanh(-x) = (e^(-2x) - 1) / (e^(-2x) + 1) =  (2/(e^(-2x) + 1) - 1) = -1 × (1 - 2/(e^(2|x|) + 1))
```

### Unified formulation:
```
tanh(x) = sign(x) × (1 - 2/(e^(2|x|) + 1))
```
