### PR TITLE
[mxfp] adjust num_stages for bf16/fp16 x mxfp

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags_details/opt_flags_nvidia.py
@@ -10,12 +10,9 @@ from triton_kernels.tensor_details.layout_details.blackwell_scale import Blackwe
 
 
 def is_x_scale_swizzled(precision_config):
-    return (
-        precision_config is not None
-        and precision_config.a_mx_scale is not None
-        and isinstance(precision_config.a_mx_scale, Tensor)
-        and isinstance(precision_config.a_mx_scale.storage.layout, BlackwellActMXScaleLayout)
-    )
+    return (precision_config is not None and precision_config.a_mx_scale is not None
+            and isinstance(precision_config.a_mx_scale, Tensor)
+            and isinstance(precision_config.a_mx_scale.storage.layout, BlackwellActMXScaleLayout))
 
 
 def compute_grid_size(routing_data, batch_size, m, n, block_m, block_n):
@@ -146,10 +143,8 @@ def compute_num_stages(
         stage_size += block_n * (block_k // int(MXFP_BLOCK_SIZE))
     num_stages = min(smem_capacity // int(stage_size), 4)
     if num_stages == 0:
-        warnings.warn(
-            f"num_stages computed is 0 with {stage_size=} and {smem_capacity=}, "
-            "bumping up to 1 but this may lead to out of shared memory errors, "
-            "and in that case consider reducing block sizes."
-        )
+        warnings.warn(f"num_stages computed is 0 with {stage_size=} and {smem_capacity=}, "
+                      "bumping up to 1 but this may lead to out of shared memory errors, "
+                      "and in that case consider reducing block sizes.")
         num_stages = 1
     return num_stages


### PR DESCRIPTION
For fp16/bf16 x mxfp, we upcast weight on the fly, so we should size smem_capacity accordingly.
w/o thischange , gets the following error:
"triton.runtime.errors.OutOfResources: out of resource: shared memory, Required: 263356, Hardware limit: 232448. Reducing block sizes or `num_stages` may help"
for x.shape = [2048, >=4096] bf16 x [32, >=4096, >=4096] float8_e4m3fn block_m=64, block_n=256, block_k=128, split_k=1, is_persistent=True -> leading to num_stages=4

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because wasn't able to find a shape that runs reliably w/o OOMs. The example shape above 32 x >=4096 x >=4096 is too big. Will try to see if I can enable only on GB200.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
