### PR TITLE
[PROTON][CI] Remove condition for running Proton tests on GB200

### DIFF
--- a/.github/workflows/integration-tests-nvidia.yml
+++ b/.github/workflows/integration-tests-nvidia.yml
@@ -102,7 +102,6 @@ jobs:
       - name: Run C++ unittests
         run: make test-cpp
       - name: Run Proton tests
-        if: ${{ matrix.runner[0] != 'nvidia-gb200' }}
         run: make test-proton
       - name: Inspect cache directories
         run: |


### PR DESCRIPTION
Not sure why it was disabled previously. Should be good now
