### PR TITLE
Make WarpSpecializePartitionsOp implement RegionBranchInterface

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -527,10 +527,12 @@ def TTG_WarpSpecializeOp : TTG_Op<"warp_specialize", [
   let hasCanonicalizeMethod = 1;
 }
 
-def TTG_WarpSpecializePartitionsOp : TTG_Op<"warp_specialize.partitions", [
-  IsolatedFromAbove, RecursiveMemoryEffects, RecursivelySpeculatable,
-  Terminator, HasParent<"WarpSpecializeOp">
-]> {
+def TTG_WarpSpecializePartitionsOp
+    : TTG_Op<"warp_specialize.partitions",
+             [IsolatedFromAbove, RecursiveMemoryEffects,
+              RecursivelySpeculatable, Terminator,
+              HasParent<"WarpSpecializeOp">,
+              DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
   let summary = "container op for `ttg.warp_specialize`";
   let description = [{
     Because MLIR requires entire operations be isolated from above, this op

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -232,15 +232,9 @@ private:
     std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
     SharedMemoryAliasAnalysis *aliasAnalysis =
         solver->load<SharedMemoryAliasAnalysis>();
-    // Run the analysis rooted at every isolated from above operation, including
-    // the top-level function but also any nested regions.
-    operation->walk<mlir::WalkOrder::PreOrder>([&](Operation *op) {
-      if (op->hasTrait<OpTrait::IsIsolatedFromAbove>() &&
-          failed(solver->initializeAndRun(op))) {
-        // TODO: return error instead of bailing out..
-        llvm_unreachable("failed to run SharedMemoryAliasAnalysis");
-      }
-    });
+    if (failed(solver->initializeAndRun(operation))) {
+      llvm_unreachable("failed to run SharedMemoryAliasAnalysis");
+    }
     operation->walk<WalkOrder::PreOrder>([&](Operation *op) {
       for (auto operand : op->getOperands()) {
         getValueAlias(operand, *aliasAnalysis);

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -924,15 +924,25 @@ RegionRange WarpSpecializeOp::getPartitionRegions() {
 
 void WarpSpecializeOp::getSuccessorRegions(
     RegionBranchPoint src, SmallVectorImpl<RegionSuccessor> &successors) {
-  // The parent branches transparently into the default region.
+  // The parent branches into the default region and the partition regions.
   if (src.isParent()) {
     successors.emplace_back(&getDefaultRegion());
+    successors.emplace_back(&getPartitionOpHolder());
     return;
   }
   // And the default region branches transparently back to the parent.
-  assert(src.getTerminatorPredecessorOrNull()->getParentRegion() ==
-         &getDefaultRegion());
-  successors.push_back(RegionSuccessor(getOperation(), getResults()));
+  if (src.getTerminatorPredecessorOrNull()->getParentRegion() ==
+      &getDefaultRegion())
+    successors.push_back(RegionSuccessor(getOperation(), getResults()));
+}
+
+void WarpSpecializePartitionsOp::getSuccessorRegions(
+    RegionBranchPoint src, SmallVectorImpl<RegionSuccessor> &successors) {
+  // The parent branches to each of the partition regions, but nothing flows out
+  // of the partition regions.
+  if (src.isParent())
+    for (Region &region : getPartitionRegions())
+      successors.emplace_back(&region);
 }
 
 LogicalResult WarpSpecializeOp::verify() {

--- a/third_party/proton/Dialect/include/Analysis/ScopeIdAllocation.h
+++ b/third_party/proton/Dialect/include/Analysis/ScopeIdAllocation.h
@@ -23,7 +23,7 @@ public:
   using ScopeIdParent = std::vector<std::pair<ScopeId, ScopeId>>;
 
   ScopeIdAllocation() = default;
-  explicit ScopeIdAllocation(Operation *op) : funcOp(op) { run(); }
+  explicit ScopeIdAllocation(FunctionOpInterface op) : funcOp(op) { run(); }
 
   ScopeId getOpScopeId(Operation *op) const {
     if (auto recordOp = dyn_cast<RecordOp>(op)) {
@@ -53,7 +53,7 @@ private:
   void dominance();
   void visitTerminator(Operation *op, SmallVector<VirtualBlock> &successors);
 
-  Operation *funcOp;
+  FunctionOpInterface funcOp;
   llvm::DenseMap<ScopeId, StringRef> idToNameMap;
   llvm::DenseMap<Operation *, ScopeId> opToIdMap;
   ScopeIdParent scopeParentIds;

--- a/third_party/proton/Dialect/lib/Analysis/ScopeIdAllocation.cpp
+++ b/third_party/proton/Dialect/lib/Analysis/ScopeIdAllocation.cpp
@@ -162,13 +162,7 @@ void ScopeIdAllocation::reachability() {
   DenseMap<VirtualBlock, BlockInfo> outputBlockInfoMap;
 
   std::deque<VirtualBlock> virtualBlockList;
-  funcOp->walk<WalkOrder::PreOrder>([&](Block *block) {
-    // Seed the worklist with entry blocks of regions that are
-    // isolated-from-above.
-    if (block->isEntryBlock() &&
-        !isa<RegionBranchOpInterface>(block->getParentOp()))
-      virtualBlockList.emplace_back(block, Block::iterator());
-  });
+  virtualBlockList.emplace_back(&funcOp.getBlocks().front(), Block::iterator());
 
   while (!virtualBlockList.empty()) {
     VirtualBlock virtualBlock = virtualBlockList.front();


### PR DESCRIPTION
Existing IR traversals for things like dataflow analysis cannot automatically descend into the non-default partitions of a WarpSpecializeOp because we do not encode the edges to these regions through RegionBranchInterface.

Changing the warpspec operations to reflect these edges allows us to clean up code in the dataflow analyses that walks the IR looking for `WarpSpecializePartitionsOp`, and populates its block args.