### PR TITLE
[TEST] Fix for test nondeterminism on tl.dot-BF16xN input_precision

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3325,7 +3325,7 @@ def test_dot(M, N, K, num_warps, col_a, col_b, epilogue, input_precision, in_dty
     if 'int' not in in_dtype and 'float8' not in in_dtype:
         x *= .1
         y *= .1
-    if in_dtype == 'float32' and input_precision == "tf32":
+    if in_dtype == 'float32' and input_precision in ["tf32", "bf16x3", "bf16x6"]:
         x = (x.view('uint32') & np.uint32(0xffffe000)).view('float32')
         y = (y.view('uint32') & np.uint32(0xffffe000)).view('float32')
         w = (w.view('uint32') & np.uint32(0xffffe000)).view('float32')


### PR DESCRIPTION
We have had a number of test failures due to numpy_random. I suspect blowing the bottom bits as was already the case for TF32 is needed.

Example test failures:

https://github.com/triton-lang/triton/actions/runs/19592177401/job/56111902929#step:13:943

https://github.com/triton-lang/triton/actions/runs/19446507385/job/55645510809#step:13:946

https://github.com/triton-lang/triton/actions/runs/18967311789/job/54200126681?pr=8593#step:12:1000
