### PR TITLE
[Backend][NFC] changed MLIR builder API; prepared for LLVM bump

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -166,8 +166,8 @@ struct ElementwiseOpConversion
                                     ConversionPatternRewriter &rewriter,
                                     Type elemTy, MultipleOperandsRange operands,
                                     Location loc) const {
-    return {rewriter.create<DestOp>(loc, elemTy, operands[0],
-                                    adaptor.getAttributes().getValue())};
+    return {DestOp::create(rewriter, loc, elemTy, operands[0],
+                           adaptor.getAttributes().getValue())};
   }
 };
 

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -54,205 +54,206 @@ struct TritonLLVMOpBuilder {
   // Shortcuts for some commonly used LLVM ops to keep code simple and intuitive
   // Operators
   template <typename... Args> LLVM::SIToFPOp inttofloat(Args &&...args) {
-    return builder->create<LLVM::SIToFPOp>(loc, std::forward<Args>(args)...);
+    return LLVM::SIToFPOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::IntToPtrOp inttoptr(Args &&...args) {
-    return builder->create<LLVM::IntToPtrOp>(loc, std::forward<Args>(args)...);
+    return LLVM::IntToPtrOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::PtrToIntOp ptrtoint(Args &&...args) {
-    return builder->create<LLVM::PtrToIntOp>(loc, std::forward<Args>(args)...);
+    return LLVM::PtrToIntOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ZExtOp zext(Args &&...args) {
-    return builder->create<LLVM::ZExtOp>(loc, std::forward<Args>(args)...);
+    return LLVM::ZExtOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::SExtOp sext(Args &&...args) {
-    return builder->create<LLVM::SExtOp>(loc, std::forward<Args>(args)...);
+    return LLVM::SExtOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::FPExtOp fpext(Args &&...args) {
-    return builder->create<LLVM::FPExtOp>(loc, std::forward<Args>(args)...);
+    return LLVM::FPExtOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::FPTruncOp fptrunc(Args &&...args) {
-    return builder->create<LLVM::FPTruncOp>(loc, std::forward<Args>(args)...);
+    return LLVM::FPTruncOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::TruncOp trunc(Args &&...args) {
-    return builder->create<LLVM::TruncOp>(loc, std::forward<Args>(args)...);
+    return LLVM::TruncOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::UDivOp udiv(Args &&...args) {
-    return builder->create<LLVM::UDivOp>(loc, std::forward<Args>(args)...);
+    return LLVM::UDivOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::SDivOp sdiv(Args &&...args) {
-    return builder->create<LLVM::SDivOp>(loc, std::forward<Args>(args)...);
+    return LLVM::SDivOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::URemOp urem(Args &&...args) {
-    return builder->create<LLVM::URemOp>(loc, std::forward<Args>(args)...);
+    return LLVM::URemOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::AddOp add(Args &&...args) {
-    return builder->create<LLVM::AddOp>(loc, std::forward<Args>(args)...);
+    return LLVM::AddOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::SubOp sub(Args &&...args) {
-    return builder->create<LLVM::SubOp>(loc, std::forward<Args>(args)...);
+    return LLVM::SubOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::FAddOp fadd(Args &&...args) {
-    return builder->create<LLVM::FAddOp>(loc, std::forward<Args>(args)...);
+    return LLVM::FAddOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::MulOp mul(Args &&...args) {
-    return builder->create<LLVM::MulOp>(loc, std::forward<Args>(args)...);
+    return LLVM::MulOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::FMulOp fmul(Args &&...args) {
-    return builder->create<LLVM::FMulOp>(loc, std::forward<Args>(args)...);
+    return LLVM::FMulOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::FMAOp fma(Args &&...args) {
-    return builder->create<LLVM::FMAOp>(loc, std::forward<Args>(args)...);
+    return LLVM::FMAOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::FNegOp neg(Args &&...args) {
-    return builder->create<LLVM::FNegOp>(loc, std::forward<Args>(args)...);
+    return LLVM::FNegOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::SMaxOp smax(Args &&...args) {
-    return builder->create<LLVM::SMaxOp>(loc, std::forward<Args>(args)...);
+    return LLVM::SMaxOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::UMaxOp umax(Args &&...args) {
-    return builder->create<LLVM::UMaxOp>(loc, std::forward<Args>(args)...);
+    return LLVM::UMaxOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::MaxNumOp fmax(Args &&...args) {
-    return builder->create<LLVM::MaxNumOp>(loc, std::forward<Args>(args)...);
+    return LLVM::MaxNumOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::SMinOp smin(Args &&...args) {
-    return builder->create<LLVM::SMinOp>(loc, std::forward<Args>(args)...);
+    return LLVM::SMinOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::UMinOp umin(Args &&...args) {
-    return builder->create<LLVM::UMinOp>(loc, std::forward<Args>(args)...);
+    return LLVM::UMinOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::MinNumOp fmin(Args &&...args) {
-    return builder->create<LLVM::MinNumOp>(loc, std::forward<Args>(args)...);
+    return LLVM::MinNumOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ShlOp shl(Args &&...args) {
-    return builder->create<LLVM::ShlOp>(loc, std::forward<Args>(args)...);
+    return LLVM::ShlOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::LShrOp lshr(Args &&...args) {
-    return builder->create<LLVM::LShrOp>(loc, std::forward<Args>(args)...);
+    return LLVM::LShrOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::AShrOp ashr(Args &&...args) {
-    return builder->create<LLVM::AShrOp>(loc, std::forward<Args>(args)...);
+    return LLVM::AShrOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::AndOp and_(Args &&...args) {
-    return builder->create<LLVM::AndOp>(loc, std::forward<Args>(args)...);
+    return LLVM::AndOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::XOrOp xor_(Args &&...args) {
-    return builder->create<LLVM::XOrOp>(loc, std::forward<Args>(args)...);
+    return LLVM::XOrOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::OrOp or_(Args &&...args) {
-    return builder->create<LLVM::OrOp>(loc, std::forward<Args>(args)...);
+    return LLVM::OrOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   LLVM::BitcastOp bitcast(Value val, Type type) {
-    return builder->create<LLVM::BitcastOp>(loc, type, val);
+    return LLVM::BitcastOp::create(*builder, loc, type, val);
   }
   template <typename... Args>
   LLVM::AddrSpaceCastOp addrspacecast(Args &&...args) {
-    return builder->create<LLVM::AddrSpaceCastOp>(loc,
-                                                  std::forward<Args>(args)...);
+    return LLVM::AddrSpaceCastOp::create(*builder, loc,
+                                         std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::GEPOp gep(Args &&...args) {
-    return builder->create<LLVM::GEPOp>(loc, std::forward<Args>(args)...);
+    return LLVM::GEPOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::InsertValueOp insert_val(Args &&...args) {
-    return builder->create<LLVM::InsertValueOp>(loc,
-                                                std::forward<Args>(args)...);
+    return LLVM::InsertValueOp::create(*builder, loc,
+                                       std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ExtractValueOp extract_val(Args &&...args) {
-    return builder->create<LLVM::ExtractValueOp>(loc,
-                                                 std::forward<Args>(args)...);
+    return LLVM::ExtractValueOp::create(*builder, loc,
+                                        std::forward<Args>(args)...);
   }
   template <typename... Args>
   LLVM::InsertElementOp insert_element(Args &&...args) {
-    return builder->create<LLVM::InsertElementOp>(loc,
-                                                  std::forward<Args>(args)...);
+    return LLVM::InsertElementOp::create(*builder, loc,
+                                         std::forward<Args>(args)...);
   }
   template <typename... Args>
   LLVM::ExtractElementOp extract_element(Args &&...args) {
-    return builder->create<LLVM::ExtractElementOp>(loc,
-                                                   std::forward<Args>(args)...);
+    return LLVM::ExtractElementOp::create(*builder, loc,
+                                          std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::LoadOp load(Args &&...args) {
-    return builder->create<LLVM::LoadOp>(loc, std::forward<Args>(args)...);
+    return LLVM::LoadOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::StoreOp store(Args &&...args) {
-    return builder->create<LLVM::StoreOp>(loc, std::forward<Args>(args)...);
+    return LLVM::StoreOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   LLVM::FCmpOp fcmp_ogt(Value lhs, Value rhs) {
-    return builder->create<LLVM::FCmpOp>(loc, builder->getI1Type(),
-                                         LLVM::FCmpPredicate::ogt, lhs, rhs);
+    return LLVM::FCmpOp::create(*builder, loc, builder->getI1Type(),
+                                LLVM::FCmpPredicate::ogt, lhs, rhs);
   }
   LLVM::FCmpOp fcmp_olt(Value lhs, Value rhs) {
-    return builder->create<LLVM::FCmpOp>(loc, builder->getI1Type(),
-                                         LLVM::FCmpPredicate::olt, lhs, rhs);
+    return LLVM::FCmpOp::create(*builder, loc, builder->getI1Type(),
+                                LLVM::FCmpPredicate::olt, lhs, rhs);
   }
   LLVM::FCmpOp fcmp_eq(Value lhs, Value rhs) {
-    return builder->create<LLVM::FCmpOp>(loc, builder->getI1Type(),
-                                         LLVM::FCmpPredicate::oeq, lhs, rhs);
+    return LLVM::FCmpOp::create(*builder, loc, builder->getI1Type(),
+                                LLVM::FCmpPredicate::oeq, lhs, rhs);
   }
   template <typename... Args> LLVM::ICmpOp icmp_eq(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::eq,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::eq,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_ne(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::ne,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_slt(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::slt,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::slt,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_sle(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::sle,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::sle,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_sgt(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::sgt,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::sgt,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_sge(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::sge,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::sge,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_ult(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ult,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::ult,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_ule(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ule,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::ule,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_ugt(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ugt,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::ugt,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ICmpOp icmp_uge(Args &&...args) {
-    return builder->create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::uge,
-                                         std::forward<Args>(args)...);
+    return LLVM::ICmpOp::create(*builder, loc, LLVM::ICmpPredicate::uge,
+                                std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::SelectOp select(Args &&...args) {
-    return builder->create<LLVM::SelectOp>(loc, std::forward<Args>(args)...);
+    return LLVM::SelectOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::AddressOfOp address_of(Args &&...args) {
-    return builder->create<LLVM::AddressOfOp>(loc, std::forward<Args>(args)...);
+    return LLVM::AddressOfOp::create(*builder, loc,
+                                     std::forward<Args>(args)...);
   }
   mlir::gpu::BarrierOp barrier() {
-    return builder->create<mlir::gpu::BarrierOp>(loc);
+    return mlir::gpu::BarrierOp::create(*builder, loc);
   }
   template <typename... Args> LLVM::UndefOp undef(Args &&...args) {
-    return builder->create<LLVM::UndefOp>(loc, std::forward<Args>(args)...);
+    return LLVM::UndefOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::ZeroOp null(Args &&...args) {
-    return builder->create<LLVM::ZeroOp>(loc, std::forward<Args>(args)...);
+    return LLVM::ZeroOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   template <typename... Args> LLVM::CallOp call(Args &&...args) {
-    return builder->create<LLVM::CallOp>(loc, std::forward<Args>(args)...);
+    return LLVM::CallOp::create(*builder, loc, std::forward<Args>(args)...);
   }
   // Constants
   Value int_val(short bitwidth, int64_t val) {
     Type ty = builder->getIntegerType(bitwidth);
-    return builder->create<LLVM::ConstantOp>(loc, ty,
-                                             builder->getIntegerAttr(ty, val));
+    return LLVM::ConstantOp::create(*builder, loc, ty,
+                                    builder->getIntegerAttr(ty, val));
   }
   Value i1_val(int64_t val) { return int_val(1, val); }
   Value true_val() { return int_val(1, true); }

--- a/include/triton/Dialect/TritonGPU/Transforms/PartitionBuilder.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PartitionBuilder.h
@@ -36,7 +36,7 @@ template <typename OpT, typename... Args>
 OpT createInto(OpBuilder &b, Location loc,
                std::optional<SetVector<int>> partitionSet,
                StageCluster stageCluster, Args &&...args) {
-  auto op = b.create<OpT>(loc, std::forward<Args>(args)...);
+  auto op = OpT::create(b, loc, std::forward<Args>(args)...);
   if (partitionSet) {
     setPartition(op, *partitionSet);
     setStageCluster(b, op, stageCluster);

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -159,7 +159,7 @@ void MembarOrFenceAnalysis::visitTerminator(
 
 void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
   OpBuilder::InsertionGuard g(*builder);
-  auto barrierOp = builder->create<triton::gpu::LocalBarrierOp>(op->getLoc());
+  auto barrierOp = triton::gpu::LocalBarrierOp::create(*builder, op->getLoc());
 }
 
 void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,

--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -43,7 +43,7 @@ static void padToMaxWarpGroups(WarpSpecializeOp op, int numExtraWarpGroups) {
       body.addArgument(capture.getType(), capture.getLoc());
     OpBuilder b(op.getContext());
     b.setInsertionPointToStart(&body);
-    b.create<WarpReturnOp>(op.getLoc());
+    WarpReturnOp::create(b, op.getLoc());
   }
   op.setPartitionNumWarps(partitionNumWarps);
 

--- a/lib/Conversion/TritonGPUToLLVM/AssertOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AssertOpToLLVM.cpp
@@ -26,10 +26,10 @@ struct AssertOpConversion : public ConvertOpToLLVMPattern<triton::AssertOp> {
     Value condition = b.int_val(elemTy.getIntOrFloatBitWidth(), 0);
     for (auto elem : elems) {
       if (elemTy.isSignedInteger() || elemTy.isSignlessInteger()) {
-        condition = b.or_(
-            condition,
-            b.icmp_eq(elem, rewriter.create<LLVM::ConstantOp>(
-                                loc, elemTy, rewriter.getZeroAttr(elemTy))));
+        condition = b.or_(condition,
+                          b.icmp_eq(elem, LLVM::ConstantOp::create(
+                                              rewriter, loc, elemTy,
+                                              rewriter.getZeroAttr(elemTy))));
       } else {
         assert(false && "Unsupported type for assert");
         return failure();
@@ -87,9 +87,9 @@ struct AssertOpConversion : public ConvertOpToLLVMPattern<triton::AssertOp> {
     // Split a block after the call.
     Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
     rewriter.setInsertionPointToEnd(ifBlock);
-    rewriter.create<LLVM::BrOp>(loc, thenBlock);
+    LLVM::BrOp::create(rewriter, loc, thenBlock);
     rewriter.setInsertionPointToEnd(prevBlock);
-    rewriter.create<LLVM::CondBrOp>(loc, condition, ifBlock, thenBlock);
+    LLVM::CondBrOp::create(rewriter, loc, condition, ifBlock, thenBlock);
     rewriter.setInsertionPointToStart(thenBlock);
   }
 

--- a/lib/Conversion/TritonGPUToLLVM/ControlFlowOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ControlFlowOpToLLVM.cpp
@@ -28,19 +28,19 @@ struct ReturnOpConversion : public ConvertOpToLLVMPattern<triton::ReturnOp> {
       LLVM::ReturnOp newOp;
       if (adaptor.getOperands().size() < 2) {
         // Single or no return value.
-        newOp =
-            rewriter.create<LLVM::ReturnOp>(op.getLoc(), adaptor.getOperands());
+        newOp = LLVM::ReturnOp::create(rewriter, op.getLoc(),
+                                       adaptor.getOperands());
       } else {
         // Pack the results into a struct.
         auto packedResultsTy = this->getTypeConverter()->packFunctionResults(
             funcOp.getResultTypes());
         Value packedResults =
-            rewriter.create<LLVM::UndefOp>(op.getLoc(), packedResultsTy);
+            LLVM::UndefOp::create(rewriter, op.getLoc(), packedResultsTy);
         for (auto it : llvm::enumerate(adaptor.getOperands())) {
           packedResults = b.insert_val(packedResultsTy, packedResults,
                                        it.value(), it.index());
         }
-        newOp = rewriter.create<LLVM::ReturnOp>(op.getLoc(), packedResults);
+        newOp = LLVM::ReturnOp::create(rewriter, op.getLoc(), packedResults);
       }
       newOp->setAttrs(op->getAttrs());
       rewriter.replaceOp(op, newOp->getResults());
@@ -122,9 +122,10 @@ private:
                 this->getTypeConverter()->packFunctionResults(resultTypes)))
         return nullptr;
     }
-    auto newCallOp = rewriter.create<LLVM::CallOp>(
-        callOp.getLoc(), packedResult ? TypeRange(packedResult) : TypeRange(),
-        promotedOperands, callOp->getAttrs());
+    auto newCallOp = LLVM::CallOp::create(rewriter, callOp.getLoc(),
+                                          packedResult ? TypeRange(packedResult)
+                                                       : TypeRange(),
+                                          promotedOperands, callOp->getAttrs());
     newCallOp.getProperties().setOpBundleSizes(
         rewriter.getDenseI32ArrayAttr({}));
     newCallOp.getProperties().setOperandSegmentSizes(
@@ -145,8 +146,8 @@ private:
       // Extract individual results from the structure and return them as list.
       results.reserve(numResults);
       for (unsigned i = 0; i < numResults; ++i) {
-        results.push_back(rewriter.create<LLVM::ExtractValueOp>(
-            callOp.getLoc(), newCallOp->getResult(0), i));
+        results.push_back(LLVM::ExtractValueOp::create(
+            rewriter, callOp.getLoc(), newCallOp->getResult(0), i));
       }
     }
     return results;

--- a/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/DotOpToLLVM/FMA.cpp
@@ -33,11 +33,12 @@ public:
       // got 'i32'
       llvm::TypeSwitch<Type>(tgtTy)
           .Case<FloatType>([&](auto) {
-            accum = builder.create<LLVM::FMulAddOp>(loc, aElem, bElem, accum);
+            accum = LLVM::FMulAddOp::create(builder, loc, aElem, bElem, accum);
           })
           .Case<IntegerType>([&](auto) {
-            accum = builder.create<LLVM::AddOp>(
-                loc, builder.create<LLVM::MulOp>(loc, aElem, bElem), accum);
+            accum = LLVM::AddOp::create(
+                builder, loc, LLVM::MulOp::create(builder, loc, aElem, bElem),
+                accum);
           });
     }
     return accum;

--- a/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -83,9 +83,9 @@ struct CmpIOpConversion
                                           Type elemTy,
                                           MultipleOperandsRange operands,
                                           Location loc) const {
-    return {rewriter.create<LLVM::ICmpOp>(
-        loc, elemTy, ArithCmpIPredicateToLLVM(op.getPredicate()),
-        operands[0][0], operands[0][1])};
+    return {LLVM::ICmpOp::create(rewriter, loc, elemTy,
+                                 ArithCmpIPredicateToLLVM(op.getPredicate()),
+                                 operands[0][0], operands[0][1])};
   }
 
   static LLVM::ICmpPredicate
@@ -123,9 +123,9 @@ struct CmpFOpConversion
   createDestOps(arith::CmpFOp op, OpAdaptor adaptor,
                 ConversionPatternRewriter &rewriter, Type elemTy,
                 MultipleOperandsRange operands, Location loc) {
-    return {rewriter.create<LLVM::FCmpOp>(
-        loc, elemTy, ArithCmpFPredicateToLLVM(op.getPredicate()),
-        operands[0][0], operands[0][1])};
+    return {LLVM::FCmpOp::create(rewriter, loc, elemTy,
+                                 ArithCmpFPredicateToLLVM(op.getPredicate()),
+                                 operands[0][0], operands[0][1])};
   }
 
   static LLVM::FCmpPredicate
@@ -290,20 +290,18 @@ struct ElementwiseInlineAsmOpConversion
     Type asmRetType =
         asmRetTypes.size() > 1 ? struct_ty(asmRetTypes) : asmRetTypes[0];
 
-    Value asmResults =
-        rewriter
-            .create<LLVM::InlineAsmOp>(
-                loc, asmRetType,
-                /*operands=*/packedOperands,
-                /*asm_string=*/op.getAsmString(),
-                /*constraints=*/op.getConstraints(),
-                /*has_side_effects=*/!op.getPure(),
-                /*is_align_stack=*/false, LLVM::TailCallKind::None,
-                /*asm_dialect=*/
-                LLVM::AsmDialectAttr::get(rewriter.getContext(),
-                                          LLVM::AsmDialect::AD_ATT),
-                /*operand_attrs=*/ArrayAttr())
-            ->getResult(0);
+    Value asmResults = LLVM::InlineAsmOp::create(
+                           rewriter, loc, asmRetType,
+                           /*operands=*/packedOperands,
+                           /*asm_string=*/op.getAsmString(),
+                           /*constraints=*/op.getConstraints(),
+                           /*has_side_effects=*/!op.getPure(),
+                           /*is_align_stack=*/false, LLVM::TailCallKind::None,
+                           /*asm_dialect=*/
+                           LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                                     LLVM::AsmDialect::AD_ATT),
+                           /*operand_attrs=*/ArrayAttr())
+                           ->getResult(0);
 
     // asmResults is a flat struct; pack its values into
     // [return_value][op.getPackedElement()].
@@ -413,8 +411,8 @@ struct AbsIOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    return {rewriter.create<LLVM::AbsOp>(loc, elemTy, operands[0][0],
-                                         /*is_int_min_poison=*/false)};
+    return {LLVM::AbsOp::create(rewriter, loc, elemTy, operands[0][0],
+                                /*is_int_min_poison=*/false)};
   }
 };
 
@@ -436,11 +434,11 @@ struct AbsFOpConversion
       assert(num_bits <= 16);
       auto mask = (1u << (num_bits - 1u)) - 1u;
       auto maskAttr = rewriter.getIntegerAttr(elemTy, mask);
-      auto maskConst = rewriter.create<LLVM::ConstantOp>(loc, maskAttr);
+      auto maskConst = LLVM::ConstantOp::create(rewriter, loc, maskAttr);
       return {b.and_(operands[0][0], maskConst)};
     }
 
-    return {rewriter.create<LLVM::FAbsOp>(loc, elemTy, operands[0][0])};
+    return {LLVM::FAbsOp::create(rewriter, loc, elemTy, operands[0][0])};
   }
 };
 
@@ -462,9 +460,9 @@ struct SelectOpConversion
     } else {
       llvmOperands = {operands[0][0], operands[0][1], operands[0][2]};
     }
-    return {rewriter.create<LLVM::SelectOp>(
-        loc, llvmOperands[1].getType(), llvmOperands,
-        adaptor.getAttributes().getValue())};
+    return {LLVM::SelectOp::create(rewriter, loc, llvmOperands[1].getType(),
+                                   llvmOperands,
+                                   adaptor.getAttributes().getValue())};
   }
 };
 template <typename OpTy>
@@ -499,24 +497,24 @@ struct MinMaxFOpConversion
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
     if (hwNanPropagationSupported) {
-      return {rewriter.create<DestOpNanProp>(loc, elemTy, operands[0][0],
-                                             operands[0][1])};
+      return {DestOpNanProp::create(rewriter, loc, elemTy, operands[0][0],
+                                    operands[0][1])};
     }
     // Handle workaround for NaN propagation, i.e. software emulation of NaN
     // propagation. If any of the operands is NaN, return NaN.
     auto lhs = operands[0][0];
     auto rhs = operands[0][1];
     auto lhsIsNan =
-        rewriter.create<LLVM::FCmpOp>(loc, LLVM::FCmpPredicate::une, lhs, lhs);
+        LLVM::FCmpOp::create(rewriter, loc, LLVM::FCmpPredicate::une, lhs, lhs);
     auto rhsIsNan =
-        rewriter.create<LLVM::FCmpOp>(loc, LLVM::FCmpPredicate::une, rhs, rhs);
-    auto isNan = rewriter.create<LLVM::OrOp>(loc, lhsIsNan, rhsIsNan);
-    auto nonNanRes = rewriter.create<DestOpNoNanProp>(loc, elemTy, lhs, rhs);
+        LLVM::FCmpOp::create(rewriter, loc, LLVM::FCmpPredicate::une, rhs, rhs);
+    auto isNan = LLVM::OrOp::create(rewriter, loc, lhsIsNan, rhsIsNan);
+    auto nonNanRes = DestOpNoNanProp::create(rewriter, loc, elemTy, lhs, rhs);
 
     auto nan = LLVM::createNaNConstant(loc, rewriter, elemTy);
 
     // Select the result based on the isNan flag.
-    return {rewriter.create<LLVM::SelectOp>(loc, isNan, nan, nonNanRes)};
+    return {LLVM::SelectOp::create(rewriter, loc, isNan, nan, nonNanRes)};
   }
 
 private:
@@ -543,28 +541,28 @@ struct ClampFOpConversion
     // Clip pattern not found, use min/max.
     if (op.getPropagateNan() == PropagateNan::ALL) {
       if (targetInfo.supportMaximumMinimum()) {
-        auto v = rewriter.create<LLVM::MaximumOp>(loc, elemTy, operands[0][0],
-                                                  operands[0][1]);
-        return {rewriter.create<LLVM::MinimumOp>(loc, v, operands[0][2])};
+        auto v = LLVM::MaximumOp::create(rewriter, loc, elemTy, operands[0][0],
+                                         operands[0][1]);
+        return {LLVM::MinimumOp::create(rewriter, loc, v, operands[0][2])};
       }
       // On pre-80 compute capability, we need to handle NaN propagation
       // manually. We need to check only the first operand for clamp.
       auto lhs = operands[0][0];
-      auto isNan = rewriter.create<LLVM::FCmpOp>(loc, LLVM::FCmpPredicate::une,
-                                                 lhs, lhs);
-      auto v = rewriter.create<LLVM::MaxNumOp>(loc, elemTy, operands[0][0],
-                                               operands[0][1]);
-      auto nonNanRes = rewriter.create<LLVM::MinNumOp>(loc, v, operands[0][2]);
+      auto isNan = LLVM::FCmpOp::create(rewriter, loc, LLVM::FCmpPredicate::une,
+                                        lhs, lhs);
+      auto v = LLVM::MaxNumOp::create(rewriter, loc, elemTy, operands[0][0],
+                                      operands[0][1]);
+      auto nonNanRes = LLVM::MinNumOp::create(rewriter, loc, v, operands[0][2]);
       auto nan = LLVM::createNaNConstant(loc, rewriter, elemTy);
       // Select the result based on the isNan flag.
-      return {rewriter.create<LLVM::SelectOp>(loc, isNan, nan, nonNanRes)};
+      return {LLVM::SelectOp::create(rewriter, loc, isNan, nan, nonNanRes)};
     }
 
     // No NaN propagation.
     assert(op.getPropagateNan() == PropagateNan::NONE);
-    auto v = rewriter.create<LLVM::MaxNumOp>(loc, elemTy, operands[0][0],
-                                             operands[0][1]);
-    return {rewriter.create<LLVM::MinNumOp>(loc, v, operands[0][2])};
+    auto v = LLVM::MaxNumOp::create(rewriter, loc, elemTy, operands[0][0],
+                                    operands[0][1]);
+    return {LLVM::MinNumOp::create(rewriter, loc, v, operands[0][2])};
   }
 
 protected:

--- a/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/FuncOpToLLVM.cpp
@@ -91,8 +91,9 @@ struct FuncOpConversion : public ConvertOpToLLVMPattern<triton::FuncOp> {
     }
 
     // 3. Add the new arguments to the region
-    auto amendedFuncOp = rewriter.create<triton::FuncOp>(
-        funcOp.getLoc(), funcOp.getName(), amendedFuncTy, amendedAttrs);
+    auto amendedFuncOp =
+        triton::FuncOp::create(rewriter, funcOp.getLoc(), funcOp.getName(),
+                               amendedFuncTy, amendedAttrs);
     auto &region = funcOp.getBody();
     if (!isKernel) {
       region.addArgument(sharedPtrTy, loc);

--- a/lib/Conversion/TritonGPUToLLVM/HistogramOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/HistogramOpToLLVM.cpp
@@ -68,8 +68,8 @@ static SmallVector<Value> computeWarpLevelHistogram(
       }
       // at this point, 'bin_mask' tells you which elements are in the kth bin
       // owned by this thread.
-      Value bitCount = rewriter.create<LLVM::CtPopOp>(
-          loc, int_ty(numThreadPerWarp), binMask);
+      Value bitCount = LLVM::CtPopOp::create(rewriter, loc,
+                                             int_ty(numThreadPerWarp), binMask);
       if (numThreadPerWarp > 32)
         bitCount = b.trunc(i32_ty, bitCount);
       warpLevelHistogram[k] = b.add(warpLevelHistogram[k], bitCount);
@@ -80,8 +80,8 @@ static SmallVector<Value> computeWarpLevelHistogram(
 
 static void atomicAdd(Value ptr, Value val, Location loc,
                       ConversionPatternRewriter &rewriter) {
-  rewriter.create<LLVM::AtomicRMWOp>(loc, LLVM::AtomicBinOp::add, ptr, val,
-                                     LLVM::AtomicOrdering::monotonic);
+  LLVM::AtomicRMWOp::create(rewriter, loc, LLVM::AtomicBinOp::add, ptr, val,
+                            LLVM::AtomicOrdering::monotonic);
 }
 
 static SmallVector<Value> computeCrossWarpHistogram(
@@ -115,7 +115,7 @@ static SmallVector<Value> computeCrossWarpHistogram(
     atomicAdd(sharedMemPtr, warpLevelHistogramValue, loc, rewriter);
   }
   if (afterAtomics) {
-    rewriter.create<LLVM::BrOp>(loc, afterAtomics);
+    LLVM::BrOp::create(rewriter, loc, afterAtomics);
     rewriter.setInsertionPointToStart(afterAtomics);
   }
   b.barrier();

--- a/lib/Conversion/TritonGPUToLLVM/ReduceScanCommon.h
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceScanCommon.h
@@ -93,12 +93,12 @@ inline SmallVector<Value> applyCombineOp(Location loc,
   thenBlockArgs.reserve(results.size());
   for (auto result : results) {
     auto ty = result.getType();
-    auto undef = rewriter.create<LLVM::UndefOp>(loc, ty);
+    auto undef = LLVM::UndefOp::create(rewriter, loc, ty);
     thenBlockArgs.push_back(undef);
     thenBlock->addArgument(ty, loc);
   }
-  rewriter.create<LLVM::CondBrOp>(loc, pred, &newCombine, combineArgs,
-                                  thenBlock, thenBlockArgs);
+  LLVM::CondBrOp::create(rewriter, loc, pred, &newCombine, combineArgs,
+                         thenBlock, thenBlockArgs);
 
   // Split a block after the call.
   rewriter.setInsertionPointToEnd(&newCombine);

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -113,7 +113,7 @@ struct ArithConstantSplatOpConversion
     // LLVM IR.
     if (type::isFloat8(elemType))
       elemType = rewriter.getIntegerType(8);
-    auto constOp = rewriter.create<LLVM::ConstantOp>(loc, elemType, val);
+    auto constOp = LLVM::ConstantOp::create(rewriter, loc, elemType, val);
     auto typeConverter = getTypeConverter();
     auto llStruct = SplatOpConversion::convertSplatLikeOp(
         elemType, op.getType(), constOp, typeConverter, rewriter, loc);
@@ -141,7 +141,7 @@ struct ArithConstantArrayOpConversion
     auto elemType = values.getElementType();
     SmallVector<Value> llVals;
     for (auto v : values.getValues<APInt>()) {
-      auto ll = rewriter.create<LLVM::ConstantOp>(loc, elemType, v);
+      auto ll = LLVM::ConstantOp::create(rewriter, loc, elemType, v);
       llVals.push_back(ll);
     }
     size_t elemsPerThread = getTotalElemsPerThread(tensorTy);

--- a/lib/Conversion/TritonToTritonGPU/RelayoutTritonGPU.cpp
+++ b/lib/Conversion/TritonToTritonGPU/RelayoutTritonGPU.cpp
@@ -45,8 +45,8 @@ struct TMEMLoadOpPattern : public OpConversionPattern<ttng::TMEMLoadOp> {
     rewriter.modifyOpInPlace(op, [&] { op.getResult().setType(type); });
     Type resultType = getTypeConverter()->convertType(op.getType());
     rewriter.setInsertionPointAfter(op);
-    auto cvt = rewriter.create<ConvertLayoutOp>(op.getLoc(), resultType,
-                                                op.getResult());
+    auto cvt = ConvertLayoutOp::create(rewriter, op.getLoc(), resultType,
+                                       op.getResult());
     rewriter.replaceAllUsesExcept(op.getResult(), cvt, cvt);
     return success();
   }
@@ -62,7 +62,7 @@ struct TMEMStoreOpPattern : public OpConversionPattern<ttng::TMEMStoreOp> {
         getTMEMTensorLayout(typeConverter, op.getSrc().getType(),
                             op.getDst().getType(), lookupNumWarps(op));
     Value src =
-        rewriter.create<ConvertLayoutOp>(op.getLoc(), type, adaptor.getSrc());
+        ConvertLayoutOp::create(rewriter, op.getLoc(), type, adaptor.getSrc());
     rewriter.modifyOpInPlace(op, [&] { op.getSrcMutable().assign(src); });
     return success();
   }
@@ -79,7 +79,7 @@ struct TMEMAllocOpPattern : public OpConversionPattern<ttng::TMEMAllocOp> {
     RankedTensorType type = getTMEMTensorLayout(
         typeConverter, op.getSrc().getType(), op.getType(), lookupNumWarps(op));
     Value src =
-        rewriter.create<ConvertLayoutOp>(op.getLoc(), type, adaptor.getSrc());
+        ConvertLayoutOp::create(rewriter, op.getLoc(), type, adaptor.getSrc());
     rewriter.modifyOpInPlace(op, [&] { op.getSrcMutable().assign(src); });
     return success();
   }

--- a/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
+++ b/lib/Conversion/TritonToTritonGPU/TritonGPUConversion.cpp
@@ -56,7 +56,8 @@ TritonGPUTypeConverter::TritonGPUTypeConverter(MLIRContext *context,
   if (enableSourceRemat) {
     addSourceMaterialization([](OpBuilder &builder, RankedTensorType tensorType,
                                 ValueRange inputs, Location loc) -> Value {
-      return builder.create<UnrealizedConversionCastOp>(loc, tensorType, inputs)
+      return UnrealizedConversionCastOp::create(builder, loc, tensorType,
+                                                inputs)
           .getResult(0);
     });
   }
@@ -67,7 +68,7 @@ TritonGPUTypeConverter::TritonGPUTypeConverter(MLIRContext *context,
   addTargetMaterialization([](OpBuilder &builder, RankedTensorType tensorType,
                               ValueRange inputs, Location loc) {
     auto cast =
-        builder.create<triton::gpu::ConvertLayoutOp>(loc, tensorType, inputs);
+        triton::gpu::ConvertLayoutOp::create(builder, loc, tensorType, inputs);
     return cast.getResult();
   });
 }
@@ -163,7 +164,8 @@ static LogicalResult convertGatherScatterIndices(Operation *op,
       getNewIndicesType(type, lookupThreadsPerWarp(b), lookupNumWarps(op));
   if (!newType)
     return failure();
-  Value index = b.create<ConvertLayoutOp>(op->getLoc(), newType, indices.get());
+  Value index =
+      ConvertLayoutOp::create(b, op->getLoc(), newType, indices.get());
   indices.set(index);
   return success();
 }

--- a/lib/Dialect/Triton/IR/Dialect.cpp
+++ b/lib/Dialect/Triton/IR/Dialect.cpp
@@ -40,8 +40,8 @@ void TritonInlinerInterface::handleTerminator(Operation *op,
 
   // Replace the return with a branch to the dest.
   OpBuilder builder(op);
-  builder.create<mlir::cf::BranchOp>(op->getLoc(), newDest,
-                                     returnOp.getOperands());
+  mlir::cf::BranchOp::create(builder, op->getLoc(), newDest,
+                             returnOp.getOperands());
   op->erase();
 }
 

--- a/lib/Dialect/Triton/IR/Ops.cpp
+++ b/lib/Dialect/Triton/IR/Ops.cpp
@@ -736,10 +736,10 @@ LogicalResult ExpandDimsOp::canonicalize(ExpandDimsOp op,
 
     auto newExpandTy = RankedTensorType::get(
         newExpandShape, srcTy.getElementType(), newExpandEnc);
-    auto newExpand = rewriter.create<ExpandDimsOp>(op.getLoc(), newExpandTy,
-                                                   src, op.getAxis());
-    auto newBroadcast = rewriter.create<BroadcastOp>(
-        broadcast.getLoc(), op.getType(), newExpand.getResult());
+    auto newExpand = ExpandDimsOp::create(rewriter, op.getLoc(), newExpandTy,
+                                          src, op.getAxis());
+    auto newBroadcast = BroadcastOp::create(
+        rewriter, broadcast.getLoc(), op.getType(), newExpand.getResult());
     rewriter.replaceOp(op, {newBroadcast.getResult()});
     return success();
   }

--- a/lib/Dialect/Triton/IR/Utility.cpp
+++ b/lib/Dialect/Triton/IR/Utility.cpp
@@ -12,10 +12,10 @@ Value tt::getPredMask(RewriterBase &rewriter, Type typeLike, Value currentMask,
   Location loc = pred.getLoc();
   Value mask = pred;
   if (isa<RankedTensorType>(maskType)) {
-    mask = rewriter.create<tt::SplatOp>(loc, maskType, pred);
+    mask = tt::SplatOp::create(rewriter, loc, maskType, pred);
   }
   if (currentMask) {
-    mask = rewriter.create<arith::AndIOp>(loc, mask, currentMask);
+    mask = arith::AndIOp::create(rewriter, loc, mask, currentMask);
   }
   return mask;
 }
@@ -96,12 +96,13 @@ Value tt::getLastInductionValue(OpBuilder &b, scf::ForOp loop) {
   Location loc = loop.getLoc();
   // (ub - lb -1) // step * step + lb
   Value diff =
-      b.create<arith::SubIOp>(loc, loop.getUpperBound(), loop.getLowerBound());
-  diff = b.create<arith::SubIOp>(
-      loc, diff, b.create<arith::ConstantOp>(loc, b.getI32IntegerAttr(1)));
-  Value ceilStep = b.create<arith::MulIOp>(
-      loc, b.create<arith::DivSIOp>(loc, diff, loop.getStep()), loop.getStep());
-  return b.create<arith::AddIOp>(loc, ceilStep, loop.getLowerBound());
+      arith::SubIOp::create(b, loc, loop.getUpperBound(), loop.getLowerBound());
+  diff = arith::SubIOp::create(
+      b, loc, diff, arith::ConstantOp::create(b, loc, b.getI32IntegerAttr(1)));
+  Value ceilStep = arith::MulIOp::create(
+      b, loc, arith::DivSIOp::create(b, loc, diff, loop.getStep()),
+      loop.getStep());
+  return arith::AddIOp::create(b, loc, ceilStep, loop.getLowerBound());
 }
 
 bool tt::isKernel(FunctionOpInterface funcOp) {

--- a/lib/Dialect/Triton/Transforms/ArithTypeConversion.cpp
+++ b/lib/Dialect/Triton/Transforms/ArithTypeConversion.cpp
@@ -16,9 +16,9 @@ struct RewriteArithSelectOp : mlir::OpConversionPattern<mlir::arith::SelectOp> {
                   mlir::ConversionPatternRewriter &rewriter) const override {
     // Note we're replacing the select op with an if op because we are
     // converting one value into many values.
-    auto newIf = rewriter.create<mlir::scf::IfOp>(
-        op.getLoc(), mlir::TypeRange(adaptor.getTrueValue()), op.getCondition(),
-        true);
+    auto newIf = mlir::scf::IfOp::create(
+        rewriter, op.getLoc(), mlir::TypeRange(adaptor.getTrueValue()),
+        op.getCondition(), true);
     // We set the attributes from the op in case the op has any additional
     // attributes
     newIf->setAttrs(op->getAttrs());
@@ -26,10 +26,11 @@ struct RewriteArithSelectOp : mlir::OpConversionPattern<mlir::arith::SelectOp> {
     {
       mlir::ConversionPatternRewriter::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(newIf.thenBlock());
-      rewriter.create<mlir::scf::YieldOp>(op->getLoc(), adaptor.getTrueValue());
+      mlir::scf::YieldOp::create(rewriter, op->getLoc(),
+                                 adaptor.getTrueValue());
       rewriter.setInsertionPointToStart(newIf.elseBlock());
-      rewriter.create<mlir::scf::YieldOp>(op->getLoc(),
-                                          adaptor.getFalseValue());
+      mlir::scf::YieldOp::create(rewriter, op->getLoc(),
+                                 adaptor.getFalseValue());
     }
 
     // Replace the old operation results

--- a/lib/Dialect/Triton/Transforms/Combine.cpp
+++ b/lib/Dialect/Triton/Transforms/Combine.cpp
@@ -167,10 +167,10 @@ public:
         {broadcastLhsShape[0], broadcastRhsShape[2]},
         cast<ShapedType>(broadcastLhsOp.getSrc().getType()).getElementType());
     rewriter.setInsertionPoint(op);
-    auto newAcc = rewriter.create<SplatOp>(
-        op->getLoc(), newAccType,
-        rewriter.create<arith::ConstantOp>(op->getLoc(),
-                                           rewriter.getF32FloatAttr(0)));
+    auto newAcc =
+        SplatOp::create(rewriter, op->getLoc(), newAccType,
+                        arith::ConstantOp::create(rewriter, op->getLoc(),
+                                                  rewriter.getF32FloatAttr(0)));
     rewriter.replaceOpWithNewOp<DotOp>(op, expandLhsOp.getSrc(),
                                        expandRhsOp.getSrc(), newAcc,
                                        InputPrecision::TF32, 0);

--- a/lib/Dialect/Triton/Transforms/FunctionTypeConversion.cpp
+++ b/lib/Dialect/Triton/Transforms/FunctionTypeConversion.cpp
@@ -39,9 +39,9 @@ struct CallOpConversion : public OpConversionPattern<CallOp> {
                                           oldNumFlattenedResults);
     }
 
-    auto newCallOp = rewriter.create<CallOp>(
-        callOp->getLoc(), callOp.getCallee(), convertedResults,
-        flattenValues(adaptor.getOperands()));
+    auto newCallOp =
+        CallOp::create(rewriter, callOp->getLoc(), callOp.getCallee(),
+                       convertedResults, flattenValues(adaptor.getOperands()));
     // Preserve any additional attributes that may have been set on the op
     newCallOp->setAttrs(callOp->getAttrs());
 
@@ -63,8 +63,8 @@ struct ReturnOpConversion : public OpConversionPattern<ReturnOp> {
   LogicalResult
   matchAndRewrite(ReturnOp returnOp, OneToNOpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    auto newReturnOp = rewriter.create<ReturnOp>(
-        returnOp->getLoc(), flattenValues(adaptor.getOperands()));
+    auto newReturnOp = ReturnOp::create(rewriter, returnOp->getLoc(),
+                                        flattenValues(adaptor.getOperands()));
     // Preserve any additional attributes that may have been set on the op
     newReturnOp->setAttrs(returnOp->getAttrs());
 

--- a/lib/Dialect/Triton/Transforms/LoopInvariantCodeMotion.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopInvariantCodeMotion.cpp
@@ -59,9 +59,9 @@ class LoopInvariantCodeMotionPass
               Location loc = loopLike->getLoc();
               Value cond;
               if (auto forOp = dyn_cast<scf::ForOp>(loopLike.getOperation())) {
-                cond = rewriter.create<arith::CmpIOp>(
-                    loc, arith::CmpIPredicate::slt, forOp.getLowerBound(),
-                    forOp.getUpperBound());
+                cond = arith::CmpIOp::create(
+                    rewriter, loc, arith::CmpIPredicate::slt,
+                    forOp.getLowerBound(), forOp.getUpperBound());
               } else if (auto whileOp =
                              dyn_cast<scf::WhileOp>(loopLike.getOperation())) {
                 // TODO: Support Load Op hoisting for while loop.

--- a/lib/Dialect/Triton/Transforms/LoopPeeling.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopPeeling.cpp
@@ -21,24 +21,24 @@ void peelLoopEpilogue(
   Value lowerBound = forOp.getLowerBound();
   Value upperBound = forOp.getUpperBound();
   Value step = forOp.getStep();
-  Value newUpperBound = rewriter.create<arith::SubIOp>(loc, upperBound, step);
+  Value newUpperBound = arith::SubIOp::create(rewriter, loc, upperBound, step);
 
   rewriter.setInsertionPointAfter(forOp);
   Value lastIV = getLastInductionValue(rewriter, forOp);
 
-  auto cond = rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
-                                             lowerBound, upperBound);
+  auto cond = arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::slt,
+                                    lowerBound, upperBound);
 
   // Create an if op to execute the peeled iteration
   IRMapping map;
   map.map(forOp.getRegionIterArgs(), forOp.getResults());
   map.map(forOp.getInductionVar(), lastIV);
-  auto ifOp = rewriter.create<scf::IfOp>(loc, forOp.getResultTypes(), cond,
-                                         /*hasElse=*/true);
+  auto ifOp = scf::IfOp::create(rewriter, loc, forOp.getResultTypes(), cond,
+                                /*hasElse=*/true);
   ifOp.getThenRegion().front().erase();
   forOp.getBodyRegion().cloneInto(&ifOp.getThenRegion(), map);
   rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
-  rewriter.create<scf::YieldOp>(loc, forOp.getResults());
+  scf::YieldOp::create(rewriter, loc, forOp.getResults());
 
   forOp->replaceUsesWithIf(ifOp, [&](OpOperand &operand) {
     return !ifOp->isAncestor(operand.getOwner());

--- a/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
+++ b/lib/Dialect/Triton/Transforms/ReorderBroadcast.cpp
@@ -92,8 +92,8 @@ struct MoveSplatAfterElementwisePattern
                                                 scalarResultTys);
 
     for (unsigned iRes = 0; iRes < resultTypes.size(); ++iRes) {
-      auto newResult = rewriter.create<SplatOp>(loc, resultTypes[iRes],
-                                                newOp->getResult(iRes));
+      auto newResult = SplatOp::create(rewriter, loc, resultTypes[iRes],
+                                       newOp->getResult(iRes));
       rewriter.replaceAllUsesWith(op->getResult(iRes), newResult);
     }
     return success();
@@ -168,7 +168,7 @@ struct MoveBroadcastAfterElementwisePattern
           dyn_cast<RankedTensorType>(operand.getType()).getElementType();
       auto newTy = srcTy.clone(bcSrcShape, elemTy);
       if (auto splatOp = llvm::dyn_cast<SplatOp>(definingOp)) {
-        auto newSplat = rewriter.create<SplatOp>(loc, newTy, splatOp.getSrc());
+        auto newSplat = SplatOp::create(rewriter, loc, newTy, splatOp.getSrc());
         newOperands.push_back(newSplat);
         continue;
       }
@@ -178,7 +178,7 @@ struct MoveBroadcastAfterElementwisePattern
         auto scalarValue = constAttr.getSplatValue<Attribute>();
         auto splatValue = SplatElementsAttr::get(newTy, scalarValue);
         auto newConstant =
-            rewriter.create<arith::ConstantOp>(loc, newTy, splatValue);
+            arith::ConstantOp::create(rewriter, loc, newTy, splatValue);
         newOperands.push_back(newConstant);
         continue;
       }
@@ -197,8 +197,8 @@ struct MoveBroadcastAfterElementwisePattern
     auto newOp = cloneWithNewArgsAndResultTypes(rewriter, op, newOperands,
                                                 newResultTypes);
     for (unsigned iRes = 0; iRes < newResultTypes.size(); ++iRes) {
-      auto newResult = rewriter.create<BroadcastOp>(loc, resultTypes[iRes],
-                                                    newOp->getResult(iRes));
+      auto newResult = BroadcastOp::create(rewriter, loc, resultTypes[iRes],
+                                           newOp->getResult(iRes));
       rewriter.replaceAllUsesWith(op->getResult(iRes), newResult);
     }
     return success();

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -179,7 +179,7 @@ struct CanonicalizeConvertFromHistogram
     if (mask) {
       auto sharedType = getI1SameShape(src.getType());
       rewriter.setInsertionPoint(op);
-      mask = rewriter.create<ConvertLayoutOp>(op.getLoc(), sharedType, mask);
+      mask = ConvertLayoutOp::create(rewriter, op.getLoc(), sharedType, mask);
     }
 
     rewriter.replaceOpWithNewOp<triton::HistogramOp>(
@@ -1069,8 +1069,8 @@ void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
         partitionNumWarps, {}, {}, {});
   OpBuilder::InsertionGuard guard(builder);
   Block *container = builder.createBlock(state.regions.back().get());
-  builder.create<WarpSpecializePartitionsOp>(state.location,
-                                             partitionNumRegions);
+  WarpSpecializePartitionsOp::create(builder, state.location,
+                                     partitionNumRegions);
 }
 
 void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -207,7 +207,7 @@ getSharedMemoryMMAOperand(Value v, mlir::PatternRewriter &rewriter, int opIdx,
   auto newType = MemDescType::get(argType.getShape(), argType.getElementType(),
                                   newLayout, SharedMemorySpace);
   rewriter.setInsertionPointAfterValue(arg);
-  return rewriter.create<LocalAllocOp>(arg.getLoc(), newType, arg);
+  return LocalAllocOp::create(rewriter, arg.getLoc(), newType, arg);
 }
 
 static LocalAllocOp
@@ -229,7 +229,7 @@ getSharedMemoryScale(Value arg, mlir::PatternRewriter &rewriter, Location loc) {
   auto newType = MemDescType::get(argType.getShape(), argType.getElementType(),
                                   newLayout, SharedMemorySpace);
   rewriter.setInsertionPointAfterValue(arg);
-  return rewriter.create<LocalAllocOp>(loc, newType, arg);
+  return LocalAllocOp::create(rewriter, loc, newType, arg);
 }
 
 SmallVector<unsigned, 3>
@@ -336,7 +336,7 @@ static MMAEncodingResult createMMAEncodingForDot(DotOpInterface dotOp,
 
   auto oldAcc = dotOp->getOperand(2);
   auto newAcc =
-      rewriter.create<ConvertLayoutOp>(oldAcc.getLoc(), newRetType, oldAcc);
+      ConvertLayoutOp::create(rewriter, oldAcc.getLoc(), newRetType, oldAcc);
 
   return {mmaEnc, newRetType, newAcc, versionMajor, versionMinor};
 }
@@ -350,7 +350,7 @@ static Value convertDotOperandForMMA(Value v, int opIdx, int bitwidth,
   auto newVEncoding = DotOperandEncodingAttr::get(
       v.getContext(), opIdx, newRetType.getEncoding(), minType);
   auto newVType = vType.cloneWithEncoding(newVEncoding);
-  return rewriter.create<ConvertLayoutOp>(v.getLoc(), newVType, v);
+  return ConvertLayoutOp::create(rewriter, v.getLoc(), newVType, v);
 }
 
 } // namespace
@@ -422,9 +422,10 @@ public:
                                     /*isMMAv5Fp4Padded=*/false,
                                     /*forceTranspose=*/false, dotOp);
 
-      newDot = rewriter.create<triton::nvidia_gpu::WarpGroupDotOp>(
-          dotOp.getLoc(), mmaResult.newRetType, a, b, mmaResult.newAcc, nullptr,
-          dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc(), false);
+      newDot = triton::nvidia_gpu::WarpGroupDotOp::create(
+          rewriter, dotOp.getLoc(), mmaResult.newRetType, a, b,
+          mmaResult.newAcc, nullptr, dotOp.getInputPrecision(),
+          dotOp.getMaxNumImpreciseAcc(), false);
     } else {
       int minBitwidth =
           std::min(computeOrigBitWidth(a), computeOrigBitWidth(b));
@@ -432,9 +433,9 @@ public:
                                   rewriter);
       b = convertDotOperandForMMA(b, 1, minBitwidth, mmaResult.newRetType,
                                   rewriter);
-      newDot = rewriter.create<DotOp>(
-          dotOp.getLoc(), mmaResult.newRetType, a, b, mmaResult.newAcc,
-          dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
+      newDot = DotOp::create(rewriter, dotOp.getLoc(), mmaResult.newRetType, a,
+                             b, mmaResult.newAcc, dotOp.getInputPrecision(),
+                             dotOp.getMaxNumImpreciseAcc());
     }
 
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(dotOp, dotOp.getType(),
@@ -507,15 +508,15 @@ static Value splitBOperand(Value b, mlir::PatternRewriter &rewriter) {
     auto tensorType = dyn_cast<RankedTensorType>(operand.get().getType());
     if (!tensorType)
       continue;
-    Value newOperand = rewriter.create<ConvertLayoutOp>(
-        operand.get().getLoc(), tensorType.cloneWithEncoding(newLayout),
-        operand.get());
+    Value newOperand = ConvertLayoutOp::create(
+        rewriter, operand.get().getLoc(),
+        tensorType.cloneWithEncoding(newLayout), operand.get());
     loadOp->setOperand(operand.getOperandNumber(), newOperand);
   }
   loadOp->getResult(0).setType(bType.cloneWithEncoding(newLayout));
   Value newB = loadOp->getResult(0);
   rewriter.setInsertionPointAfter(loadOp);
-  auto cvt = rewriter.create<ConvertLayoutOp>(b.getLoc(), bType, newB);
+  auto cvt = ConvertLayoutOp::create(rewriter, b.getLoc(), bType, newB);
   rewriter.replaceAllUsesExcept(newB, cvt.getResult(), cvt);
   return newB;
 }
@@ -582,18 +583,18 @@ public:
         instrShape[0], instrShape[1], oldRetType, numWarps);
     auto newAccType = oldRetType.cloneWithEncoding(newDistributedEncoding);
     Value cvtAcc =
-        rewriter.create<ConvertLayoutOp>(loc, newAccType, dotOp.getOperand(2));
+        ConvertLayoutOp::create(rewriter, loc, newAccType, dotOp.getOperand(2));
     auto tokType = rewriter.getType<AsyncTokenType>();
-    auto acc = rewriter.create<triton::nvidia_gpu::TMEMAllocOp>(
-        loc, accMemDescType, tokType, cvtAcc);
-    auto vTrue = rewriter.create<arith::ConstantIntOp>(dotOp.getLoc(), 1, 1);
-    auto mma = rewriter.create<triton::nvidia_gpu::TCGen5MMAOp>(
-        loc, tokType, a, b, acc, acc.getToken(), /*useD=*/vTrue,
+    auto acc = triton::nvidia_gpu::TMEMAllocOp::create(
+        rewriter, loc, accMemDescType, tokType, cvtAcc);
+    auto vTrue = arith::ConstantIntOp::create(rewriter, dotOp.getLoc(), 1, 1);
+    auto mma = triton::nvidia_gpu::TCGen5MMAOp::create(
+        rewriter, loc, tokType, a, b, acc, acc.getToken(), /*useD=*/vTrue,
         /*pred=*/vTrue);
     mma.setTwoCtas(useTwoCTAs);
 
-    auto ld = rewriter.create<triton::nvidia_gpu::TMEMLoadOp>(
-        loc, newAccType, tokType, acc, /*dep=*/mma.getToken());
+    auto ld = triton::nvidia_gpu::TMEMLoadOp::create(
+        rewriter, loc, newAccType, tokType, acc, /*dep=*/mma.getToken());
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(dotOp, oldRetType, ld);
     return success();
   }
@@ -640,8 +641,8 @@ Value addSmemStageToScaleLoad(Value scale, mlir::PatternRewriter &rewriter) {
       getSharedMemoryScale(scaleAfterLoad, rewriter, op->getLoc());
 
   rewriter.setInsertionPointAfterValue(scaleSmemAlloc);
-  auto localLoad = rewriter.create<LocalLoadOp>(
-      op->getLoc(), scaleAfterLoad.getType(), scaleSmemAlloc);
+  auto localLoad = LocalLoadOp::create(
+      rewriter, op->getLoc(), scaleAfterLoad.getType(), scaleSmemAlloc);
 
   rewriter.replaceAllUsesExcept(scaleAfterLoad, localLoad.getResult(),
                                 scaleSmemAlloc);
@@ -761,15 +762,16 @@ public:
           ctx, shape, opIdx, mmaWarps, blocked.getCTALayout());
       auto newEnc = triton::gpu::LinearEncodingAttr::get(ctx, ll);
       auto newTy = RankedTensorType::get(shape, ty.getElementType(), newEnc);
-      return rewriter.create<ConvertLayoutOp>(scale.getLoc(), newTy, scale);
+      return ConvertLayoutOp::create(rewriter, scale.getLoc(), newTy, scale);
     };
     Value aScale = convertScale(dotOp.getAScale(), /*opIdx=*/0);
     Value bScale = convertScale(dotOp.getBScale(), /*opIdx=*/1);
 
-    newDot = rewriter.create<triton::DotScaledOp>(
-        dotOp.getLoc(), mmaResult.newRetType, newA, newB, mmaResult.newAcc,
-        aScale, bScale, dotOp.getAElemType(), dotOp.getBElemType(),
-        dotOp.getFastMath(), dotOp.getLhsKPack(), dotOp.getRhsKPack());
+    newDot = triton::DotScaledOp::create(
+        rewriter, dotOp.getLoc(), mmaResult.newRetType, newA, newB,
+        mmaResult.newAcc, aScale, bScale, dotOp.getAElemType(),
+        dotOp.getBElemType(), dotOp.getFastMath(), dotOp.getLhsKPack(),
+        dotOp.getRhsKPack());
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(dotOp, dotOp.getType(),
                                                  newDot->getResult(0));
     return success();
@@ -862,10 +864,10 @@ public:
         nvidia_gpu::getTmemCompatibleLayout(m, n, oldRetType, numWarps);
     auto newAccType = oldRetType.cloneWithEncoding(newDistributedEncoding);
     Value cvtAcc =
-        rewriter.create<ConvertLayoutOp>(loc, newAccType, dotOp.getOperand(2));
+        ConvertLayoutOp::create(rewriter, loc, newAccType, dotOp.getOperand(2));
     auto tokType = rewriter.getType<AsyncTokenType>();
-    auto acc = rewriter.create<triton::nvidia_gpu::TMEMAllocOp>(
-        loc, accMemDescType, tokType, cvtAcc);
+    auto acc = triton::nvidia_gpu::TMEMAllocOp::create(
+        rewriter, loc, accMemDescType, tokType, cvtAcc);
 
     RankedTensorType oldScaleAType = dotOp.getAScale().getType();
     RankedTensorType oldScaleBType = dotOp.getBScale().getType();
@@ -892,25 +894,26 @@ public:
     auto rhsScale = addSmemStageToScaleLoad(dotOp.getBScale(), rewriter);
 
     Value newScaleA =
-        rewriter.create<ConvertLayoutOp>(loc, newScaleAType, lhsScale);
+        ConvertLayoutOp::create(rewriter, loc, newScaleAType, lhsScale);
     Value newScaleB =
-        rewriter.create<ConvertLayoutOp>(loc, newScaleBType, rhsScale);
+        ConvertLayoutOp::create(rewriter, loc, newScaleBType, rhsScale);
 
     // We don't need to track memory dependencies for the scale operands since
     // they are not pipelined.
-    auto scaleA = rewriter.create<triton::nvidia_gpu::TMEMAllocOp>(
-        loc, scaleAType, /*token=*/Type(), newScaleA);
-    auto scaleB = rewriter.create<triton::nvidia_gpu::TMEMAllocOp>(
-        loc, scaleBType, /*token=*/Type(), newScaleB);
+    auto scaleA = triton::nvidia_gpu::TMEMAllocOp::create(
+        rewriter, loc, scaleAType, /*token=*/Type(), newScaleA);
+    auto scaleB = triton::nvidia_gpu::TMEMAllocOp::create(
+        rewriter, loc, scaleBType, /*token=*/Type(), newScaleB);
 
-    auto vTrue = rewriter.create<arith::ConstantIntOp>(dotOp.getLoc(), 1, 1);
-    auto mmaOp = rewriter.create<triton::nvidia_gpu::TCGen5MMAScaledOp>(
-        loc, tokType, a, b, acc.getResult(), acc.getToken(), scaleA.getResult(),
-        scaleB.getResult(), dotOp.getAElemType(), dotOp.getBElemType(),
+    auto vTrue = arith::ConstantIntOp::create(rewriter, dotOp.getLoc(), 1, 1);
+    auto mmaOp = triton::nvidia_gpu::TCGen5MMAScaledOp::create(
+        rewriter, loc, tokType, a, b, acc.getResult(), acc.getToken(),
+        scaleA.getResult(), scaleB.getResult(), dotOp.getAElemType(),
+        dotOp.getBElemType(),
         /*useD=*/vTrue, /*pred=*/vTrue);
 
-    auto ld = rewriter.create<triton::nvidia_gpu::TMEMLoadOp>(
-        loc, newAccType, tokType, acc, mmaOp.getToken());
+    auto ld = triton::nvidia_gpu::TMEMLoadOp::create(
+        rewriter, loc, newAccType, tokType, acc, mmaOp.getToken());
     rewriter.replaceOpWithNewOp<ConvertLayoutOp>(dotOp, oldRetType, ld);
     return success();
   }
@@ -924,9 +927,9 @@ static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
   Type operandElType =
       cast<RankedTensorType>(operand.getType()).getElementType();
   if (type::isFloat8(operandElType)) {
-    return builder.create<FpToFpOp>(loc, tensorPromotedType, operand);
+    return FpToFpOp::create(builder, loc, tensorPromotedType, operand);
   }
-  return builder.create<arith::ExtFOp>(loc, tensorPromotedType, operand);
+  return arith::ExtFOp::create(builder, loc, tensorPromotedType, operand);
 }
 
 static bool mmav2SupportsFp8Operands(int computeCapability) {
@@ -976,17 +979,17 @@ static void transposeDotOp(DotScaledOp dotOp) {
   OpBuilder builder(dotOp);
   Value lhs = dotOp.getA();
   std::array<int, 2> transOrder = {1, 0};
-  Value lhsTransposed = builder.create<TransOp>(lhs.getLoc(), lhs, transOrder);
+  Value lhsTransposed = TransOp::create(builder, lhs.getLoc(), lhs, transOrder);
   Value rhs = dotOp.getB();
-  Value rhsTransposed = builder.create<TransOp>(rhs.getLoc(), rhs, transOrder);
+  Value rhsTransposed = TransOp::create(builder, rhs.getLoc(), rhs, transOrder);
   Value c = dotOp.getC();
-  Value cTransposed = builder.create<TransOp>(c.getLoc(), c, transOrder);
-  Value result = builder.create<DotScaledOp>(
-      dotOp.getLoc(), cTransposed.getType(), rhsTransposed, lhsTransposed,
-      cTransposed, dotOp.getBScale(), dotOp.getAScale(), dotOp.getBElemType(),
-      dotOp.getAElemType(), dotOp.getFastMath());
+  Value cTransposed = TransOp::create(builder, c.getLoc(), c, transOrder);
+  Value result = DotScaledOp::create(
+      builder, dotOp.getLoc(), cTransposed.getType(), rhsTransposed,
+      lhsTransposed, cTransposed, dotOp.getBScale(), dotOp.getAScale(),
+      dotOp.getBElemType(), dotOp.getAElemType(), dotOp.getFastMath());
   Operation *transposedResult =
-      builder.create<TransOp>(result.getLoc(), result, transOrder);
+      TransOp::create(builder, result.getLoc(), result, transOrder);
   dotOp.replaceAllUsesWith(transposedResult);
   dotOp.erase();
 }

--- a/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceAsyncCopy.cpp
@@ -84,7 +84,8 @@ struct ClipAsyncCopySizePerThread
     auto convertBlockLayout = [&](Value src, BlockedEncodingAttr enc) {
       auto ty = cast<RankedTensorType>(src.getType());
       auto newTy = ty.cloneWithEncoding(enc);
-      auto cvt = rewriter.create<ConvertLayoutOp>(copyOp->getLoc(), newTy, src);
+      auto cvt =
+          ConvertLayoutOp::create(rewriter, copyOp->getLoc(), newTy, src);
       return cvt.getResult();
     };
     src = convertBlockLayout(src, newBlockEnc);

--- a/lib/Dialect/TritonGPU/Transforms/CombineTensorSelectAndIf.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CombineTensorSelectAndIf.cpp
@@ -124,8 +124,8 @@ public:
       for (arith::SelectOp selectOp : selectOps) {
         newResultTypes.push_back(selectOp.getResult().getType());
       }
-      auto newIfOp = builder.create<scf::IfOp>(
-          loc, newResultTypes, ifOp.getCondition(), /*hasElse*/ true);
+      auto newIfOp = scf::IfOp::create(builder, loc, newResultTypes,
+                                       ifOp.getCondition(), /*hasElse*/ true);
       // Move the existing blocks to the new if.
       newIfOp.getThenRegion().takeBody(ifOp.getThenRegion());
 
@@ -133,7 +133,8 @@ public:
         newIfOp.getElseRegion().takeBody(ifOp.getElseRegion());
       } else {
         // Create an empty yield
-        auto yieldOp = newIfOp.getElseBodyBuilder().create<scf::YieldOp>(loc);
+        auto builder = newIfOp.getElseBodyBuilder();
+        auto yieldOp = scf::YieldOp::create(builder, loc);
       }
 
       SmallVector<Value> ifYieldOperands = newIfOp.thenYield().getOperands();
@@ -147,7 +148,7 @@ public:
       // Update yields
       auto updateYield = [&](scf::YieldOp yield, SmallVector<Value> &operands) {
         builder.setInsertionPoint(yield);
-        builder.create<scf::YieldOp>(loc, operands);
+        scf::YieldOp::create(builder, loc, operands);
         yield.erase();
       };
       updateYield(newIfOp.thenYield(), ifYieldOperands);

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -41,8 +41,8 @@ DecomposeScaledBlocked::matchAndRewrite(DotScaledOp scaledDotOp,
   scaledA = cvtDotOperand(rewriter, scaledDotOp, 0, scaledA);
   auto scaledB = scaleArg(rewriter, scaledDotOp, 1, computeType);
   scaledB = cvtDotOperand(rewriter, scaledDotOp, 1, scaledB);
-  auto newDot = rewriter.create<DotOp>(scaledDotOp.getLoc(), scaledA, scaledB,
-                                       scaledDotOp.getC());
+  auto newDot = DotOp::create(rewriter, scaledDotOp.getLoc(), scaledA, scaledB,
+                              scaledDotOp.getC());
 
   rewriter.replaceOpWithNewOp<ConvertLayoutOp>(scaledDotOp,
                                                scaledDotOp.getType(), newDot);
@@ -75,20 +75,20 @@ DecomposeScaledBlocked::scaleTo16(PatternRewriter &rewriter,
   auto intType = rewriter.getIntegerType(intWidth);
 
   auto zexted =
-      rewriter.create<arith::ExtUIOp>(loc, scaleTy.clone(intType), scale);
+      arith::ExtUIOp::create(rewriter, loc, scaleTy.clone(intType), scale);
   // getFpMantissaWidth() returns the number of bits in the mantissa plus the
   // sign bit!
   int shiftValue = largeFpType.getFPMantissaWidth() - 1;
   auto shiftConst =
-      rewriter.create<arith::ConstantIntOp>(loc, shiftValue, intWidth);
+      arith::ConstantIntOp::create(rewriter, loc, shiftValue, intWidth);
   auto shift =
-      rewriter.create<SplatOp>(loc, scaleTy.clone(intType), shiftConst);
-  auto shlRes = rewriter.create<arith::ShLIOp>(loc, zexted, shift);
+      SplatOp::create(rewriter, loc, scaleTy.clone(intType), shiftConst);
+  auto shlRes = arith::ShLIOp::create(rewriter, loc, zexted, shift);
   Value scaleFP =
-      rewriter.create<BitcastOp>(loc, scaleTy.clone(largeFpType), shlRes);
+      BitcastOp::create(rewriter, loc, scaleTy.clone(largeFpType), shlRes);
   if (largeFpType != computeType) {
-    scaleFP = rewriter.create<arith::TruncFOp>(loc, scaleTy.clone(computeType),
-                                               scaleFP);
+    scaleFP = arith::TruncFOp::create(rewriter, loc, scaleTy.clone(computeType),
+                                      scaleFP);
   }
   return cast<TypedValue<RankedTensorType>>(scaleFP);
 }
@@ -113,24 +113,24 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::broadcastScale(
     // 2.1.2) Cast scale16 to SliceEncoding
     auto sliceEnc = SliceEncodingAttr::get(ctx, rank, blockedEnc);
     auto sliceType = scaleTy.cloneWithEncoding(sliceEnc);
-    scale = rewriter.create<ConvertLayoutOp>(loc, sliceType, scale);
+    scale = ConvertLayoutOp::create(rewriter, loc, sliceType, scale);
   }
-  auto expandScale = rewriter.create<ExpandDimsOp>(loc, scale, rank);
+  auto expandScale = ExpandDimsOp::create(rewriter, loc, scale, rank);
   // 2.2) Broadcast the dimension to size 32
   auto scaleShape = to_vector(scaleTy.getShape());
   scaleShape.push_back(32);
-  auto broadcastScale = rewriter.create<BroadcastOp>(
-      loc, expandScale.getType().clone(scaleShape), expandScale);
+  auto broadcastScale = BroadcastOp::create(
+      rewriter, loc, expandScale.getType().clone(scaleShape), expandScale);
   // 2.3) Transpose the dimension to the scaled dimension
   auto transposeOrder = llvm::to_vector(llvm::seq<int32_t>(rank));
   transposeOrder.insert(transposeOrder.begin() + dim + 1, rank);
   auto transposedScale =
-      rewriter.create<TransOp>(loc, broadcastScale, transposeOrder);
+      TransOp::create(rewriter, loc, broadcastScale, transposeOrder);
   // 2.4) Reshape to the shape of v
   scaleShape.pop_back();
   scaleShape[dim] *= 32;
   auto reshapeScale =
-      rewriter.create<ReshapeOp>(loc, scaleShape, transposedScale);
+      ReshapeOp::create(rewriter, loc, scaleShape, transposedScale);
   return reshapeScale;
 }
 
@@ -148,28 +148,28 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::maskNan(
 
   // Scale is NaN
   auto scaleTy = scale.getType();
-  auto constFF = rewriter.create<arith::ConstantOp>(
-      loc, scaleTy,
+  auto constFF = arith::ConstantOp::create(
+      rewriter, loc, scaleTy,
       DenseElementsAttr::get(scaleTy,
                              APInt(scaleTy.getElementTypeBitWidth(), 0xff)));
   auto scaleIsNan = cast<TypedValue<RankedTensorType>>(
-      rewriter
-          .create<arith::CmpIOp>(loc, arith::CmpIPredicate::eq, scale, constFF)
+      arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::eq, scale,
+                            constFF)
           .getResult());
   auto cond = broadcastScale(rewriter, scaledDotOp, mod, scaleIsNan, dim);
   // Make scale is NaN compatible with mxfp
   auto condTy = cond.getType();
   condTy = condTy.cloneWithEncoding(mxfp.getType().getEncoding());
-  cond = rewriter.create<ConvertLayoutOp>(loc, condTy, cond);
+  cond = ConvertLayoutOp::create(rewriter, loc, condTy, cond);
 
   // Create NaN
   auto mxfpTy = mxfp.getType();
   auto nan = APFloat::getNaN(
       cast<FloatType>(mxfpTy.getElementType()).getFloatSemantics());
-  auto constNan = rewriter.create<arith::ConstantOp>(
-      loc, mxfpTy, DenseElementsAttr::get(mxfpTy, nan));
+  auto constNan = arith::ConstantOp::create(
+      rewriter, loc, mxfpTy, DenseElementsAttr::get(mxfpTy, nan));
 
-  auto result = rewriter.create<arith::SelectOp>(loc, cond, constNan, mxfp);
+  auto result = arith::SelectOp::create(rewriter, loc, cond, constNan, mxfp);
   return cast<TypedValue<RankedTensorType>>(result.getResult());
 }
 
@@ -191,11 +191,11 @@ DecomposeScaledBlocked::scaleArg(PatternRewriter &rewriter,
   // 0) Upcast value to computeType (fp16/bf16)
   if (isFp4) {
     // We always pack along the fastest moving dimension, kDim
-    v = rewriter.create<Fp4ToFpOp>(loc, v, computeType, kDim);
+    v = Fp4ToFpOp::create(rewriter, loc, v, computeType, kDim);
   } else {
     auto vType16 = v.getType().clone(computeType);
     v = cast<TypedValue<RankedTensorType>>(
-        rewriter.create<FpToFpOp>(loc, vType16, v).getResult());
+        FpToFpOp::create(rewriter, loc, vType16, v).getResult());
   }
   if (!scale)
     return v;
@@ -206,7 +206,7 @@ DecomposeScaledBlocked::scaleArg(PatternRewriter &rewriter,
 
   // 2) Multiply
   auto mxfp = cast<TypedValue<RankedTensorType>>(
-      rewriter.create<arith::MulFOp>(loc, v, reshapeScale).getResult());
+      arith::MulFOp::create(rewriter, loc, v, reshapeScale).getResult());
 
   // 3) If the scale is NaN, return NaN, else return the scaled value.
   return maskNan(rewriter, scaledDotOp, mxfp, scale, kDim);
@@ -229,7 +229,7 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::extendAndBroadcastScale(
   // Notice: this is an inplace change.
   if (opIdx == 1) {
     auto order = getTransposeOrder(rank);
-    scale = rewriter.create<TransOp>(loc, scale, order);
+    scale = TransOp::create(rewriter, loc, scale, order);
   }
 
   // 1) Cast scale to compute type (fp16/bf16)
@@ -237,7 +237,7 @@ TypedValue<RankedTensorType> DecomposeScaledBlocked::extendAndBroadcastScale(
 
   // 2) Broadcast scale to the same shape as v and convert the layout
   auto reshapeScale = broadcastScale(rewriter, scaledDotOp, mod, scale16, kDim);
-  return rewriter.create<ConvertLayoutOp>(loc, dstType, reshapeScale);
+  return ConvertLayoutOp::create(rewriter, loc, dstType, reshapeScale);
 }
 
 TypedValue<RankedTensorType>
@@ -250,7 +250,7 @@ DecomposeScaledBlocked::cvtDotOperand(PatternRewriter &rewriter,
   auto encoding =
       DotOperandEncodingAttr::get(ctx, opIdx, retEnc, vType.getElementType());
   auto retTy = vType.cloneWithEncoding(encoding);
-  return rewriter.create<ConvertLayoutOp>(v.getLoc(), retTy, v);
+  return ConvertLayoutOp::create(rewriter, v.getLoc(), retTy, v);
 }
 
 void populateDecomposeScaledBlockedPatterns(RewritePatternSet &patterns,

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeAccumulatorInit.cpp
@@ -215,9 +215,9 @@ public:
       rewriter.setInsertionPoint(forOp);
 
       Value vTrue =
-          rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(true));
+          arith::ConstantOp::create(rewriter, loc, rewriter.getBoolAttr(true));
       Value vFalse =
-          rewriter.create<arith::ConstantOp>(loc, rewriter.getBoolAttr(false));
+          arith::ConstantOp::create(rewriter, loc, rewriter.getBoolAttr(false));
 
       // Find the accumulator
       auto [accUse, accDef] = getAccumulatorUseAndDef(mmaOp);
@@ -283,8 +283,8 @@ public:
         rewriter.setInsertionPoint(zeroInitOp->first);
         bool zeroingBeforeMMA = zeroInitOp->first->isBeforeInBlock(mmaOp);
         Value prevFlagValue = zeroingBeforeMMA ? loopArgFlagValue : vTrue;
-        auto selectFlagOp = rewriter.create<arith::SelectOp>(
-            loc, condition, thenInitsToZero ? vFalse : prevFlagValue,
+        auto selectFlagOp = arith::SelectOp::create(
+            rewriter, loc, condition, thenInitsToZero ? vFalse : prevFlagValue,
             thenInitsToZero ? prevFlagValue : vFalse);
         setUseAccFlag(mmaOp,
                       zeroingBeforeMMA ? selectFlagOp : loopArgFlagValue);

--- a/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/OptimizeDotOperands.cpp
@@ -66,15 +66,15 @@ public:
       return failure();
     rewriter.setInsertionPoint(trans);
     auto sharedMemorySpace = SharedMemorySpaceAttr::get(getContext());
-    auto alloc = rewriter.create<LocalAllocOp>(
-        trans.getLoc(),
+    auto alloc = LocalAllocOp::create(
+        rewriter, trans.getLoc(),
         MemDescType::get(srcTy.getShape(), srcTy.getElementType(),
                          newInnerCvtEnc, sharedMemorySpace),
         trans.getSrc());
-    auto newTrans = rewriter.create<MemDescTransOp>(trans.getLoc(), alloc,
-                                                    ArrayRef<int32_t>({1, 0}));
+    auto newTrans = MemDescTransOp::create(rewriter, trans.getLoc(), alloc,
+                                           ArrayRef<int32_t>({1, 0}));
     auto localLoadOp =
-        rewriter.create<LocalLoadOp>(trans.getLoc(), sharedLoadTy, newTrans);
+        LocalLoadOp::create(rewriter, trans.getLoc(), sharedLoadTy, newTrans);
     rewriter.modifyOpInPlace(cvtOp, [&]() {
       cvtOp.getSrcMutable().assign(localLoadOp.getResult());
     });
@@ -123,8 +123,8 @@ public:
     MemDescType innerTy =
         MemDescType::get(srcTy.getShape(), srcTy.getElementType(), newInnerEnc,
                          allocType.getMemorySpace());
-    auto newAlloc = rewriter.create<LocalAllocOp>(allocOp.getLoc(), innerTy,
-                                                  trans.getSrc());
+    auto newAlloc = LocalAllocOp::create(rewriter, allocOp.getLoc(), innerTy,
+                                         trans.getSrc());
     rewriter.replaceOpWithNewOp<MemDescTransOp>(allocOp, newAlloc,
                                                 ArrayRef<int32_t>({1, 0}));
     return success();
@@ -171,8 +171,8 @@ public:
     if (!isa<NVMMASharedEncodingAttr>(innerTy.getEncoding()))
       return failure();
 
-    auto newAlloc = rewriter.create<LocalAllocOp>(allocOp.getLoc(), innerTy,
-                                                  reshapeOp.getSrc());
+    auto newAlloc = LocalAllocOp::create(rewriter, allocOp.getLoc(), innerTy,
+                                         reshapeOp.getSrc());
     rewriter.replaceOpWithNewOp<MemDescReshapeOp>(allocOp, allocOp.getType(),
                                                   newAlloc);
     return success();
@@ -268,16 +268,16 @@ private:
 
     Value shared = localLoad.getSrc();
 
-    Value reshaped5D = rewriter.create<MemDescReshapeOp>(
-        reshapeOp5D.getLoc(), shared, reshape5DShape);
+    Value reshaped5D = MemDescReshapeOp::create(rewriter, reshapeOp5D.getLoc(),
+                                                shared, reshape5DShape);
     SmallVector<int32_t> transposeOrder32(transposeOrder.begin(),
                                           transposeOrder.end());
-    Value transposed = rewriter.create<MemDescTransOp>(
-        transOp.getLoc(), reshaped5D, transposeOrder32);
+    Value transposed = MemDescTransOp::create(rewriter, transOp.getLoc(),
+                                              reshaped5D, transposeOrder32);
     SmallVector<int64_t> scale2DShapeVec(scale2DShape.begin(),
                                          scale2DShape.end());
-    Value reshaped2D = rewriter.create<MemDescReshapeOp>(
-        reshapeOp2D.getLoc(), transposed, scale2DShapeVec);
+    Value reshaped2D = MemDescReshapeOp::create(rewriter, reshapeOp2D.getLoc(),
+                                                transposed, scale2DShapeVec);
 
     opOperand.assign(reshaped2D);
     rewriter.eraseOp(tmemAlloc);

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/LowerLoops.cpp
@@ -159,7 +159,7 @@ void createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
                      Value insertIdx, Value extractIdx,
                      CoarseSchedule &schedule) {
   OpBuilderForStage builder(loadOp.getLoc(), forOp, schedule);
-  Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
+  Value zero = arith::ConstantIntOp::create(builder, forOp.getLoc(), 0, 32);
 
   Operation *firstUse = getFirstUseOfPipelinedOp({loadOp}, forOp, schedule);
   assert(firstUse && "LoadOp has no users");
@@ -174,15 +174,15 @@ void createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
 
   // Create async copy
   Value view = createSingleBufferView(builder, alloc, insertIdx);
-  Operation *copy = builder.create<ttg::AsyncCopyGlobalToLocalOp>(
-      src, view, mask, other, loadOp.getCache(), loadOp.getEvict(),
+  Operation *copy = ttg::AsyncCopyGlobalToLocalOp::create(
+      builder, src, view, mask, other, loadOp.getCache(), loadOp.getEvict(),
       loadOp.getIsVolatile());
   Operation *commit =
-      builder.create<ttg::AsyncCommitGroupOp>(copy->getResult(0));
+      ttg::AsyncCommitGroupOp::create(builder, copy->getResult(0));
 
   // Create wait and local load
   builder.setStageCluster(schedule[firstUse]);
-  auto wait = builder.create<ttg::AsyncWaitOp>(commit->getResult(0), 0);
+  auto wait = ttg::AsyncWaitOp::create(builder, commit->getResult(0), 0);
   auto viewLoad = createSingleBufferView(builder, alloc, extractIdx);
 
   if (!loadOp.getOther() || isZeroConst(loadOp.getOther())) {
@@ -192,10 +192,10 @@ void createAsyncCopy(scf::ForOp forOp, tt::LoadOp loadOp, Value alloc,
   } else if (loadOp->use_begin() != loadOp->use_end()) {
     // Otherwise, create a select for non-zero other values as they are not
     // handled by AsyncCopyGlobalToLocalOp for now.
-    auto sharedLoad = builder.create<ttg::LocalLoadOp>(
-        loadOp.getType(), viewLoad, wait.getResult());
-    auto select = builder.create<arith::SelectOp>(
-        loadOp.getType(),
+    auto sharedLoad = ttg::LocalLoadOp::create(builder, loadOp.getType(),
+                                               viewLoad, wait.getResult());
+    auto select = arith::SelectOp::create(
+        builder, loadOp.getType(),
         // Use the mask operand from the original load, not the one with a
         // potentially transformed layout.
         loadOp.getMask(), sharedLoad.getResult(), other);
@@ -212,7 +212,7 @@ void createTMAAsyncCopy(
     function_ref<void(OpBuilderForStage &, Value, Value, Value, Value)>
         createCopy) {
   OpBuilderForStage builder(loadOp->getLoc(), forOp, schedule);
-  Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
+  Value zero = arith::ConstantIntOp::create(builder, forOp.getLoc(), 0, 32);
 
   Operation *firstUse = getFirstUseOfPipelinedOp({loadOp}, forOp, schedule);
   assert(firstUse && "LoadOp has no users");
@@ -226,7 +226,7 @@ void createTMAAsyncCopy(
   // Create async copy
   Value view = createSingleBufferView(builder, alloc, insertIdx);
 
-  Value pred = builder.create<arith::ConstantIntOp>(1, 1);
+  Value pred = arith::ConstantIntOp::create(builder, 1, 1);
   createCopy(builder, desc, barrier, view, pred);
 
   // Create local load after the wait
@@ -252,8 +252,8 @@ void createTMAAsyncLoad(scf::ForOp forOp, tt::DescriptorLoadOp loadOp,
             builder, loadOp.getLoc(),
             loadOp.getDesc().getType().getBlockType().getEncoding(),
             loadOp.getIndices());
-        builder.create<ttng::AsyncTMACopyGlobalToLocalOp>(
-            loadOp.getLoc(), tmaPtr, indices, barrier, view, pred);
+        ttng::AsyncTMACopyGlobalToLocalOp::create(
+            builder, loadOp.getLoc(), tmaPtr, indices, barrier, view, pred);
       });
 }
 
@@ -265,8 +265,8 @@ void createTMAAsyncGather(scf::ForOp forOp, tt::DescriptorGatherOp gatherOp,
                             insertIdx, extractIdx, barrier, waitOp, schedule,
                             [&](OpBuilderForStage &builder, Value tmaPtr,
                                 Value barrier, Value view, Value pred) {
-                              builder.create<ttng::AsyncTMAGatherOp>(
-                                  gatherOp.getLoc(), tmaPtr,
+                              ttng::AsyncTMAGatherOp::create(
+                                  builder, gatherOp.getLoc(), tmaPtr,
                                   gatherOp.getXOffsets(), gatherOp.getYOffset(),
                                   barrier, view, pred);
                             });
@@ -303,20 +303,20 @@ void convertScalarToTensorLoad(Operation *op, CoarseSchedule &schedule,
   auto newPtrTy =
       RankedTensorType::get({1}, scalarLoad.getPtr().getType(), blockedEnc);
   auto newPtr =
-      builder.create<tt::SplatOp>(op->getLoc(), newPtrTy, scalarLoad.getPtr());
+      tt::SplatOp::create(builder, op->getLoc(), newPtrTy, scalarLoad.getPtr());
   scalarLoad.getPtrMutable().assign(newPtr);
   if (scalarLoad.getMask()) {
     auto newMaskTy =
         RankedTensorType::get({1}, scalarLoad.getMask().getType(), blockedEnc);
-    auto newMask = builder.create<tt::SplatOp>(op->getLoc(), newMaskTy,
-                                               scalarLoad.getMask());
+    auto newMask = tt::SplatOp::create(builder, op->getLoc(), newMaskTy,
+                                       scalarLoad.getMask());
     scalarLoad.getMaskMutable().assign(newMask);
   }
   if (scalarLoad.getOther()) {
     auto newOtherTy =
         RankedTensorType::get({1}, scalarLoad.getOther().getType(), blockedEnc);
-    auto newOther = builder.create<tt::SplatOp>(op->getLoc(), newOtherTy,
-                                                scalarLoad.getOther());
+    auto newOther = tt::SplatOp::create(builder, op->getLoc(), newOtherTy,
+                                        scalarLoad.getOther());
     scalarLoad.getOtherMutable().assign(newOther);
   }
   auto newDstTy = RankedTensorType::get({1}, scalarLoad.getType(), blockedEnc);
@@ -324,8 +324,8 @@ void convertScalarToTensorLoad(Operation *op, CoarseSchedule &schedule,
   builder.setInsertionPointAfter(op);
   Operation *firstUse = getFirstUseOfPipelinedOp({op}, forOp, schedule);
   builder.setStageCluster(schedule[firstUse]);
-  Operation *unsplat = builder.create<tt::UnsplatOp>(op->getLoc(), scalarTy,
-                                                     scalarLoad.getResult());
+  Operation *unsplat = tt::UnsplatOp::create(builder, op->getLoc(), scalarTy,
+                                             scalarLoad.getResult());
   scalarLoad.getResult().replaceAllUsesExcept(unsplat->getResult(0), unsplat);
 }
 
@@ -396,8 +396,8 @@ void createTMABarrierAndWait(
     OpBuilderForStage builder(forOp.getLoc(), group[0], schedule);
     Value barrier = triton::createSingleBufferView(builder, barrierAlloc,
                                                    loadGroup.insertIdx);
-    Value pred = builder.create<arith::ConstantIntOp>(1, 1);
-    builder.create<ttng::BarrierExpectOp>(barrier, sizeInBytes, pred);
+    Value pred = arith::ConstantIntOp::create(builder, 1, 1);
+    ttng::BarrierExpectOp::create(builder, barrier, sizeInBytes, pred);
 
     builder.setInsertionPointAfter(group.back());
     Operation *firstUse = getFirstUseOfPipelinedOp(group, forOp, schedule);
@@ -405,7 +405,7 @@ void createTMABarrierAndWait(
     Value barrierViewWait = triton::createSingleBufferView(
         builder, barrierAlloc, loadGroup.extractIdx);
     auto wait =
-        builder.create<ttng::WaitBarrierOp>(barrierViewWait, loadGroup.phase);
+        ttng::WaitBarrierOp::create(builder, barrierViewWait, loadGroup.phase);
 
     // Update the async loads info.
     for (Operation *op : group) {
@@ -525,9 +525,9 @@ scf::ForOp lowerLoads(scf::ForOp forOp, CoarseSchedule &schedule,
   // NOTE: We create two duplicates values, insertIdx and extractIdx so that the
   // pipeliner will re-materialize the value in later stages of the pipeline
   // instead of carrying it as a dependency across multiple iterations.
-  Value minusOne = builder.create<arith::ConstantIntOp>(loc, -1, 32);
-  Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-  Value one = builder.create<arith::ConstantIntOp>(loc, 1, 32);
+  Value minusOne = arith::ConstantIntOp::create(builder, loc, -1, 32);
+  Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+  Value one = arith::ConstantIntOp::create(builder, loc, 1, 32);
   SmallVector<Value> newOperands;
   unsigned newOperandIndex = forOp.getBody()->getNumArguments();
   for (auto [_, loadGroup] : loadGroups) {
@@ -569,15 +569,15 @@ scf::ForOp lowerLoads(scf::ForOp forOp, CoarseSchedule &schedule,
     builder.setInsertionPoint(forOp.getBody(), forOp.getBody()->begin());
 
     Value numBuffersVal =
-        builder.create<arith::ConstantIntOp>(loc, numBuffers, 32);
+        arith::ConstantIntOp::create(builder, loc, numBuffers, 32);
     loadGroup.insertIdx = createIncrementModulo(builder, loc, insertIdx,
                                                 numBuffersVal, zero, one);
     Value cndExt = nullptr;
     loadGroup.extractIdx = createIncrementModulo(
         builder, loc, extractIdx, numBuffersVal, zero, one, &cndExt);
     if (phase) {
-      Value nextPhase = builder.create<arith::XOrIOp>(loc, phase, one);
-      phase = builder.create<arith::SelectOp>(loc, cndExt, nextPhase, phase);
+      Value nextPhase = arith::XOrIOp::create(builder, loc, phase, one);
+      phase = arith::SelectOp::create(builder, loc, cndExt, nextPhase, phase);
       loadGroup.phase = phase;
     }
   }
@@ -618,7 +618,7 @@ scf::ForOp lowerLoads(scf::ForOp forOp, CoarseSchedule &schedule,
     // Insert sync point for any possibly outstanding loads after the loop. This
     // can happen as we speculatively execute loads in the loop.
     builder.setInsertionPointAfter(forOp);
-    builder.create<ttg::AsyncWaitOp>(loc, ValueRange({}), 0);
+    ttg::AsyncWaitOp::create(builder, loc, ValueRange({}), 0);
   }
 
   // Make sure all ops have attributes.
@@ -680,15 +680,15 @@ Operation *hoistBufferOutOfLoop(scf::ForOp forOp, Operation *op,
   if (auto tmemAlloc = dyn_cast<ttng::TMEMAllocOp>(newAlloc)) {
     tmemAlloc.getSrcMutable().clear();
     builder.setInsertionPointAfter(op);
-    Value trueVal = builder.create<arith::ConstantIntOp>(1, 1);
-    newStore = builder.create<ttng::TMEMStoreOp>(tmemAlloc.getResult(),
-                                                 op->getOperand(0), trueVal);
+    Value trueVal = arith::ConstantIntOp::create(builder, 1, 1);
+    newStore = ttng::TMEMStoreOp::create(builder, tmemAlloc.getResult(),
+                                         op->getOperand(0), trueVal);
   } else {
     auto localAlloc = cast<ttg::LocalAllocOp>(newAlloc);
     localAlloc.getSrcMutable().clear();
     builder.setInsertionPointAfter(op);
-    newStore = builder.create<ttg::LocalStoreOp>(op->getOperand(0),
-                                                 localAlloc.getResult());
+    newStore = ttg::LocalStoreOp::create(builder, op->getOperand(0),
+                                         localAlloc.getResult());
   }
   replaceUsesAndPropagateType(builder, op, newAlloc->getResult(0));
   op->erase();
@@ -757,18 +757,18 @@ void createBarrierAndWaitOps(scf::ForOp forOp, CoarseSchedule &schedule,
 
   OpBuilderForStage builder(mma.getLoc(), mma, schedule);
   Value barrierAlloc = createBarrierAlloc(forOp, numStages);
-  Value vTrue = builder.create<arith::ConstantIntOp>(1, 1);
+  Value vTrue = arith::ConstantIntOp::create(builder, 1, 1);
   Value phase = forOp.getRegionIterArg(phaseArgIdx);
-  Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
+  Value zero = arith::ConstantIntOp::create(builder, forOp.getLoc(), 0, 32);
   Value barrierIdx;
   if (numStages > 1) {
     barrierIdx = forOp.getRegionIterArg(barrierIdxArgIdx);
   } else {
     barrierIdx = zero;
   }
-  Value one = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 1, 32);
+  Value one = arith::ConstantIntOp::create(builder, forOp.getLoc(), 1, 32);
   Value numStagesVal =
-      builder.create<arith::ConstantIntOp>(forOp.getLoc(), numStages, 32);
+      arith::ConstantIntOp::create(builder, forOp.getLoc(), numStages, 32);
 
   Value barrierSlice =
       triton::createSingleBufferView(builder, barrierAlloc, barrierIdx);
@@ -788,7 +788,7 @@ void createBarrierAndWaitOps(scf::ForOp forOp, CoarseSchedule &schedule,
 
   builder.setInsertionPointAfter(mma);
   builder.setStageCluster({mainWaitStage, mainWaitCluster});
-  builder.create<ttng::WaitBarrierOp>(barrierSlice, phase, waitBuffers);
+  ttng::WaitBarrierOp::create(builder, barrierSlice, phase, waitBuffers);
 
   // Add waits before loads in conditional blocks
   for (auto user : alloc->getUsers()) {
@@ -804,7 +804,7 @@ void createBarrierAndWaitOps(scf::ForOp forOp, CoarseSchedule &schedule,
       if (loadStage < mainWaitStage) {
         builder.setStageCluster({loadStage, loadCluster});
         builder.setInsertionPoint(load);
-        builder.create<ttng::WaitBarrierOp>(barrierSlice, phase, waitBuffers);
+        ttng::WaitBarrierOp::create(builder, barrierSlice, phase, waitBuffers);
       }
     }
   }
@@ -812,14 +812,14 @@ void createBarrierAndWaitOps(scf::ForOp forOp, CoarseSchedule &schedule,
   builder.setStageCluster(schedule[mma]);
   auto yieldOp = cast<scf::YieldOp>(forOp.getBody()->getTerminator());
   builder.setInsertionPoint(yieldOp);
-  Value newPhase = builder.create<arith::XOrIOp>(phase, one);
+  Value newPhase = arith::XOrIOp::create(builder, phase, one);
   Value newBarrierIdx = barrierIdx;
   if (numStages > 1) {
     Value barWrap;
     newBarrierIdx = createIncrementModulo(builder, builder.getLoc(), barrierIdx,
                                           numStagesVal, zero, one, &barWrap);
-    newPhase = builder.create<arith::SelectOp>(phase.getType(), barWrap,
-                                               newPhase, phase);
+    newPhase = arith::SelectOp::create(builder, phase.getType(), barWrap,
+                                       newPhase, phase);
   }
   yieldOp->replaceUsesOfWith(phase, newPhase);
   yieldOp->replaceUsesOfWith(barrierIdx, newBarrierIdx);
@@ -844,16 +844,17 @@ void multibufferTensorMemory(scf::ForOp forOp, CoarseSchedule &schedule,
   OpBuilderForStage builder(alloc.getLoc(), alloc, schedule);
   auto newAlloc = createTMemAlloc(builder, alloc, true, tmemUseNumStages);
   Value numStagesVal =
-      builder.create<arith::ConstantIntOp>(tmemUseNumStages, 32);
-  Value zero = builder.create<arith::ConstantIntOp>(0, 32);
-  Value one = builder.create<arith::ConstantIntOp>(1, 32);
+      arith::ConstantIntOp::create(builder, tmemUseNumStages, 32);
+  Value zero = arith::ConstantIntOp::create(builder, 0, 32);
+  Value one = arith::ConstantIntOp::create(builder, 1, 32);
 
   bool multibufferingIsValid = false;
 
   SmallVector<Operation *> allocUsers =
       llvm::to_vector(alloc.getResult().getUsers());
-  Value replTok = OpBuilder(forOp).create<ub::PoisonOp>(
-      forOp.getLoc(), builder.getType<AsyncTokenType>());
+  auto auxBuilder = OpBuilder(forOp);
+  Value replTok = ub::PoisonOp::create(auxBuilder, forOp.getLoc(),
+                                       builder.getType<AsyncTokenType>());
   if (newAlloc.getToken()) {
     newAlloc.getToken().replaceAllUsesWith(replTok);
   }
@@ -872,8 +873,8 @@ void multibufferTensorMemory(scf::ForOp forOp, CoarseSchedule &schedule,
         Value newBufIdx = createIncrementModulo(
             builder, forOp.getLoc(), curBufIdx, numStagesVal, zero, one);
         if (Value pred = store.getPred()) {
-          newBufIdx = builder.create<arith::SelectOp>(newBufIdx.getType(), pred,
-                                                      newBufIdx, curBufIdx);
+          newBufIdx = arith::SelectOp::create(builder, newBufIdx.getType(),
+                                              pred, newBufIdx, curBufIdx);
         }
         replaceAllUsesDominatedBy(store, newBufIdx, curBufIdx, domInfo);
         bufIdxDefs.push_back({store, newBufIdx});
@@ -925,8 +926,9 @@ void multibufferTensorMemory(scf::ForOp forOp, CoarseSchedule &schedule,
       Value curBufIdx = getCurrBufIdx(mma.getOperation());
       Value newBufIdx = createIncrementModulo(
           builder, forOp.getLoc(), curBufIdx, numStagesVal, zero, one);
-      newBufIdx = builder.create<arith::SelectOp>(
-          newBufIdx.getType(), mma.useAccumulator(), curBufIdx, newBufIdx);
+      newBufIdx =
+          arith::SelectOp::create(builder, newBufIdx.getType(),
+                                  mma.useAccumulator(), curBufIdx, newBufIdx);
       replaceAllUsesDominatedBy(mma.getOperation(), newBufIdx, curBufIdx,
                                 domInfo);
       bufIdxDefs.push_back({mma.getOperation(), newBufIdx});
@@ -983,8 +985,9 @@ scf::ForOp lowerMMA(ttng::MMAv5OpInterface mma, scf::ForOp forOp,
   }
 
   OpBuilder builder(forOp);
-  Value minusOne = builder.create<arith::ConstantIntOp>(forOp.getLoc(), -1, 32);
-  Value zero = builder.create<arith::ConstantIntOp>(forOp.getLoc(), 0, 32);
+  Value minusOne =
+      arith::ConstantIntOp::create(builder, forOp.getLoc(), -1, 32);
+  Value zero = arith::ConstantIntOp::create(builder, forOp.getLoc(), 0, 32);
 
   // Add arguments to the forOp
   unsigned newOperandIndex = forOp.getInitArgs().size();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/MMAv5PipelineUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/MMAv5PipelineUtility.cpp
@@ -301,7 +301,7 @@ ttng::TMEMAllocOp ttng::createTMemAlloc(OpBuilder &builder,
   Type accMemDescType = triton::gpu::MemDescType::get(
       shape, oldRetType.getElementType(), oldRetType.getEncoding(),
       oldRetType.getMemorySpace(), /*mutableMemory=*/true);
-  return builder.create<ttng::TMEMAllocOp>(
-      oldTMemAllocOp.getLoc(), accMemDescType,
+  return ttng::TMEMAllocOp::create(
+      builder, oldTMemAllocOp.getLoc(), accMemDescType,
       builder.getType<gpu::AsyncTokenType>(), /*src=*/Value());
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipelineExpander.cpp
@@ -318,18 +318,18 @@ LogicalResult LoopPipelinerInternal::emitPrologue(RewriterBase &rewriter) {
     // special handling for induction variable as the increment is implicit.
     // iv = lb + i * step
     Type t = lb.getType();
-    Value iv = rewriter.create<arith::AddIOp>(
-        loc, lb,
-        rewriter.create<arith::MulIOp>(
-            loc, step,
-            rewriter.create<arith::ConstantOp>(loc,
-                                               rewriter.getIntegerAttr(t, i))));
+    Value iv = arith::AddIOp::create(
+        rewriter, loc, lb,
+        arith::MulIOp::create(
+            rewriter, loc, step,
+            arith::ConstantOp::create(rewriter, loc,
+                                      rewriter.getIntegerAttr(t, i))));
     setValueMapping(forOp.getInductionVar(), iv, i);
 
     if (dynamicLoop) {
       // pred = ub > lb + (i * step)
-      predicates[i] = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::slt, iv, ub);
+      predicates[i] = arith::CmpIOp::create(rewriter, loc,
+                                            arith::CmpIPredicate::slt, iv, ub);
     }
 
     for (Operation *op : opOrder) {
@@ -365,8 +365,8 @@ LogicalResult LoopPipelinerInternal::emitPrologue(RewriterBase &rewriter) {
             Value prevValue = valueMapping
                 [forOp.getRegionIterArgs()[operand.getOperandNumber()]]
                 [i - stages[op]];
-            source = rewriter.create<arith::SelectOp>(
-                loc, predicates[predicateIdx], source, prevValue);
+            source = arith::SelectOp::create(
+                rewriter, loc, predicates[predicateIdx], source, prevValue);
           }
           setValueMapping(forOp.getRegionIterArgs()[operand.getOperandNumber()],
                           source, i - stages[op] + 1);
@@ -460,15 +460,15 @@ scf::ForOp LoopPipelinerInternal::createKernelLoop(
     Type t = ub.getType();
     Location loc = forOp.getLoc();
     // newUb = ub - maxStage * step
-    Value maxStageValue = rewriter.create<arith::ConstantOp>(
-        loc, rewriter.getIntegerAttr(t, maxStage));
+    Value maxStageValue = arith::ConstantOp::create(
+        rewriter, loc, rewriter.getIntegerAttr(t, maxStage));
     Value maxStageByStep =
-        rewriter.create<arith::MulIOp>(loc, step, maxStageValue);
-    newUb = rewriter.create<arith::SubIOp>(loc, ub, maxStageByStep);
+        arith::MulIOp::create(rewriter, loc, step, maxStageValue);
+    newUb = arith::SubIOp::create(rewriter, loc, ub, maxStageByStep);
   }
   auto newForOp =
-      rewriter.create<scf::ForOp>(forOp.getLoc(), forOp.getLowerBound(), newUb,
-                                  forOp.getStep(), newLoopArg);
+      scf::ForOp::create(rewriter, forOp.getLoc(), forOp.getLowerBound(), newUb,
+                         forOp.getStep(), newLoopArg);
   newForOp->setAttrs(forOp->getAttrs());
   // When there are no iter args, the loop body terminator will be created.
   // Since we always create it below, remove the terminator if it was created.
@@ -522,13 +522,13 @@ LogicalResult LoopPipelinerInternal::createKernel(
 
         // offset = (maxStage - stages[op]) * step
         Type t = step.getType();
-        Value offset = rewriter.create<arith::MulIOp>(
-            forOp.getLoc(), step,
-            rewriter.create<arith::ConstantOp>(
-                forOp.getLoc(),
+        Value offset = arith::MulIOp::create(
+            rewriter, forOp.getLoc(), step,
+            arith::ConstantOp::create(
+                rewriter, forOp.getLoc(),
                 rewriter.getIntegerAttr(t, maxStage - stages[op])));
-        Value iv = rewriter.create<arith::AddIOp>(
-            forOp.getLoc(), newForOp.getInductionVar(), offset);
+        Value iv = arith::AddIOp::create(rewriter, forOp.getLoc(),
+                                         newForOp.getInductionVar(), offset);
         nestedNewOp->setOperand(operand->getOperandNumber(), iv);
         rewriter.setInsertionPointAfter(newOp);
         continue;
@@ -609,8 +609,8 @@ LogicalResult LoopPipelinerInternal::createKernel(
         auto defStage = stages.find(def);
         if (defStage != stages.end() && defStage->second < maxStage) {
           Value pred = predicates[defStage->second];
-          source = rewriter.create<arith::SelectOp>(
-              pred.getLoc(), pred, source,
+          source = arith::SelectOp::create(
+              rewriter, pred.getLoc(), pred, source,
               newForOp.getBody()
                   ->getArguments()[yieldOperand.getOperandNumber() + 1]);
         }
@@ -651,7 +651,7 @@ LogicalResult LoopPipelinerInternal::createKernel(
                       maxStage - defStage->second + 1);
     }
   }
-  rewriter.create<scf::YieldOp>(forOp.getLoc(), yieldOperands);
+  scf::YieldOp::create(rewriter, forOp.getLoc(), yieldOperands);
   return success();
 }
 
@@ -664,8 +664,8 @@ LoopPipelinerInternal::emitEpilogue(RewriterBase &rewriter,
   // removed by dead code if not used.
 
   auto createConst = [&](int v) {
-    return rewriter.create<arith::ConstantOp>(loc,
-                                              rewriter.getIntegerAttr(t, v));
+    return arith::ConstantOp::create(rewriter, loc,
+                                     rewriter.getIntegerAttr(t, v));
   };
 
   // total_iterations = cdiv(range_diff, step);
@@ -673,42 +673,44 @@ LoopPipelinerInternal::emitEpilogue(RewriterBase &rewriter,
   // - total_iterations = (range_diff + step + (step < 0 ? 1 : -1)) / step
   Value zero = createConst(0);
   Value one = createConst(1);
-  Value stepLessZero = rewriter.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::slt, step, zero);
-  Value stepDecr =
-      rewriter.create<arith::SelectOp>(loc, stepLessZero, one, createConst(-1));
+  Value stepLessZero = arith::CmpIOp::create(
+      rewriter, loc, arith::CmpIPredicate::slt, step, zero);
+  Value stepDecr = arith::SelectOp::create(rewriter, loc, stepLessZero, one,
+                                           createConst(-1));
 
-  Value rangeDiff = rewriter.create<arith::SubIOp>(loc, ub, lb);
-  Value rangeIncrStep = rewriter.create<arith::AddIOp>(loc, rangeDiff, step);
+  Value rangeDiff = arith::SubIOp::create(rewriter, loc, ub, lb);
+  Value rangeIncrStep = arith::AddIOp::create(rewriter, loc, rangeDiff, step);
   Value rangeDecr =
-      rewriter.create<arith::AddIOp>(loc, rangeIncrStep, stepDecr);
-  Value totalIterations = rewriter.create<arith::DivSIOp>(loc, rangeDecr, step);
+      arith::AddIOp::create(rewriter, loc, rangeIncrStep, stepDecr);
+  Value totalIterations =
+      arith::DivSIOp::create(rewriter, loc, rangeDecr, step);
 
   // If total_iters < max_stage, start the epilogue at zero to match the
   // ramp-up in the prologue.
   // start_iter = max(0, total_iters - max_stage)
-  Value iterI = rewriter.create<arith::SubIOp>(loc, totalIterations,
-                                               createConst(maxStage));
-  iterI = rewriter.create<arith::MaxSIOp>(loc, zero, iterI);
+  Value iterI = arith::SubIOp::create(rewriter, loc, totalIterations,
+                                      createConst(maxStage));
+  iterI = arith::MaxSIOp::create(rewriter, loc, zero, iterI);
 
   // Capture predicates for dynamic loops.
   SmallVector<Value> predicates(maxStage + 1);
 
   for (int64_t i = 1; i <= maxStage; i++) {
     // newLastIter = lb + step * iterI
-    Value newlastIter = rewriter.create<arith::AddIOp>(
-        loc, lb, rewriter.create<arith::MulIOp>(loc, step, iterI));
+    Value newlastIter = arith::AddIOp::create(
+        rewriter, loc, lb, arith::MulIOp::create(rewriter, loc, step, iterI));
 
     setValueMapping(forOp.getInductionVar(), newlastIter, i);
 
     // increment to next iterI
-    iterI = rewriter.create<arith::AddIOp>(loc, iterI, one);
+    iterI = arith::AddIOp::create(rewriter, loc, iterI, one);
 
     if (dynamicLoop) {
       // Disable stages when `i` is greater than total_iters.
       // pred = total_iters >= i
-      predicates[i] = rewriter.create<arith::CmpIOp>(
-          loc, arith::CmpIPredicate::sge, totalIterations, createConst(i));
+      predicates[i] =
+          arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::sge,
+                                totalIterations, createConst(i));
     }
   }
 
@@ -770,8 +772,8 @@ LoopPipelinerInternal::emitEpilogue(RewriterBase &rewriter,
           unsigned nextVersion = currentVersion + 1;
           Value pred = predicates[currentVersion];
           Value prevValue = valueMapping[mapVal][currentVersion];
-          auto selOp = rewriter.create<arith::SelectOp>(loc, pred, pair.value(),
-                                                        prevValue);
+          auto selOp = arith::SelectOp::create(rewriter, loc, pred,
+                                               pair.value(), prevValue);
           returnValues[ri] = selOp;
           if (nextVersion <= maxStage)
             setValueMapping(mapVal, selOp, nextVersion);
@@ -856,12 +858,12 @@ Value mlir::triton::emitPredicateForStage(RewriterBase &rewriter,
                                           uint64_t stage) {
   auto loc = inductionVar.getLoc();
   auto type = inductionVar.getType();
-  Value c = rewriter.create<arith::SubIOp>(
-      loc, upperBound,
-      rewriter.create<arith::MulIOp>(
-          loc, step,
-          rewriter.create<arith::ConstantOp>(
-              loc, rewriter.getIntegerAttr(type, maxStage - stage))));
-  return rewriter.create<arith::CmpIOp>(loc, arith::CmpIPredicate::slt,
-                                        inductionVar, c);
+  Value c = arith::SubIOp::create(
+      rewriter, loc, upperBound,
+      arith::MulIOp::create(
+          rewriter, loc, step,
+          arith::ConstantOp::create(
+              rewriter, loc, rewriter.getIntegerAttr(type, maxStage - stage))));
+  return arith::CmpIOp::create(rewriter, loc, arith::CmpIPredicate::slt,
+                               inductionVar, c);
 }

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -298,11 +298,11 @@ Operation *mlir::triton::predicateOp(RewriterBase &rewriter, Operation *op,
 Operation *mlir::triton::wrapInMaskOp(RewriterBase &rewriter, Operation *op,
                                       Value pred) {
   auto mask =
-      rewriter.create<ttg::MaskOp>(op->getLoc(), op->getResultTypes(), pred);
+      ttg::MaskOp::create(rewriter, op->getLoc(), op->getResultTypes(), pred);
   rewriter.createBlock(&mask->getRegion(0));
   rewriter.setInsertionPointToStart(&mask->getRegion(0).front());
   auto newOp = rewriter.clone(*op);
-  rewriter.create<ttg::MaskReturnOp>(op->getLoc(), newOp->getResults());
+  ttg::MaskReturnOp::create(rewriter, op->getLoc(), newOp->getResults());
   op->replaceAllUsesWith(mask->getResults());
   rewriter.eraseOp(op);
   return mask;
@@ -332,8 +332,8 @@ void mlir::triton::resolveMaskOp(ModuleOp moduleOp,
         if (op->getNumResults() > 0) {
           SmallVector<Value> results;
           for (auto result : op->getResults()) {
-            auto poisonOp = rewriter.create<mlir::ub::PoisonOp>(
-                op->getLoc(), result.getType());
+            auto poisonOp = mlir::ub::PoisonOp::create(rewriter, op->getLoc(),
+                                                       result.getType());
             results.push_back(poisonOp);
           }
           op->replaceAllUsesWith(results);
@@ -475,7 +475,7 @@ Value mlir::triton::createScalarAlloc(ImplicitLocOpBuilder &rewriter, Type type,
   ttg::MemDescType memDescType = ttg::MemDescType::get(
       {numBuffers, 1}, type, barrierEncoding, sharedMemorySpace,
       /*mutableMemory=*/true);
-  return rewriter.create<ttg::LocalAllocOp>(memDescType, Value());
+  return ttg::LocalAllocOp::create(rewriter, memDescType, Value());
 }
 
 // Create an allocation and init the mbarriers.
@@ -487,15 +487,15 @@ Value mlir::triton::createBarrierAlloc(Operation *op, int numBarriers,
       createScalarAlloc(rewriter, rewriter.getI64Type(), numBarriers);
   for (unsigned i = 0; i < numBarriers; i++) {
     Value barrierView = createSingleBufferView(rewriter, barrierAlloc, i);
-    rewriter.create<ttng::InitBarrierOp>(barrierView, arriveCount);
+    ttng::InitBarrierOp::create(rewriter, barrierView, arriveCount);
   }
   // Invalidate and deallocate the barriers.
   rewriter.setInsertionPointAfter(op);
   for (unsigned i = 0; i < numBarriers; i++) {
     Value barrierView = createSingleBufferView(rewriter, barrierAlloc, i);
-    rewriter.create<ttng::InvalBarrierOp>(barrierView);
+    ttng::InvalBarrierOp::create(rewriter, barrierView);
   }
-  rewriter.create<ttg::LocalDeallocOp>(barrierAlloc);
+  ttg::LocalDeallocOp::create(rewriter, barrierAlloc);
   return barrierAlloc;
 }
 
@@ -511,10 +511,10 @@ Value mlir::triton::createAlloc(Operation *insertBefore, RankedTensorType ty,
   Type memdescType = ttg::MemDescType::get(bufferShape, ty.getElementType(),
                                            sharedEnc, sharedMemorySpace,
                                            /*mutableMemory=*/true);
-  Value alloc = builder.create<ttg::LocalAllocOp>(loc, memdescType);
+  Value alloc = ttg::LocalAllocOp::create(builder, loc, memdescType);
 
   builder.setInsertionPointAfter(insertBefore);
-  builder.create<ttg::LocalDeallocOp>(insertBefore->getLoc(), alloc);
+  ttg::LocalDeallocOp::create(builder, insertBefore->getLoc(), alloc);
   return alloc;
 }
 
@@ -563,8 +563,8 @@ void mlir::triton::combineRedundantWaitOps(
     if (waitGroup.size() == 1)
       continue;
     OpBuilder builder(waitGroup.front());
-    auto newWaitOp = builder.create<ttg::AsyncWaitOp>(waitOp.getLoc(),
-                                                      depTokens, minWaitNumber);
+    auto newWaitOp = ttg::AsyncWaitOp::create(builder, waitOp.getLoc(),
+                                              depTokens, minWaitNumber);
     for (auto waitOp : waitGroup) {
       toDelete[waitOp] = newWaitOp;
     }
@@ -684,25 +684,25 @@ triton::createSingleBufferView(OpBuilder &builder, Value alloc, Value idx) {
   auto viewDescType = ttg::MemDescType::get(
       shape, allocDescType.getElementType(), allocDescType.getEncoding(),
       allocDescType.getMemorySpace(), allocDescType.getMutableMemory());
-  return builder.create<ttg::MemDescIndexOp>(alloc.getLoc(), viewDescType,
-                                             alloc, idx);
+  return ttg::MemDescIndexOp::create(builder, alloc.getLoc(), viewDescType,
+                                     alloc, idx);
 }
 
 TypedValue<ttg::MemDescType>
 triton::createSingleBufferView(OpBuilder &builder, Value alloc, int idx) {
-  Value idxVal = builder.create<arith::ConstantIntOp>(alloc.getLoc(), idx, 32);
+  Value idxVal = arith::ConstantIntOp::create(builder, alloc.getLoc(), idx, 32);
   return createSingleBufferView(builder, alloc, idxVal);
 }
 
 Value triton::createIncrementModulo(OpBuilder &builder, Location loc,
                                     Value counter, Value modulus, Value zero,
                                     Value one, Value *outWrapCond) {
-  Value addOne = builder.create<arith::AddIOp>(loc, counter, one);
-  Value outOfRangeCond = builder.create<arith::CmpIOp>(
-      loc, arith::CmpIPredicate::sge, addOne, modulus);
+  Value addOne = arith::AddIOp::create(builder, loc, counter, one);
+  Value outOfRangeCond = arith::CmpIOp::create(
+      builder, loc, arith::CmpIPredicate::sge, addOne, modulus);
   if (outWrapCond)
     *outWrapCond = outOfRangeCond;
-  return builder.create<arith::SelectOp>(loc, outOfRangeCond, zero, addOne);
+  return arith::SelectOp::create(builder, loc, outOfRangeCond, zero, addOne);
 }
 
 /////////////////////////////
@@ -722,8 +722,8 @@ allocTMABuffers(scf::ForOp forOp,
     // loop-carried value. That would save us from allocating another buffer
     // just for the init value
     auto loc = op.getLoc();
-    Value alloc = rewriter.create<triton::gpu::GlobalScratchAllocOp>(
-        loc, triton::getPointerType(rewriter.getI8Type()),
+    Value alloc = triton::gpu::GlobalScratchAllocOp::create(
+        rewriter, loc, triton::getPointerType(rewriter.getI8Type()),
         maxStage * ttng::TMA_SIZE_BYTES, ttng::TMA_ALIGN);
     tmaBufferMapping[op.getOperation()] = alloc;
   });
@@ -732,9 +732,9 @@ allocTMABuffers(scf::ForOp forOp,
 static Value subviewTMADescriptor(OpBuilder &builder, Location loc, Value alloc,
                                   Value counter) {
   Value tmaSizeVal =
-      builder.create<arith::ConstantIntOp>(loc, ttng::TMA_SIZE_BYTES, 32);
-  Value offset = builder.create<arith::MulIOp>(loc, tmaSizeVal, counter);
-  return builder.create<triton::AddPtrOp>(loc, alloc.getType(), alloc, offset);
+      arith::ConstantIntOp::create(builder, loc, ttng::TMA_SIZE_BYTES, 32);
+  Value offset = arith::MulIOp::create(builder, loc, tmaSizeVal, counter);
+  return triton::AddPtrOp::create(builder, loc, alloc.getType(), alloc, offset);
 }
 
 static LogicalResult rewriteTMABufferUpdates(
@@ -744,8 +744,9 @@ static LogicalResult rewriteTMABufferUpdates(
     triton::CoarseSchedule &schedule) {
   assert(tmaBufferMapping.size() == tmaCounters.size());
 
-  Value numBuffersVal = mlir::OpBuilder(forOp).create<arith::ConstantIntOp>(
-      forOp.getLoc(), numBuffers, 32);
+  auto auxBuilder = mlir::OpBuilder(forOp);
+  Value numBuffersVal =
+      arith::ConstantIntOp::create(auxBuilder, forOp.getLoc(), numBuffers, 32);
 
   for (auto [iOp, pair] : llvm::enumerate(tmaBufferMapping)) {
     auto &[op, alloc] = pair;
@@ -762,9 +763,9 @@ static LogicalResult rewriteTMABufferUpdates(
     if (failed(ttng::createTMADesc(nextBuf, makeDescOp, builder))) {
       return failure();
     }
-    builder.create<ttng::TensormapFenceproxyAcquireOp>(nextBuf);
-    Value nextDesc = builder.create<ttng::ReinterpretTensorDescOp>(
-        makeDescOp.getType(), nextBuf);
+    ttng::TensormapFenceproxyAcquireOp::create(builder, nextBuf);
+    Value nextDesc = ttng::ReinterpretTensorDescOp::create(
+        builder, makeDescOp.getType(), nextBuf);
 
     makeDescOp.getResult().replaceAllUsesWith(nextDesc);
 
@@ -804,8 +805,8 @@ scf::ForOp triton::lowerTMADescriptors(scf::ForOp forOp,
 
   IRRewriter builder(forOp);
   Location loc = forOp.getLoc();
-  Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 32);
-  Value one = builder.create<arith::ConstantIntOp>(loc, 1, 32);
+  Value zero = arith::ConstantIntOp::create(builder, loc, 0, 32);
+  Value one = arith::ConstantIntOp::create(builder, loc, 1, 32);
   SmallVector<Value> newOperands;
   unsigned newOperandIndex = forOp.getBody()->getNumArguments();
   // Create one counter per TMA buffer. This allows the descriptors to be

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/SoftwarePipeliner.cpp
@@ -66,12 +66,12 @@ static void expandLoops(ModuleOp moduleOp) {
     if (auto predOp = dyn_cast<triton::gpu::PredicateStageOp>(op)) {
       if (isEpilogue) {
         // Return false for the predicate of the peeled iteration
-        return rewriter.create<mlir::arith::ConstantIntOp>(
-            predOp.getLoc(), predOp.getResult().getType(), 0);
+        return mlir::arith::ConstantIntOp::create(
+            rewriter, predOp.getLoc(), predOp.getResult().getType(), 0);
       } else {
         if (predOp.getStage() == predOp.getMaxStage() - 1) {
-          return rewriter.create<mlir::arith::ConstantIntOp>(
-              predOp.getLoc(), predOp.getResult().getType(), 1);
+          return mlir::arith::ConstantIntOp::create(
+              rewriter, predOp.getLoc(), predOp.getResult().getType(), 1);
         } else {
           OpBuilder::InsertionGuard guard(rewriter);
           rewriter.setInsertionPoint(op);
@@ -126,9 +126,9 @@ static void expandLoops(ModuleOp moduleOp) {
       options.emitPredicateStageFn =
           [](RewriterBase &rewriter, Value inductionVar, Value upperBound,
              Value step, uint64_t maxStage, uint64_t stage) {
-            return rewriter.create<triton::gpu::PredicateStageOp>(
-                inductionVar.getLoc(), inductionVar, upperBound, step, maxStage,
-                stage);
+            return triton::gpu::PredicateStageOp::create(
+                rewriter, inductionVar.getLoc(), inductionVar, upperBound, step,
+                maxStage, stage);
           };
     }
     IRRewriter rewriter(forOp);

--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -53,10 +53,10 @@ public:
               mod.getContext(), dstDotOp, srcType.getShape(), order,
               triton::gpu::getCTALayout(srcEncoding), srcType.getElementType()),
           sharedMemorySpace);
-      auto tmp = builder.create<triton::gpu::LocalAllocOp>(
-          cvtOp.getLoc(), tmpType, cvtOp.getSrc());
-      auto newConvert = builder.create<triton::gpu::LocalLoadOp>(cvtOp.getLoc(),
-                                                                 dstType, tmp);
+      auto tmp = triton::gpu::LocalAllocOp::create(builder, cvtOp.getLoc(),
+                                                   tmpType, cvtOp.getSrc());
+      auto newConvert = triton::gpu::LocalLoadOp::create(
+          builder, cvtOp.getLoc(), dstType, tmp);
       cvtOp.replaceAllUsesWith(newConvert.getResult());
       cvtOp.erase();
     });

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -470,8 +470,8 @@ Value LayoutPropagation::getValueAs(Value value, Attribute encoding) {
     OpBuilder rewriter(value.getContext());
     rewriter.setInsertionPointAfterValue(rewrittenValue);
     auto tmpType = tensorType.cloneWithEncoding(encoding);
-    Value converted = rewriter.create<ConvertLayoutOp>(value.getLoc(), tmpType,
-                                                       rewrittenValue);
+    Value converted = ConvertLayoutOp::create(rewriter, value.getLoc(), tmpType,
+                                              rewrittenValue);
     // TODO: we could cache the conversion.
     return converted;
   }
@@ -527,9 +527,9 @@ Operation *LayoutPropagation::rewriteForOp(scf::ForOp forOp) {
           getValueAs(operand, *layouts[result].encodings.begin());
     operands.push_back(convertedOperand);
   }
-  auto newForOp = rewriter.create<scf::ForOp>(
-      forOp.getLoc(), forOp.getLowerBound(), forOp.getUpperBound(),
-      forOp.getStep(), operands);
+  auto newForOp =
+      scf::ForOp::create(rewriter, forOp.getLoc(), forOp.getLowerBound(),
+                         forOp.getUpperBound(), forOp.getStep(), operands);
   newForOp->setAttrs(forOp->getAttrs());
   newForOp.getBody()->getOperations().splice(
       newForOp.getBody()->getOperations().begin(),
@@ -578,7 +578,7 @@ Operation *LayoutPropagation::rewriteWhileOp(scf::WhileOp whileOp) {
   }
 
   auto newWhileOp =
-      rewriter.create<scf::WhileOp>(whileOp.getLoc(), returnTypes, operands);
+      scf::WhileOp::create(rewriter, whileOp.getLoc(), returnTypes, operands);
   SmallVector<Type> argsTypesBefore;
   for (Value operand : operands)
     argsTypesBefore.push_back(operand.getType());
@@ -625,8 +625,8 @@ Operation *LayoutPropagation::rewriteIfOp(scf::IfOp ifOp) {
     Attribute encoding = *(it->second.encodings.begin());
     newResultTypes[i] = origType.cloneWithEncoding(encoding);
   }
-  auto newIfOp = rewriter.create<scf::IfOp>(ifOp.getLoc(), newResultTypes,
-                                            ifOp.getCondition(), true, true);
+  auto newIfOp = scf::IfOp::create(rewriter, ifOp.getLoc(), newResultTypes,
+                                   ifOp.getCondition(), true, true);
   newIfOp.getThenRegion().takeBody(ifOp.getThenRegion());
   newIfOp.getElseRegion().takeBody(ifOp.getElseRegion());
   for (auto [oldResult, newResult] :
@@ -720,7 +720,7 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     Value src = getValueAs(convertOp.getSrc(), srcEncoding);
     auto tensorType = cast<RankedTensorType>(op->getResult(0).getType());
     auto newType = tensorType.cloneWithEncoding(encoding);
-    auto cvt = rewriter.create<ConvertLayoutOp>(op->getLoc(), newType, src);
+    auto cvt = ConvertLayoutOp::create(rewriter, op->getLoc(), newType, src);
     map(op->getResult(0), cvt.getResult());
     return cvt.getOperation();
   }
@@ -728,8 +728,8 @@ Operation *LayoutPropagation::rewriteOp(Operation *op) {
     Operation *newOp = rewriter.clone(*op);
     auto tensorType = cast<RankedTensorType>(op->getResult(0).getType());
     auto newType = tensorType.cloneWithEncoding(encoding);
-    auto cvt = rewriter.create<ConvertLayoutOp>(op->getLoc(), newType,
-                                                newOp->getResult(0));
+    auto cvt = ConvertLayoutOp::create(rewriter, op->getLoc(), newType,
+                                       newOp->getResult(0));
     map(op->getResult(0), cvt.getResult());
     return cvt.getOperation();
   }
@@ -918,7 +918,7 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
       for (int operandIdx : operandsToRewrite) {
         yieldOperands.push_back(mapping.lookup(yieldOp.getOperand(operandIdx)));
       }
-      builder.create<scf::YieldOp>(op->getLoc(), yieldOperands);
+      scf::YieldOp::create(builder, op->getLoc(), yieldOperands);
       op->erase();
       continue;
     }
@@ -926,8 +926,8 @@ void LayoutRematerialization::rewriteSlice(SetVector<Value> &slice,
       Operation *newOp = builder.clone(*op);
       auto tensorType = cast<RankedTensorType>(op->getResult(0).getType());
       auto newType = tensorType.cloneWithEncoding(layout[op->getResult(0)]);
-      auto cvt = builder.create<ConvertLayoutOp>(op->getLoc(), newType,
-                                                 newOp->getResult(0));
+      auto cvt = ConvertLayoutOp::create(builder, op->getLoc(), newType,
+                                         newOp->getResult(0));
       mapping.map(op->getResult(0), cvt.getResult());
       addRematValue(op->getResult(0), layout[op->getResult(0)],
                     cvt.getResult());
@@ -1359,8 +1359,8 @@ void LayoutRematerialization::hoistConvertDotOperand(
     if (!type)
       continue;
     auto newType = type.cloneWithEncoding(layout[loadOp->getResult(0)]);
-    auto newConvertOp = builder.create<ConvertLayoutOp>(
-        convertOp.getLoc(), newType, loadOp->getResult(0));
+    auto newConvertOp = ConvertLayoutOp::create(builder, convertOp.getLoc(),
+                                                newType, loadOp->getResult(0));
     mapping.map(loadOp->getResult(0), newConvertOp.getResult());
   }
 
@@ -1461,8 +1461,8 @@ void LayoutRematerialization::hoistConvertOnTopOfExtOrBroadcast(
   auto tensorType =
       cast<RankedTensorType>(extOrBroadcastOp->getOperand(0).getType());
   auto newType = tensorType.cloneWithEncoding(srcEncoding);
-  auto newConvertOp = builder.create<ConvertLayoutOp>(
-      convertOp.getLoc(), newType, extOrBroadcastOp->getOperand(0));
+  auto newConvertOp = ConvertLayoutOp::create(
+      builder, convertOp.getLoc(), newType, extOrBroadcastOp->getOperand(0));
   Operation *newExtOrBroadcast = builder.clone(*extOrBroadcastOp);
   newExtOrBroadcast->setOperand(0, newConvertOp.getResult());
   auto oldExtOrBroadcastType =
@@ -1575,7 +1575,7 @@ void LayoutRematerialization::hoistConvertIntoConditionals(
   auto hoistRemat = [&](OpBuilder &b, Value v, Attribute encoding) {
     auto tensorType = cast<RankedTensorType>(v.getType());
     auto newType = tensorType.cloneWithEncoding(encoding);
-    Value newCvt = b.create<ConvertLayoutOp>(convertOp.getLoc(), newType, v);
+    Value newCvt = ConvertLayoutOp::create(b, convertOp.getLoc(), newType, v);
 
     mapping.map(v, newCvt);
     slice.remove(v);

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -32,7 +32,7 @@ static OwningOpRef<ModuleOp> takeIntoFunction(ModuleAxisInfoAnalysis &axisInfo,
 
   auto b = OpBuilder::atBlockBegin(containerBlock);
   FunctionType funcType = b.getFunctionType(partition->getArgumentTypes(), {});
-  auto containerFunc = b.create<FuncOp>(mod.getLoc(), "container", funcType);
+  auto containerFunc = FuncOp::create(b, mod.getLoc(), "container", funcType);
   containerFunc.getBody().takeBody(*partition);
   container.get()->setAttrs(mod->getAttrs());
   container.get()->setAttr(AttrNumWarpsName, b.getI32IntegerAttr(numWarps));
@@ -40,7 +40,7 @@ static OwningOpRef<ModuleOp> takeIntoFunction(ModuleAxisInfoAnalysis &axisInfo,
   // Replace `ttg.warp_return` with `tt.return` to make the IR valid.
   containerFunc.walk([&](WarpReturnOp op) {
     b.setInsertionPoint(op);
-    b.create<ReturnOp>(op.getLoc());
+    ReturnOp::create(b, op.getLoc());
     op.erase();
   });
 
@@ -74,7 +74,7 @@ static void extractPartitionBody(OwningOpRef<ModuleOp> container,
   // Rewrite the returns.
   containerFunc.walk([](ReturnOp op) {
     OpBuilder b(op);
-    b.create<WarpReturnOp>(op.getLoc());
+    WarpReturnOp::create(b, op.getLoc());
     op.erase();
   });
 

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/RewritePartitionDependencies.cpp
@@ -137,7 +137,7 @@ AsyncRef DependencyRewriter::allocateAsyncValue(RankedTensorType tensorType,
   auto arefTy = triton::nvws::ArefType::get(
       b.getContext(),
       triton::nvws::TypeArrayAttr::get(b.getContext(), alloc.getType()));
-  auto aref = b.create<triton::nvws::ArefCreateOp>(b.getLoc(), arefTy, alloc);
+  auto aref = triton::nvws::ArefCreateOp::create(b, b.getLoc(), arefTy, alloc);
 
   return AsyncRef{aref, getBufferViewType(allocType),
                   b.getType<AsyncTokenType>()};

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -39,11 +39,11 @@ public:
     if (firstOp != nullptr && lastOp != nullptr) {
       assert(firstOp->getParentRegion() == lastOp->getParentRegion());
       b.setInsertionPoint(_firstOp);
-      b.create<tti::ExperimentalLockAcquireOp>(auxData.lock[_firstOp].value,
-                                               pred);
+      tti::ExperimentalLockAcquireOp::create(b, auxData.lock[_firstOp].value,
+                                             pred);
       b.setInsertionPointAfter(_lastOp);
-      b.create<tti::ExperimentalLockReleaseOp>(auxData.lock[_firstOp].value,
-                                               pred);
+      tti::ExperimentalLockReleaseOp::create(b, auxData.lock[_firstOp].value,
+                                             pred);
     }
   }
 
@@ -167,14 +167,14 @@ private:
             for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
               auto writeVis = auxData.writeVisibility[(int)memType][op];
               if (writeVis.value) {
-                b.create<tti::ExperimentalCopyWriteVisibilityOp>(
-                    thread, static_cast<int64_t>(destMask), writeVis.value,
+                tti::ExperimentalCopyWriteVisibilityOp::create(
+                    b, thread, static_cast<int64_t>(destMask), writeVis.value,
                     writeVis.type, nullptr);
               }
               auto readVis = auxData.readVisibility[(int)memType][op];
               if (readVis.value) {
-                b.create<tti::ExperimentalCopyReadVisibilityOp>(
-                    thread, static_cast<int64_t>(destMask), readVis.value,
+                tti::ExperimentalCopyReadVisibilityOp::create(
+                    b, thread, static_cast<int64_t>(destMask), readVis.value,
                     readVis.type, nullptr);
               }
             }
@@ -183,9 +183,10 @@ private:
       }
       if (auto initOp = dyn_cast<ttng::InitBarrierOp>(op)) {
         if (auxData.barriers[op].value && auxData.barrierStates[op].value) {
-          b.create<tti::ExperimentalInitBarrierStateOp>(
-              initOp.getAlloc(), initOp.getCount(), auxData.barriers[op].value,
-              auxData.barrierStates[op].value, auxData.barrierStates[op].type);
+          tti::ExperimentalInitBarrierStateOp::create(
+              b, initOp.getAlloc(), initOp.getCount(),
+              auxData.barriers[op].value, auxData.barrierStates[op].value,
+              auxData.barrierStates[op].type);
         }
       }
       if (auto waitOp = dyn_cast<ttng::WaitBarrierOp>(op)) {
@@ -198,14 +199,14 @@ private:
           auto barrier = waitOp.getAlloc();
           if (auxData.barriers[op].value && auxData.waiting[op].value &&
               auxData.barrierStates[op].value) {
-            b.create<tti::ExperimentalSetWaitingOp>(
-                barrier, baseThread, waitOp.getPhase(),
+            tti::ExperimentalSetWaitingOp::create(
+                b, barrier, baseThread, waitOp.getPhase(),
                 auxData.barriers[op].value, auxData.waiting[op].value,
                 auxData.waiting[op].type, pred);
             int activeMask = getActiveMask(op);
 
-            b.create<tti::ExperimentalCheckAllActiveWaitingOp>(
-                activeMask, auxData.barriers[op].value,
+            tti::ExperimentalCheckAllActiveWaitingOp::create(
+                b, activeMask, auxData.barriers[op].value,
                 auxData.waiting[op].value, auxData.waiting[op].type,
                 auxData.barrierStates[op].value, auxData.barrierStates[op].type,
                 pred);
@@ -225,14 +226,14 @@ private:
           if (auxData.writeVisibility[(int)memType][op].value) {
             // Transfer visible writes and reads to all peer threads
             uint64_t peerMask = getThreadPeersMask(thread);
-            b.create<tti::ExperimentalTransferVisibleWritesOp>(
-                barrier, peerMask, _barriers,
+            tti::ExperimentalTransferVisibleWritesOp::create(
+                b, barrier, peerMask, _barriers,
                 auxData.writeVisibility[(int)memType][op].value,
                 auxData.writeVisibility[(int)memType][op].type,
                 auxData.writeTracking[(int)memType][op].value,
                 auxData.writeTracking[(int)memType][op].type, pred);
-            b.create<tti::ExperimentalTransferVisibleReadsOp>(
-                barrier, peerMask, _barriers,
+            tti::ExperimentalTransferVisibleReadsOp::create(
+                b, barrier, peerMask, _barriers,
                 auxData.readVisibility[(int)memType][op].value,
                 auxData.readVisibility[(int)memType][op].type,
                 auxData.readTracking[(int)memType][op].value,
@@ -240,19 +241,19 @@ private:
           }
         }
         if (auxData.barriers[op].value && auxData.waiting[op].value) {
-          b.create<tti::ExperimentalClearWaitingOp>(
-              barrier, baseThread, auxData.barriers[op].value,
+          tti::ExperimentalClearWaitingOp::create(
+              b, barrier, baseThread, auxData.barriers[op].value,
               auxData.waiting[op].value, auxData.waiting[op].type, pred);
         }
       }
       if (auto asyncCommitGroupOp = dyn_cast<ttg::AsyncCommitGroupOp>(op)) {
-        b.create<tti::ExperimentalCommitAccessesOp>(
-            thread, auxData.asyncCpCommits[op].value,
+        tti::ExperimentalCommitAccessesOp::create(
+            b, thread, auxData.asyncCpCommits[op].value,
             auxData.asyncCpCommits[op].type, nullptr);
       }
       if (auto asyncWaitOp = dyn_cast<ttg::AsyncWaitOp>(op)) {
-        b.create<tti::ExperimentalClearOutstandingCommitsTransferWritesOp>(
-            thread, getThreadPeersMask(thread), asyncWaitOp.getNum(),
+        tti::ExperimentalClearOutstandingCommitsTransferWritesOp::create(
+            b, thread, getThreadPeersMask(thread), asyncWaitOp.getNum(),
             auxData.asyncCpCommits[op].value, auxData.asyncCpCommits[op].type,
             auxData.writeVisibility[(int)MemType::SHARED_MEM][op].value,
             auxData.writeVisibility[(int)MemType::SHARED_MEM][op].type,
@@ -262,14 +263,14 @@ private:
         if (wgmmaOp.getIsAsync() == true) {
           // Add commit (implicit in ttgir) after staging wgmma's operand for
           // read
-          b.create<tti::ExperimentalCommitAccessesOp>(
-              thread, auxData.wgmmaCommits[op].value,
+          tti::ExperimentalCommitAccessesOp::create(
+              b, thread, auxData.wgmmaCommits[op].value,
               auxData.wgmmaCommits[op].type, nullptr);
         }
       }
       if (auto wgmmaWaitOp = dyn_cast<ttng::WarpGroupDotWaitOp>(op)) {
-        b.create<tti::ExperimentalClearOutstandingCommitsTransferReadsOp>(
-            thread, getThreadPeersMask(thread), wgmmaWaitOp.getPendings(),
+        tti::ExperimentalClearOutstandingCommitsTransferReadsOp::create(
+            b, thread, getThreadPeersMask(thread), wgmmaWaitOp.getPendings(),
             auxData.wgmmaCommits[op].value, auxData.wgmmaCommits[op].type,
             auxData.readVisibility[(int)MemType::SHARED_MEM][op].value,
             auxData.readVisibility[(int)MemType::SHARED_MEM][op].type, nullptr);
@@ -311,7 +312,7 @@ private:
     Value pred = opInfo->pred;
     auto combinePredicates = [&](Value barrierPred) -> Value {
       if (barrierPred && pred) {
-        return b.create<arith::AndIOp>(b.getLoc(), barrierPred, pred);
+        return arith::AndIOp::create(b, b.getLoc(), barrierPred, pred);
       }
       return barrierPred ? barrierPred : pred;
     };
@@ -330,8 +331,8 @@ private:
         addWriteChecks(b, op, buf, pred, memType, thread, effect.operandName);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier &&
             _barriers) {
-          b.create<tti::ExperimentalSetReadVisibilityOp>(
-              buf, getThreadPeersMask(thread), _buffers,
+          tti::ExperimentalSetReadVisibilityOp::create(
+              b, buf, getThreadPeersMask(thread), _buffers,
               auxData.readVisibility[(int)memType][op].value,
               auxData.readVisibility[(int)memType][op].type, pred);
         }
@@ -339,8 +340,8 @@ private:
             MemEffectsOpInfo::TrackingKind::wgmmaCommit) {
           assert(isa<ttng::WarpGroupDotOp>(op));
           assert(memType == MemType::SHARED_MEM);
-          b.create<tti::ExperimentalStageAccessForCommitOp>(
-              buf, thread, _buffers, auxData.wgmmaCommits[op].value,
+          tti::ExperimentalStageAccessForCommitOp::create(
+              b, buf, thread, _buffers, auxData.wgmmaCommits[op].value,
               auxData.wgmmaCommits[op].type, pred);
         }
         assert(opInfo->trackingKind !=
@@ -353,25 +354,25 @@ private:
         addReadChecks(b, op, buf, pred, memType, thread, effect.operandName);
         if (opInfo->trackingKind == MemEffectsOpInfo::TrackingKind::Barrier &&
             _barriers) {
-          b.create<tti::ExperimentalSetWriteVisibilityOp>(
-              buf, getThreadPeersMask(thread), _buffers,
+          tti::ExperimentalSetWriteVisibilityOp::create(
+              b, buf, getThreadPeersMask(thread), _buffers,
               auxData.writeVisibility[(int)memType][op].value,
               auxData.writeVisibility[(int)memType][op].type, pred);
-          b.create<tti::ExperimentalClearWriteTrackingOp>(
-              buf, _buffers, auxData.writeTracking[(int)memType][op].value,
+          tti::ExperimentalClearWriteTrackingOp::create(
+              b, buf, _buffers, auxData.writeTracking[(int)memType][op].value,
               auxData.writeTracking[(int)memType][op].type, pred);
-          b.create<tti::ExperimentalClearReadVisibilityOp>(
-              buf, _buffers, auxData.readVisibility[(int)memType][op].value,
+          tti::ExperimentalClearReadVisibilityOp::create(
+              b, buf, _buffers, auxData.readVisibility[(int)memType][op].value,
               auxData.readVisibility[(int)memType][op].type, pred);
-          b.create<tti::ExperimentalClearReadTrackingOp>(
-              buf, _buffers, auxData.readTracking[(int)memType][op].value,
+          tti::ExperimentalClearReadTrackingOp::create(
+              b, buf, _buffers, auxData.readTracking[(int)memType][op].value,
               auxData.readTracking[(int)memType][op].type, pred);
         }
         if (opInfo->trackingKind ==
             MemEffectsOpInfo::TrackingKind::asyncCpCommit) {
           assert(memType == MemType::SHARED_MEM);
-          b.create<tti::ExperimentalStageAccessForCommitOp>(
-              buf, thread, _buffers, auxData.asyncCpCommits[op].value,
+          tti::ExperimentalStageAccessForCommitOp::create(
+              b, buf, thread, _buffers, auxData.asyncCpCommits[op].value,
               auxData.asyncCpCommits[op].type, pred);
         }
         assert(opInfo->trackingKind !=
@@ -387,14 +388,14 @@ private:
         if (!auxData.writeVisibility[(int)memType][op].value) {
           continue;
         }
-        b.create<tti::ExperimentalTrackVisibleWritesOp>(
-            barrier, thread, _barriers,
+        tti::ExperimentalTrackVisibleWritesOp::create(
+            b, barrier, thread, _barriers,
             auxData.writeVisibility[(int)memType][op].value,
             auxData.writeVisibility[(int)memType][op].type,
             auxData.writeTracking[(int)memType][op].value,
             auxData.writeTracking[(int)memType][op].type, combinedPred);
-        b.create<tti::ExperimentalTrackVisibleReadsOp>(
-            barrier, thread, _barriers,
+        tti::ExperimentalTrackVisibleReadsOp::create(
+            b, barrier, thread, _barriers,
             auxData.readVisibility[(int)memType][op].value,
             auxData.readVisibility[(int)memType][op].type,
             auxData.readTracking[(int)memType][op].value,
@@ -402,12 +403,12 @@ private:
       }
       if (auxData.barriers[op].value && auxData.barrierStates[op].value &&
           barrierInfo.count > 0) {
-        b.create<tti::ExperimentalVerifyBarrierArriveOp>(
-            barrier, barrierInfo.count, auxData.barriers[op].value,
+        tti::ExperimentalVerifyBarrierArriveOp::create(
+            b, barrier, barrierInfo.count, auxData.barriers[op].value,
             auxData.barrierStates[op].value, auxData.barrierStates[op].type,
             combinedPred);
-        b.create<tti::ExperimentalUpdateBarrierStateOp>(
-            barrier, barrierInfo.count, auxData.barriers[op].value,
+        tti::ExperimentalUpdateBarrierStateOp::create(
+            b, barrier, barrierInfo.count, auxData.barriers[op].value,
             auxData.barrierStates[op].value, auxData.barrierStates[op].type,
             combinedPred);
       }
@@ -420,15 +421,16 @@ private:
     auto buffers = auxData.buffers[(int)memType][op].value;
     if (!auxData.barriers.empty()) {
       StringAttr operandNameAttr = b.getStringAttr(operandName);
-      b.create<tti::ExperimentalVerifyWriteVisibilityOp>(
-          buf, thread, buffers, auxData.writeVisibility[(int)memType][op].value,
+      tti::ExperimentalVerifyWriteVisibilityOp::create(
+          b, buf, thread, buffers,
+          auxData.writeVisibility[(int)memType][op].value,
           auxData.writeVisibility[(int)memType][op].type, operandNameAttr,
           pred);
     }
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM && auxData.asyncCpCommits[op].value) {
-      b.create<tti::ExperimentalCheckOutstandingCommitsOp>(
-          buf, buffers, auxData.asyncCpCommits[op].value,
+      tti::ExperimentalCheckOutstandingCommitsOp::create(
+          b, buf, buffers, auxData.asyncCpCommits[op].value,
           auxData.asyncCpCommits[op].type, "async_copy_global_to_shared", pred);
     }
   }
@@ -439,14 +441,15 @@ private:
     auto buffers = auxData.buffers[(int)memType][op].value;
     if (!auxData.barriers.empty()) {
       StringAttr operandNameAttr = b.getStringAttr(operandName);
-      b.create<tti::ExperimentalVerifyReadVisibilityOp>(
-          buf, thread, buffers, auxData.readVisibility[(int)memType][op].value,
+      tti::ExperimentalVerifyReadVisibilityOp::create(
+          b, buf, thread, buffers,
+          auxData.readVisibility[(int)memType][op].value,
           auxData.readVisibility[(int)memType][op].type, operandNameAttr, pred);
     }
     // commit-num-based synchronization is only supported for shared memory
     if (memType == MemType::SHARED_MEM && auxData.wgmmaCommits[op].value) {
-      b.create<tti::ExperimentalCheckOutstandingCommitsOp>(
-          buf, buffers, auxData.wgmmaCommits[op].value,
+      tti::ExperimentalCheckOutstandingCommitsOp::create(
+          b, buf, buffers, auxData.wgmmaCommits[op].value,
           auxData.wgmmaCommits[op].type, "warpgroup_mma operand read", pred);
     }
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -45,8 +45,8 @@ public:
         return WalkResult::advance();
 
       OpBuilder builder(dotOp);
-      auto fence = builder.create<FenceAsyncSharedOp>(dotOp.getLoc(),
-                                                      /*bCluster=*/false);
+      auto fence = FenceAsyncSharedOp::create(builder, dotOp.getLoc(),
+                                              /*bCluster=*/false);
       // If there is all the dependencies are outside of the loop try to hoist
       // the fence.
       while (auto loopOp = fence->getParentOfType<LoopLikeOpInterface>()) {

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -72,13 +72,13 @@ findBufferAccessMemdescSubview(Operation *subview) {
     shape = to_vector(indexOp.getType().getShape());
     offsets = {indexOp.getIndex()};
     for (auto i : llvm::seq(std::max<int>(0, shape.size() - 1)))
-      offsets.push_back(builder.create<arith::ConstantIntOp>(loc, 0, 32));
+      offsets.push_back(arith::ConstantIntOp::create(builder, loc, 0, 32));
   } else {
     auto subsliceOp = cast<ttg::MemDescSubsliceOp>(subview);
     src = subsliceOp.getSrc();
     shape = to_vector(subsliceOp.getType().getShape());
     for (auto offset : subsliceOp.getOffsets())
-      offsets.push_back(builder.create<arith::ConstantIntOp>(loc, offset, 32));
+      offsets.push_back(arith::ConstantIntOp::create(builder, loc, offset, 32));
   }
   auto [alloc, parentAccess] = findBufferAccess(src);
   if (!alloc)

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/PromoteLHSToTMem.cpp
@@ -88,9 +88,9 @@ public:
     if (newLayout != srcLayout) {
       auto ty = cast<RankedTensorType>(src.getType());
       auto newTy = ty.cloneWithEncoding(newLayout);
-      src = rewriter.create<ttg::ConvertLayoutOp>(loc, newTy, src);
+      src = ttg::ConvertLayoutOp::create(rewriter, loc, newTy, src);
     }
-    Value tMemAlloc = rewriter.create<TMEMAllocOp>(loc, lhsMemDescType, src);
+    Value tMemAlloc = TMEMAllocOp::create(rewriter, loc, lhsMemDescType, src);
     tcGen5MMAOp.getAMutable().assign(tMemAlloc);
     return success();
   }

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxFenceInsertion.cpp
@@ -90,7 +90,7 @@ private:
 
 void ProxyFenceAnalysis::insertFence(Operation *op, OpBuilder *builder) {
   OpBuilder::InsertionGuard g(*builder);
-  builder->create<triton::nvidia_gpu::FenceAsyncSharedOp>(op->getLoc(), false);
+  triton::nvidia_gpu::FenceAsyncSharedOp::create(*builder, op->getLoc(), false);
 }
 
 void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/RemoveTMEMTokens.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/RemoveTMEMTokens.cpp
@@ -57,8 +57,8 @@ public:
     for (auto func : getOperation().getOps<FuncOp>()) {
       auto b = OpBuilder::atBlockBegin(&func.getBody().front());
       // Placeholder value that will get DCE'd by the canonicalizer.
-      Value dummy = b.create<ub::PoisonOp>(
-          func.getLoc(), b.getType<triton::gpu::AsyncTokenType>());
+      Value dummy = ub::PoisonOp::create(
+          b, func.getLoc(), b.getType<triton::gpu::AsyncTokenType>());
       func.walk([&](Operation *op) { removeTMEMToken(op, dummy); });
     }
   }

--- a/lib/Target/LLVMIR/LLVMDILocalVariable.cpp
+++ b/lib/Target/LLVMIR/LLVMDILocalVariable.cpp
@@ -82,8 +82,8 @@ struct LLVMDILocalVariablePass
       // a subclass of mlir::Value, which is the value defined by this operation
       OpResult opResult = op->getResult(0);
       // create and insert this call-dbg-value intrinsic after the op
-      Operation *dbgOp = builder.create<LLVM::DbgValueOp>(
-          childLoc, opResult, diLocalVarAttr, diExprAttr);
+      Operation *dbgOp = LLVM::DbgValueOp::create(builder, childLoc, opResult,
+                                                  diLocalVarAttr, diExprAttr);
     }
   }
 

--- a/python/src/ir.h
+++ b/python/src/ir.h
@@ -66,7 +66,7 @@ public:
 
   template <typename OpTy, typename... Args> OpTy create(Args &&...args) {
     auto loc = getLastLoc();
-    return builder->create<OpTy>(loc, std::forward<Args>(args)...);
+    return OpTy::create(*builder, loc, std::forward<Args>(args)...);
   }
 
   // Overload to create or fold a single result operation.

--- a/third_party/amd/include/TritonAMDGPUToLLVM/GCNAsmFormat.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/GCNAsmFormat.h
@@ -67,7 +67,7 @@ class GCNInstrExecution;
 //
 // create inst
 // auto &mul_inst =
-// gcnBuilder.create<GCNInstr>("v_mul")->float_op_type(bitwidth);
+// GCNInstr::create(gcnBuilder, "v_mul")->float_op_type(bitwidth);
 //
 // launch insts
 // mul_inst(res, lhs, rhs);
@@ -88,9 +88,9 @@ class GCNInstrExecution;
 // GCNBuilder can build a GCN asm with multiple instructions, sample code:
 //
 // GCNBuilder builder;
-// auto &rcp = gcnBuilder.create<GCNInstr>("v_rcp")->float_op_type(bitwidth);
+// auto &rcp = GCNInstr::create(gcnBuilder, "v_rcp")->float_op_type(bitwidth);
 // auto &mul_inst =
-// gcnBuilder.create<GCNInstr>("v_mul")->float_op_type(bitwidth);
+// GCNInstr::create(gcnBuilder, "v_mul")->float_op_type(bitwidth);
 //
 // rcp(...);
 // mul_inst(...);
@@ -100,8 +100,8 @@ class GCNInstrExecution;
 // multiple times with different operands, e.g.
 //
 //   auto &mul_inst =
-//   gcnBuilder.create<GCNInstr>("v_mul")->float_op_type(bitwidth); mul_inst(...
-//   some operands ...); mul_inst(... some different operands ...);
+//   GCNInstr::create(gcnBuilder, "v_mul")->float_op_type(bitwidth);
+//   mul_inst(... some operands ...); mul_inst(... some different operands ...);
 //
 // Finally, we will get a GCN code with two mov instructions.
 //

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/MFMA.cpp
@@ -211,8 +211,8 @@ struct DotOpMFMAConversionHelper {
         } else {
           auto multiplierAttr =
               rewriter.getFloatAttr(dstElemTy, 1.0 / duplicationRate);
-          auto multiplierVal =
-              rewriter.create<LLVM::ConstantOp>(loc, dstElemTy, multiplierAttr);
+          auto multiplierVal = LLVM::ConstantOp::create(
+              rewriter, loc, dstElemTy, multiplierAttr);
           accElem = tb.fmul(accElem, multiplierVal);
         }
       }
@@ -734,9 +734,9 @@ struct ScaledDotOpMFMAConversionHelper : DotOpMFMAConversionHelper {
           for (int n = 0; n < numRepN; ++n) {
             // Insert pingpong cluster barrier when needed.
             if (is2Step && currIter++ == halfPoint) {
-              rewriter.create<ROCDL::SchedBarrier>(loc, 0);
-              rewriter.create<ROCDL::SBarrierOp>(loc);
-              rewriter.create<ROCDL::SchedBarrier>(loc, 0);
+              ROCDL::SchedBarrier::create(rewriter, loc, 0);
+              ROCDL::SBarrierOp::create(rewriter, loc);
+              ROCDL::SchedBarrier::create(rewriter, loc, 0);
             }
             Value acc = tb.undef(vecTy);
             for (unsigned v = 0; v < elemsPerVec; ++v) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -58,8 +58,8 @@ ValueTable getValuesFromDotOperandLayoutStruct(
                 tb.insert_element(ty, rawElems, elems[idx], tb.i32_val(k));
           } else {
             // pad with zeros
-            Value zero = rewriter.create<LLVM::ConstantOp>(
-                loc, elemTy, rewriter.getZeroAttr(elemTy));
+            Value zero = LLVM::ConstantOp::create(rewriter, loc, elemTy,
+                                                  rewriter.getZeroAttr(elemTy));
             rawElems = tb.insert_element(ty, rawElems, zero, tb.i32_val(k));
           }
         }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -219,10 +219,10 @@ cvtScalePkUpcastFromFp8(Location loc, ConversionPatternRewriter &rewriter,
   }
   Type resType = vec_ty(resElemType, 2);
   Value scale = b.f32_val(1);
-  auto result1 = rewriter.create<ConvertOp>(loc, resType, i32v, scale,
-                                            /*srcLoHiSel=*/false);
-  auto result2 = rewriter.create<ConvertOp>(loc, resType, i32v, scale,
-                                            /*srcLoHiSel=*/true);
+  auto result1 = ConvertOp::create(rewriter, loc, resType, i32v, scale,
+                                   /*srcLoHiSel=*/false);
+  auto result2 = ConvertOp::create(rewriter, loc, resType, i32v, scale,
+                                   /*srcLoHiSel=*/true);
   SmallVector<Value> ret(4);
   ret[0] = b.extract_element(resElemType, result1, idx[0]);
   ret[1] = b.extract_element(resElemType, result1, idx[1]);
@@ -247,11 +247,11 @@ cvtScalePkDowncastToFp8(Location loc, ConversionPatternRewriter &rewriter,
   if constexpr (std::is_same_v<ConvertOp, ROCDL::CvtScaleF32PkFp8F32Op> ||
                 std::is_same_v<ConvertOp, ROCDL::CvtScaleF32PkBf8F32Op>) {
     v2I16Vec =
-        rewriter.create<ConvertOp>(loc, v2I16Ty, v2I16Vec, v[0], v[1], scale,
-                                   /*dstLoHiSel=*/false);
+        ConvertOp::create(rewriter, loc, v2I16Ty, v2I16Vec, v[0], v[1], scale,
+                          /*dstLoHiSel=*/false);
     v2I16Vec =
-        rewriter.create<ConvertOp>(loc, v2I16Ty, v2I16Vec, v[2], v[3], scale,
-                                   /*dstLoHiSel=*/true);
+        ConvertOp::create(rewriter, loc, v2I16Ty, v2I16Vec, v[2], v[3], scale,
+                          /*dstLoHiSel=*/true);
   } else {
     Type v2F16Ty = vec_ty(v[0].getType(), 2);
     Value srcVec = b.undef(v2F16Ty);
@@ -259,12 +259,14 @@ cvtScalePkDowncastToFp8(Location loc, ConversionPatternRewriter &rewriter,
     auto idx1 = b.i32_val(1);
     srcVec = b.insert_element(v2F16Ty, srcVec, v[0], idx0);
     srcVec = b.insert_element(v2F16Ty, srcVec, v[1], idx1);
-    v2I16Vec = rewriter.create<ConvertOp>(loc, v2I16Ty, v2I16Vec, srcVec, scale,
-                                          /*dstLoHiSel=*/false);
+    v2I16Vec =
+        ConvertOp::create(rewriter, loc, v2I16Ty, v2I16Vec, srcVec, scale,
+                          /*dstLoHiSel=*/false);
     srcVec = b.insert_element(v2F16Ty, srcVec, v[2], idx0);
     srcVec = b.insert_element(v2F16Ty, srcVec, v[3], idx1);
-    v2I16Vec = rewriter.create<ConvertOp>(loc, v2I16Ty, v2I16Vec, srcVec, scale,
-                                          /*dstLoHiSel=*/true);
+    v2I16Vec =
+        ConvertOp::create(rewriter, loc, v2I16Ty, v2I16Vec, srcVec, scale,
+                          /*dstLoHiSel=*/true);
   }
 
   auto fp8x4VecTy = vec_ty(i8_ty, 4);
@@ -594,9 +596,9 @@ static SmallVector<Value> cvtPkF8ToFp32(Location loc,
   auto dstType = f32_ty;
 
   auto resultLo =
-      rewriter.create<ConvertOp>(loc, resType, i32v, /*wordSel=*/false);
+      ConvertOp::create(rewriter, loc, resType, i32v, /*wordSel=*/false);
   auto resultHi =
-      rewriter.create<ConvertOp>(loc, resType, i32v, /*wordSel=*/true);
+      ConvertOp::create(rewriter, loc, resType, i32v, /*wordSel=*/true);
   auto f32x2VecTy = vec_ty(dstType, 2);
   SmallVector<Value> ret(4);
   auto retVec = b.bitcast(resultLo, f32x2VecTy);
@@ -618,10 +620,10 @@ static SmallVector<Value> cvtPkFp32ToF8(Location loc,
   Type v2I16Ty = vec_ty(i16_ty, 2);
   Value result = b.undef(i32_ty);
 
-  result = rewriter.create<ConvertOp>(loc, i32_ty, v[0], v[1], result,
-                                      /*wordSel=*/false);
-  result = rewriter.create<ConvertOp>(loc, i32_ty, v[2], v[3], result,
-                                      /*wordSel=*/true);
+  result = ConvertOp::create(rewriter, loc, i32_ty, v[0], v[1], result,
+                             /*wordSel=*/false);
+  result = ConvertOp::create(rewriter, loc, i32_ty, v[2], v[3], result,
+                             /*wordSel=*/true);
   auto fp8x4VecTy = vec_ty(i8_ty, 4);
   auto fp8x4Vec = b.bitcast(result, fp8x4VecTy);
   SmallVector<Value> ret(4);
@@ -975,7 +977,7 @@ convertFp32ToFp16RTZ(Location loc, ConversionPatternRewriter &rewriter,
   Type v2f16Ty = vec_ty(f16_ty, 2);
 
   Value result;
-  result = rewriter.create<ROCDL::CvtPkRtz>(loc, v2f16Ty, v[0], v[1]);
+  result = ROCDL::CvtPkRtz::create(rewriter, loc, v2f16Ty, v[0], v[1]);
   SmallVector<Value> ret(2);
   auto idx0 = b.i32_val(0);
   auto idx1 = b.i32_val(1);
@@ -1090,7 +1092,7 @@ static SmallVector<Value> Fp32_to_F16_RTNE(Location loc,
     return {
         convertFp32ToBf16(loc, rewriter, operands[0][0], RoundingMode::RTNE)};
   }
-  return {rewriter.create<LLVM::FPTruncOp>(loc, outElemTy, operands[0][0])};
+  return {LLVM::FPTruncOp::create(rewriter, loc, outElemTy, operands[0][0])};
 }
 
 static Value Fp8E5M2FNUZ_to_Fp16_oneValue(Location loc,
@@ -1878,7 +1880,7 @@ Value EmitDualBF16ElementwiseOp(Location loc,
                                 MultipleOperandsRange operands) {
   auto v0 = convertBf16ToFp32(loc, rewriter, operands[0][0]);
   auto v1 = convertBf16ToFp32(loc, rewriter, operands[0][1]);
-  auto result = rewriter.create<OP>(loc, f32_ty, v0, v1);
+  auto result = OP::create(rewriter, loc, f32_ty, v0, v1);
   return convertFp32ToBf16(loc, rewriter, result, RoundingMode::RTNE);
 }
 
@@ -1891,8 +1893,8 @@ struct FDivOpConversion
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
 
-    return {rewriter.create<LLVM::FDivOp>(loc, elemTy, operands[0][0],
-                                          operands[0][1])};
+    return {LLVM::FDivOp::create(rewriter, loc, elemTy, operands[0][0],
+                                 operands[0][1])};
   }
 };
 
@@ -1930,8 +1932,8 @@ struct FMulOpConversion
             EmitDualBF16ElementwiseOp<LLVM::FMulOp>(loc, rewriter, operands)};
       }
     } else {
-      return {rewriter.create<LLVM::FMulOp>(loc, elemTy, operands[0][0],
-                                            operands[0][1])};
+      return {LLVM::FMulOp::create(rewriter, loc, elemTy, operands[0][0],
+                                   operands[0][1])};
     }
   }
 
@@ -1952,8 +1954,8 @@ struct FAddOpConversion
     if (lhsElemTy.isBF16() && rhsElemTy.isBF16()) {
       return {EmitDualBF16ElementwiseOp<LLVM::FAddOp>(loc, rewriter, operands)};
     } else {
-      return {rewriter.create<LLVM::FAddOp>(loc, elemTy, operands[0][0],
-                                            operands[0][1])};
+      return {LLVM::FAddOp::create(rewriter, loc, elemTy, operands[0][0],
+                                   operands[0][1])};
     }
   }
 };
@@ -1971,8 +1973,8 @@ struct FSubOpConversion
     if (lhsElemTy.isBF16() && rhsElemTy.isBF16()) {
       return {EmitDualBF16ElementwiseOp<LLVM::FSubOp>(loc, rewriter, operands)};
     } else {
-      return {rewriter.create<LLVM::FSubOp>(loc, elemTy, operands[0][0],
-                                            operands[0][1])};
+      return {LLVM::FSubOp::create(rewriter, loc, elemTy, operands[0][0],
+                                   operands[0][1])};
     }
   }
 };
@@ -1984,7 +1986,7 @@ static SmallVector<Value> S8_to_Bf16(Location loc,
   SmallVector<Value> inValues = {v[0], v[1], v[2], v[3]};
   SmallVector<Value> outValues = {};
   for (Value inVal : inValues) {
-    Value bf16Val = rewriter.create<LLVM::SIToFPOp>(loc, bf16_ty, inVal);
+    Value bf16Val = LLVM::SIToFPOp::create(rewriter, loc, bf16_ty, inVal);
     outValues.push_back(bf16Val);
   }
   return outValues;
@@ -2007,10 +2009,11 @@ struct SIToFPOpConversion
       assert(outVals.size() == 4);
       return outVals;
     } else if (outElemTy.isBF16()) {
-      auto value = rewriter.create<LLVM::SIToFPOp>(loc, f32_ty, operands[0][0]);
+      auto value =
+          LLVM::SIToFPOp::create(rewriter, loc, f32_ty, operands[0][0]);
       return {convertFp32ToBf16(loc, rewriter, value, RoundingMode::RTNE)};
     } else {
-      return {rewriter.create<LLVM::SIToFPOp>(loc, elemTy, operands[0][0])};
+      return {LLVM::SIToFPOp::create(rewriter, loc, elemTy, operands[0][0])};
     }
   }
 };
@@ -2026,9 +2029,9 @@ struct FPToSIOpConversion
     auto inElemTy = getElementType(op.getIn());
     if (inElemTy.isBF16()) {
       auto value = convertBf16ToFp32(loc, rewriter, operands[0][0]);
-      return {rewriter.create<LLVM::FPToSIOp>(loc, elemTy, value)};
+      return {LLVM::FPToSIOp::create(rewriter, loc, elemTy, value)};
     } else {
-      return {rewriter.create<LLVM::FPToSIOp>(loc, elemTy, operands[0][0])};
+      return {LLVM::FPToSIOp::create(rewriter, loc, elemTy, operands[0][0])};
     }
   }
 };
@@ -2047,7 +2050,7 @@ struct ExtFOpConversion
       assert(outElemTy.isF32() && "unsupported conversion");
       return {convertBf16ToFp32(loc, rewriter, operands[0][0])};
     } else {
-      return {rewriter.create<LLVM::FPExtOp>(loc, elemTy, operands[0][0])};
+      return {LLVM::FPExtOp::create(rewriter, loc, elemTy, operands[0][0])};
     }
   }
 };
@@ -2073,7 +2076,7 @@ struct TruncFOpConversion
       return Fp32_to_F16_RTNE(loc, rewriter, inElemTy, outElemTy, operands,
                               isaFamily);
     }
-    return {rewriter.create<LLVM::FPTruncOp>(loc, elemTy, operands[0][0])};
+    return {LLVM::FPTruncOp::create(rewriter, loc, elemTy, operands[0][0])};
   }
 
 private:
@@ -2282,8 +2285,8 @@ struct PreciseSqrtOpConversion
     // If the op is neither FP32 nor denorm flushing(ftz), it's directly lowered
     // to LLVM::SqrtOp.
     if (elemTy.getIntOrFloatBitWidth() != 32 || !ftz) {
-      return {rewriter.create<LLVM::SqrtOp>(
-          loc, elemTy, operands[0], adaptor.getAttributes().getValue())};
+      return {LLVM::SqrtOp::create(rewriter, loc, elemTy, operands[0],
+                                   adaptor.getAttributes().getValue())};
     }
 
     // On the AMDGPU backend, instructions legalized from LLVM::SqrtOp are
@@ -2324,7 +2327,7 @@ struct PreciseSqrtOpConversion
     const unsigned fcZero = fcNegZero | fcPosZero;
 
     Value isZeroOrPosInf =
-        rewriter.create<LLVM::IsFPClass>(loc, i1_ty, sqrtX, fcPosInf | fcZero);
+        LLVM::IsFPClass::create(rewriter, loc, i1_ty, sqrtX, fcPosInf | fcZero);
     return {b.select(isZeroOrPosInf, sqrtX, sqrtS)};
   }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/GCNAsmFormat.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/GCNAsmFormat.cpp
@@ -76,12 +76,12 @@ mlir::Value GCNBuilder::launch(RewriterBase &rewriter, Location loc, Type resTy,
                                bool hasSideEffect, bool isAlignStack,
                                ArrayRef<Attribute> attrs) const {
   auto *ctx = rewriter.getContext();
-  auto inlineAsm = rewriter.create<LLVM::InlineAsmOp>(
-      loc, resTy, getAllMLIRArgs(), // operands
-      dump(),                       // asm_string
-      getConstraints(),             // constraints
-      hasSideEffect,                // has_side_effects
-      isAlignStack,                 // is_align_stack
+  auto inlineAsm = LLVM::InlineAsmOp::create(
+      rewriter, loc, resTy, getAllMLIRArgs(), // operands
+      dump(),                                 // asm_string
+      getConstraints(),                       // constraints
+      hasSideEffect,                          // has_side_effects
+      isAlignStack,                           // is_align_stack
       LLVM::TailCallKind::None,
       LLVM::AsmDialectAttr::get(ctx,
                                 LLVM::AsmDialect::AD_ATT), // asm_dialect

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -159,13 +159,13 @@ LogicalResult emitFence(Operation *op, ConversionPatternRewriter &rewriter,
   StringAttr scope = mlir::StringAttr::get(loc.getContext(), *scopeStr);
 
   if (emitReleaseFence && preAtomic) {
-    rewriter.create<LLVM::FenceOp>(loc, TypeRange{},
-                                   LLVM::AtomicOrdering::release, scope);
+    LLVM::FenceOp::create(rewriter, loc, TypeRange{},
+                          LLVM::AtomicOrdering::release, scope);
   }
 
   if (emitAcquireFence && !preAtomic) {
-    rewriter.create<LLVM::FenceOp>(loc, TypeRange{},
-                                   LLVM::AtomicOrdering::acquire, scope);
+    LLVM::FenceOp::create(rewriter, loc, TypeRange{},
+                          LLVM::AtomicOrdering::acquire, scope);
   }
   return success();
 }
@@ -208,9 +208,9 @@ std::pair<Block *, Block *> emitBranch(RewriterBase &rewriter, Location loc,
       rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
   Block *body = rewriter.createBlock(after);
   rewriter.setInsertionPointToEnd(currentBlock);
-  rewriter.create<LLVM::CondBrOp>(loc, cond, body, after);
+  LLVM::CondBrOp::create(rewriter, loc, cond, body, after);
   rewriter.setInsertionPointToStart(body);
-  rewriter.create<LLVM::BrOp>(loc, after);
+  LLVM::BrOp::create(rewriter, loc, after);
   rewriter.setInsertionPointToStart(body);
   return {body, after};
 }
@@ -227,7 +227,7 @@ struct LoadStoreConversionBase {
     mlir::Attribute zeroAttr = builder.getZeroAttr(vecTy.getElementType());
     auto denseValue =
         DenseElementsAttr::get(cast<mlir::ShapedType>(vecTy), zeroAttr);
-    Value zeroVal = builder.create<LLVM::ConstantOp>(loc, vecTy, denseValue);
+    Value zeroVal = LLVM::ConstantOp::create(builder, loc, vecTy, denseValue);
     return zeroVal;
   }
 
@@ -422,7 +422,7 @@ struct DirectToLdsLoadConversionBase : public LoadStoreConversionBase {
     auto structTy = LLVM::LLVMStructType::getLiteral(
         rewriter.getContext(), ArrayRef<Type>{srcTy, i1_ty, otherTy, i32_ty});
     for (int i = 0; i < srcElems.size(); i++) {
-      Value packedArr = rewriter.create<LLVM::UndefOp>(loc, structTy);
+      Value packedArr = LLVM::UndefOp::create(rewriter, loc, structTy);
       // src
       packedArr = b.insert_val(packedArr, srcElems[i], 0);
       // mask
@@ -876,9 +876,9 @@ struct BufferLoadToLocalOpConversion
                          resElemTy, vec, emitBufferLoadLds);
 
     // Drop the result token.
-    Value zero = rewriter.create<LLVM::ConstantOp>(
-        op.getLoc(), IntegerType::get(op.getContext(), 32),
-        rewriter.getI32IntegerAttr(0));
+    Value zero = LLVM::ConstantOp::create(rewriter, op.getLoc(),
+                                          IntegerType::get(op.getContext(), 32),
+                                          rewriter.getI32IntegerAttr(0));
     rewriter.replaceOp(op, zero);
     return success();
   }
@@ -1002,9 +1002,9 @@ struct AsyncCopyGlobalToLocalOpConversion
                          resElemTy, vec, emitGlobalLoadLds);
 
     // Drop the result token.
-    Value zero = rewriter.create<LLVM::ConstantOp>(
-        op.getLoc(), IntegerType::get(op.getContext(), 32),
-        rewriter.getI32IntegerAttr(0));
+    Value zero = LLVM::ConstantOp::create(rewriter, op.getLoc(),
+                                          IntegerType::get(op.getContext(), 32),
+                                          rewriter.getI32IntegerAttr(0));
     rewriter.replaceOp(op, zero);
     return success();
   }
@@ -1019,8 +1019,8 @@ struct AsyncCopyGlobalToLocalOpConversion
 
     if (llvm::is_contained({ISAFamily::CDNA3, ISAFamily::CDNA4},
                            targetInfo.getISAFamily())) {
-      auto globalLoadLdsOp = rewriter.create<ROCDL::GlobalLoadLDSOp>(
-          loc, srcPtr, shmemAddr, vecBits / 8,
+      auto globalLoadLdsOp = ROCDL::GlobalLoadLDSOp::create(
+          rewriter, loc, srcPtr, shmemAddr, vecBits / 8,
           /*offset=*/0, cacheModifiers, nullptr, nullptr, nullptr);
       if (targetInfo.requiresAliasInfoForAsyncOps())
         AMD::addAsyncCopyAliasScope(globalLoadLdsOp);
@@ -1619,9 +1619,9 @@ struct AtomicCASOpConversion
         // TODO: USE ATOMIC CAS OP on Tensor
         auto successOrdering = *atomicMemOrdering;
         auto failureOrdering = LLVM::AtomicOrdering::monotonic;
-        auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
-            loc, casPtr, casCmp, casVal, successOrdering, failureOrdering,
-            StringRef(scopeStr.value()));
+        auto cmpxchg = LLVM::AtomicCmpXchgOp::create(
+            rewriter, loc, casPtr, casCmp, casVal, successOrdering,
+            failureOrdering, StringRef(scopeStr.value()));
 
         // Extract the new_loaded value from the pair.
         Value ret = b.extract_val(valueElemTy, cmpxchg, i);
@@ -1637,16 +1637,16 @@ struct AtomicCASOpConversion
         rewriter.setInsertionPointToEnd(curBlock);
         auto tid = getThreadId(rewriter, loc);
         Value pred = b.icmp_eq(tid, b.i32_val(i));
-        rewriter.create<LLVM::CondBrOp>(loc, pred, atomicBlock, endBlock);
+        LLVM::CondBrOp::create(rewriter, loc, pred, atomicBlock, endBlock);
 
         // Build main block with atomic_cmpxchg.
         rewriter.setInsertionPointToEnd(atomicBlock);
 
         auto successOrdering = LLVM::AtomicOrdering::acq_rel;
         auto failureOrdering = LLVM::AtomicOrdering::monotonic;
-        auto cmpxchg = rewriter.create<LLVM::AtomicCmpXchgOp>(
-            loc, casPtr, casCmp, casVal, successOrdering, failureOrdering,
-            StringRef("agent"));
+        auto cmpxchg = LLVM::AtomicCmpXchgOp::create(
+            rewriter, loc, casPtr, casCmp, casVal, successOrdering,
+            failureOrdering, StringRef("agent"));
 
         if (!op.getResult().use_empty()) {
           // Extract the new_loaded value from the pair.
@@ -1656,7 +1656,7 @@ struct AtomicCASOpConversion
           b.store(newLoaded, atomPtr);
         }
 
-        rewriter.create<LLVM::BrOp>(loc, ValueRange(), endBlock);
+        LLVM::BrOp::create(rewriter, loc, ValueRange(), endBlock);
 
         // Build the last block: synced load from shared memory, exit.
         rewriter.setInsertionPointToStart(endBlock);
@@ -1667,7 +1667,7 @@ struct AtomicCASOpConversion
         }
 
         GCNBuilder BuilderMemfenceLDS;
-        BuilderMemfenceLDS.create<>("s_waitcnt lgkmcnt(0)")->operator()();
+        BuilderMemfenceLDS.create("s_waitcnt lgkmcnt(0)")->operator()();
         BuilderMemfenceLDS.launch(rewriter, loc, void_ty(ctx));
         b.barrier();
         Value atomPtr =
@@ -1920,7 +1920,7 @@ struct AsyncWaitOpConversion : public ConvertOpToLLVMPattern<AsyncWaitOp> {
       unsigned otherCnts = ~0xC00F; // C00F has bits 15:14 and 3:0 set
       unsigned waitValue = lowBits | highBits | otherCnts;
 
-      rewriter.create<ROCDL::SWaitcntOp>(loc, waitValue);
+      ROCDL::SWaitcntOp::create(rewriter, loc, waitValue);
       break;
     }
     case ISAFamily::GFX1250: {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -152,14 +152,14 @@ private:
       case AMD::ISAFamily::CDNA4: {
         if (bitWidth == 16) {
           dsReadTr =
-              rewriter.create<ROCDL::ds_read_tr16_b64>(loc, vTy, vecAddr);
+              ROCDL::ds_read_tr16_b64::create(rewriter, loc, vTy, vecAddr);
         } else {
           if (isPackedLoad) {
             dsReadTr =
-                rewriter.create<ROCDL::ds_read_tr4_b64>(loc, vTyI32, vecAddr);
+                ROCDL::ds_read_tr4_b64::create(rewriter, loc, vTyI32, vecAddr);
           } else {
             dsReadTr =
-                rewriter.create<ROCDL::ds_read_tr8_b64>(loc, vTyI32, vecAddr);
+                ROCDL::ds_read_tr8_b64::create(rewriter, loc, vTyI32, vecAddr);
           }
         }
         break;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/OptimizeLDSUtility.cpp
@@ -83,10 +83,10 @@ createNewConvertOps(OpBuilder &builder, triton::gpu::ConvertLayoutOp &cvtOp,
   RankedTensorType newSrcType = RankedTensorType::get(
       srcType.getShape(), srcType.getElementType(), tmpLayout);
 
-  auto tmpCvt = builder.create<triton::gpu::ConvertLayoutOp>(
-      cvtOp.getLoc(), newSrcType, cvtOp.getSrc());
-  auto newEpilogueCvt = builder.create<triton::gpu::ConvertLayoutOp>(
-      cvtOp.getLoc(), newDstType, tmpCvt);
+  auto tmpCvt = triton::gpu::ConvertLayoutOp::create(
+      builder, cvtOp.getLoc(), newSrcType, cvtOp.getSrc());
+  auto newEpilogueCvt = triton::gpu::ConvertLayoutOp::create(
+      builder, cvtOp.getLoc(), newDstType, tmpCvt);
   tmpCvt->setAttrs(cvtOp->getAttrs());
   newEpilogueCvt->setAttrs(cvtOp->getAttrs());
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SPMDOpToLLVM.cpp
@@ -20,7 +20,7 @@ struct GetNumProgramsOpConversion
     Location loc = op->getLoc();
     assert(op.getAxisAsInt() < 3);
     Value blockId =
-        rewriter.create<::mlir::gpu::GridDimOp>(loc, dims[op.getAxisAsInt()]);
+        ::mlir::gpu::GridDimOp::create(rewriter, loc, dims[op.getAxisAsInt()]);
     rewriter.replaceOpWithNewOp<arith::TruncIOp>(op, i32_ty, blockId);
     return success();
   }
@@ -39,13 +39,13 @@ struct CondBarrierOpConversion
         rewriter.splitBlock(currentBlock, rewriter.getInsertionPoint());
     Block *trueBlock = rewriter.createBlock(afterCondBarBlock);
     rewriter.setInsertionPointToEnd(currentBlock);
-    rewriter.create<LLVM::CondBrOp>(loc, adaptor.getPred(), trueBlock,
-                                    afterCondBarBlock);
+    LLVM::CondBrOp::create(rewriter, loc, adaptor.getPred(), trueBlock,
+                           afterCondBarBlock);
 
     // conditional barrier
     rewriter.setInsertionPointToStart(trueBlock);
-    rewriter.create<ROCDL::SBarrierOp>(loc);
-    rewriter.create<LLVM::BrOp>(loc, afterCondBarBlock);
+    ROCDL::SBarrierOp::create(rewriter, loc);
+    LLVM::BrOp::create(rewriter, loc, afterCondBarBlock);
     rewriter.eraseOp(op);
     return success();
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
@@ -34,7 +34,7 @@ Operation *createSchedBarrier(PatternRewriter &rewriter, Location loc,
                               mlir::amdgpu::sched_barrier_opt_enum maskValue) {
   IntegerAttr mask =
       rewriter.getI32IntegerAttr(static_cast<int32_t>(maskValue));
-  return rewriter.create<ROCDL::SchedBarrier>(loc, mask);
+  return ROCDL::SchedBarrier::create(rewriter, loc, mask);
 }
 
 // Insert an experimental intrinsic for instruction group level parallelism.
@@ -42,7 +42,7 @@ Operation *createSchedBarrier(PatternRewriter &rewriter, Location loc,
 Operation *createIglpOpt(PatternRewriter &rewriter, Location loc, int value) {
   IntegerAttr iglpValue =
       rewriter.getI32IntegerAttr(static_cast<int32_t>(value));
-  return rewriter.create<ROCDL::IglpOpt>(loc, iglpValue);
+  return ROCDL::IglpOpt::create(rewriter, loc, iglpValue);
 }
 
 struct InstructionSchedHintsRewriter
@@ -170,8 +170,8 @@ struct TritonAMDGPUInsertInstructionSchedHints
         if (result.wasInterrupted()) {
           OpBuilder rewriter(ctx);
           rewriter.setInsertionPointToStart(forOp.getBody());
-          rewriter.create<triton::amdgpu::InstructionSchedHint>(forOp->getLoc(),
-                                                                schedHint);
+          triton::amdgpu::InstructionSchedHint::create(
+              rewriter, forOp->getLoc(), schedHint);
         }
       });
       break;

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -274,8 +274,8 @@ private:
     // Ask for 16B alignment on global_smem because that's the largest we should
     // ever need (4xi32).
     auto arrayTy = LLVM::LLVMArrayType::get(elemTy, 0);
-    auto global = b.create<LLVM::GlobalOp>(
-        loc, arrayTy, /*isConstant=*/false, LLVM::Linkage::External,
+    auto global = LLVM::GlobalOp::create(
+        b, loc, arrayTy, /*isConstant=*/false, LLVM::Linkage::External,
         "global_smem", /*value=*/Attribute(), /*alignment=*/16,
         // Add ROCm support.
         static_cast<unsigned>(NVVM::NVVMMemorySpace::Shared));

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -149,8 +149,8 @@ upcast8xMxfp4_HW(RewriterBase &rewriter, Location loc, ArrayRef<Value> xVals,
   }
   SmallVector<Value, 4> results;
   for (int srcSelIndex : llvm::seq(4))
-    results.push_back(rewriter.create<ConvertOp>(loc, resType, packedVec,
-                                                 scaleF32, srcSelIndex));
+    results.push_back(ConvertOp::create(rewriter, loc, resType, packedVec,
+                                        scaleF32, srcSelIndex));
   return results;
 }
 
@@ -179,12 +179,12 @@ upcast4xMxfp8_HW(RewriterBase &rewriter, Location loc, ArrayRef<Value> xVals,
     scaleF32 = b.bitcast(b.shl(b.zext(i32_ty, scale), b.i32_val(23)), f32_ty);
   }
   SmallVector<Value, 2> results;
-  results.push_back(rewriter.create<ConvertOp>(loc, resType, packedVec,
-                                               scaleF32,
-                                               /*srcLoHiSel=*/false));
-  results.push_back(rewriter.create<ConvertOp>(loc, resType, packedVec,
-                                               scaleF32,
-                                               /*srcLoHiSel=*/true));
+  results.push_back(ConvertOp::create(rewriter, loc, resType, packedVec,
+                                      scaleF32,
+                                      /*srcLoHiSel=*/false));
+  results.push_back(ConvertOp::create(rewriter, loc, resType, packedVec,
+                                      scaleF32,
+                                      /*srcLoHiSel=*/true));
   return results;
 }
 } // namespace mlir::LLVM::AMD

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -400,7 +400,7 @@ Value convertAndCastTensor(PatternRewriter &rewriter, Value value,
       RankedTensorType::get(oldType.getShape(), oldElemType, newEncoding);
 
   Value convertedTensor =
-      rewriter.create<ttg::ConvertLayoutOp>(loc, convertedType, value);
+      ttg::ConvertLayoutOp::create(rewriter, loc, convertedType, value);
 
   if (newElemType == oldElemType)
     return convertedTensor;
@@ -413,27 +413,27 @@ Value convertAndCastTensor(PatternRewriter &rewriter, Value value,
     unsigned oldWidth = oldElemType.getIntOrFloatBitWidth();
     unsigned newWidth = newElemType.getIntOrFloatBitWidth();
     if (oldWidth == newWidth)
-      castedTensor = rewriter.create<arith::BitcastOp>(loc, convertedType,
-                                                       convertedTensor);
+      castedTensor = arith::BitcastOp::create(rewriter, loc, convertedType,
+                                              convertedTensor);
     else if (oldWidth > newWidth)
       castedTensor =
-          rewriter.create<arith::TruncIOp>(loc, castedType, convertedTensor);
+          arith::TruncIOp::create(rewriter, loc, castedType, convertedTensor);
     else if (oldElemType.isSignedInteger())
       castedTensor =
-          rewriter.create<arith::ExtSIOp>(loc, castedType, convertedTensor);
+          arith::ExtSIOp::create(rewriter, loc, castedType, convertedTensor);
     else
       castedTensor =
-          rewriter.create<arith::ExtUIOp>(loc, castedType, convertedTensor);
+          arith::ExtUIOp::create(rewriter, loc, castedType, convertedTensor);
   } else {
     if (oldElemType.isF16() && newElemType.isF32())
       castedTensor =
-          rewriter.create<arith::ExtFOp>(loc, castedType, convertedTensor);
+          arith::ExtFOp::create(rewriter, loc, castedType, convertedTensor);
     else if (oldElemType.isF32() && newElemType.isF16())
       castedTensor =
-          rewriter.create<arith::TruncFOp>(loc, castedType, convertedTensor);
+          arith::TruncFOp::create(rewriter, loc, castedType, convertedTensor);
     else
       castedTensor =
-          rewriter.create<tt::FpToFpOp>(loc, castedType, convertedTensor);
+          tt::FpToFpOp::create(rewriter, loc, castedType, convertedTensor);
   }
   return castedTensor;
 }
@@ -736,9 +736,10 @@ public:
                                mfmaInstr->aElementType);
       b = convertAndCastTensor(rewriter, b, newBEncoding,
                                mfmaInstr->bElementType);
-      newDot = rewriter.create<triton::DotScaledOp>(
-          dotOp.getLoc(), newAcc.getType(), a, b, newAcc, Value(), Value(),
-          aScaledElemTy.value(), bScaledElemTy.value(), /*fastMath=*/false);
+      newDot = triton::DotScaledOp::create(
+          rewriter, dotOp.getLoc(), newAcc.getType(), a, b, newAcc, Value(),
+          Value(), aScaledElemTy.value(), bScaledElemTy.value(),
+          /*fastMath=*/false);
     } else {
       auto newAEncoding =
           ttg::DotOperandEncodingAttr::get(ctx, 0, mfmaEnc, kWidth);
@@ -748,9 +749,9 @@ public:
                                mfmaInstr->aElementType);
       b = convertAndCastTensor(rewriter, b, newBEncoding,
                                mfmaInstr->bElementType);
-      newDot = rewriter.create<tt::DotOp>(dotOp.getLoc(), newAcc.getType(), a,
-                                          b, newAcc, dotOp.getInputPrecision(),
-                                          dotOp.getMaxNumImpreciseAcc());
+      newDot = tt::DotOp::create(rewriter, dotOp.getLoc(), newAcc.getType(), a,
+                                 b, newAcc, dotOp.getInputPrecision(),
+                                 dotOp.getMaxNumImpreciseAcc());
     }
 
     Value dotOutput =
@@ -859,8 +860,8 @@ public:
     auto newRetType = RankedTensorType::get(
         oldRetType.getShape(), oldRetType.getElementType(), mfmaEnc);
 
-    auto newAcc = rewriter.create<ttg::ConvertLayoutOp>(
-        dotOp.getC().getLoc(), newRetType, dotOp.getC());
+    auto newAcc = ttg::ConvertLayoutOp::create(rewriter, dotOp.getC().getLoc(),
+                                               newRetType, dotOp.getC());
 
     auto upcastForMMA = [&](TensorValue v, int idx,
                             ScaleDotElemType type) -> TensorValue {
@@ -869,7 +870,7 @@ public:
           ctx, idx, newRetType.getEncoding(), kWidths[idx]);
       auto newVType = RankedTensorType::get(
           vType.getShape(), vType.getElementType(), newVEncoding);
-      v = rewriter.create<ttg::ConvertLayoutOp>(v.getLoc(), newVType, v);
+      v = ttg::ConvertLayoutOp::create(rewriter, v.getLoc(), newVType, v);
       // Don't need to covert int8 holding mxfp4--the upcast_mxfp op can
       // take int8 tensor as input.
       if (type == ScaleDotElemType::BF16 || type == ScaleDotElemType::FP16 ||
@@ -881,7 +882,7 @@ public:
           useFp16 ? rewriter.getF16Type() : rewriter.getBF16Type(),
           newVEncoding);
       return cast<TensorValue>(
-          rewriter.create<FpToFpOp>(v.getLoc(), upcastedType, v).getResult());
+          FpToFpOp::create(rewriter, v.getLoc(), upcastedType, v).getResult());
     };
     a = upcastForMMA(a, 0, aElemType);
     b = upcastForMMA(b, 1, bElemType);
@@ -911,24 +912,24 @@ public:
       auto newScaleType = RankedTensorType::get(
           scale.getType().getShape(), scale.getType().getElementType(),
           newScaleEncoding);
-      auto convOp = rewriter.create<ttg::ConvertLayoutOp>(scale.getLoc(),
-                                                          newScaleType, scale);
+      auto convOp = ttg::ConvertLayoutOp::create(rewriter, scale.getLoc(),
+                                                 newScaleType, scale);
 
       Builder b(v.getContext());
       // TODO: Emit device assert to check scale tensor range fitting into fp16?
       Type outputElemType = useFp16 ? b.getF16Type() : b.getBF16Type();
       auto outputType =
           amdgpu::UpcastMXFPOp::deduceOutputType(v, elemType, outputElemType);
-      return rewriter.create<amdgpu::UpcastMXFPOp>(
-          dotOp.getLoc(), outputType, v, convOp, elemType, fastMath);
+      return amdgpu::UpcastMXFPOp::create(rewriter, dotOp.getLoc(), outputType,
+                                          v, convOp, elemType, fastMath);
     };
 
     Value scaledA =
         upcastMXFP(a, aScale, dotOp.getAElemType(), dotOp.getFastMath());
     Value scaledB =
         upcastMXFP(b, bScale, dotOp.getBElemType(), dotOp.getFastMath());
-    auto newDot = rewriter.create<DotOp>(dotOp.getLoc(), newRetType, scaledA,
-                                         scaledB, newAcc);
+    auto newDot = DotOp::create(rewriter, dotOp.getLoc(), newRetType, scaledA,
+                                scaledB, newAcc);
     rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(dotOp, oldRetType,
                                                       newDot);
     return success();
@@ -999,11 +1000,11 @@ public:
     // 4) Upcast with scale
     TensorValue result;
     if (isFp4) {
-      result = rewriter.create<triton::amdgpu::ScaledUpcastFp4Op>(
-          loc, scaleType16, v, reshapeScale, kDim);
+      result = triton::amdgpu::ScaledUpcastFp4Op::create(
+          rewriter, loc, scaleType16, v, reshapeScale, kDim);
     } else {
-      result = rewriter.create<triton::amdgpu::ScaledUpcastFp8Op>(
-          loc, scaleType16, v, reshapeScale);
+      result = triton::amdgpu::ScaledUpcastFp8Op::create(
+          rewriter, loc, scaleType16, v, reshapeScale);
     }
 
     // 5) If the scale is NaN, return NaN, else return the scaled value.
@@ -1101,8 +1102,8 @@ public:
     auto newRetType =
         RankedTensorType::get(oldShape, oldRetType.getElementType(), mfmaEnc);
 
-    auto newAcc = rewriter.create<ttg::ConvertLayoutOp>(
-        dotOp.getC().getLoc(), newRetType, dotOp.getC());
+    auto newAcc = ttg::ConvertLayoutOp::create(rewriter, dotOp.getC().getLoc(),
+                                               newRetType, dotOp.getC());
 
     auto order = ttg::getMatrixOrder(rank, /*rowMajor=*/true);
     auto standardOutDims = standardOutDimNames(ctx, rank);
@@ -1154,11 +1155,10 @@ public:
                 v.getContext(), newEnc, vType.getShape(), newOrder,
                 triton::gpu::getCTALayout(srcEncoding), vType.getElementType()),
             sharedMemorySpace);
-        auto tmp = builder.create<triton::gpu::LocalAllocOp>(dotOp.getLoc(),
-                                                             tmpType, v);
-        auto newConvert =
-            builder.create<triton::amdgpu::LocalLoadPackedTransposedOp>(
-                dotOp.getLoc(), newVType, tmp);
+        auto tmp = triton::gpu::LocalAllocOp::create(builder, dotOp.getLoc(),
+                                                     tmpType, v);
+        auto newConvert = triton::amdgpu::LocalLoadPackedTransposedOp::create(
+            builder, dotOp.getLoc(), newVType, tmp);
         if (opIdx == 0) {
           aShape = newConvert.getType().getShape();
           aEncLL *= newEnc.toLinearLayout(aShape);
@@ -1174,7 +1174,7 @@ public:
           bEncLL *= newEnc.toLinearLayout(bShape);
         auto newVType = RankedTensorType::get(vType.getShape(),
                                               vType.getElementType(), newEnc);
-        return rewriter.create<ttg::ConvertLayoutOp>(v.getLoc(), newVType, v);
+        return ttg::ConvertLayoutOp::create(rewriter, v.getLoc(), newVType, v);
       }
     };
     a = convertInputLayout(a, 0);
@@ -1207,12 +1207,12 @@ public:
 
       if (!scale) {
         // 0x7F is 1.0 in E8M0
-        return rewriter.create<arith::ConstantOp>(
-            dotOp->getLoc(), newScaleType,
+        return arith::ConstantOp::create(
+            rewriter, dotOp->getLoc(), newScaleType,
             DenseElementsAttr::get(newScaleType, llvm::APInt(8, 0x7F)));
       } else {
-        return rewriter.create<ttg::ConvertLayoutOp>(scale.getLoc(),
-                                                     newScaleType, scale);
+        return ttg::ConvertLayoutOp::create(rewriter, scale.getLoc(),
+                                            newScaleType, scale);
       }
     };
     auto newAScale =
@@ -1220,9 +1220,9 @@ public:
     auto newBScale =
         convertScaleLayout(bScale, bShape, bEncLL, /*dotOperandIdx=*/1);
 
-    auto newDot = rewriter.create<triton::DotScaledOp>(
-        dotOp.getLoc(), newRetType, a, b, newAcc, newAScale, newBScale,
-        aElemType, bElemType, dotOp.getFastMath());
+    auto newDot = triton::DotScaledOp::create(
+        rewriter, dotOp.getLoc(), newRetType, a, b, newAcc, newAScale,
+        newBScale, aElemType, bElemType, dotOp.getFastMath());
 
     rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(dotOp, oldRetType,
                                                       newDot);
@@ -1298,8 +1298,8 @@ public:
     auto newRetType =
         RankedTensorType::get(oldShape, oldRetType.getElementType(), wmmaEnc);
 
-    auto newAcc = rewriter.create<ttg::ConvertLayoutOp>(
-        dotOp.getC().getLoc(), newRetType, dotOp.getC());
+    auto newAcc = ttg::ConvertLayoutOp::create(rewriter, dotOp.getC().getLoc(),
+                                               newRetType, dotOp.getC());
 
     StringAttr kRegister = StringAttr::get(ctx, "register");
     StringAttr kLane = StringAttr::get(ctx, "lane");
@@ -1326,7 +1326,7 @@ public:
                                             vType.getElementType(), newEnc);
       (opIdx == 0 ? aEncLL : bEncLL) *=
           newEnc.toLinearLayout(opIdx == 0 ? aShape : bShape);
-      return rewriter.create<ttg::ConvertLayoutOp>(v.getLoc(), newVType, v);
+      return ttg::ConvertLayoutOp::create(rewriter, v.getLoc(), newVType, v);
     };
     a = convertInputLayout(a, 0, aElemType == ScaleDotElemType::E2M1);
     b = convertInputLayout(b, 1, bElemType == ScaleDotElemType::E2M1);
@@ -1353,12 +1353,12 @@ public:
 
       if (!scale) {
         // 0x7F is 1.0 in E8M0
-        return rewriter.create<arith::ConstantOp>(
-            dotOp->getLoc(), newScaleType,
+        return arith::ConstantOp::create(
+            rewriter, dotOp->getLoc(), newScaleType,
             DenseElementsAttr::get(newScaleType, llvm::APInt(8, 0x7F)));
       } else {
-        return rewriter.create<ttg::ConvertLayoutOp>(scale.getLoc(),
-                                                     newScaleType, scale);
+        return ttg::ConvertLayoutOp::create(rewriter, scale.getLoc(),
+                                            newScaleType, scale);
       }
     };
     auto newAScale =
@@ -1366,9 +1366,9 @@ public:
     auto newBScale =
         convertScaleLayout(bScale, bShape, bEncLL, /*dotOperandIdx=*/1);
 
-    auto newDot = rewriter.create<triton::DotScaledOp>(
-        dotOp.getLoc(), newRetType, a, b, newAcc, newAScale, newBScale,
-        aElemType, bElemType, dotOp.getFastMath());
+    auto newDot = triton::DotScaledOp::create(
+        rewriter, dotOp.getLoc(), newRetType, a, b, newAcc, newAScale,
+        newBScale, aElemType, bElemType, dotOp.getFastMath());
 
     auto m = dotOp->getParentOfType<ModuleOp>();
     rewriter.replaceOpWithNewOp<ttg::ConvertLayoutOp>(dotOp, oldRetType,
@@ -1382,7 +1382,7 @@ static Value promoteOperand(OpBuilder &builder, Location loc, Value operand,
                             Type promotedType) {
   Type tensorPromotedType = cast<RankedTensorType>(operand.getType())
                                 .cloneWith(std::nullopt, promotedType);
-  return builder.create<triton::FpToFpOp>(loc, tensorPromotedType, operand);
+  return triton::FpToFpOp::create(builder, loc, tensorPromotedType, operand);
 }
 
 // Promote operands of dot op if the existing combination is not natively
@@ -1572,8 +1572,8 @@ public:
                                          operandTypes[0]);
     Value castedB = convertAndCastTensor(rewriter, b, newBType.getEncoding(),
                                          operandTypes[1]);
-    auto newDot = rewriter.create<tt::DotOp>(
-        dotOp.getLoc(), newRetType, castedA, castedB, newAcc,
+    auto newDot = tt::DotOp::create(
+        rewriter, dotOp.getLoc(), newRetType, castedA, castedB, newAcc,
         dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
 
     Value dotOutput = convertAndCastTensor(rewriter, newDot, oldRetEncoding,
@@ -1612,12 +1612,12 @@ public:
         rmode =
             RoundingModeAttr::get(rewriter.getContext(), RoundingMode::RTNE);
       }
-      return rewriter.create<FpToFpOp>(loc, dstTy, v, rmode);
+      return FpToFpOp::create(rewriter, loc, dstTy, v, rmode);
     }
     if (!isFloat(srcElTy) && isFloat(dstElTy))
-      return rewriter.create<arith::SIToFPOp>(loc, dstTy, v);
+      return arith::SIToFPOp::create(rewriter, loc, dstTy, v);
     if (isFloat(srcElTy) && !isFloat(dstElTy))
-      return rewriter.create<arith::FPToSIOp>(loc, dstTy, v);
+      return arith::FPToSIOp::create(rewriter, loc, dstTy, v);
     assert(false && "int -> int cast is unexpected in FMA legalization");
     return Value();
   }
@@ -1687,9 +1687,9 @@ public:
     if (dotTypes.a.isF16() && dotTypes.b.isF16() && dotTypes.c.isF16() &&
         dotTypes.d.isF16() && k % 2 == 0) {
       auto newC = castToElTy(rewriter, dotOp.getC(), f32_ty);
-      auto newDot = rewriter.create<DotOp>(
-          dotOp.getLoc(), newC.getType(), dotOp.getA(), dotOp.getB(), newC,
-          dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
+      auto newDot = DotOp::create(
+          rewriter, dotOp.getLoc(), newC.getType(), dotOp.getA(), dotOp.getB(),
+          newC, dotOp.getInputPrecision(), dotOp.getMaxNumImpreciseAcc());
       auto newD = castToElTy(rewriter, newDot.getResult(), f16_ty);
       rewriter.replaceOp(dotOp, newD);
       return success();
@@ -1729,9 +1729,9 @@ public:
     auto newB = castToElTy(rewriter, dotOp.getB(), commonTy);
     auto newC = castToElTy(rewriter, dotOp.getC(), commonTy);
 
-    auto newDot = rewriter.create<DotOp>(dotOp.getLoc(), newC.getType(), newA,
-                                         newB, newC, dotOp.getInputPrecision(),
-                                         dotOp.getMaxNumImpreciseAcc());
+    auto newDot = DotOp::create(rewriter, dotOp.getLoc(), newC.getType(), newA,
+                                newB, newC, dotOp.getInputPrecision(),
+                                dotOp.getMaxNumImpreciseAcc());
     auto newD = castToElTy(rewriter, newDot.getResult(), dotTypes.d);
 
     rewriter.replaceOp(dotOp, newD);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -204,8 +204,8 @@ maybeGetOrCreateScalarConstant(RewriterBase &rewriter, Location loc, Value expr,
   if (auto constOp = dyn_cast_or_null<arith::ConstantOp>(op)) {
     Value val = constOp.getResult();
     if (matchPattern(val, m_Constant(&constVal)) && constVal.isSplat())
-      return rewriter.create<arith::ConstantOp>(
-          loc, constVal.getSplatValue<IntegerAttr>());
+      return arith::ConstantOp::create(rewriter, loc,
+                                       constVal.getSplatValue<IntegerAttr>());
   }
 
   // Check for block arguments
@@ -300,7 +300,7 @@ Value createAddUniformAndNonUniform(RewriterBase &rewriter, Location loc,
   auto castNonUniform = createCastOffset(rewriter, loc, nonUniform, resultTy);
 
   Value uniformSplat =
-      rewriter.create<tt::SplatOp>(loc, castNonUniform.getType(), castUniform);
+      tt::SplatOp::create(rewriter, loc, castNonUniform.getType(), castUniform);
 
   if (isTensorIntZero(nonUniform))
     return uniformSplat;
@@ -322,7 +322,7 @@ bool canNarrowOffset(Value baseOffset, Value addOffset) {
 Value createTensorZero(RewriterBase &rw, Location loc, RankedTensorType type) {
   mlir::Attribute zeroAttr = rw.getZeroAttr(type.getElementType());
   auto zeroDenseAttr = DenseElementsAttr::get(type, zeroAttr);
-  return rw.create<arith::ConstantOp>(loc, zeroDenseAttr);
+  return arith::ConstantOp::create(rw, loc, zeroDenseAttr);
 }
 
 std::pair<Value, Value>
@@ -361,22 +361,22 @@ createDecomposeOffsetFromMul(RewriterBase &rewriter, Location loc, Value expr,
   auto [uniformOffsetR, nonUniformOffsetR] = createDecomposeOffsetFromExpr(
       rewriter, loc, mulOp.getRhs(), bitness, scalarToSplatMap);
   Value uniformMul =
-      rewriter.create<arith::MulIOp>(loc, uniformOffsetL, uniformOffsetR);
+      arith::MulIOp::create(rewriter, loc, uniformOffsetL, uniformOffsetR);
 
-  Value uniformOffsetLSplat = rewriter.create<tt::SplatOp>(
-      loc, nonUniformOffsetL.getType(), uniformOffsetL);
-  Value uniformOffsetRSplat = rewriter.create<tt::SplatOp>(
-      loc, nonUniformOffsetR.getType(), uniformOffsetR);
+  Value uniformOffsetLSplat = tt::SplatOp::create(
+      rewriter, loc, nonUniformOffsetL.getType(), uniformOffsetL);
+  Value uniformOffsetRSplat = tt::SplatOp::create(
+      rewriter, loc, nonUniformOffsetR.getType(), uniformOffsetR);
 
-  Value nonUNonU =
-      rewriter.create<arith::MulIOp>(loc, nonUniformOffsetL, nonUniformOffsetR);
-  Value nonUU = rewriter.create<arith::MulIOp>(loc, uniformOffsetLSplat,
-                                               nonUniformOffsetR);
-  Value uNonU = rewriter.create<arith::MulIOp>(loc, nonUniformOffsetL,
-                                               uniformOffsetRSplat);
+  Value nonUNonU = arith::MulIOp::create(rewriter, loc, nonUniformOffsetL,
+                                         nonUniformOffsetR);
+  Value nonUU = arith::MulIOp::create(rewriter, loc, uniformOffsetLSplat,
+                                      nonUniformOffsetR);
+  Value uNonU = arith::MulIOp::create(rewriter, loc, nonUniformOffsetL,
+                                      uniformOffsetRSplat);
 
-  Value tmp = rewriter.create<arith::AddIOp>(loc, nonUNonU, nonUU);
-  Value nonUniformMul = rewriter.create<arith::AddIOp>(loc, tmp, uNonU);
+  Value tmp = arith::AddIOp::create(rewriter, loc, nonUNonU, nonUU);
+  Value nonUniformMul = arith::AddIOp::create(rewriter, loc, tmp, uNonU);
   return {uniformMul, nonUniformMul};
 }
 
@@ -397,7 +397,8 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
   // a tensor. Note that this means we won't be able to decompose across loop
   // boundaries (TODO: giuseros).
   if (llvm::isa<BlockArgument>(expr)) {
-    Value scalarZero = rewriter.create<arith::ConstantIntOp>(loc, 0, bitness);
+    Value scalarZero = arith::ConstantIntOp::create(
+        rewriter, loc, static_cast<int64_t>(0), bitness);
     return {scalarZero, expr};
   }
 
@@ -407,15 +408,15 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
           .Case<tt::BroadcastOp>([&](auto broadcastOp) {
             auto [uniform, nonUniform] = createDecomposeOffsetFromExpr(
                 rewriter, loc, broadcastOp.getSrc(), bitness, scalarToSplatMap);
-            auto broadcastNonUniform = rewriter.create<tt::BroadcastOp>(
-                loc, broadcastOp.getType(), nonUniform);
+            auto broadcastNonUniform = tt::BroadcastOp::create(
+                rewriter, loc, broadcastOp.getType(), nonUniform);
             return std::make_pair(uniform, broadcastNonUniform);
           })
           .Case<tt::ExpandDimsOp>([&](auto expandOp) {
             auto [uniform, nonUniform] = createDecomposeOffsetFromExpr(
                 rewriter, loc, expandOp.getSrc(), bitness, scalarToSplatMap);
-            auto expandNonUniform = rewriter.create<tt::ExpandDimsOp>(
-                loc, nonUniform, expandOp.getAxis());
+            auto expandNonUniform = tt::ExpandDimsOp::create(
+                rewriter, loc, nonUniform, expandOp.getAxis());
             return std::make_pair(uniform, expandNonUniform);
           })
           .Case<arith::AddIOp>([&](Operation *op) {
@@ -429,8 +430,8 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
           .Default([&](Operation *op) {
             // Base case 3: it is not a supported operation. We assume no
             // uniform part
-            Value scalarZero =
-                rewriter.create<arith::ConstantIntOp>(loc, 0, bitness);
+            Value scalarZero = arith::ConstantIntOp::create(
+                rewriter, loc, static_cast<int64_t>(0), bitness);
             return std::make_pair(scalarZero, expr);
           });
 
@@ -559,7 +560,7 @@ Value createTensorPointer(RewriterBase &rewriter, Value basePtr, Value offset,
   // Scalar case: we only need to `tt.addptr %basePtr, %offset`
   if (!tensorType) {
     auto addPtrOp =
-        rewriter.create<tt::AddPtrOp>(loc, basePtr.getType(), basePtr, offset);
+        tt::AddPtrOp::create(rewriter, loc, basePtr.getType(), basePtr, offset);
     for (const auto &attribute : fatPtrAttrs.attributes)
       addPtrOp->setAttr(attribute.getFirst(), attribute.getSecond());
     return addPtrOp.getResult();
@@ -578,9 +579,9 @@ Value createTensorPointer(RewriterBase &rewriter, Value basePtr, Value offset,
     offset = createTruncIOffset(rewriter, loc, offset, rewriter.getI32Type());
 
   tt::SplatOp tensorPtr =
-      rewriter.create<tt::SplatOp>(loc, tensorPtrType, basePtr);
+      tt::SplatOp::create(rewriter, loc, tensorPtrType, basePtr);
   tt::AddPtrOp addPtrOp =
-      rewriter.create<tt::AddPtrOp>(loc, tensorPtrType, tensorPtr, offset);
+      tt::AddPtrOp::create(rewriter, loc, tensorPtrType, tensorPtr, offset);
 
   for (const auto &attribute : fatPtrAttrs.attributes)
     addPtrOp->setAttr(attribute.getFirst(), attribute.getSecond());
@@ -664,8 +665,8 @@ public:
     RankedTensorType outType = splatOp.getResult().getType();
     auto newOffsetType = RankedTensorType::get(
         outType.getShape(), fatPtrOffset.getType(), outType.getEncoding());
-    tt::SplatOp offset = rewriter.create<tt::SplatOp>(
-        splatOp.getLoc(), newOffsetType, fatPtrOffset);
+    tt::SplatOp offset = tt::SplatOp::create(rewriter, splatOp.getLoc(),
+                                             newOffsetType, fatPtrOffset);
     rewriter.replaceOpWithMultiple(splatOp, {{fatPtrBase, offset}});
     fatPtrs[{fatPtrBase, offset}] = fatPtrs.at({fatPtrBase, fatPtrOffset});
 
@@ -704,8 +705,8 @@ public:
         dyn_cast<RankedTensorType>(broadcastOp.getResult().getType());
     auto newOffsetType = RankedTensorType::get(
         outType.getShape(), offsetType.getElementType(), outType.getEncoding());
-    tt::BroadcastOp newOffset = rewriter.create<tt::BroadcastOp>(
-        broadcastOp.getLoc(), newOffsetType, fatPtrOffset);
+    tt::BroadcastOp newOffset = tt::BroadcastOp::create(
+        rewriter, broadcastOp.getLoc(), newOffsetType, fatPtrOffset);
     rewriter.replaceOpWithMultiple(broadcastOp, {{fatPtrBase, newOffset}});
     fatPtrs[{fatPtrBase, newOffset}] = fatPtrs.at({fatPtrBase, fatPtrOffset});
     return success();
@@ -764,8 +765,8 @@ public:
     if (llvm::isa<tt::PointerType>(addPtrOp.getPtr().getType())) {
       assert(llvm::isa<IntegerType>(origOffset.getType()) &&
              "expected offset to be integer type");
-      auto newAddPtrOp = rewriter.create<tt::AddPtrOp>(
-          curLoc, fatPtrBase.getType(), fatPtrBase, origOffset);
+      auto newAddPtrOp = tt::AddPtrOp::create(
+          rewriter, curLoc, fatPtrBase.getType(), fatPtrBase, origOffset);
       doSetDiscardableAttrs(newAddPtrOp);
 
       rewriter.replaceOpWithMultiple(addPtrOp, {{newAddPtrOp, fatPtrOffset}});
@@ -780,8 +781,8 @@ public:
     // Early exit for the case of a constant tensor
     if (auto scalarConst =
             maybeGetOrCreateScalarConstant(rewriter, curLoc, origOffset)) {
-      tt::AddPtrOp newAddPtrOp = rewriter.create<tt::AddPtrOp>(
-          curLoc, fatPtrBase.getType(), fatPtrBase, *scalarConst);
+      tt::AddPtrOp newAddPtrOp = tt::AddPtrOp::create(
+          rewriter, curLoc, fatPtrBase.getType(), fatPtrBase, *scalarConst);
       doSetDiscardableAttrs(newAddPtrOp);
 
       rewriter.replaceOpWithMultiple(addPtrOp, {{newAddPtrOp, fatPtrOffset}});
@@ -797,8 +798,8 @@ public:
     auto [uniformOffset, nonUniformOffset] =
         createDecomposeOffsetFromExpr(rewriter, curLoc, origOffset, bitness);
 
-    auto newAddPtrOp = rewriter.create<tt::AddPtrOp>(
-        curLoc, fatPtrBase.getType(), fatPtrBase, uniformOffset);
+    auto newAddPtrOp = tt::AddPtrOp::create(
+        rewriter, curLoc, fatPtrBase.getType(), fatPtrBase, uniformOffset);
     doSetDiscardableAttrs(newAddPtrOp);
 
     // Vector offset update (if any): bump the tensor offset
@@ -1052,8 +1053,8 @@ public:
     auto slicedOffsetsTy = RankedTensorType::get(
         resultType.getShape(), fatPtrOffsetTy.getElementType(),
         resultType.getEncoding());
-    Value slicedOffsets = rewriter.create<tt::amdgpu::ExtractSliceOp>(
-        loc, Type{slicedOffsetsTy}, Value{fatPtrOffset},
+    Value slicedOffsets = tt::amdgpu::ExtractSliceOp::create(
+        rewriter, loc, Type{slicedOffsetsTy}, Value{fatPtrOffset},
         extractSliceOp.getStaticOffsetsAttr());
 
     rewriter.replaceOpWithMultiple(extractSliceOp,
@@ -1105,8 +1106,8 @@ public:
     }
 
     SmallVector<Value> initArgs = flattenValues(adaptor.getInitArgs());
-    auto newForOp = rewriter.create<scf::ForOp>(
-        forOp.getLoc(), getSingleValue(adaptor.getLowerBound()),
+    auto newForOp = scf::ForOp::create(
+        rewriter, forOp.getLoc(), getSingleValue(adaptor.getLowerBound()),
         getSingleValue(adaptor.getUpperBound()),
         getSingleValue(adaptor.getStep()), initArgs);
 
@@ -1239,7 +1240,7 @@ public:
             initArgs, [](Value v) { return !v.getType().isInteger(1); }),
         [](Value v) { return v.getType(); });
     auto newWhileOp =
-        rewriter.create<scf::WhileOp>(whileOp.getLoc(), resultTypes, initArgs);
+        scf::WhileOp::create(rewriter, whileOp.getLoc(), resultTypes, initArgs);
 
     newWhileOp->setAttrs(whileOp->getAttrs());
     rewriter.inlineRegionBefore(whileOp.getBefore(), newWhileOp.getBefore(),
@@ -1307,9 +1308,10 @@ public:
     SmallVector<Value> trueOperands = flattenValues(remappedTrueOperands);
     SmallVector<Value> falseOperands = flattenValues(remappedFalseOperands);
 
-    auto newOp = rewriter.create<cf::CondBranchOp>(
-        branchOp.getLoc(), branchOp.getCondition(), branchOp.getTrueDest(),
-        trueOperands, branchOp.getFalseDest(), falseOperands);
+    auto newOp = cf::CondBranchOp::create(
+        rewriter, branchOp.getLoc(), branchOp.getCondition(),
+        branchOp.getTrueDest(), trueOperands, branchOp.getFalseDest(),
+        falseOperands);
 
     convertSimpleBlockSignature(branchOp.getTrueDest(), remappedTrueOperands,
                                 rewriter, fatPtrs);
@@ -1350,9 +1352,9 @@ public:
     ValueRange fatPtrTrue = adaptor.getTrueValue();
     // Simple case of a scalar select: update the base pointer
     if (!isa<RankedTensorType>(selectOp.getType())) {
-      auto newSelectOp = rewriter.create<arith::SelectOp>(
-          selectOp.getLoc(), selectOp.getType(), selectOp.getCondition(),
-          fatPtrTrue[0], selectOp.getFalseValue());
+      auto newSelectOp = arith::SelectOp::create(
+          rewriter, selectOp.getLoc(), selectOp.getType(),
+          selectOp.getCondition(), fatPtrTrue[0], selectOp.getFalseValue());
       rewriter.replaceOpWithMultiple(selectOp, {{newSelectOp, fatPtrTrue[1]}});
       fatPtrs[{newSelectOp, /*fatPtrOffset*/ fatPtrTrue[1]}] =
           fatPtrs.at({fatPtrTrue[0], fatPtrTrue[1]});
@@ -1360,12 +1362,12 @@ public:
     }
 
     // Rewrite to select(fatBaseT, fatBaseF) and select(fatOffsetT, fatOffsetF)
-    auto newBase = rewriter.create<arith::SelectOp>(
-        selectOp.getLoc(), selectOp.getCondition(), fatPtrTrue[0],
-        fatPtrFalse[0]);
-    auto newOffset = rewriter.create<arith::SelectOp>(
-        selectOp.getLoc(), selectOp.getCondition(), fatPtrTrue[1],
-        fatPtrFalse[1]);
+    auto newBase = arith::SelectOp::create(rewriter, selectOp.getLoc(),
+                                           selectOp.getCondition(),
+                                           fatPtrTrue[0], fatPtrFalse[0]);
+    auto newOffset = arith::SelectOp::create(rewriter, selectOp.getLoc(),
+                                             selectOp.getCondition(),
+                                             fatPtrTrue[1], fatPtrFalse[1]);
 
     assert((fatPtrs.at({fatPtrTrue[0], fatPtrTrue[1]}) ==
             fatPtrs.at({fatPtrFalse[0], fatPtrFalse[1]})) &&
@@ -1433,9 +1435,9 @@ public:
     }
 #endif
 
-    auto newIfOp = rewriter.create<scf::IfOp>(
-        ifOp.getLoc(), ifOp.thenYield().getOperandTypes(), ifOp.getCondition(),
-        withElseRegion);
+    auto newIfOp = scf::IfOp::create(rewriter, ifOp.getLoc(),
+                                     ifOp.thenYield().getOperandTypes(),
+                                     ifOp.getCondition(), withElseRegion);
     rewriter.inlineBlockBefore(ifOp.thenBlock(), newIfOp.thenBlock(),
                                newIfOp.thenBlock()->begin());
     if (withElseRegion)
@@ -1487,8 +1489,8 @@ public:
     ArrayRef<ValueRange> remappedDestOperands = adaptor.getDestOperands();
     SmallVector<Value> trueOperands = flattenValues(remappedDestOperands);
 
-    auto newOp = rewriter.create<cf::BranchOp>(
-        branchOp.getLoc(), branchOp.getDest(), trueOperands);
+    auto newOp = cf::BranchOp::create(rewriter, branchOp.getLoc(),
+                                      branchOp.getDest(), trueOperands);
     convertSimpleBlockSignature(branchOp.getDest(), remappedDestOperands,
                                 rewriter, fatPtrs);
     rewriter.replaceOp(branchOp, newOp);
@@ -1523,8 +1525,9 @@ public:
         result.getShape(),
         llvm::cast<RankedTensorType>(fatPtrOffset.getType()).getElementType(),
         result.getEncoding());
-    auto newOffset = rewriter.create<tt::ExpandDimsOp>(
-        expandOp.getLoc(), newResult, fatPtrOffset, adaptor.getAxis());
+    auto newOffset =
+        tt::ExpandDimsOp::create(rewriter, expandOp.getLoc(), newResult,
+                                 fatPtrOffset, adaptor.getAxis());
     rewriter.replaceOpWithMultiple(expandOp, {{fatPtrBase, newOffset}});
     fatPtrs[{fatPtrBase, newOffset}] = fatPtrs.at({fatPtrBase, fatPtrOffset});
 
@@ -1564,9 +1567,8 @@ public:
     auto newOffsetType = RankedTensorType::get(outType.getShape(),
                                                offsetTensorTy.getElementType(),
                                                outType.getEncoding());
-    tt::gpu::ConvertLayoutOp cvtOffset =
-        rewriter.create<tt::gpu::ConvertLayoutOp>(cvtOp.getLoc(), newOffsetType,
-                                                  fatPtrOffset);
+    tt::gpu::ConvertLayoutOp cvtOffset = tt::gpu::ConvertLayoutOp::create(
+        rewriter, cvtOp.getLoc(), newOffsetType, fatPtrOffset);
     rewriter.replaceOpWithMultiple(cvtOp, {{fatPtrBase, cvtOffset}});
     fatPtrs[{fatPtrBase, cvtOffset}] = fatPtrs.at({fatPtrBase, fatPtrOffset});
 
@@ -1686,10 +1688,11 @@ struct InitFuncPtrArgs : OpRewritePattern<tt::FuncOp> {
         continue;
       }
 
-      Value zeroOffset =
-          rewriter.create<arith::ConstantIntOp>(newOp.getLoc(), 0, bitness);
-      auto dummyCast = rewriter.create<UnrealizedConversionCastOp>(
-          arg.getLoc(), TypeRange{arg.getType()}, ValueRange{arg, zeroOffset});
+      Value zeroOffset = arith::ConstantIntOp::create(
+          rewriter, newOp.getLoc(), static_cast<int64_t>(0), bitness);
+      auto dummyCast = UnrealizedConversionCastOp::create(
+          rewriter, arg.getLoc(), TypeRange{arg.getType()},
+          ValueRange{arg, zeroOffset});
       rewriter.replaceAllUsesExcept(arg, dummyCast.getResult(0), dummyCast);
       fatPtrs[{arg, zeroOffset}].canNarrow = true;
       if (bitness != 64)

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
@@ -199,7 +199,7 @@ struct CoalesceAsyncCopyWrites
     auto convertLayout = [&rewriter](auto loc, Value old, auto newEnc) {
       auto oldTy = cast<RankedTensorType>(old.getType());
       RankedTensorType newSrcTy = oldTy.cloneWithEncoding(newEnc);
-      return rewriter.create<ttg::ConvertLayoutOp>(loc, newSrcTy, old);
+      return ttg::ConvertLayoutOp::create(rewriter, loc, newSrcTy, old);
     };
 
     auto loc = copyOp->getLoc();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -480,15 +480,15 @@ struct ConvertTritonLoadToBufferLoad : public mlir::OpRewritePattern<SourceOp> {
 
       auto bufferLoadOp = [&]() {
         if constexpr (std::is_same_v<SourceOp, triton::LoadOp>) {
-          return rewriter.create<triton::amdgpu::BufferLoadOp>(
-              op->getLoc(), op.getType(), basePtr, tensorOffset, blockStride,
-              op.getCache(), maybeMask, maybeOther);
+          return triton::amdgpu::BufferLoadOp::create(
+              rewriter, op->getLoc(), op.getType(), basePtr, tensorOffset,
+              blockStride, op.getCache(), maybeMask, maybeOther);
         } else if constexpr (std::is_same_v<
                                  SourceOp,
                                  triton::gpu::AsyncCopyGlobalToLocalOp>) {
-          return rewriter.create<triton::amdgpu::BufferLoadToLocalOp>(
-              op->getLoc(), op.getType(), op.getResult(), basePtr, tensorOffset,
-              maybeMask, maybeOther, blockStride, op.getCache());
+          return triton::amdgpu::BufferLoadToLocalOp::create(
+              rewriter, op->getLoc(), op.getType(), op.getResult(), basePtr,
+              tensorOffset, maybeMask, maybeOther, blockStride, op.getCache());
         } else {
           static_assert(always_false<SourceOp>::value,
                         "Unsupported type in ConvertTritonLoadToBufferLoad");

--- a/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
@@ -62,7 +62,7 @@ void refineGlobalLoadLayout(PatternRewriter &rewriter, Attribute encoding,
     if (tensorType) {
       Type newType = replaceEncoding(tensorType, encoding);
       newArgs.push_back(
-          rewriter.create<ttg::ConvertLayoutOp>(loc, newType, operand));
+          ttg::ConvertLayoutOp::create(rewriter, loc, newType, operand));
     } else {
       newArgs.push_back(operand);
     }
@@ -70,7 +70,7 @@ void refineGlobalLoadLayout(PatternRewriter &rewriter, Attribute encoding,
 
   // Construct new load with the new encoding
   auto attrs = load->getAttrs();
-  auto newLoad = rewriter.create<tt::LoadOp>(loc, newArgs, attrs);
+  auto newLoad = tt::LoadOp::create(rewriter, loc, newArgs, attrs);
 
   // Cast the results back to the original layout
   auto loadType = load.getType();
@@ -96,11 +96,11 @@ void transposeInRegsitersBeforeStoreInLocalMemory(
   auto loc = memStoreOp->getLoc();
   auto newLoadType = replaceEncoding(data.getType(), newLoadEncoding);
   auto nonTransposed =
-      rewriter.create<ttg::ConvertLayoutOp>(loc, newLoadType, data);
+      ttg::ConvertLayoutOp::create(rewriter, loc, newLoadType, data);
 
   auto transposedType = replaceEncoding(data.getType(), transposedEncoding);
-  auto inThreadTransposed = rewriter.create<ttag::InThreadTransposeOp>(
-      loc, transposedType, nonTransposed);
+  auto inThreadTransposed = ttag::InThreadTransposeOp::create(
+      rewriter, loc, transposedType, nonTransposed);
   rewriter.startOpModification(memStoreOp);
   memStoreOp->setOperand(0, inThreadTransposed);
   rewriter.finalizeOpModification(memStoreOp);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeDotOperands.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeDotOperands.cpp
@@ -165,14 +165,14 @@ public:
     rewriter.setInsertionPointAfter(loadOp);
     auto sharedMemorySpace = ttg::SharedMemorySpaceAttr::get(ctx);
     Location loc = loadOp.getLoc();
-    auto alloc = rewriter.create<ttg::LocalAllocOp>(
-        loc,
+    auto alloc = ttg::LocalAllocOp::create(
+        rewriter, loc,
         ttg::MemDescType::get(srcTy.getShape(), srcTy.getElementType(),
                               sharedEnc, sharedMemorySpace),
         loadOp.getResult());
     LDBG("Created local alloc op: " << *alloc);
     auto localLoad =
-        rewriter.create<ttg::LocalLoadOp>(loc, directOperandType, alloc);
+        ttg::LocalLoadOp::create(rewriter, loc, directOperandType, alloc);
     LDBG("Created local load op:" << *localLoad);
     rewriter.modifyOpInPlace(
         directDot, [&]() { directDot->setOperand(opIdx, localLoad); });
@@ -270,14 +270,14 @@ public:
     Location loc = loadOp.getLoc();
     auto sharedMemorySpace = ttg::SharedMemorySpaceAttr::get(ctx);
     rewriter.setInsertionPointAfter(loadOp);
-    auto alloc = rewriter.create<ttg::LocalAllocOp>(
-        loc,
+    auto alloc = ttg::LocalAllocOp::create(
+        rewriter, loc,
         ttg::MemDescType::get(srcTy.getShape(), srcTy.getElementType(), attr,
                               sharedMemorySpace),
         loadOp.getResult());
     LDBG("Create alloc: " << alloc);
 
-    auto localLoad = rewriter.create<ttg::LocalLoadOp>(loc, srcTy, alloc);
+    auto localLoad = ttg::LocalLoadOp::create(rewriter, loc, srcTy, alloc);
     LDBG("Create localload: " << localLoad);
 
     rewriter.replaceAllUsesExcept(loadOp.getResult(), localLoad, alloc);

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -408,7 +408,7 @@ void init_triton_amd(py::module &&m) {
 
         llvm::Triple triple(amdTargetTriple);
         const llvm::Target *target =
-            llvm::TargetRegistry::lookupTarget(triple.normalize(), error);
+            llvm::TargetRegistry::lookupTarget(triple, error);
         if (!target)
           throw std::runtime_error("target lookup error: " + error);
 
@@ -467,7 +467,7 @@ void init_triton_amd(py::module &&m) {
     std::string error;
     llvm::Triple triple(amdTargetTriple);
     const llvm::Target *target =
-        llvm::TargetRegistry::lookupTarget(triple.normalize(), error);
+        llvm::TargetRegistry::lookupTarget(triple, error);
     if (!target)
       throw std::runtime_error("target lookup error: " + error);
     std::unique_ptr<llvm::MCSubtargetInfo> sti(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/Utility.h
@@ -63,7 +63,7 @@ public:
 
   template <typename OpTy, typename... Args>
   OpTy createWithAsyncTaskIds(Args &&...args) {
-    OpTy op = OpBuilder::create<OpTy>(std::forward<Args>(args)...);
+    OpTy op = OpTy::create(*this, std::forward<Args>(args)...);
     if (!asyncTaskIds.empty())
       setAsyncTaskIds(op, asyncTaskIds);
     return op;

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSBuffer.cpp
@@ -173,8 +173,8 @@ scf::IfOp rewriteIfOp(scf::IfOp ifOp, SmallVector<Operation *> &taskTopOps,
       assert(!enclosingAChannel(op, regionsWithChannels));
   } else {
     // Create an empty yield
-    auto yieldOp =
-        newIfOp.getElseBodyBuilder().create<scf::YieldOp>(ifOp.getLoc());
+    auto b = newIfOp.getElseBodyBuilder();
+    auto yieldOp = scf::YieldOp::create(b, ifOp.getLoc());
   }
 
   SmallVector<Value> elseYieldOperands = newIfOp.elseYield().getOperands();

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -1148,8 +1148,8 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     for (auto thenResult : thenYieldOp.getResults()) {
       newResultTypes.push_back(thenResult.getType());
     }
-    auto newIfOp = builder.create<scf::IfOp>(ifOp.getLoc(), newResultTypes,
-                                             ifOp.getCondition());
+    auto newIfOp = scf::IfOp::create(builder, ifOp.getLoc(), newResultTypes,
+                                     ifOp.getCondition());
     // Move the original regions to the cloned operation.
     newIfOp.getThenRegion().takeBody(ifOp.getThenRegion());
     newIfOp.getElseRegion().takeBody(ifOp.getElseRegion());

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerMem.cpp
@@ -158,8 +158,8 @@ static Value createBufferView(OpBuilderWithAsyncTaskIds &builder, Value alloc,
   auto viewDescType = triton::gpu::MemDescType::get(
       shape, allocDescType.getElementType(), allocDescType.getEncoding(),
       allocDescType.getMemorySpace(), allocDescType.getMutableMemory());
-  return builder.create<triton::gpu::MemDescIndexOp>(alloc.getLoc(),
-                                                     viewDescType, alloc, idx);
+  return triton::gpu::MemDescIndexOp::create(builder, alloc.getLoc(),
+                                             viewDescType, alloc, idx);
 }
 
 static int getTMALoadSize(tt::DescriptorLoadOp &tmaLoad) {

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -302,7 +302,7 @@ Operation *SpecializeForOp(scf::ForOp forOp, IRMapping &mapping,
   }
   if (createNewYield) {
     auto newYieldOp =
-        forBuilder.create<scf::YieldOp>(yieldOp.getLoc(), newYieldOperands);
+        scf::YieldOp::create(forBuilder, yieldOp.getLoc(), newYieldOperands);
     setAsyncTaskIds(newYieldOp, {asyncTaskId});
   }
 
@@ -396,8 +396,8 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
   ArrayRef<Type> dummyTypes;
   ImplicitLocOpBuilder impB(opList[0]->getLoc(), opList[0]);
   impB.setInsertionPoint(returnOp);
-  auto wsOp = impB.create<ttg::WarpSpecializeOp>(dummyTypes, partitionNumWarps,
-                                                 nTaskIds.size() - 1);
+  auto wsOp = ttg::WarpSpecializeOp::create(impB, dummyTypes, partitionNumWarps,
+                                            nTaskIds.size() - 1);
 
   // Clone all operations into the corresponding if blocks. If the operation
   // has multiple taskIds, it will be cloned for multiple if blocks.
@@ -415,7 +415,7 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
       SpecializeOp(op, mapping, taskBuilder, asyncTaskId);
     }
     SmallVector<Value> opnds;
-    taskBuilder.create<ttg::WarpYieldOp>(loc, opnds);
+    ttg::WarpYieldOp::create(taskBuilder, loc, opnds);
   }
 
   unsigned idx = 1;
@@ -433,7 +433,7 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
     for (Operation *op : opList) {
       SpecializeOp(op, mapping, taskBuilder, asyncTaskId);
     }
-    taskBuilder.create<ttg::WarpReturnOp>(loc);
+    ttg::WarpReturnOp::create(taskBuilder, loc);
     auto regAlloc =
         scanRegUsage(partitionBlock, asyncTaskId, requestedRegisters);
     estRegUsage.push_back(regAlloc);

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/PTXAsmFormat.h
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/PTXAsmFormat.h
@@ -32,7 +32,7 @@ struct PTXInstrExecution;
 // "b"(p));
 //
 // PTXBuilder builder;
-// auto& add = builder.create<>();
+// auto& add = ::create(builder, );
 // add.predicate(pVal).o("lo").o("u32"); // add any suffix
 // // predicate here binds %0 to pVal, pVal is a mlir::Value
 //

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/AssignStagePhase.cpp
@@ -324,13 +324,13 @@ template <class T> struct AssignStagePhase {
     b.setInsertionPointAfter(arefOp);
     auto depth =
         getArefDepth(cast<MemDescType>(arefOp.getOperand(0).getType()));
-    index.stage = b.create<arith::ConstantIntOp>(depth - 1, 32);
+    index.stage = arith::ConstantIntOp::create(b, depth - 1, 32);
 
     static_assert(std::is_same_v<T, ArefPutEnterOp> ||
                       std::is_same_v<T, ArefGetEnterOp>,
                   "ArefPutEnterOp or ArefGetEnterOp expected");
     auto initPhase = std::is_same_v<T, ArefPutEnterOp> ? 0 : 1;
-    index.phase = b.create<arith::ConstantIntOp>(initPhase, 32);
+    index.phase = arith::ConstantIntOp::create(b, initPhase, 32);
 
     for (auto partitionId : partitionIds) {
       // assign stage/phase to enter/exit Ops in each partition aref is used

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/InsertAref.cpp
@@ -153,15 +153,15 @@ void createNVWSDescriptorLoadOp(OpBuilder &builder, Operation *ttDescLoadOp,
                                 PartitionSet &partitions, Location loc) {
   auto txCount = getTxCount(ttDescLoadOp);
   if (auto descLoad = dyn_cast<triton::DescriptorLoadOp>(ttDescLoadOp)) {
-    auto newDescLoad = builder.create<triton::nvws::DescriptorLoadOp>(
-        loc, descLoad.getDesc(), descLoad.getIndices(), txCount, dataBuf,
-        descLoad.getCache(), descLoad.getEvict());
+    auto newDescLoad = triton::nvws::DescriptorLoadOp::create(
+        builder, loc, descLoad.getDesc(), descLoad.getIndices(), txCount,
+        dataBuf, descLoad.getCache(), descLoad.getEvict());
     newDescLoad->setAttrs(descLoad->getAttrs());
     setPartition(newDescLoad, producerPartition);
   } else if (auto descGather =
                  dyn_cast<triton::DescriptorGatherOp>(ttDescLoadOp)) {
-    auto newDescGather = builder.create<triton::nvws::DescriptorGatherOp>(
-        loc, descGather.getDesc(), descGather.getXOffsets(),
+    auto newDescGather = triton::nvws::DescriptorGatherOp::create(
+        builder, loc, descGather.getDesc(), descGather.getXOffsets(),
         descGather.getYOffset(), txCount, dataBuf);
     newDescGather->setAttrs(descGather->getAttrs());
     setPartition(newDescGather, producerPartition);

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -199,14 +199,14 @@ Value createBarriers(ImplicitLocOpBuilder &b1, ImplicitLocOpBuilder &b2,
   Value barrierAlloc = createScalarAlloc(b1, b1.getI64Type(), numBarriers);
   for (unsigned i = 0; i < numBarriers; i++) {
     Value barrierView = createSingleBufferView(b1, barrierAlloc, i);
-    b1.create<InitBarrierOp>(barrierView, arrivalCount);
+    InitBarrierOp::create(b1, barrierView, arrivalCount);
   }
   // Invalidate and deallocate the barriers.
   for (unsigned i = 0; i < numBarriers; i++) {
     Value barrierView = createSingleBufferView(b2, barrierAlloc, i);
-    b2.create<InvalBarrierOp>(barrierView);
+    InvalBarrierOp::create(b2, barrierView);
   }
-  b2.create<LocalDeallocOp>(barrierAlloc);
+  LocalDeallocOp::create(b2, barrierAlloc);
   return barrierAlloc;
 }
 
@@ -252,7 +252,7 @@ SmallVector<Value> getSubViews(ArefValue arefVal, Value stage, Location loc,
           tensorShape, memDescType.getElementType(), memDescType.getEncoding(),
           memDescType.getMemorySpace(), true);
       auto singleBuffer =
-          rewriter.create<MemDescIndexOp>(loc, memDescTypeNew, buffer, stage);
+          MemDescIndexOp::create(rewriter, loc, memDescTypeNew, buffer, stage);
       assignStageCluster(singleBuffer, partitionIds, stageCluster, rewriter);
       views.push_back(singleBuffer);
     }
@@ -266,10 +266,9 @@ void createTMALoad(triton::nvws::DescriptorLoadOp op, PatternRewriter &rewriter,
   auto indices = translateTMAIndices(
       rewriter, op.getLoc(),
       op.getDesc().getType().getBlockType().getEncoding(), op.getIndices());
-  auto newLoadOp =
-      rewriter.create<triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp>(
-          op.getLoc(), op.getDesc(), indices, barrierAlloc, op.getResult(),
-          pred);
+  auto newLoadOp = triton::nvidia_gpu::AsyncTMACopyGlobalToLocalOp::create(
+      rewriter, op.getLoc(), op.getDesc(), indices, barrierAlloc,
+      op.getResult(), pred);
   assignStageCluster(newLoadOp, getPartitionIds(op), getStageCluster(op),
                      rewriter);
 };
@@ -277,8 +276,8 @@ void createTMALoad(triton::nvws::DescriptorLoadOp op, PatternRewriter &rewriter,
 void createTMAGather(triton::nvws::DescriptorGatherOp op,
                      PatternRewriter &rewriter, Value barrierAlloc,
                      Value pred) {
-  auto newGatherOp = rewriter.create<triton::nvidia_gpu::AsyncTMAGatherOp>(
-      op.getLoc(), op.getDesc(), op.getXOffsets(), op.getYOffset(),
+  auto newGatherOp = triton::nvidia_gpu::AsyncTMAGatherOp::create(
+      rewriter, op.getLoc(), op.getDesc(), op.getXOffsets(), op.getYOffset(),
       barrierAlloc, op.getResult(), pred);
   assignStageCluster(newGatherOp, getPartitionIds(op), getStageCluster(op),
                      rewriter);
@@ -303,9 +302,9 @@ void lowerTMALoad(ArefPutEnterOp op, Value fullBarrier,
   if (loadOps.empty())
     return;
 
-  Value pred = rewriter.create<arith::ConstantIntOp>(loc, 1, 1);
-  auto expectOp = rewriter.create<triton::nvidia_gpu::BarrierExpectOp>(
-      loc, fullBarrier, txCount, pred);
+  Value pred = arith::ConstantIntOp::create(rewriter, loc, 1, 1);
+  auto expectOp = triton::nvidia_gpu::BarrierExpectOp::create(
+      rewriter, loc, fullBarrier, txCount, pred);
   assignStageCluster(expectOp, getPartitionIds(op), getStageCluster(op),
                      rewriter);
 
@@ -325,7 +324,7 @@ void lowerTMALoad(ArefPutEnterOp op, Value fullBarrier,
 
 void insertWaitOp(PatternRewriter &rewriter, Operation *op, Value barrier,
                   Value phase, Value stage) {
-  auto waitOp = rewriter.create<WaitBarrierOp>(op->getLoc(), barrier, phase);
+  auto waitOp = WaitBarrierOp::create(rewriter, op->getLoc(), barrier, phase);
   assignStageCluster(waitOp, getPartitionIds(op), getStageCluster(op),
                      rewriter);
 }
@@ -444,11 +443,11 @@ void insertArriveBarrier(Location loc, ArrayRef<AsyncOp> asyncOps,
     switch (asyncOpEnum) {
     case AsyncOp::NONE:
     case AsyncOp::WGMMA:
-      arriveOp = rewriter.create<nvidia_gpu::ArriveBarrierOp>(loc, mbar, 1);
+      arriveOp = nvidia_gpu::ArriveBarrierOp::create(rewriter, loc, mbar, 1);
       break;
     case AsyncOp::TC5MMA:
     case AsyncOp::TMEMCopy:
-      arriveOp = rewriter.create<nvidia_gpu::TCGen5CommitOp>(loc, mbar);
+      arriveOp = nvidia_gpu::TCGen5CommitOp::create(rewriter, loc, mbar);
       break;
     case AsyncOp::TMALoad:
       // nothing to do, the arrive is done by HW
@@ -497,7 +496,7 @@ void rewritePutExitOp(ArefPutExitOp op, PatternRewriter &rewriter,
   }();
 
   if (needFence) {
-    auto fence = rewriter.create<FenceAsyncSharedOp>(loc, /*bCluster=*/false);
+    auto fence = FenceAsyncSharedOp::create(rewriter, loc, /*bCluster=*/false);
     assignStageCluster(fence, getPartitionIds(op), stageCluster, rewriter);
   }
 
@@ -534,7 +533,7 @@ void rewriteGetExitOp(ArefGetExitOp op, PatternRewriter &rewriter,
   }();
 
   if (needFence) {
-    auto fence = rewriter.create<FenceAsyncSharedOp>(loc, /*bCluster=*/false);
+    auto fence = FenceAsyncSharedOp::create(rewriter, loc, /*bCluster=*/false);
     assignStageCluster(fence, getPartitionIds(op), stageCluster, rewriter);
   }
 
@@ -610,7 +609,7 @@ public:
     auto sorted = topologicalSort(opToDelete);
     OpBuilder b(op);
     auto replToken =
-        b.create<ub::PoisonOp>(op.getLoc(), b.getType<AsyncTokenType>());
+        ub::PoisonOp::create(b, op.getLoc(), b.getType<AsyncTokenType>());
     for (auto op : sorted) {
       if (auto enterOp = dyn_cast<ArefPutEnterOp>(op))
         enterOp.getToken().replaceAllUsesWith(replToken);
@@ -706,7 +705,7 @@ ExitOp createCombinedArefOps(SmallVector<EnterOp> &enterOps,
   }
 
   builder.setInsertionPointAfter(aref);
-  auto zero = builder.create<arith::ConstantIntOp>(aref.getLoc(), 0, 32);
+  auto zero = arith::ConstantIntOp::create(builder, aref.getLoc(), 0, 32);
 
   if (combinedEnterInsertPoint) {
     // Combined get enter must be placed after combined put enter
@@ -714,18 +713,18 @@ ExitOp createCombinedArefOps(SmallVector<EnterOp> &enterOps,
   } else {
     builder.setInsertionPoint(firstEnter);
   }
-  auto combinedEnter = builder.create<EnterOp>(
-      firstEnter.getLoc(), arefEnterBuffers, builder.getType<AsyncTokenType>(),
-      aref, zero, zero);
+  auto combinedEnter =
+      EnterOp::create(builder, firstEnter.getLoc(), arefEnterBuffers,
+                      builder.getType<AsyncTokenType>(), aref, zero, zero);
   assignStageCluster(combinedEnter, getPartitionIds(firstEnter),
                      getStageCluster(firstEnter), builder);
 
   builder.setInsertionPoint(lastExit);
   llvm::SmallVector<Attribute> AsyncOpAttrs(opAttrsSet.begin(),
                                             opAttrsSet.end());
-  auto combinedExit = builder.create<ExitOp>(
-      firstEnter.getLoc(), aref, combinedEnter.getToken(), zero,
-      builder.getArrayAttr(AsyncOpAttrs));
+  auto combinedExit = ExitOp::create(builder, firstEnter.getLoc(), aref,
+                                     combinedEnter.getToken(), zero,
+                                     builder.getArrayAttr(AsyncOpAttrs));
   assignStageCluster(combinedExit, getPartitionIds(lastExit),
                      getStageCluster(lastExit), builder);
 

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/Utilities.cpp
@@ -12,10 +12,10 @@ namespace mlir::triton::nvws {
 Operation *createAlloc(OpBuilder &builder, Location loc,
                        MemDescType memDescType, Value src) {
   if (isa<SharedMemorySpaceAttr>(memDescType.getMemorySpace())) {
-    return builder.create<LocalAllocOp>(loc, memDescType, src);
+    return LocalAllocOp::create(builder, loc, memDescType, src);
   } else {
     assert(isa<TensorMemorySpaceAttr>(memDescType.getMemorySpace()));
-    return builder.create<TMEMAllocOp>(loc, memDescType, src);
+    return TMEMAllocOp::create(builder, loc, memDescType, src);
   }
 }
 
@@ -23,7 +23,7 @@ ArefCreateOp createArefCreateOp(OpBuilder &builder, ArrayRef<Type> arefTypes,
                                 ValueRange allocOps, Location loc) {
   auto ctx = builder.getContext();
   auto arefTy = ArefType::get(ctx, TypeArrayAttr::get(ctx, arefTypes));
-  return builder.create<ArefCreateOp>(loc, arefTy, allocOps);
+  return ArefCreateOp::create(builder, loc, arefTy, allocOps);
 }
 
 int getArefDepth(MemDescType bufTy) {

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -212,10 +212,10 @@ public:
 
     // If this is inside a warp specialize op, compute the relative thread ID
     // within the warp group.
-    Value tid = rewriter.create<NVVM::ThreadIdXOp>(loc, i32_ty);
+    Value tid = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
     if (std::optional<int> startId =
             getWarpGroupStartThreadId(rewriter.getInsertionBlock()))
-      tid = rewriter.create<LLVM::SubOp>(loc, tid, b.i32_val(*startId));
+      tid = LLVM::SubOp::create(rewriter, loc, tid, b.i32_val(*startId));
 
     Value warpId = b.udiv(tid, b.i32_val(32));
     // This indicates to PTXAS that the result and its derived values are
@@ -233,15 +233,15 @@ class ClusterCTAIdOpPattern : public OpRewritePattern<ttn::ClusterCTAIdOp> {
   LogicalResult matchAndRewrite(ttn::ClusterCTAIdOp op,
                                 PatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    auto a0 = rewriter.create<NVVM::BlockInClusterIdXOp>(loc, i32_ty);
-    auto a1 = rewriter.create<NVVM::BlockInClusterIdYOp>(loc, i32_ty);
-    auto a2 = rewriter.create<NVVM::BlockInClusterIdZOp>(loc, i32_ty);
-    auto a3 = rewriter.create<NVVM::ClusterDimBlocksXOp>(loc, i32_ty);
-    auto a4 = rewriter.create<NVVM::ClusterDimBlocksYOp>(loc, i32_ty);
-    auto p1 = rewriter.create<LLVM::MulOp>(loc, a2, a4);
-    auto s1 = rewriter.create<LLVM::AddOp>(loc, a1, p1);
-    auto p2 = rewriter.create<LLVM::MulOp>(loc, s1, a3);
-    auto res = rewriter.create<LLVM::AddOp>(loc, a0, p2);
+    auto a0 = NVVM::BlockInClusterIdXOp::create(rewriter, loc, i32_ty);
+    auto a1 = NVVM::BlockInClusterIdYOp::create(rewriter, loc, i32_ty);
+    auto a2 = NVVM::BlockInClusterIdZOp::create(rewriter, loc, i32_ty);
+    auto a3 = NVVM::ClusterDimBlocksXOp::create(rewriter, loc, i32_ty);
+    auto a4 = NVVM::ClusterDimBlocksYOp::create(rewriter, loc, i32_ty);
+    auto p1 = LLVM::MulOp::create(rewriter, loc, a2, a4);
+    auto s1 = LLVM::AddOp::create(rewriter, loc, a1, p1);
+    auto p2 = LLVM::MulOp::create(rewriter, loc, s1, a3);
+    auto res = LLVM::AddOp::create(rewriter, loc, a0, p2);
     rewriter.replaceOp(op, res);
     return success();
   }
@@ -269,7 +269,7 @@ public:
     auto *addrOpr =
         ptxBuilder.newAddrOperand(op.getAddr(), "l", 0 /* in_off */);
     auto &ld =
-        ptxBuilder.create<>("ld")
+        ptxBuilder.create("ld")
             ->global()
             .o("cta", op.getScope() == triton::nvgpu::MemSyncScope::CTA)
             .o("gpu", op.getScope() == triton::nvgpu::MemSyncScope::GPU)
@@ -515,15 +515,15 @@ static Value createTMAlloc(IRRewriter &rewriter, LLVM::LLVMFuncOp func,
       "@$0 tcgen05.alloc.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
       ".sync.aligned.shared::cta.b32 [$1], " + std::to_string(size) + ";";
 
-  auto &allocOp = *ptxBuilder.create<>(ptxString);
+  auto &allocOp = *ptxBuilder.create(ptxString);
   allocOp(
       {ptxBuilder.newOperand(pred, "b"), ptxBuilder.newOperand(sharedMem, "r")},
       /*onlyAttachMLIRArgs=*/true);
   auto voidTy = void_ty(func->getContext());
   ptxBuilder.launch(rewriter, loc, void_ty(func->getContext()));
-  rewriter.create<NVVM::Barrier0Op>(loc);
+  NVVM::Barrier0Op::create(rewriter, loc);
   Value address = b.load(i32_ty, sharedMem);
-  rewriter.create<NVVM::Barrier0Op>(loc);
+  NVVM::Barrier0Op::create(rewriter, loc);
   address = b.inttoptr(ptr_ty(func.getContext(), 6), address);
   return address;
 }
@@ -533,7 +533,7 @@ static void createRelinquishAlloc(IRRewriter &rewriter, Location loc,
   PTXBuilder ptxBuilder;
   std::string ptxString = "@$0 tcgen05.relinquish_alloc_permit.cta_group::" +
                           std::to_string(twoCTAs ? 2 : 1) + ".sync.aligned;";
-  auto &f = *ptxBuilder.create<>(ptxString);
+  auto &f = *ptxBuilder.create(ptxString);
   f({ptxBuilder.newOperand(pred, "b")}, /*onlyAttachMLIRArgs=*/true);
   ptxBuilder.launch(rewriter, loc, void_ty(rewriter.getContext()));
 }
@@ -545,14 +545,14 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
     auto ctx = ret->getContext();
     auto loc = ret.getLoc();
     auto voidTy = void_ty(ctx);
-    b.create<NVVM::Barrier0Op>(loc);
+    NVVM::Barrier0Op::create(b, loc);
     PTXBuilder ptxBuilder;
     // Calculate the predicate in the inline asm to avoid creating long
     // liveranges.
     std::string ptxString =
         "@$0 tcgen05.dealloc.cta_group::" + std::to_string(twoCTAs ? 2 : 1) +
         ".sync.aligned.b32 $1, " + std::to_string(size) + ";";
-    auto &dealloc = *ptxBuilder.create<>(ptxString);
+    auto &dealloc = *ptxBuilder.create(ptxString);
     dealloc(
         {ptxBuilder.newOperand(pred, "b"), ptxBuilder.newOperand(alloc, "r")},
         /*onlyAttachMLIRArgs=*/true);
@@ -576,8 +576,8 @@ static Value initTensorMemory(LLVM::LLVMFuncOp func) {
   // A proper error will be raised by the frontend, but to allow compilation to
   // continue we emit a trap.
   if (size > 512) {
-    rewriter.create<LLVM::Trap>(loc);
-    return rewriter.create<LLVM::UndefOp>(loc, ptr_ty(ctx, 6));
+    LLVM::Trap::create(rewriter, loc);
+    return LLVM::UndefOp::create(rewriter, loc, ptr_ty(ctx, 6));
   }
 
   int numCTAs = triton::gpu::TritonGPUDialect::getNumCTAs(mod);
@@ -585,7 +585,7 @@ static Value initTensorMemory(LLVM::LLVMFuncOp func) {
   // should be fine for now.
   bool useTwoCTAs = numCTAs == 2;
   // This code is only executed by the default warp group.
-  Value threadId = rewriter.create<NVVM::ThreadIdXOp>(loc, i32_ty);
+  Value threadId = NVVM::ThreadIdXOp::create(rewriter, loc, i32_ty);
   Value pred = b.icmp_ult(threadId, b.i32_val(32));
   Value alloc = createTMAlloc(rewriter, func, size, pred, useTwoCTAs);
   createRelinquishAlloc(rewriter, loc, pred, useTwoCTAs);
@@ -658,7 +658,7 @@ nvgpu::rewriteAsPtxAsm(Operation *op, PatternRewriter &rewriter,
       getPtxOperands(operandsAndConstraints, ptxBuilder, loc, rewriter);
   SmallVector<PTXBuilder::Operand *> outputsAndOperands = ptxOutputs;
   outputsAndOperands.append(ptxOperands.begin(), ptxOperands.end());
-  auto &ptxInstr = *ptxBuilder.create<PTXInstr>(ptxAsm);
+  auto &ptxInstr = *ptxBuilder.create(ptxAsm);
   ptxInstr(outputsAndOperands, /*onlyAttachMLIRArgs=*/true);
   auto retTy =
       op->getNumResults() == 0 ? void_ty(ctx) : op->getResult(0).getType();

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -71,7 +71,7 @@ struct InitBarrierOpConversion
     ::mlir::triton::PTXBuilder ptxBuilder;
     const std::string ptx = "@$0 mbarrier.init.shared::cta.b64 [$1], " +
                             std::to_string(op.getCount()) + ";";
-    auto &barSyncOp = *ptxBuilder.create<>(ptx);
+    auto &barSyncOp = *ptxBuilder.create(ptx);
     barSyncOp({ptxBuilder.newOperand(pred, "b"),
                ptxBuilder.newOperand(smemObj.getBase(), "r")},
               /*onlyAttachMLIRArgs=*/true);
@@ -100,7 +100,7 @@ struct InvalBarrierOpConversion
     Value pred = b.icmp_eq(id, b.i32_val(0));
     ::mlir::triton::PTXBuilder ptxBuilder;
     const std::string ptx = "@$0 mbarrier.inval.shared::cta.b64 [$1];";
-    auto &barSyncOp = *ptxBuilder.create<>(ptx);
+    auto &barSyncOp = *ptxBuilder.create(ptx);
     barSyncOp({ptxBuilder.newOperand(pred, "b"),
                ptxBuilder.newOperand(smemObj.getBase(), "r")},
               /*onlyAttachMLIRArgs=*/true);
@@ -132,7 +132,7 @@ struct BarrierExpectConversion
     const std::string ptx =
         "@$0 mbarrier.arrive.expect_tx.shared.b64 _, [$1], " +
         std::to_string(op.getSize()) + ";";
-    auto &barSyncOp = *ptxBuilder.create<>(ptx);
+    auto &barSyncOp = *ptxBuilder.create(ptx);
     barSyncOp({ptxBuilder.newOperand(pred, "b"),
                ptxBuilder.newOperand(smemObj.getBase(), "r")},
               /*onlyAttachMLIRArgs=*/true);
@@ -211,7 +211,7 @@ struct WaitBarrierOpConversion
       }
     }
     ::mlir::triton::PTXBuilder ptxBuilder;
-    auto &waitLoop = *ptxBuilder.create<>(ptx);
+    auto &waitLoop = *ptxBuilder.create(ptx);
     SmallVector<::mlir::triton::PTXBuilder::Operand *, 3> operands = {
         ptxBuilder.newOperand(smemObj.getBase(), "r"),
         ptxBuilder.newOperand(adaptor.getPhase(), "r")};
@@ -252,7 +252,7 @@ struct ArriveBarrierOpConversion
         ptxBuilder.newOperand(pred, "b"),
         ptxBuilder.newOperand(adaptor.getAlloc(), "r")};
 
-    auto arriveOp = *ptxBuilder.create<>(ptxAsm.str());
+    auto arriveOp = *ptxBuilder.create(ptxAsm.str());
     arriveOp(operands, /*onlyAttachMLIRArgs=*/true);
     auto voidTy = void_ty(getContext());
     ptxBuilder.launch(rewriter, op.getLoc(), voidTy);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -322,8 +322,8 @@ private:
     }
 
     // Cluster barrier
-    rewriter.create<triton::nvidia_gpu::ClusterArriveOp>(loc, false);
-    rewriter.create<triton::nvidia_gpu::ClusterWaitOp>(loc);
+    triton::nvidia_gpu::ClusterArriveOp::create(rewriter, loc, false);
+    triton::nvidia_gpu::ClusterWaitOp::create(rewriter, loc);
 
     // Load from remote shared memory
     {
@@ -362,8 +362,8 @@ private:
     }
 
     // Cluster barrier
-    rewriter.create<triton::nvidia_gpu::ClusterArriveOp>(loc, false);
-    rewriter.create<triton::nvidia_gpu::ClusterWaitOp>(loc);
+    triton::nvidia_gpu::ClusterArriveOp::create(rewriter, loc, false);
+    triton::nvidia_gpu::ClusterWaitOp::create(rewriter, loc);
 
     return success();
   }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM.cpp
@@ -149,29 +149,29 @@ struct WarpGroupDotWaitOpConversion
     }
     auto packedType =
         LLVM::LLVMStructType::getLiteral(rewriter.getContext(), types);
-    Value packed = rewriter.create<LLVM::UndefOp>(loc, packedType);
+    Value packed = LLVM::UndefOp::create(rewriter, loc, packedType);
     unsigned outputStructIndex = 0;
     for (Value input : inputs) {
       for (auto [i, type] : llvm::enumerate(
                cast<LLVM::LLVMStructType>(input.getType()).getBody())) {
-        Value value = rewriter.create<LLVM::ExtractValueOp>(loc, input, i);
-        packed = rewriter.create<LLVM::InsertValueOp>(
-            loc, packedType, packed, value, outputStructIndex++);
+        Value value = LLVM::ExtractValueOp::create(rewriter, loc, input, i);
+        packed = LLVM::InsertValueOp::create(rewriter, loc, packedType, packed,
+                                             value, outputStructIndex++);
       }
     }
-    Value packedOutput =
-        rewriter.create<triton::nvgpu::WGMMAWaitGroupOp>(loc, packed, pendings);
+    Value packedOutput = triton::nvgpu::WGMMAWaitGroupOp::create(
+        rewriter, loc, packed, pendings);
     // Unpack the output into the original struct types.
     SmallVector<Value> outputs;
     outputStructIndex = 0;
     for (Type type : inputs.getTypes()) {
       auto structType = cast<LLVM::LLVMStructType>(type);
-      Value unpacked = rewriter.create<LLVM::UndefOp>(loc, structType);
+      Value unpacked = LLVM::UndefOp::create(rewriter, loc, structType);
       for (auto [i, type] : llvm::enumerate(structType.getBody())) {
-        Value value = rewriter.create<LLVM::ExtractValueOp>(
-            loc, packedOutput, outputStructIndex++);
-        unpacked = rewriter.create<LLVM::InsertValueOp>(loc, structType,
-                                                        unpacked, value, i);
+        Value value = LLVM::ExtractValueOp::create(rewriter, loc, packedOutput,
+                                                   outputStructIndex++);
+        unpacked = LLVM::InsertValueOp::create(rewriter, loc, structType,
+                                               unpacked, value, i);
       }
       outputs.push_back(unpacked);
     }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAHelpers.h
@@ -130,7 +130,7 @@ public:
       bases[kWarp][1] = {0, 0};
       auto warpGroupToOffsetb128 = LinearLayout(
           bases, warpToOffset.getOutDims(), /*requireSurjective=*/false);
-      Value warpId = rewriter.create<nvgpu::WarpIdOp>(loc);
+      Value warpId = nvgpu::WarpIdOp::create(rewriter, loc);
       Value warpStrideb128 =
           applyLinearLayout(loc, rewriter, warpGroupToOffsetb128,
                             {{kWarp, warpId}})[0]

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv2.cpp
@@ -44,7 +44,7 @@ Value loadC(Value tensor, Value llTensor,
     int numCPackedElem = 4 / numMmaRets;
     Type cPackTy = vec_ty(cElemTy, numCPackedElem);
     for (int i = 0; i < fcSize; i += numCPackedElem) {
-      Value pack = rewriter.create<LLVM::UndefOp>(loc, cPackTy);
+      Value pack = LLVM::UndefOp::create(rewriter, loc, cPackTy);
       for (int j = 0; j < numCPackedElem; ++j) {
         pack = b.insert_element(cPackTy, pack,
                                 b.extract_val(cElemTy, llTensor, i + j),

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -354,7 +354,7 @@ struct FpToFpOpConversion
   static Value convertFp16ToFp32(Location loc,
                                  ConversionPatternRewriter &rewriter,
                                  const Value &v) {
-    return rewriter.create<LLVM::FPExtOp>(loc, f32_ty, v);
+    return LLVM::FPExtOp::create(rewriter, loc, f32_ty, v);
   }
 
   static Value convertFp32ToBf16(Location loc,
@@ -608,7 +608,7 @@ struct SIToFPOpConversion
       assert(outVals.size() == 4);
       return outVals;
     } else {
-      return {rewriter.create<LLVM::SIToFPOp>(loc, elemTy, operands[0][0])};
+      return {LLVM::SIToFPOp::create(rewriter, loc, elemTy, operands[0][0])};
     }
   }
 
@@ -627,7 +627,7 @@ struct FPToSIOpConversion
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
     auto inElemTy = getElementType(op.getIn());
-    return {rewriter.create<LLVM::FPToSIOp>(loc, elemTy, operands[0][0])};
+    return {LLVM::FPToSIOp::create(rewriter, loc, elemTy, operands[0][0])};
   }
 };
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -116,7 +116,7 @@ Value createCachePolicy(triton::EvictionPolicy opEvict,
 
   if (hasL2EvictPolicy && hardwareSupport) {
     auto &policy =
-        ptxBuilder.create<>("createpolicy.fractional")
+        ptxBuilder.create("createpolicy.fractional")
             ->o("L2::evict_first",
                 opEvict == triton::EvictionPolicy::EVICT_FIRST)
             .o("L2::evict_last", opEvict == triton::EvictionPolicy::EVICT_LAST)
@@ -307,7 +307,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
         for (size_t ii = 0; ii < nWords; ++ii) {
           // PTX doesn't support mov.u8, so we need to use mov.u16
           PTXInstr &mov =
-              ptxBuilder.create<>("mov")->o("u" + std::to_string(movWidth));
+              ptxBuilder.create("mov")->o("u" + std::to_string(movWidth));
 
           size_t size = width / valueElemNBits;
 
@@ -344,7 +344,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
           createCachePolicy(op.getEvict(), rewriter, loc, computeCapability);
 
       // Define the instruction opcode
-      auto &ld = ptxBuilder.create<>("ld")
+      auto &ld = ptxBuilder.create("ld")
                      ->o("volatile", op.getIsVolatile())
                      .global()
                      .o("ca", op.getCache() == triton::CacheModifier::CA)
@@ -531,7 +531,7 @@ struct StoreOpConversion : public ConvertOpToLLVMPattern<triton::StoreOp>,
           createCachePolicy(op.getEvict(), rewriter, loc, computeCapability);
 
       auto &ptxStoreInstr =
-          ptxBuilder.create<>("st")
+          ptxBuilder.create("st")
               ->global()
               .o("wb", op.getCache() == triton::CacheModifier::WB)
               .o("cg", op.getCache() == triton::CacheModifier::CG)
@@ -570,8 +570,8 @@ void createBarrier(ConversionPatternRewriter &rewriter, Location loc,
   if (numCTAs == 1) {
     b.barrier();
   } else {
-    rewriter.create<triton::nvidia_gpu::ClusterArriveOp>(loc, false);
-    rewriter.create<triton::nvidia_gpu::ClusterWaitOp>(loc);
+    triton::nvidia_gpu::ClusterArriveOp::create(rewriter, loc, false);
+    triton::nvidia_gpu::ClusterWaitOp::create(rewriter, loc);
   }
 }
 
@@ -636,7 +636,7 @@ struct AtomicCASOpConversion
       auto *ptrOpr = ptxBuilderAtomicCAS.newAddrOperand(casPtr, "l");
       auto *cmpOpr = ptxBuilderAtomicCAS.newOperand(casCmp, tyId);
       auto *valOpr = ptxBuilderAtomicCAS.newOperand(casVal, tyId);
-      auto &atom = *ptxBuilderAtomicCAS.create<PTXInstr>("atom");
+      auto &atom = *ptxBuilderAtomicCAS.create("atom");
       auto sTy = "b" + std::to_string(valueElemNBits);
       std::string semStr;
       llvm::raw_string_ostream os(semStr);
@@ -662,7 +662,7 @@ struct AtomicCASOpConversion
         PTXBuilder ptxBuilderStore;
         auto *dstOprStore = ptxBuilderStore.newAddrOperand(atomPtr, "r");
         auto *valOprStore = ptxBuilderStore.newOperand(old, tyId);
-        auto &st = *ptxBuilderStore.create<PTXInstr>("st");
+        auto &st = *ptxBuilderStore.create("st");
         st.shared().o(sTy);
         st(dstOprStore, valOprStore).maybePredicate(threadPred);
         auto ASMReturnTy = void_ty(ctx);
@@ -845,8 +845,8 @@ public:
       if (doPTXLDPromotion) {
         Type convertedValueTy =
             getTypeConverter()->convertType(getElementTypeOrSelf(op.getType()));
-        auto loadAcquireOp = rewriter.create<triton::nvgpu::LoadAcquireOp>(
-            op.getLoc(), convertedValueTy, rmwPtr, pred,
+        auto loadAcquireOp = triton::nvgpu::LoadAcquireOp::create(
+            rewriter, op.getLoc(), convertedValueTy, rmwPtr, pred,
             op.getSem() == triton::MemSemantic::ACQUIRE
                 ? triton::nvgpu::MemSemantic::ACQUIRE
                 : triton::nvgpu::MemSemantic::RELAXED,
@@ -895,23 +895,22 @@ public:
                             ? nullptr
                             : LLVM::getSharedMemoryBase(
                                   loc, rewriter, targetInfo, op.getOperation());
-        rewriter.create<LLVM::CondBrOp>(loc, pred, atomicBlock, endBlock,
-                                        undefVal);
+        LLVM::CondBrOp::create(rewriter, loc, pred, atomicBlock, endBlock,
+                               undefVal);
 
         // Codegen the atomic-rmw instruction(s)
         rewriter.setInsertionPointToEnd(atomicBlock);
-        Value atom = rewriter
-                         .create<LLVM::AtomicRMWOp>(
-                             loc, *llvmAtomicBinOp, rmwPtr, valElements[i],
-                             *llvmAtomicMemOrdering, StringRef("device"))
-                         .getResult();
+        Value atom =
+            LLVM::AtomicRMWOp::create(rewriter, loc, *llvmAtomicBinOp, rmwPtr,
+                                      valElements[i], *llvmAtomicMemOrdering,
+                                      StringRef("device"))
+                .getResult();
         // Handle the 2 bf16 case
         if (packed == 2 && valueElemNBits == 16) {
-          Value atom2 = rewriter
-                            .create<LLVM::AtomicRMWOp>(
-                                loc, *llvmAtomicBinOp, ptrElements[i + 1],
-                                valElements[i + 1], *llvmAtomicMemOrdering,
-                                StringRef("device"))
+          Value atom2 = LLVM::AtomicRMWOp::create(
+                            rewriter, loc, *llvmAtomicBinOp, ptrElements[i + 1],
+                            valElements[i + 1], *llvmAtomicMemOrdering,
+                            StringRef("device"))
                             .getResult();
           auto vecTy = vec_ty(valueElemTy, vec);
           auto tmp =
@@ -921,7 +920,7 @@ public:
 
         if (tensorTy) {
           // Return from predicated block
-          rewriter.create<LLVM::BrOp>(loc, atom, endBlock);
+          LLVM::BrOp::create(rewriter, loc, atom, endBlock);
 
           // Recover values from predicated block
           rewriter.setInsertionPointToStart(endBlock);
@@ -940,7 +939,7 @@ public:
           }
         } else {
           if (!doesAtomicNeedMEM) {
-            rewriter.create<LLVM::BrOp>(loc, atom, endBlock);
+            LLVM::BrOp::create(rewriter, loc, atom, endBlock);
             rewriter.eraseOp(op);
             // if type isn't a tensor and there is no need to write to SMEM then
             // we are done here
@@ -952,7 +951,7 @@ public:
           // Note: there is no need to use the BlockArgument here because
           //       the value is recovered from SMEM in the !tensorTy case
           b.store(atom, atomPtr);
-          rewriter.create<LLVM::BrOp>(loc, atom, endBlock);
+          LLVM::BrOp::create(rewriter, loc, atom, endBlock);
 
           // Recover values from predicated block (from SMEM)
           rewriter.setInsertionPointToStart(endBlock);
@@ -1002,7 +1001,7 @@ public:
       }
 
       auto scope = stringifyMemSyncScope(op.getScope()).str();
-      auto &atom = ptxBuilderAtomicRMW.create<>("atom")->global().o(scope);
+      auto &atom = ptxBuilderAtomicRMW.create("atom")->global().o(scope);
       auto rmwOp = stringifyRMWOp(atomicRmwAttr).str();
       auto sBits = std::to_string(valueElemNBits);
       switch (atomicRmwAttr) {
@@ -1153,7 +1152,7 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto structTy =
         LLVM::LLVMStructType::getLiteral(ctx, ArrayRef<Type>{ptrTy, i1_ty});
     for (int i = 0; i < srcElems.size(); i++) {
-      Value packedArr = rewriter.create<LLVM::UndefOp>(loc, structTy);
+      Value packedArr = LLVM::UndefOp::create(rewriter, loc, structTy);
       packedArr = b.insert_val(packedArr, srcElems[i], 0);
       auto maskElem = llMask ? maskElems[i] : b.false_val();
       packedArr = b.insert_val(packedArr, maskElem, 1);
@@ -1257,9 +1256,9 @@ struct AsyncCopyGlobalToLocalOpConversion
         warpId, rewriter, targetInfo, maxVec, emitCpAsync);
 
     // Drop the result token.
-    Value zero = rewriter.create<LLVM::ConstantOp>(
-        op.getLoc(), IntegerType::get(op.getContext(), 32),
-        rewriter.getI32IntegerAttr(0));
+    Value zero = LLVM::ConstantOp::create(rewriter, op.getLoc(),
+                                          IntegerType::get(op.getContext(), 32),
+                                          rewriter.getI32IntegerAttr(0));
     rewriter.replaceOp(op, zero);
     return success();
   }
@@ -1338,7 +1337,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto mod = op->getParentOfType<ModuleOp>();
     int numWarps = ttg::lookupNumWarps(op);
     int warpSize = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
-    Value warpID = rewriter.create<nvgpu::WarpIdOp>(loc);
+    Value warpID = nvgpu::WarpIdOp::create(rewriter, loc);
     Value pred = adaptor.getPred();
     // Select just one thread for the TMA copy. This also helps the compiler to
     // figure out that the op is uniform.
@@ -1364,7 +1363,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     auto kBlock = str_attr("block");
     const auto numCopies = msgToOffset.getInDimSize(kMsg);
     auto zero = b.i32_val(0);
-    auto ctaId = rewriter.create<nvgpu::ClusterCTAIdOp>(loc);
+    auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
 
     // The bounding box inner dimension must be less than or equal to the
     // swizzle size.
@@ -1409,7 +1408,7 @@ struct AsyncTMACopyGlobalToLocalOpConversion
           ptxBuilderTMA.newOperand(barrierMemObj.getBase(), "r"));
       tmaInst += "}], [$" + std::to_string(operandIdx++) + "];";
 
-      auto &tma = *ptxBuilderTMA.create<>(tmaInst);
+      auto &tma = *ptxBuilderTMA.create(tmaInst);
       tma(operands, /*onlyAttachMLIRArgs=*/true);
       ptxBuilderTMA.launch(rewriter, loc, voidTy);
     }
@@ -1440,7 +1439,7 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
   auto mod = op->getParentOfType<ModuleOp>();
   int numWarps = ttg::lookupNumWarps(op);
   int warpSize = ttg::TritonGPUDialect::getThreadsPerWarp(mod);
-  Value warpID = rewriter.create<nvgpu::WarpIdOp>(loc);
+  Value warpID = nvgpu::WarpIdOp::create(rewriter, loc);
   auto shapePerCTA = ttg::getShapePerCTA(srcTy);
   int elementsPerCTA = product(shapePerCTA);
 
@@ -1457,7 +1456,7 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
   auto kBlock = str_attr("block");
   auto numCopies = msgToOffset.getInDimSize(kMsg);
   auto zero = b.i32_val(0);
-  auto ctaId = rewriter.create<nvgpu::ClusterCTAIdOp>(loc);
+  auto ctaId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
 
   for (int copyIdx = 0; copyIdx < numCopies; copyIdx += numWarps) {
     int numWarpsToCopy = std::min(numCopies - copyIdx, numWarps);
@@ -1487,14 +1486,14 @@ LogicalResult convertTMAStoreLikeOp(Operation *op,
       operands.push_back(ptxBuilderTMA.newOperand(coord, "r"));
     }
     operands.push_back(ptxBuilderTMA.newOperand(shMemPtr, "r"));
-    auto &tma = *ptxBuilderTMA.create<>(tmaInst);
+    auto &tma = *ptxBuilderTMA.create(tmaInst);
     tma(operands, /*onlyAttachMLIRArgs=*/true);
     ptxBuilderTMA.launch(rewriter, loc, voidTy);
   }
 
   // TODO: Separate the syncronizations operations into separate TTGIR ops to
   // be able to schedule them at the high level.
-  rewriter.create<NVVM::CpAsyncBulkCommitGroupOp>(loc);
+  NVVM::CpAsyncBulkCommitGroupOp::create(rewriter, loc);
 
   rewriter.eraseOp(op);
   return success();
@@ -1650,8 +1649,8 @@ static LogicalResult iterateGatherScatterIndices(
   if (freeVars[kLane] != (threadsPerWarp - 1))
     return op->emitError("x offsets must be broadcasted across each warp");
 
-  Value warpId = rewriter.create<nvgpu::WarpIdOp>(loc);
-  Value blockId = rewriter.create<nvgpu::ClusterCTAIdOp>(loc);
+  Value warpId = nvgpu::WarpIdOp::create(rewriter, loc);
+  Value blockId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
 
   // Mask out warps with redundant x offsets.
   pred = b.and_(pred,
@@ -1733,7 +1732,7 @@ LogicalResult AsyncTMAGatherOpConversion::matchAndRewrite(
       operands.push_back(ptxBuilder.newOperand(xOffset, "r"));
     operands.push_back(ptxBuilder.newOperand(barrierMemObj.getBase(), "r"));
 
-    auto &tma = *ptxBuilder.create<>(tmaInst);
+    auto &tma = *ptxBuilder.create(tmaInst);
     tma(operands, /*attachOnlyMLIRArgs=*/true);
     ptxBuilder.launch(rewriter, loc, voidTy);
   };
@@ -1784,7 +1783,7 @@ LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
       operands.push_back(ptxBuilder.newOperand(xOffset, "r"));
     operands.push_back(ptxBuilder.newOperand(shMemPtr, "r"));
 
-    auto &tma = *ptxBuilder.create<>(tmaInst);
+    auto &tma = *ptxBuilder.create(tmaInst);
     tma(operands, /*attachOnlyMLIRArgs=*/true);
     ptxBuilder.launch(rewriter, loc, voidTy);
   };
@@ -1797,7 +1796,7 @@ LogicalResult AsyncTMAScatterOpConversion::matchAndRewrite(
 
   // TODO: Separate the syncronizations operations into separate TTGIR ops to
   // be able to schedule them at the high level.
-  rewriter.create<NVVM::CpAsyncBulkCommitGroupOp>(loc);
+  NVVM::CpAsyncBulkCommitGroupOp::create(rewriter, loc);
 
   rewriter.eraseOp(op);
   return success();
@@ -1818,8 +1817,8 @@ struct AsyncCopyMbarrierArriveOpConversion
         typeConverter->convertType(op.getBarrier().getType().getElementType()),
         rewriter);
     TritonLLVMOpBuilder b(loc, rewriter);
-    rewriter.create<NVVM::CpAsyncMBarrierArriveSharedOp>(
-        loc, barrierMemObj.getBase(), noinc);
+    NVVM::CpAsyncMBarrierArriveSharedOp::create(rewriter, loc,
+                                                barrierMemObj.getBase(), noinc);
     op->erase();
     return success();
   }
@@ -1835,7 +1834,7 @@ struct AsyncWaitOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto num = op->getAttrOfType<IntegerAttr>("num");
-    rewriter.create<NVVM::CpAsyncWaitGroupOp>(loc, num);
+    NVVM::CpAsyncWaitGroupOp::create(rewriter, loc, num);
 
     // Drop the result token.
     TritonLLVMOpBuilder b(loc, rewriter);
@@ -1853,7 +1852,7 @@ struct AsyncCommitGroupOpConversion
   matchAndRewrite(triton::gpu::AsyncCommitGroupOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
-    rewriter.create<NVVM::CpAsyncCommitGroupOp>(loc);
+    NVVM::CpAsyncCommitGroupOp::create(rewriter, loc);
 
     // Drop the result token.
     TritonLLVMOpBuilder b(loc, rewriter);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PTXAsmFormat.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/PTXAsmFormat.cpp
@@ -99,12 +99,12 @@ mlir::Value PTXBuilder::launch(OpBuilder &rewriter, Location loc, Type resTy,
                                bool hasSideEffect, bool isAlignStack,
                                ArrayRef<Attribute> attrs) const {
   auto *ctx = rewriter.getContext();
-  auto inlineAsm = rewriter.create<LLVM::InlineAsmOp>(
-      loc, resTy, getAllMLIRArgs(), // operands
-      dump(),                       // asm_string
-      getConstraints(),             // constraints
-      hasSideEffect,                // has_side_effects
-      isAlignStack,                 // is_align_stack
+  auto inlineAsm = LLVM::InlineAsmOp::create(
+      rewriter, loc, resTy, getAllMLIRArgs(), // operands
+      dump(),                                 // asm_string
+      getConstraints(),                       // constraints
+      hasSideEffect,                          // has_side_effects
+      isAlignStack,                           // is_align_stack
       LLVM::TailCallKind::None,
       LLVM::AsmDialectAttr::get(ctx,
                                 LLVM::AsmDialect::AD_ATT), // asm_dialect

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/SPMDOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/SPMDOpToLLVM.cpp
@@ -12,20 +12,20 @@ static Value getNumPrograms(OpBuilder &rewriter, int numCTAs, Location loc,
   if (numCTAs == 1) {
     switch (axis) {
     case ProgramIDDim::X:
-      return rewriter.create<NVVM::GridDimXOp>(loc, i32_ty);
+      return NVVM::GridDimXOp::create(rewriter, loc, i32_ty);
     case ProgramIDDim::Y:
-      return rewriter.create<NVVM::GridDimYOp>(loc, i32_ty);
+      return NVVM::GridDimYOp::create(rewriter, loc, i32_ty);
     case ProgramIDDim::Z:
-      return rewriter.create<NVVM::GridDimZOp>(loc, i32_ty);
+      return NVVM::GridDimZOp::create(rewriter, loc, i32_ty);
     }
   } else {
     switch (axis) {
     case ProgramIDDim::X:
-      return rewriter.create<NVVM::ClusterDimXOp>(loc, i32_ty);
+      return NVVM::ClusterDimXOp::create(rewriter, loc, i32_ty);
     case ProgramIDDim::Y:
-      return rewriter.create<NVVM::ClusterDimYOp>(loc, i32_ty);
+      return NVVM::ClusterDimYOp::create(rewriter, loc, i32_ty);
     case ProgramIDDim::Z:
-      return rewriter.create<NVVM::ClusterDimZOp>(loc, i32_ty);
+      return NVVM::ClusterDimZOp::create(rewriter, loc, i32_ty);
     }
   }
   llvm_unreachable("invalid axis");

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TMAToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TMAToLLVM.cpp
@@ -31,9 +31,8 @@ void tensormap_cp_fenceproxy(Location loc, MLIRContext *ctx,
   auto *sizeOpr = ptxBuilder.newConstantOperand(TMA_SIZE_BYTES);
 
   // Define the instruction opcode
-  auto &cp =
-      *ptxBuilder.create<>("tensormap.cp_fenceproxy.global.shared::cta."
-                           "tensormap::generic.release.gpu.sync.aligned");
+  auto &cp = *ptxBuilder.create("tensormap.cp_fenceproxy.global.shared::cta."
+                                "tensormap::generic.release.gpu.sync.aligned");
 
   // Execute collectively on first warp in block
   constexpr int kWarpSize = 32;
@@ -56,7 +55,7 @@ void tensormap_replace_generic(Location loc, MLIRContext *ctx,
   auto newValOpr = ptxBuilder.newConstantOperand(newVal);
 
   // Define the instruction opcode
-  auto &replace = ptxBuilder.create<>("tensormap.replace.tile")
+  auto &replace = ptxBuilder.create("tensormap.replace.tile")
                       ->o(fieldName)
                       .o("shared::cta")
                       .o("b1024")
@@ -95,7 +94,7 @@ void tensormap_replace_generic(Location loc, MLIRContext *ctx,
   newValOpr = ptxBuilder.newOperand(newVal, constraint);
 
   // Define the instruction opcode
-  auto &replace = ptxBuilder.create<>("tensormap.replace.tile")
+  auto &replace = ptxBuilder.create("tensormap.replace.tile")
                       ->o(fieldName)
                       .o("shared::cta")
                       .o("b1024")
@@ -203,14 +202,14 @@ struct TensormapFenceproxyAcquireOpConversion
     Value threadId = getThreadId(rewriter, loc);
     Value pred = b.icmp_slt(threadId, b.i32_val(kWarpSize));
     auto &fence =
-        *ptxBuilder.create<>("fence.proxy.tensormap::generic.acquire.gpu");
+        *ptxBuilder.create("fence.proxy.tensormap::generic.acquire.gpu");
     fence(descAddrOpr, sizeOpr).predicate(pred);
 
     // Workaround for a ptxas bug missing a fence after generic.acquire.gpu.
     // TODO: remove the workaround once ptxas is fixed.
-    auto &commit = *ptxBuilder.create<>("cp.async.bulk.commit_group");
+    auto &commit = *ptxBuilder.create("cp.async.bulk.commit_group");
     commit().predicate(pred);
-    auto &wait = *ptxBuilder.create<>("cp.async.bulk.wait_group.read 0");
+    auto &wait = *ptxBuilder.create("cp.async.bulk.wait_group.read 0");
     wait().predicate(pred);
 
     ptxBuilder.launch(rewriter, loc, getVoidType());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -28,8 +28,8 @@ LLVM::LLVMFuncOp getVprintfDeclaration(RewriterBase &rewriter) {
   RewriterBase::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(moduleOp.getBody());
 
-  return rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(context), funcName,
-                                           funcType);
+  return LLVM::LLVMFuncOp::create(rewriter, UnknownLoc::get(context), funcName,
+                                  funcType);
 }
 
 // extend integer to int32, extend float to float64
@@ -74,8 +74,8 @@ LLVM::LLVMFuncOp getAssertfailDeclaration(RewriterBase &rewriter) {
   auto funcType = LLVM::LLVMFunctionType::get(void_ty(ctx), argsType);
   RewriterBase::InsertionGuard guard(rewriter);
   rewriter.setInsertionPointToStart(moduleOp.getBody());
-  auto funcOp = rewriter.create<LLVM::LLVMFuncOp>(UnknownLoc::get(ctx),
-                                                  funcName, funcType);
+  auto funcOp = LLVM::LLVMFuncOp::create(rewriter, UnknownLoc::get(ctx),
+                                         funcName, funcType);
 
   funcOp.setPassthroughAttr(
       ArrayAttr::get(ctx, StringAttr::get(ctx, "noreturn")));
@@ -130,23 +130,23 @@ bool TargetInfo::supportMaximumMinimum() const {
 }
 
 Value TargetInfo::getClusterCTAId(RewriterBase &rewriter, Location loc) const {
-  return rewriter.create<triton::nvgpu::ClusterCTAIdOp>(loc,
-                                                        rewriter.getI32Type());
+  return triton::nvgpu::ClusterCTAIdOp::create(rewriter, loc,
+                                               rewriter.getI32Type());
 }
 
 Value TargetInfo::ballot(RewriterBase &rewriter, Location loc, Type type,
                          Value cmp) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   Value threadMask = b.int_val(type.getIntOrFloatBitWidth(), -1);
-  return rewriter.create<NVVM::VoteSyncOp>(loc, type, threadMask, cmp,
-                                           NVVM::VoteSyncKind::ballot);
+  return NVVM::VoteSyncOp::create(rewriter, loc, type, threadMask, cmp,
+                                  NVVM::VoteSyncKind::ballot);
 }
 
 void TargetInfo::barrier(Location loc, RewriterBase &rewriter,
                          bool isWarpSync) const {
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   if (isWarpSync) {
-    rewriter.create<NVVM::SyncWarpOp>(loc, b.i32_val(0xffffffff));
+    NVVM::SyncWarpOp::create(rewriter, loc, b.i32_val(0xffffffff));
   } else {
     b.barrier();
   }
@@ -154,7 +154,7 @@ void TargetInfo::barrier(Location loc, RewriterBase &rewriter,
 
 static Value mapa(RewriterBase &rewriter, Location loc, Value ptr, Value ctaid,
                   Value pred) {
-  return rewriter.create<NVVM::MapaOp>(loc, ptr.getType(), ptr, ctaid);
+  return NVVM::MapaOp::create(rewriter, loc, ptr.getType(), ptr, ctaid);
 }
 
 static std::string getConstraintForBitwidth(unsigned bitwidth) {
@@ -275,7 +275,7 @@ void TargetInfo::storeDShared(RewriterBase &rewriter, Location loc, Value ptr,
   }
 
   PTXBuilder builder;
-  auto st = builder.create<>("st")
+  auto st = builder.create("st")
                 ->o("shared::cta", ctaId.has_value())
                 .o("shared", !ctaId.has_value())
                 .v(vec, /*predicate=*/vec > 1)
@@ -393,7 +393,7 @@ Value TargetInfo::loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
   }
 
   PTXBuilder builder;
-  auto ld = builder.create<>("ld")
+  auto ld = builder.create("ld")
                 ->o("shared::cta", ctaId.has_value())
                 .o("shared", !ctaId.has_value())
                 .v(vec, /*predicate=*/vec > 1)
@@ -491,9 +491,9 @@ bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
               acc[i] = b.zext(i32_ty, acc[i]);
           }
         }
-        acc[i] = rewriter.create<NVVM::ReduxOp>(loc, acc[i].getType(), acc[0],
-                                                *kind, mask, /*abs=*/false,
-                                                /*nan=*/useNanQualifier);
+        acc[i] = NVVM::ReduxOp::create(rewriter, loc, acc[i].getType(), acc[0],
+                                       *kind, mask, /*abs=*/false,
+                                       /*nan=*/useNanQualifier);
         if (acc[i].getType().isInteger()) {
           if (bitwidth < 32)
             acc[i] = b.trunc(int_ty(bitwidth), acc[i]);
@@ -540,8 +540,8 @@ void TargetInfo::printf(RewriterBase &rewriter, Value formatStrStart,
 
     Type structTy = LLVM::LLVMStructType::getLiteral(ctx, argTypes);
     auto allocated =
-        rewriter.create<LLVM::AllocaOp>(loc, ptr_ty(ctx), structTy, one,
-                                        /*alignment=*/0);
+        LLVM::AllocaOp::create(rewriter, loc, ptr_ty(ctx), structTy, one,
+                               /*alignment=*/0);
 
     for (const auto &entry : llvm::enumerate(newArgs)) {
       auto index = b.i32_val(entry.index());

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -215,8 +215,8 @@ private:
     // Ask for 16B alignment on global_smem because that's the largest we should
     // ever need (4xi32).
     auto arrayTy = LLVM::LLVMArrayType::get(elemTy, 0);
-    b.create<LLVM::GlobalOp>(
-        loc, arrayTy, /*isConstant=*/false, LLVM::Linkage::External,
+    LLVM::GlobalOp::create(
+        b, loc, arrayTy, /*isConstant=*/false, LLVM::Linkage::External,
         "global_smem", /*value=*/Attribute(), /*alignment=*/16,
         // Add ROCm support.
         static_cast<unsigned>(NVVM::NVVMMemorySpace::Shared));

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -35,8 +35,8 @@ static Value shuffleCommonImpl(Location loc, RewriterBase &rewriter, Value val,
       val = b.zext(i32_ty, val);
   }
   Value mask = b.i32_val(0xFFFFFFFF);
-  Value result = rewriter.create<NVVM::ShflOp>(loc, i32_ty, mask, val, i, clamp,
-                                               mode, UnitAttr());
+  Value result = NVVM::ShflOp::create(rewriter, loc, i32_ty, mask, val, i,
+                                      clamp, mode, UnitAttr());
   if (type != i32_ty) {
     if (bits < 32)
       result = b.trunc(int_ty(bits), result);
@@ -94,20 +94,20 @@ Value llGetPid(Location loc, RewriterBase &rewriter, ModuleOp moduleOp,
   if (numCTAs == 1) {
     switch (axis) {
     case ProgramIDDim::X:
-      return rewriter.create<NVVM::BlockIdXOp>(loc, i32_ty);
+      return NVVM::BlockIdXOp::create(rewriter, loc, i32_ty);
     case ProgramIDDim::Y:
-      return rewriter.create<NVVM::BlockIdYOp>(loc, i32_ty);
+      return NVVM::BlockIdYOp::create(rewriter, loc, i32_ty);
     case ProgramIDDim::Z:
-      return rewriter.create<NVVM::BlockIdZOp>(loc, i32_ty);
+      return NVVM::BlockIdZOp::create(rewriter, loc, i32_ty);
     }
   } else {
     switch (axis) {
     case ProgramIDDim::X:
-      return rewriter.create<NVVM::ClusterIdXOp>(loc, i32_ty);
+      return NVVM::ClusterIdXOp::create(rewriter, loc, i32_ty);
     case ProgramIDDim::Y:
-      return rewriter.create<NVVM::ClusterIdYOp>(loc, i32_ty);
+      return NVVM::ClusterIdYOp::create(rewriter, loc, i32_ty);
     case ProgramIDDim::Z:
-      return rewriter.create<NVVM::ClusterIdZOp>(loc, i32_ty);
+      return NVVM::ClusterIdZOp::create(rewriter, loc, i32_ty);
     }
   }
   llvm_unreachable("invalid axis");
@@ -123,12 +123,13 @@ Value permute(Location loc, RewriterBase &rewriter, Value a, Value b,
 
 /// Create a predicate with just single active thread.
 Value createElectPredicate(Location loc, RewriterBase &rewriter) {
-  return rewriter.create<NVVM::ElectSyncOp>(loc, i1_ty, /*membermask=*/Value());
+  return NVVM::ElectSyncOp::create(rewriter, loc, i1_ty,
+                                   /*membermask=*/Value());
 }
 
 void createSyncWarp(Location loc, OpBuilder &rewriter) {
   TritonLLVMOpBuilder b(loc, rewriter);
-  rewriter.create<NVVM::SyncWarpOp>(loc, b.i32_val(0xffffffff));
+  NVVM::SyncWarpOp::create(rewriter, loc, b.i32_val(0xffffffff));
 }
 
 Value createElectPredicateWarp0(Location loc, RewriterBase &rewriter) {
@@ -383,8 +384,8 @@ LogicalResult lowerLdStMatrix(
           }
           inputs.push_back(b.bitcast(input, i32_ty));
         }
-        rewriter.create<NVVM::StMatrixOp>(loc, vecAddr, inputs, layout, shape,
-                                          eltType);
+        NVVM::StMatrixOp::create(rewriter, loc, vecAddr, inputs, layout, shape,
+                                 eltType);
       } else {
         unsigned numLdMatrix = elemsPerInstr / elemsPerVec;
         assert(numLdMatrix > 0 &&
@@ -394,9 +395,8 @@ LogicalResult lowerLdStMatrix(
                 ? i32_ty
                 : static_cast<Type>(LLVM::LLVMStructType::getLiteral(
                       ctx, SmallVector<Type>(numLdMatrix, i32_ty)));
-        auto res = rewriter
-                       .create<NVVM::LdMatrixOp>(loc, ldResultTy, vecAddr, vec,
-                                                 layout, shape, eltType)
+        auto res = NVVM::LdMatrixOp::create(rewriter, loc, ldResultTy, vecAddr,
+                                            vec, layout, shape, eltType)
                        .getResult();
         // Extract result into srcVals
         for (int j = 0; j < elemsPerInstr / elemsPerVec; j++) {

--- a/third_party/nvidia/unittest/Conversion/TritonGPUToLLVM/PTXAsmFormatTest.cpp
+++ b/third_party/nvidia/unittest/Conversion/TritonGPUToLLVM/PTXAsmFormatTest.cpp
@@ -24,10 +24,10 @@ protected:
     builder.setInsertionPointToStart(&block);
 
     // a b1 value for predicate.
-    v[0] = builder.create<arith::ConstantIntOp>(builder.getUnknownLoc(), 1, 1);
+    v[0] = arith::ConstantIntOp::create(builder, builder.getUnknownLoc(), 1, 1);
     for (int i = 0; i < numValues; i++) {
       v[i + 1] =
-          builder.create<arith::ConstantIntOp>(builder.getUnknownLoc(), i, 32);
+          arith::ConstantIntOp::create(builder, builder.getUnknownLoc(), i, 32);
     }
   }
 

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/PatternProtonGPUOpToLLVM.cpp
@@ -21,22 +21,22 @@ Value getLinearId(Location loc, ConversionPatternRewriter &rewriter) {
   // to support various backend intrinsics (e.g. amd).
   // 2. We avoid using the targetInfo's programId() because of its coupling
   // with cluster id in Nvidia TritonGPU's llvm lowering.
-  Value pidX = rewriter.create<arith::IndexCastOp>(
-      loc, i64_ty,
-      rewriter.create<mlir::gpu::BlockIdOp>(loc, mlir::gpu::Dimension::x));
-  Value pidY = rewriter.create<arith::IndexCastOp>(
-      loc, i64_ty,
-      rewriter.create<mlir::gpu::BlockIdOp>(loc, mlir::gpu::Dimension::y));
-  Value pidZ = rewriter.create<arith::IndexCastOp>(
-      loc, i64_ty,
-      rewriter.create<mlir::gpu::BlockIdOp>(loc, mlir::gpu::Dimension::z));
+  Value pidX = arith::IndexCastOp::create(
+      rewriter, loc, i64_ty,
+      mlir::gpu::BlockIdOp::create(rewriter, loc, mlir::gpu::Dimension::x));
+  Value pidY = arith::IndexCastOp::create(
+      rewriter, loc, i64_ty,
+      mlir::gpu::BlockIdOp::create(rewriter, loc, mlir::gpu::Dimension::y));
+  Value pidZ = arith::IndexCastOp::create(
+      rewriter, loc, i64_ty,
+      mlir::gpu::BlockIdOp::create(rewriter, loc, mlir::gpu::Dimension::z));
 
-  Value gridDimX = rewriter.create<arith::IndexCastOp>(
-      loc, i64_ty,
-      rewriter.create<::mlir::gpu::GridDimOp>(loc, mlir::gpu::Dimension::x));
-  Value gridDimY = rewriter.create<arith::IndexCastOp>(
-      loc, i64_ty,
-      rewriter.create<::mlir::gpu::GridDimOp>(loc, mlir::gpu::Dimension::y));
+  Value gridDimX = arith::IndexCastOp::create(
+      rewriter, loc, i64_ty,
+      ::mlir::gpu::GridDimOp::create(rewriter, loc, mlir::gpu::Dimension::x));
+  Value gridDimY = arith::IndexCastOp::create(
+      rewriter, loc, i64_ty,
+      ::mlir::gpu::GridDimOp::create(rewriter, loc, mlir::gpu::Dimension::y));
   Value linearId =
       b.trunc(i32_ty, b.add(b.add(pidX, b.mul(pidY, gridDimX)),
                             b.mul(pidZ, b.mul(gridDimX, gridDimY))));
@@ -144,9 +144,9 @@ struct InitializeOpConversion
     // Add the 'else' block and the condition.
     Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
-    rewriter.create<cf::CondBranchOp>(loc, isFirstThread, ifBlock, thenBlock);
+    cf::CondBranchOp::create(rewriter, loc, isFirstThread, ifBlock, thenBlock);
     rewriter.setInsertionPointToEnd(ifBlock);
-    rewriter.create<cf::BranchOp>(loc, thenBlock);
+    cf::BranchOp::create(rewriter, loc, thenBlock);
 
     rewriter.eraseOp(op);
     return success();
@@ -249,7 +249,7 @@ struct FinalizeOpConversion
     // Add the 'else' block and the condition.
     Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
-    rewriter.create<cf::CondBranchOp>(loc, isFirstThread, ifBlock, thenBlock);
+    cf::CondBranchOp::create(rewriter, loc, isFirstThread, ifBlock, thenBlock);
 
     // Write back the data.
     const int upper = bufferSizeInWords - wordsPerEntry;
@@ -272,11 +272,11 @@ struct FinalizeOpConversion
     copyWord(bufCounterOffset, gmemWbCounterOffset, memSpace);
     Value pred = b.icmp_slt(idx, b.i32_val(upper));
     Value updatedIdx = b.add(idx, b.i32_val(wordsPerEntry));
-    rewriter.create<cf::CondBranchOp>(loc, pred, writeBackBlock, updatedIdx,
-                                      thenBlock, ArrayRef<Value>());
+    cf::CondBranchOp::create(rewriter, loc, pred, writeBackBlock, updatedIdx,
+                             thenBlock, ArrayRef<Value>());
 
     rewriter.setInsertionPointToEnd(ifBlock);
-    rewriter.create<cf::BranchOp>(loc, writeBackBlock, initIdx);
+    cf::BranchOp::create(rewriter, loc, writeBackBlock, initIdx);
 
     writeBackPostFinalTime(b, rewriter, op, isFirstThread, scratchPtr);
 
@@ -306,9 +306,9 @@ private:
     // Add the 'else' block and the condition.
     Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
-    rewriter.create<cf::CondBranchOp>(loc, isFirstThread, ifBlock, thenBlock);
+    cf::CondBranchOp::create(rewriter, loc, isFirstThread, ifBlock, thenBlock);
     rewriter.setInsertionPointToEnd(ifBlock);
-    rewriter.create<cf::BranchOp>(loc, thenBlock);
+    cf::BranchOp::create(rewriter, loc, thenBlock);
   }
 
 protected:
@@ -373,8 +373,8 @@ struct SegmentAllocOpConversion
     Value bufferBase = b.extract_val(bufferBaseTy, buffer, 0);
     auto indexPtrTy =
         ptr_ty(rewriter.getContext(), targetInfo.getIndexPtrAddrSpace());
-    auto indexPtr = rewriter.create<LLVM::AllocaOp>(
-        loc, indexPtrTy, i32_ty, b.i32_val(1), /*alignment=*/0);
+    auto indexPtr = LLVM::AllocaOp::create(rewriter, loc, indexPtrTy, i32_ty,
+                                           b.i32_val(1), /*alignment=*/0);
     b.store(b.i32_val(0), indexPtr);
 
     auto segmentObj = LLVM::SegmentObject(bufferBase, segmentBase, indexPtr);
@@ -516,9 +516,9 @@ struct InitCtxOpConversion
     // Add the 'else' block and the condition.
     Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
-    rewriter.create<cf::CondBranchOp>(loc, isFirstThread, ifBlock, thenBlock);
+    cf::CondBranchOp::create(rewriter, loc, isFirstThread, ifBlock, thenBlock);
     rewriter.setInsertionPointToEnd(ifBlock);
-    rewriter.create<cf::BranchOp>(loc, thenBlock);
+    cf::BranchOp::create(rewriter, loc, thenBlock);
 
     rewriter.eraseOp(op);
     return success();
@@ -624,9 +624,9 @@ struct SaveCtxOpConversion
     // Add the 'else' block and the condition.
     Block *thenBlock = rewriter.splitBlock(ifBlock, op->getIterator());
     rewriter.setInsertionPointToEnd(prevBlock);
-    rewriter.create<cf::CondBranchOp>(loc, isWarpMaster, ifBlock, thenBlock);
+    cf::CondBranchOp::create(rewriter, loc, isWarpMaster, ifBlock, thenBlock);
     rewriter.setInsertionPointToEnd(ifBlock);
-    rewriter.create<cf::BranchOp>(loc, thenBlock);
+    cf::BranchOp::create(rewriter, loc, thenBlock);
 
     rewriter.eraseOp(op);
     return success();

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AddSchedBarriers.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/AddSchedBarriers.cpp
@@ -39,7 +39,7 @@ struct AddSchedBarriers
       auto loc = op.getLoc();
       if (!isa_and_nonnull<ROCDL::SchedBarrier>(op->getPrevNode())) {
         builder.setInsertionPoint(op);
-        builder.create<ROCDL::SchedBarrier>(loc, zeroAttrValue);
+        ROCDL::SchedBarrier::create(builder, loc, zeroAttrValue);
       }
     });
 
@@ -47,7 +47,7 @@ struct AddSchedBarriers
       auto loc = op.getLoc();
       if (!isa_and_nonnull<ROCDL::SchedBarrier>(op->getNextNode())) {
         builder.setInsertionPointAfter(op);
-        builder.create<ROCDL::SchedBarrier>(loc, zeroAttrValue);
+        ROCDL::SchedBarrier::create(builder, loc, zeroAttrValue);
       }
     });
   }

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonAMDGPUToLLVM/TargetInfo.cpp
@@ -22,7 +22,7 @@ Value TargetInfo::clock(ConversionPatternRewriter &rewriter, Location loc,
                        rewriter, loc, clock64IntrinsicName, i64_ty, {})
                        .getResult(0);
   if (!isClock64)
-    clockVal = rewriter.create<LLVM::TruncOp>(loc, i32_ty, clockVal);
+    clockVal = LLVM::TruncOp::create(rewriter, loc, i32_ty, clockVal);
 
   return clockVal;
 }

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/ProtonNvidiaGPUToLLVM/TargetInfo.cpp
@@ -52,7 +52,7 @@ Value TargetInfo::globalTime(ConversionPatternRewriter &rewriter,
 
 Value TargetInfo::processorId(ConversionPatternRewriter &rewriter,
                               Location loc) const {
-  return rewriter.create<NVVM::SmIdOp>(loc, i32_ty);
+  return NVVM::SmIdOp::create(rewriter, loc, i32_ty);
 }
 
 int TargetInfo::getAddressSpace(Attribute addressSpace) const {

--- a/third_party/proton/Dialect/lib/ProtonGPUToLLVM/Utility.cpp
+++ b/third_party/proton/Dialect/lib/ProtonGPUToLLVM/Utility.cpp
@@ -5,8 +5,8 @@ namespace mlir {
 
 Value getRawThreadId(OpBuilder &rewriter, Location loc) {
   Value tid =
-      rewriter.create<::mlir::gpu::ThreadIdOp>(loc, ::mlir::gpu::Dimension::x);
-  Value threadId = rewriter.create<arith::IndexCastOp>(loc, i32_ty, tid);
+      ::mlir::gpu::ThreadIdOp::create(rewriter, loc, ::mlir::gpu::Dimension::x);
+  Value threadId = arith::IndexCastOp::create(rewriter, loc, i32_ty, tid);
   return threadId;
 }
 
@@ -42,7 +42,7 @@ Value SegmentObject::getStruct(Location loc,
       mlir::cast<LLVM::LLVMPointerType>(indexPtr.getType()).getAddressSpace();
   auto structTy =
       getStructType(loc.getContext(), memorySpace, indexPtrAddrSpace);
-  Value segmentStruct = rewriter.create<LLVM::UndefOp>(loc, structTy);
+  Value segmentStruct = LLVM::UndefOp::create(rewriter, loc, structTy);
   segmentStruct = b.insert_val(structTy, segmentStruct, base, 0);
   segmentStruct = b.insert_val(structTy, segmentStruct, segmentBase, 1);
   segmentStruct = b.insert_val(structTy, segmentStruct, indexPtr, 2);

--- a/third_party/proton/Dialect/triton_proton.cc
+++ b/third_party/proton/Dialect/triton_proton.cc
@@ -78,7 +78,7 @@ void init_triton_proton(py::module &&m) {
           auto nameAttr = mlir::StringAttr::get(opBuilder.getContext(),
                                                 llvm::StringRef(name));
           auto loc = opBuilder.getUnknownLoc();
-          opBuilder.create<proton::RecordOp>(loc, isStart, nameAttr);
+          proton::RecordOp::create(opBuilder, loc, isStart, nameAttr);
         });
 
   m.def("add_convert_proton_to_protongpu",


### PR DESCRIPTION
This PR changes the builder API which is a part of the upstream MLIR changes. The previous `create` pattern is marked as deprecated:

```cpp
// before upstream changes
rewriter.create<OpType>(loc, ...)

// after
OpType::create(rewriter, loc, ...)
```

Note: this PR comes without an LLVM bump

cc: @antiagainst 
