### PR TITLE
[AMD][CI] Using cache dir for pip

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -104,9 +104,8 @@ jobs:
 
           ccache --zero-stats
           if [ "${{ matrix.runner[0] }}" = "amd-gfx950" ]; then
-            chown -R root:root /triton-data
-            pip install --cache-dir /triton-data -r python/requirements.txt
-            pip install --cache-dir /triton-data -r python/test-requirements.txt
+            pip install --cache-dir /triton-data/pip-cache -r python/requirements.txt
+            pip install --cache-dir /triton-data/pip-cache -r python/test-requirements.txt
           fi
           make dev-install
       - name: Print ccache stats


### PR DESCRIPTION
To make more robust and circumvents occasional network slowdowns, we have set up cache-dir on OSSCI. This PR introduce changes to use cache-dir iff version/requirements exist.