### PR TITLE
Remove verification of tmem allocation size

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Types.cpp
+++ b/lib/Dialect/TritonGPU/IR/Types.cpp
@@ -143,14 +143,6 @@ LogicalResult MemDescType::verify(function_ref<InFlightDiagnostic()> emitError,
                          << ll.getOutDimSize(dims[0]) << "x"
                          << ll.getOutDimSize(dims[1]);
     }
-    // Note the following holds for both M=64 and M=128 with 2CTA
-    auto nCol = ll.getInDimSize(StringAttr::get(ctx, "col"));
-    if (nCol / (enc.getCTASplitM() * enc.getCTASplitN()) >
-        512 * 32 / bitwidth) {
-      return emitError() << "nCol / (CTASplitM * CTASplitN) must be less than "
-                            "or equal to 512 * 32 / bitwidth but got "
-                         << nCol / (enc.getCTASplitM() * enc.getCTASplitN());
-    }
   } else if (auto enc = dyn_cast<SharedEncodingTrait>(encoding)) {
     if (memorySpace != SharedMemorySpaceAttr::get(ctx)) {
       return emitError()


### PR DESCRIPTION
This check can fail, because `supportMMA` does not validate that the
result of a dot must be able to fit in tmem before using MMAv5. This
then results in an assertion failure.

Instead of hardcoding this constraint in the optimizer, remove the check
and allow the allocator to run out of tmem later.