### PR TITLE
[BACKEND] Support clamp optimization on scalars

### DIFF
--- a/test/Conversion/tritongpu_to_llvm_hopper.mlir
+++ b/test/Conversion/tritongpu_to_llvm_hopper.mlir
@@ -229,6 +229,20 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
 
 // -----
 
+// CHECK-LABEL: clamp_scalar
+module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @clamp_scalar(%x : f32, %limit : f32) {
+    %cst = arith.constant 0.000000e+00 : f32
+    %neg_limit = arith.subf %cst, %limit : f32
+
+    // CHECK: nvvm.fmin.xorsign.abs.f
+    %12 = tt.clampf %x, %neg_limit, %limit, propagateNan = none : f32
+    tt.return
+  }
+}
+
+// -----
+
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [0, 1]}>
 #mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 16]}>
 // CHECK-LABEL: convert_mma_to_blocked

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -671,7 +671,11 @@ struct ClampFOpConversion
         computeCapability(computeCapability) {}
 
   bool isClipPattern(ClampFOp op) const {
-    bool xorsignAbsAvailable = (computeCapability >= 90);
+    // min.xorsign.abs requires hopper or newer
+    if (computeCapability < 90) {
+      return false;
+    }
+
     // Pattern matching the sequence of clamp(x, -limit, limit) to generate
     // more efficient PTX code. NOTE: This pattern matching is not general
     // enough, but it is sufficient. We detect only two cases here:
@@ -684,38 +688,40 @@ struct ClampFOpConversion
     //   %cst_6 = arith.constant dense<-6.0000e+00>
     //   %cst_7 = arith.constant dense<6.0000e+00>
     //   %160 = tt.clamp %158, %cst_6, %cst_7
-    bool patternFound = false;
 
     auto getSplatInitializer = [](Value v) -> std::optional<double> {
-      if (auto constOp = v.getDefiningOp<arith::ConstantOp>()) {
-        if (auto attr = mlir::dyn_cast<DenseIntOrFPElementsAttr>(
-                constOp.getValueAttr())) {
-          if (attr.isSplat()) {
-            return attr.getSplatValue<APFloat>().convertToDouble();
-          }
+      DenseIntOrFPElementsAttr denseAttr;
+      if (matchPattern(v, m_Constant(&denseAttr))) {
+        if (denseAttr.isSplat()) {
+          return denseAttr.getSplatValue<APFloat>().convertToDouble();
         }
+        return std::nullopt;
+      }
+      FloatAttr floatAttr;
+      if (matchPattern(v, m_Constant(&floatAttr))) {
+        return floatAttr.getValue().convertToDouble();
       }
       return std::nullopt;
     };
 
-    if (xorsignAbsAvailable) {
-      if (auto subOp = op.getOperand(1).getDefiningOp<arith::SubFOp>()) {
-        if (subOp.getOperand(1) == op.getOperand(2)) {
-          auto initializer = getSplatInitializer(subOp.getOperand(0));
-          if (initializer.has_value() && initializer.value() == 0.0) {
-            patternFound = true;
-          }
-        }
-      } else {
-        auto initializer1 = getSplatInitializer(op.getOperand(1));
-        auto initializer2 = getSplatInitializer(op.getOperand(2));
-        if (initializer1.has_value() && initializer2.has_value() &&
-            initializer1.value() == -initializer2.value()) {
-          patternFound = true;
+    // clampf %x (sub 0.0 %max) %max
+    if (auto subOp = op.getOperand(1).getDefiningOp<arith::SubFOp>()) {
+      if (subOp.getOperand(1) == op.getOperand(2)) {
+        auto initializer = getSplatInitializer(subOp.getOperand(0));
+        if (initializer.has_value() && initializer.value() == 0.0) {
+          return true;
         }
       }
     }
-    return patternFound;
+
+    // clampf %x, %min, %max (where min = -max = constant)
+    auto initializer1 = getSplatInitializer(op.getOperand(1));
+    auto initializer2 = getSplatInitializer(op.getOperand(2));
+    if (initializer1.has_value() && initializer2.has_value() &&
+        initializer1.value() == -initializer2.value()) {
+      return true;
+    }
+    return false;
   }
 
   SmallVector<Value> emitOptimization(ClampFOp op,


### PR DESCRIPTION
While poking around in this code, I noticed this optimization only supports tensors. This PR generalizes it to work on scalars as well.