### PR TITLE
Fix intermediate IR during expandLoops

### DIFF
--- a/lib/Dialect/Triton/IR/Utility.cpp
+++ b/lib/Dialect/Triton/IR/Utility.cpp
@@ -98,7 +98,8 @@ Value tt::getLastInductionValue(OpBuilder &b, scf::ForOp loop) {
   Value diff =
       arith::SubIOp::create(b, loc, loop.getUpperBound(), loop.getLowerBound());
   diff = arith::SubIOp::create(
-      b, loc, diff, arith::ConstantOp::create(b, loc, b.getI32IntegerAttr(1)));
+      b, loc, diff,
+      arith::ConstantOp::create(b, loc, b.getIntegerAttr(diff.getType(), 1)));
   Value ceilStep = arith::MulIOp::create(
       b, loc, arith::DivSIOp::create(b, loc, diff, loop.getStep()),
       loop.getStep());

--- a/lib/Dialect/Triton/Transforms/LoopPeeling.cpp
+++ b/lib/Dialect/Triton/Transforms/LoopPeeling.cpp
@@ -33,11 +33,10 @@ void peelLoopEpilogue(
   IRMapping map;
   map.map(forOp.getRegionIterArgs(), forOp.getResults());
   map.map(forOp.getInductionVar(), lastIV);
-  auto ifOp = scf::IfOp::create(rewriter, loc, forOp.getResultTypes(), cond,
-                                /*hasElse=*/true);
-  ifOp.getThenRegion().front().erase();
+  auto ifOp = scf::IfOp::create(rewriter, loc, forOp.getResultTypes(), cond);
   forOp.getBodyRegion().cloneInto(&ifOp.getThenRegion(), map);
-  rewriter.setInsertionPointToStart(&ifOp.getElseRegion().front());
+  auto newElseBlock = rewriter.createBlock(&ifOp.getElseRegion());
+  rewriter.setInsertionPointToStart(newElseBlock);
   scf::YieldOp::create(rewriter, loc, forOp.getResults());
 
   forOp->replaceUsesWithIf(ifOp, [&](OpOperand &operand) {


### PR DESCRIPTION
1. Ensure the types of the operands to subi are always the same.
2. Set the builder location before inserting constants, otherwise they end up being inserted in a location that does not dominate the uses. Flatten the control flow so it is obvious we always create an op.
3. Avoid inserting two yields in the else block if the `if` does not produce a result (since the builder automatically inserts one in that case). Simplify the code to just create both blocks ourselves.

Add an assert that the intermediate IR is valid, which currently fails on existing lit tests.

I haven't constructed an example where these survive the pipeliner, but it seems desirable to address these either way. It makes it less confusing to inspect the IR during pipelining, and the invalid IR may break things in unexpected ways in the future. (e.g. in the call to applyPatternsGreedily in resolveMaskOps)