### PR TITLE
[Frontend][BC-breaking] Propagate constexpr through builtin min/max

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -248,13 +248,6 @@ def is_two_ctas(layout_a: ttgl.constexpr, layout_b: ttgl.constexpr) -> ttgl.cons
     return has_cta_split(layout_a, [2, 1]) and has_cta_split(layout_b, [1, 2])
 
 
-@gluon.constexpr_function
-def constexpr_min(a, b):
-    if a < b:
-        return a
-    return b
-
-
 @gluon.jit
 def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexpr, block_layout_a: ttgl.constexpr,
                block_layout_b: ttgl.constexpr, block_layout_c: ttgl.constexpr, mma_layout: ttgl.constexpr,
@@ -279,8 +272,7 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
     fence_async_shared(cluster=two_ctas)
 
     if USE_TCGEN05:
-        tmem_shape: ttgl.constexpr = (constexpr_min(M // mma_layout.cta_split_num[0],
-                                                    128), N // mma_layout.cta_split_num[1])
+        tmem_shape: ttgl.constexpr = (min(M // mma_layout.cta_split_num[0], 128), N // mma_layout.cta_split_num[1])
         tmem_layout: ttgl.constexpr = TensorMemoryLayout(tmem_shape, col_stride=32 // acc_dtype.primitive_bitwidth,
                                                          cta_split_num=mma_layout.cta_split_num, two_ctas=two_ctas)
 

--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -606,3 +606,49 @@ def test_constexpr_function_taking_list():
     a: tl.constexpr = function_taking_list(make_list(4, 8, 16))
     # CHECK: call @{{.*}}anchor{{.*}}cconstexpr_8_
     anchor(a)
+
+
+@filecheck_test
+@triton.jit
+def test_constexpr_min_max():
+    a: tl.constexpr = min(1, 2)
+    # CHECK: call @{{.*}}anchor{{.*}}cconstexpr_1_
+    anchor(a)
+
+    b: tl.constexpr = min(1, 2, -3)
+    # CHECK: call @{{.*}}anchor{{.*}}cconstexpr_-3_
+    anchor(b)
+
+    c: tl.constexpr = max(3, 4)
+    # CHECK: call @{{.*}}anchor{{.*}}cconstexpr_4_
+    anchor(c)
+
+    d: tl.constexpr = max(3, 4, 5)
+    # CHECK: call @{{.*}}anchor{{.*}}cconstexpr_5_
+    anchor(d)
+
+
+def test_constexpr_min_error():
+
+    @triton.jit
+    def min_kernel(a: tl.constexpr, b: tl.constexpr):
+        min(a, b)
+
+    with pytest.raises(CompilationError):
+        run_parser(min_kernel, args=(1.0, float("nan")))
+
+    with pytest.raises(CompilationError):
+        run_parser(min_kernel, args=(1.0, -0.0))
+
+
+def test_constexpr_max_error():
+
+    @triton.jit
+    def max_kernel(a: tl.constexpr, b: tl.constexpr):
+        max(a, b)
+
+    with pytest.raises(CompilationError):
+        run_parser(max_kernel, args=(1.0, float("nan")))
+
+    with pytest.raises(CompilationError):
+        run_parser(max_kernel, args=(1.0, -0.0))

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -362,8 +362,8 @@ class CodeGenerator(ast.NodeVisitor):
     }
     builtin_namespace.update((
         ('print', language.core.device_print),
-        ('min', language.minimum),
-        ('max', language.maximum),
+        ('min', language.core.builtin_min),
+        ('max', language.core.builtin_max),
     ))
 
     def _unsupported(self, node, message):

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -3431,3 +3431,42 @@ def binary_op_type_legalization(lhs, rhs, semantic):
 def extern(fn):
     """A decorator for external functions."""
     return builtin(fn)
+
+
+_NOTHING = object()
+
+
+def is_negative_zero(x):
+    return x == 0.0 and math.copysign(1.0, x) < 0
+
+
+@builtin
+def builtin_max(*args, propagate_nan=_NOTHING, _semantic=None):
+    args = _unwrap_if_constexpr(args)
+    is_constexpr = all(not isinstance(x, base_value) for x in args)
+    if is_constexpr:
+        assert propagate_nan is _NOTHING, "propagate_nan is not supported on builtin max"
+        assert not any(math.isnan(x) for x in args)
+        assert not any(is_negative_zero(x) for x in args)
+        return constexpr(builtins.max(_unwrap_if_constexpr(args)))
+
+    warn("builtin max on tensor values is deprecated, use tl.maximum instead", DeprecationWarning)
+    if propagate_nan is _NOTHING:
+        propagate_nan = PropagateNan.NONE
+    return maximum(*args, propagate_nan=propagate_nan, _semantic=_semantic)
+
+
+@builtin
+def builtin_min(*args, propagate_nan=_NOTHING, _semantic=None):
+    args = _unwrap_if_constexpr(args)
+    is_constexpr = all(not isinstance(x, base_value) for x in args)
+    if is_constexpr:
+        assert propagate_nan is _NOTHING, "propagate_nan is not supported on builtin min"
+        assert not any(math.isnan(x) for x in args)
+        assert not any(is_negative_zero(x) for x in args)
+        return constexpr(builtins.min(_unwrap_if_constexpr(args)))
+
+    warn("builtin min on tensor values is deprecated, use tl.minimum instead", DeprecationWarning)
+    if propagate_nan is _NOTHING:
+        propagate_nan = PropagateNan.NONE
+    return minimum(*args, propagate_nan=propagate_nan, _semantic=_semantic)


### PR DESCRIPTION
Also adds a deprecation warning for builtin min/max with tensor values; as well as supporting n-way min/max.