### PR TITLE
[NFC] Simplify populating axisinfo map

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -1350,13 +1350,8 @@ void ModuleAxisInfoAnalysis::initialize(FunctionOpInterface funcOp,
     // pessimistic state.
     if (axisInfo.getRank() == 0)
       axisInfo = AxisInfo::getPessimisticValueState(value);
-    AxisInfo curAxisInfo;
-    if (axisInfoMap->count(value)) {
-      curAxisInfo = AxisInfo::join(axisInfo, axisInfoMap->lookup(value));
-    } else {
-      curAxisInfo = axisInfo;
-    }
-    (*axisInfoMap)[value] = curAxisInfo;
+    auto &valInfo = (*axisInfoMap)[value];
+    valInfo = AxisInfo::join(axisInfo, valInfo);
   };
   funcOp.walk([&](Operation *op) {
     for (auto value : op->getResults()) {


### PR DESCRIPTION
A default constructed `AxisInfo` passed as an operand to `AxisInfo::join` will always result in `join` returning the other operand. This means that we can call `join` unconditionally even when there is no existing entry in the map.

This collapses the three separate map lookups (the check, the join, and the population) to just a single one.