### PR TITLE
[BACKEND] Take indices rather than reps as inputs to `{smem,tmem}Load`

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TensorMemoryToLLVM.cpp
@@ -604,9 +604,7 @@ static void copySharedToTmem(ConversionPatternRewriter &rewriter, Location loc,
   }
 
   for (int col = 0; col < cvt.getInDimSize(kCol); col += instrShape[1]) {
-    // smemLoad takes the colRep. It'd be nice to change this but we would need
-    // to change the wgmma and mmav5 lowering
-    auto desc = loader.smemLoad(0, col / instrShape[1], rewriter, loc);
+    auto desc = loader.smemLoad(0, col, rewriter, loc);
     auto tmemAddr =
         b.or_(b.ptrtoint(i32_ty, baseDst), b.i32_val(col * bitwidth / 32),
               /*disjoint=*/true);


### PR DESCRIPTION
The previous code was doing a bad job at trying to guess the CTA-level
size of the tile being lowered. Here, we completely give up and instead
ask the caller to provide the starting coordinates of the subtensor they
want to lower rather than the reps.

In the passing, we also switch the `tmemLoad` logic to use LinearLayouts

Fixes https://github.com/triton-lang/triton/issues/8606
