### PR TITLE
triton_kernels: use tl.clamp whenever possible

### DIFF
--- a/python/triton_kernels/triton_kernels/numerics_details/flexpoint.py
+++ b/python/triton_kernels/triton_kernels/numerics_details/flexpoint.py
@@ -115,9 +115,7 @@ def flex_to_float(x, scale_ptr):
 
 @triton.jit
 def clip(x, limit):
-    res = tl.minimum(x, limit)
-    res = tl.maximum(-limit, res)
-    return res
+    return tl.clamp(x, -limit, limit)
 
 
 @triton.jit

--- a/python/triton_kernels/triton_kernels/swiglu_details/_swiglu.py
+++ b/python/triton_kernels/triton_kernels/swiglu_details/_swiglu.py
@@ -5,9 +5,10 @@ import triton.language as tl
 
 @triton.jit
 def clip(x, limit, clip_lower: tl.constexpr):
-    res = tl.minimum(x, limit)
     if clip_lower:
-        res = tl.maximum(-limit, res)
+        res = tl.clamp(x, -limit, limit)
+    else:
+        res = tl.minimum(x, limit)
     return res
 
 


### PR DESCRIPTION
In many cases `tl.clamp` can be compiled to a single instruction rather than two instructions for `tl.minimum` + `tl.maximum`:
- Output saturation instruction modifier to clamp output to [0, 1]
- `min.xorsign.abs.f32` instructions on Hopper+
- `V_MED3_F32` instructions on AMD

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `expected to be bit-exact`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
