### PR TITLE
Revert "Remove constexprs from params in `jit.py`"

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -740,6 +740,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
         # TODO(jlebar): Remove uses of these fields outside this file, then
         # remove the fields here.
         self.arg_names = [p.name for p in self.params]
+        self.constexprs = [p.num for p in self.params if p.is_constexpr]
 
         # Hooks that will be called prior to executing "run"
         self.pre_run_hooks = []


### PR DESCRIPTION
Reverts triton-lang/triton#8536

Reverting as this is causing some problems in OAI internal workloads. Similar to what is seen in torch.compile I'm guessing