### PR TITLE
Fix resolving epilogue mask ops in nested loops

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h
@@ -77,8 +77,7 @@ Operation *wrapInMaskOp(RewriterBase &rewriter, Operation *op, Value pred);
 
 // Utilize high level predication abstraction to perform optimizations before
 // lowering to predicated operations
-void resolveMaskOp(ModuleOp moduleOp,
-                   DenseSet<triton::gpu::MaskOp> &peeledMaskOps);
+void resolveMaskOp(ModuleOp moduleOp);
 
 // Return true if the given ForOp has the attribute
 // `tt.disallow_acc_multi_buffer` set to true.

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/PipeliningUtility.cpp
@@ -2,7 +2,6 @@
 #include "mlir/Analysis/TopologicalSortUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/UB/IR/UBOps.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -308,8 +307,7 @@ Operation *mlir::triton::wrapInMaskOp(RewriterBase &rewriter, Operation *op,
   return mask;
 }
 
-void mlir::triton::resolveMaskOp(ModuleOp moduleOp,
-                                 DenseSet<ttg::MaskOp> &peeledMaskOps) {
+void mlir::triton::resolveMaskOp(ModuleOp moduleOp) {
   IRRewriter rewriter(moduleOp);
 
   // Canonicalize the IR to simplify the arithmetic ops defining the mask
@@ -319,29 +317,6 @@ void mlir::triton::resolveMaskOp(ModuleOp moduleOp,
   arithDialect->getCanonicalizationPatterns(patterns);
   if (mlir::applyPatternsGreedily(moduleOp, std::move(patterns)).failed())
     return llvm::report_fatal_error("Failed to canonicalize the IR");
-
-  // Prune all the statically dead mask ops in the epilogue. This is a
-  // hack, ideally we should do it for all the mask ops, but it is incorrect if
-  // we have speculatively executed async cp operations that will store to shmem
-  // even if the mask is false.
-  for (auto maskOp : peeledMaskOps) {
-    rewriter.setInsertionPoint(maskOp);
-    while (&maskOp.getBody()->front() != maskOp.getBody()->getTerminator()) {
-      Operation *op = &maskOp.getBody()->front();
-      if (isConstantIntValue(maskOp.getPred(), 0)) {
-        if (op->getNumResults() > 0) {
-          SmallVector<Value> results;
-          for (auto result : op->getResults()) {
-            auto poisonOp = mlir::ub::PoisonOp::create(rewriter, op->getLoc(),
-                                                       result.getType());
-            results.push_back(poisonOp);
-          }
-          op->replaceAllUsesWith(results);
-        }
-        op->erase();
-      }
-    }
-  }
 
   SmallVector<ttg::MaskOp> maskOps;
   moduleOp->walk([&](ttg::MaskOp maskOp) { maskOps.push_back(maskOp); });

--- a/test/TritonGPU/loop-pipeline-expand.mlir
+++ b/test/TritonGPU/loop-pipeline-expand.mlir
@@ -57,3 +57,42 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 128], threadsPerWarp = [32, 1], warpsPerCTA = [8, 1], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#shared1 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @nested_loop_gen5_mma
+  tt.func public @nested_loop_gen5_mma(%arg0: !tt.ptr<bf16>, %arg1: i1) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<1024x128xf32, #blocked>
+    %true = arith.constant true
+    %false = arith.constant false
+    %c0_i32 = arith.constant 0 : i32
+    %c16_i32 = arith.constant 16 : i32
+    %c32_i32 = arith.constant 32 : i32
+    %0 = tt.splat %arg0 : !tt.ptr<bf16> -> tensor<128x128x!tt.ptr<bf16>, #blocked>
+    %1 = tt.load %0 : tensor<128x128x!tt.ptr<bf16>, #blocked>
+    %2 = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #shared, #smem, mutable>
+    %3 = ttg.local_alloc %1 {loop.cluster = 2 : i32, loop.stage = 0 : i32} : (tensor<128x128xbf16, #blocked>) -> !ttg.memdesc<128x128xbf16, #shared1, #smem>
+    %result, %token = ttng.tmem_alloc : () -> (!ttg.memdesc<1024x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.async.token)
+    %4 = ttng.tmem_store %cst, %result[%token], %true : tensor<1024x128xf32, #blocked> -> !ttg.memdesc<1024x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %result_0 = ttng.tmem_alloc {loop.cluster = 0 : i32, loop.stage = 0 : i32} : () -> !ttg.memdesc<1024x128xbf16, #tmem, #ttng.tensor_memory, mutable>
+    scf.for %arg2 = %c0_i32 to %c32_i32 step %c16_i32  : i32 {
+      // In order for both the outer and inner loop to be pipelined, the inner
+      // loop cannot be directly nested in the outer loop, so add an if in the
+      // middle.
+      scf.if %arg1 {
+        %5 = scf.for %arg3 = %c0_i32 to %arg2 step %c16_i32 iter_args(%arg4 = %4) -> (!ttg.async.token)  : i32 {
+          %6 = ttng.tc_gen5_mma %result_0, %3, %result[%arg4], %false, %true, %2[%true] {is_async, loop.cluster = 2 : i32, loop.stage = 0 : i32} : !ttg.memdesc<1024x128xbf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xbf16, #shared1, #smem>, !ttg.memdesc<1024x128xf32, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared, #smem, mutable>
+          ttng.wait_barrier %2, %c0_i32 deps %result_0, %3 {loop.cluster = 1 : i32, loop.stage = 1 : i32} : !ttg.memdesc<1xi64, #shared, #smem, mutable>, !ttg.memdesc<1024x128xbf16, #tmem, #ttng.tensor_memory, mutable>, !ttg.memdesc<128x128xbf16, #shared1, #smem>
+          scf.yield %6 : !ttg.async.token
+        } {tt.num_stages = 4 : i32, tt.scheduled_max_stage = 1 : i32}
+      } {loop.cluster = 2 : i32, loop.stage = 1 : i32}
+    } {tt.num_stages = 2 : i32, tt.scheduled_max_stage = 1 : i32}
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Pipeline.cpp
@@ -94,9 +94,7 @@ void expandLoops(ModuleOp moduleOp) {
       continue;
   }
 
-  // NOTE: Leave empty for now, until we utilize customEpiloguePeeling
-  DenseSet<ttg::MaskOp> peeledMaskOps;
-  tt::resolveMaskOp(moduleOp, peeledMaskOps);
+  tt::resolveMaskOp(moduleOp);
 }
 } // namespace
 


### PR DESCRIPTION
If we have nested loops where both are pipelined, the contents of peeledMaskOps will be invalidated when the outer loop is expanded, because the original outer loop will be deleted. This causes problems when we manipulate them in resolveMaskOps.

To address this, pull out the handling of MaskOps in the epilogue and do it right after we expand each loop. While here, simplify the code so we just replace the entire MaskOp with a PoisonOp, instead of replacing each of the operations it contains.