### PR TITLE
Have all threads dump Proton event buffer to gmem

### DIFF
--- a/test/Proton/amd/protongpu_to_llvm.mlir
+++ b/test/Proton/amd/protongpu_to_llvm.mlir
@@ -139,10 +139,13 @@ module attributes {"ttg.num-warps" = 8 : i32, ttg.profile_scratch_memory_alignme
   // CHECK-LABEL: convert_smem_finalize
   // CONVERT-BUILTIN: llvm.call_intrinsic "llvm.amdgcn.s.memrealtime"() : () -> i64
   // CONVERT-BUILTIN: llvm.store %{{.*}}, %{{.*}} : i64, !llvm.ptr<1>
-  // CONVERT-BUILTIN: llvm.br ^bb{{.*}}(%{{.*}} : i32)
+  // CONVERT-BUILTIN: llvm.cond_br %{{.*}}, ^bb{{.*}}(%{{.*}} : i32), ^bb{{.*}}
+  // CONVERT-BUILTIN: llvm.load %{{.*}} : !llvm.ptr<3> -> i32
+  // CONVERT-BUILTIN: llvm.store %{{.*}}, %{{.*}} : i32, !llvm.ptr<1>
+  // CONVERT-BUILTIN: llvm.load %{{.*}} : !llvm.ptr<3> -> i32
+  // CONVERT-BUILTIN: llvm.store %{{.*}}, %{{.*}} : i32, !llvm.ptr<1>
   // CONVERT-BUILTIN: llvm.call_intrinsic "llvm.amdgcn.s.memrealtime"() : () -> i64
   // CONVERT-BUILTIN: llvm.store %{{.*}}, %{{.*}} : i64, !llvm.ptr<1>
-  // CONVERT-BUILTIN: llvm.br ^bb{{.*}}
   // CHECK: llvm.return
   llvm.func @convert_smem_finalize(%arg: !llvm.ptr<1>) attributes {noinline = false, nvvm.kernel = 1 : ui1} {
     %0 = ttg.local_alloc : () -> !ttg.memdesc<512xi32, #shared, #smem, mutable>

--- a/test/Proton/nvidia/protongpu_to_llvm.mlir
+++ b/test/Proton/nvidia/protongpu_to_llvm.mlir
@@ -176,7 +176,7 @@ module attributes {"ttg.num-warps" = 8 : i32, ttg.profile_scratch_memory_alignme
   // CHECK-LABEL: convert_smem_finalize
   // CHECK-DAG: llvm.extractvalue %{{.*}}[0] : !llvm.struct<(ptr<3>, i32)>
   // CHECK-DAG: llvm.store
-  // CHECK-DAG: llvm.cond_br %{{.*}}, ^bb1, ^bb3
+  // CHECK-DAG: llvm.cond_br %{{.*}}, ^bb1, ^bb2
   // CHECK-DAG: %[[BUFFER_SIZE:.*]] = llvm.mlir.constant(2048 : i32) : i32
   // CHECK-DAG: %[[BUFFER_SIZE_OFFSET:.*]] = llvm.mlir.constant(3 : i32) : i32
   // CHECK-DAG: %[[BUFFER_SIZE_PTR:.*]] = llvm.getelementptr %{{.*}}[%[[BUFFER_SIZE_OFFSET]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>
@@ -187,15 +187,17 @@ module attributes {"ttg.num-warps" = 8 : i32, ttg.profile_scratch_memory_alignme
   // CHECK-DAG: llvm.store %[[PRE_FINAL_TIME]], %[[PRE_FINAL_TIME_PTR]] : i64, !llvm.ptr<1>
   // CHECK-DAG: ^bb1:
   // CHECK-DAG: llvm.br ^bb2
-  // CHECK-DAG: ^bb2(%[[I:.*]]: i32):
+  // CHECK-DAG: ^bb2:
+  // CHECK-DAG: llvm.cond_br %{{.*}}, ^bb3(%{{.*}} : i32), ^bb4
+  // CHECK-DAG: ^bb3(%[[I:.*]]: i32):
   // CHECK-DAG: llvm.store
   // CHECK-DAG: llvm.store
-  // CHECK-DAG: %[[UPPER:.*]] = llvm.mlir.constant(510 : i32) : i32
-  // CHECK-DAG: %[[P2:.*]] = llvm.icmp "slt" %[[I]], %[[UPPER]] : i32
-  // CHECK-DAG: %[[STEP:.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-DAG: %[[STEP:.*]] = llvm.mlir.constant(512 : i32) : i32
   // CHECK-DAG: %[[I_NEW:.*]] = llvm.add %[[I]], %[[STEP]] : i32
-  // CHECK-DAG: llvm.cond_br %[[P2]], ^bb2(%[[I_NEW]] : i32), ^bb3
-  // CHECK-DAG: ^bb3:
+  // CHECK-DAG: %[[UPPER:.*]] = llvm.mlir.constant(510 : i32) : i32
+  // CHECK-DAG: llvm.icmp "sle" %[[I_NEW]], %[[UPPER]] : i32
+  // CHECK-DAG: llvm.cond_br %{{.*}}, ^bb3(%[[I_NEW]] : i32), ^bb4
+  // CHECK-DAG: ^bb4:
   // CHECK-DAG: %[[POST_FINAL_TIME:.*]] = llvm.call_intrinsic "llvm.nvvm.read.ptx.sreg.globaltimer"() : () -> i64
   // CHECK-DAG: %[[POST_FINAL_TIME_OFFSET:.*]] = llvm.mlir.constant(8 : i32) : i32
   // CHECK-DAG: %[[POST_FINAL_TIME_PTR:.*]] = llvm.getelementptr %{{.*}}[%[[POST_FINAL_TIME_OFFSET]]] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1


### PR DESCRIPTION
Disclaimer: I had Claude write most of this.

Fixes #8591.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `it's NFC, idk if there is an existing test for this`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
