### PR TITLE
[AMD] Fix instruction selection for fp8/bf8 wmma

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -237,8 +237,12 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   const auto kDimOperandSize = aTensorTy.getShape().back();
 
   std::string intrinsicName;
-  FailureOr<WmmaIntrinsic> maybeWmmaIntrinsic = WmmaIntrinsic::get(
-      wmmaVer, mnkDim[0], mnkDim[1], mnkDim[2], aElemTy, bElemTy, dElemTy);
+  FailureOr<WmmaIntrinsic> maybeWmmaIntrinsic =
+      wmmaLayout.getIsTransposed()
+          ? WmmaIntrinsic::get(wmmaVer, mnkDim[1], mnkDim[0], mnkDim[2],
+                               bElemTy, aElemTy, dElemTy)
+          : WmmaIntrinsic::get(wmmaVer, mnkDim[0], mnkDim[1], mnkDim[2],
+                               aElemTy, bElemTy, dElemTy);
   if (failed(maybeWmmaIntrinsic)) {
     return op.emitError(
         "no matching matrix core intrinsic due to unsupported element type");

--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -128,9 +128,9 @@ def test_compile_gemm(BLOCK_M, BLOCK_N, BLOCK_K, a_dtype, b_dtype, k_dim):
     if a_dtype in ("fp8e4nv", "fp8e5"):
         a_ty = "fp8" if a_dtype == "fp8e4nv" else "bf8"
         b_ty = "fp8" if b_dtype == "fp8e4nv" else "bf8"
-        wmma_pattern += a_ty + "_" + b_ty
-
-    assert re.search(wmma_pattern, amdgcn), "The AMDGCN assembly does not contain the expected WMMA instruction."
+        # NOTE: we always use transposed=True for wmma layout, which will swap A and B
+        wmma_pattern += b_ty + "_" + a_ty
+    assert re.search(wmma_pattern, amdgcn)
 
 
 @pytest.mark.parametrize("M,N,K", get_test_gemm_shapes())
@@ -139,8 +139,6 @@ def test_compile_gemm(BLOCK_M, BLOCK_N, BLOCK_K, a_dtype, b_dtype, k_dim):
 def test_runtime_gemm(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, a_dtype, b_dtype, k_dim):
     if BLOCK_K < k_dim:
         pytest.skip("Skip tests where BLOCK_K < k_dim")
-    if a_dtype == 'float8_e4m3fn' or b_dtype == 'float8_e4m3fn':
-        pytest.skip("Skip float8_e4m3fn tests for now due to accuracy issue")
 
     torch.manual_seed(42)
 


### PR DESCRIPTION
Fix the instruction selection for asymmetric fp8/bf8 wmma when transposed, for which we will swap the operand a and b.