### PR TITLE
[AMD][Test] disable test_globaltime on gfx950

### DIFF
--- a/third_party/proton/test/test_instrumentation.py
+++ b/third_party/proton/test/test_instrumentation.py
@@ -15,6 +15,7 @@ from triton._internal_testing import (
     is_cuda,
     is_hip,
     is_hip_cdna2,
+    is_hip_cdna4,
     supports_tma,
     supports_ws,
 )
@@ -643,6 +644,7 @@ def test_timeline(tmp_path: pathlib.Path):
         assert trace_events[-1]["args"]["call_stack"][-2] == "test"
 
 
+@pytest.mark.skipif(is_hip_cdna4(), reason="nondeterministic failure")
 def test_globaltime(tmp_path: pathlib.Path):
     temp_file = tmp_path / "test_globaltime.chrome_trace"
     mode = proton.mode.Default(


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/8763 enabled it.
But it can still nondeterministically fail. See
https://github.com/triton-lang/triton/actions/runs/19586113554/job/56095247352?pr=8803#step:18:35