### PR TITLE
Avoid ambiguous call to ConstantIntOp::create

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -398,7 +398,7 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
   // boundaries (TODO: giuseros).
   if (llvm::isa<BlockArgument>(expr)) {
     Value scalarZero = arith::ConstantIntOp::create(
-        rewriter, loc, static_cast<int64_t>(0), bitness);
+        rewriter, loc, static_cast<int64_t>(0), static_cast<unsigned>(bitness));
     return {scalarZero, expr};
   }
 
@@ -431,7 +431,8 @@ createDecomposeOffsetFromExpr(RewriterBase &rewriter, Location loc, Value expr,
             // Base case 3: it is not a supported operation. We assume no
             // uniform part
             Value scalarZero = arith::ConstantIntOp::create(
-                rewriter, loc, static_cast<int64_t>(0), bitness);
+                rewriter, loc, static_cast<int64_t>(0),
+                static_cast<unsigned>(bitness));
             return std::make_pair(scalarZero, expr);
           });
 
@@ -1677,7 +1678,7 @@ struct InitFuncPtrArgs : OpRewritePattern<tt::FuncOp> {
       if (!isa<tt::PointerType>(arg.getType()))
         continue;
 
-      int64_t bitness = 64;
+      unsigned bitness = 64;
       if (auto pointerRangeAttr =
               newOp.getArgAttrOfType<IntegerAttr>(idx, "tt.pointer_range"))
         bitness = pointerRangeAttr.getInt();


### PR DESCRIPTION
This seems to be fallout from #8572

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `it fixes the build`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
