### PR TITLE
[FRONTEND] Attach lineno information to AugAssign nodes

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -703,6 +703,11 @@ class CodeGenerator(ast.NodeVisitor):
         lhs.ctx = ast.Load()
         rhs = ast.BinOp(lhs, node.op, node.value)
         assign = ast.Assign(targets=[node.target], value=rhs)
+        for x in ['lineno', 'col_offset', 'end_lineno', 'end_col_offset']:
+            if hasattr(node, x):
+                y = getattr(node, x)
+                setattr(rhs, x, y)
+                setattr(assign, x, y)
         self.visit(assign)
         return self.visit(lhs)
 


### PR DESCRIPTION
visit_AugAssign works by creating fake AST nodes for the binary operation and the assignment and visiting those. Prior to this commit, the nodes lack the correct lineno and col_offset so any errors raised here don't include the helpful '^' pointer to the offending line of code; this makes debugging painful.