### PR TITLE
[CI] Try ROCm 7.0 release instead of prealpha

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -92,6 +92,10 @@ jobs:
         run: |
           export CC=/usr/bin/clang
           export CXX=/usr/bin/clang++
+          if [ "${{ matrix.runner[0] }}" == "amd-gfx950" ]; then
+              sudo apt-get update
+              suod apt-get install clang -y
+          fi
       - name: Install Triton
         id: amd-install-triton
         run: |


### PR DESCRIPTION
The container is failing to pull currently. Looks like there is a full release available now.