### PR TITLE
Fix handling of 3D DotOp with M=1 

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -60,15 +60,9 @@ struct DotOpConversion : public ConvertOpToLLVMPattern<triton::DotOp> {
     Value A = op.getA();
     Value D = op.getResult();
 
-    // Here we assume the DotOp's operands always comes from shared memory.
-    auto AShapePerCTA = getShapePerCTA(A.getType());
-    size_t reduceAxis = 1;
-    unsigned K = AShapePerCTA[reduceAxis];
-    bool isOuter = K == 1;
-
     NvidiaMmaEncodingAttr mmaLayout = dyn_cast<NvidiaMmaEncodingAttr>(
         cast<RankedTensorType>(D.getType()).getEncoding());
-    if (!isOuter && mmaLayout && supportMMA(op, mmaLayout.getVersionMajor())) {
+    if (mmaLayout && supportMMA(op, mmaLayout.getVersionMajor())) {
       if (mmaLayout.getVersionMajor() == 2) {
         bool isHopperF64 =
             computeCapability == 90 &&
@@ -106,14 +100,8 @@ struct WarpGroupDotOpConversion
     Value A = op.getA();
     TypedValue<RankedTensorType> D = op.getResult();
 
-    // Here we assume the DotOp's operands always comes from shared memory.
-    auto AShapePerCTA = getShapePerCTA(A.getType());
-    size_t reduceAxis = 1;
-    unsigned K = AShapePerCTA[reduceAxis];
-    bool isOuter = K == 1;
-
     auto mmaLayout = cast<NvidiaMmaEncodingAttr>(D.getType().getEncoding());
-    if (!isOuter && supportMMA(op.getOperand(0), mmaLayout.getVersionMajor())) {
+    if (supportMMA(op.getOperand(0), mmaLayout.getVersionMajor())) {
       return convertWGMMA(op, adaptor, getTypeConverter(), rewriter,
                           getThreadId(rewriter, loc));
     }


### PR DESCRIPTION
We currently always look at index 1 in the shape to determine if it is
an outer product. However, for 3D operands, we actually have to look at
index 2. This causes us to incorrectly crash when supplied a 3D operand
where the first dimension is 1.

Eliminate the isOuter check entirely, since my understanding is that:
1. it is purely defensive, since we will just crash when isOuter is
   true and mmaLayout is non-null.
2. it does not disqualify all the invalid K values, so it might be
   confusing.
