### PR TITLE
CLC (cluster launch control) backend

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -294,7 +294,7 @@ def TTNG_AsyncCLCTryCancelOp : TTNG_Op<"async_clc_try_cancel", []> {
   let assemblyFormat = "$mbarAlloc`,` $clcResAlloc attr-dict `:` type(operands)";
 }
 
-def TTNG_AsyncCLCQueryCancelOp : TTNG_Op<"async_clc_query_cancel", []> {
+def TTNG_CLCQueryCancelOp : TTNG_Op<"clc_query_cancel", []> {
   let summary = "Extract CTA ID from CLC response";
 
   let description = [{

--- a/test/Conversion/tritonnvidiagpu_to_llvm.mlir
+++ b/test/Conversion/tritonnvidiagpu_to_llvm.mlir
@@ -88,11 +88,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
 #shared0 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CTAsPerCGA = [1], CTASplitNum = [1], CTAOrder = [0]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32} {
-  // CHECK-LABEL: async_clc_query_cancel
+  // CHECK-LABEL: clc_query_cancel
   // CHECK: clusterlaunchcontrol.query_cancel.is_canceled.pred.b128
   // CHECK: clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128
-  tt.func @async_clc_query_cancel(%clc_response: !ttg.memdesc<1xui128, #shared0, #smem, mutable>) {
-    %x = ttng.async_clc_query_cancel %clc_response : (!ttg.memdesc<1xui128, #shared0, #smem, mutable>) -> i32
+  tt.func @clc_query_cancel(%clc_response: !ttg.memdesc<1xui128, #shared0, #smem, mutable>) {
+    %x = ttng.clc_query_cancel %clc_response : (!ttg.memdesc<1xui128, #shared0, #smem, mutable>) -> i32
     tt.return
   }
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp
@@ -307,14 +307,13 @@ struct AsyncCLCTryCancelOpConversion
   }
 };
 
-struct AsyncCLCQueryCancelOpConversion
-    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::AsyncCLCQueryCancelOp> {
+struct CLCQueryCancelOpConversion
+    : public ConvertOpToLLVMPattern<triton::nvidia_gpu::CLCQueryCancelOp> {
   using ConvertOpToLLVMPattern<
-      triton::nvidia_gpu::AsyncCLCQueryCancelOp>::ConvertOpToLLVMPattern;
+      triton::nvidia_gpu::CLCQueryCancelOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
-  matchAndRewrite(triton::nvidia_gpu::AsyncCLCQueryCancelOp op,
-                  OpAdaptor adaptor,
+  matchAndRewrite(triton::nvidia_gpu::CLCQueryCancelOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     Location loc = op->getLoc();
 
@@ -358,5 +357,5 @@ void mlir::triton::NVIDIA::populateBarrierOpToLLVMPatterns(
   patterns.add<BarrierExpectConversion>(typeConverter, benefit);
   patterns.add<ArriveBarrierOpConversion>(typeConverter, benefit);
   patterns.add<AsyncCLCTryCancelOpConversion>(typeConverter, benefit);
-  patterns.add<AsyncCLCQueryCancelOpConversion>(typeConverter, benefit);
+  patterns.add<CLCQueryCancelOpConversion>(typeConverter, benefit);
 }


### PR DESCRIPTION
Upstream CLC backend changes from following PRs. It works well with TLX frontend (see unit test and tutorial kernel). This PR contains the backend part only.
- https://github.com/facebookexperimental/triton/pull/345 (init)
- https://github.com/facebookexperimental/triton/pull/399 (major fix in both frontend+backend)
- https://github.com/facebookexperimental/triton/pull/472 (frontend: minor fix + add tutorial kernel)
- https://github.com/facebookexperimental/triton/pull/516 (major upgrade in frontend with producer-consumer API)
- https://github.com/facebookexperimental/triton/pull/620 (unit test only)

TTGIR
- include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td

PTX lowering
- third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/BarrierOpToLLVM.cpp

MLIR
- test/Conversion/tritonnvidiagpu_to_llvm.mlir

Test
`lit test/Conversion/tritonnvidiagpu_to_llvm.mlir`

`make test-cpp`