### PR TITLE
[release-only] Forward fix after #8636

### DIFF
--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = "3.5.1"
+__version__ = '3.5.1'
 
 # ---------------------------------------
 # Note: import order is significant here.


### PR DESCRIPTION
Fix double quote typo
``
__version__ = "3.5.1"
``
should be
``
__version__ = '3.5.1'
``
After:
https://github.com/triton-lang/triton/pull/8636