### PR TITLE
Modify the NVIDIA backend driver to use libcuda.so.1.

### DIFF
--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -13,7 +13,7 @@ from triton.backends.driver import GPUDriver
 dirname = os.path.dirname(os.path.realpath(__file__))
 include_dirs = [os.path.join(dirname, "include")]
 libdevice_dir = os.path.join(dirname, "lib")
-libraries = ['cuda']
+libraries = ['libcuda.so.1']
 PyCUtensorMap = None
 
 


### PR DESCRIPTION
Fixes #8667 

Runtime environments may not include developer libraries such as `libcuda.so`, but they do contain runtime SONAME libraries like `libcuda.so.1`. Triton Language's NVIDIA driver JIT compiled kernel wrappers with `-lcuda` with translates to `libcuda.so`. This causes errors in many runtime environments that do not include that file.

This pull request fixes the issue by linking to `libcuda.so.1` instead which has been a stable SONAME since 2007.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `the existing error is exposed only by runtime environments that do not include libcuda.so`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
