### PR TITLE
[CMake] Fix build breakage due to CMAKE_LIBRARY_OUTPUT_DIRECTORY

### DIFF
--- a/lib/Plugins/CMakeLists.txt
+++ b/lib/Plugins/CMakeLists.txt
@@ -35,9 +35,16 @@ foreach( plugin ${TRITON_PLUGIN_PASSES} )
         "$<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>"
         )
 
-    set_target_properties(${plugin} PROPERTIES
+    # CMAKE_LIBRARY_OUTPUT_DIRECTORY is only set during the Python
+    # build. It is empty if building directly from the root
+    # CMakeLists.txt file. Therefore if not building from Python just
+    # use the default CMake shared lib path otherwise this causes a hard
+    # build error
+    if(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+      set_target_properties(${plugin} PROPERTIES
           LIBRARY_OUTPUT_DIRECTORY
       "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/../plugins")
+    endif(DEFINED CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 
     target_compile_options(${plugin} PRIVATE -fvisibility=hidden)
 endforeach()


### PR DESCRIPTION
If building from root `CMakeLists.txt`, we will have an empty
`CMAKE_LIBRARY_OUTPUT_DIRECTORY`, then this will try
to create `/plugins` and see permission failures.