### PR TITLE
[AMD] Extended FP conversion for gfx1250 arch

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -373,6 +373,9 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
         if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
+    if mode in ('inf', '-inf') and is_hip_gfx12():
+        pytest.skip(f"clamping from `{mode}` is not supported on AMDGPU GFX12")
+
     converter = {
         tl.float8e4nv: torch.float8_e4m3fn,
         tl.float8e5: torch.float8_e5m2,


### PR DESCRIPTION
GFX1250 arch comes with new FP conversion instruction which can convert 8x FP32/FP16/Bf16 to 8x FP8. This PR extends to the AMDGPU backend with the support of the new instructions 