### PR TITLE
refine lds layout order for transposed input

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/ReduceDataDuplication.cpp
@@ -49,9 +49,11 @@ public:
       // if input of convert_layout is transOp, actuall order is the order of
       // the transOp input. By setting lds order to be the same as input,
       // ds_write is more efficient
-      if (auto transOp = dyn_cast<TransOp>(inputOp)) {
-        order = getOrderForMemory(
-            cast<RankedTensorType>(transOp.getSrc().getType()));
+      if (inputOp) {
+        if (auto transOp = dyn_cast<TransOp>(inputOp)) {
+          order = getOrderForMemory(
+              cast<RankedTensorType>(transOp.getSrc().getType()));
+        }
       }
 
       auto sharedMemorySpace =

--- a/test/Conversion/amd/mfma-shortcut.mlir
+++ b/test/Conversion/amd/mfma-shortcut.mlir
@@ -119,7 +119,7 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32}
   tt.func public @mfma_dotop_lds_layout_order(%arg0: tensor<128x32xbf16, #mma>) {
     %1 = tt.trans %arg0 {order = array<i32: 1, 0>} : tensor<128x32xbf16, #mma> -> tensor<32x128xbf16, #linear>
     // GFX950-COUNT-2: llvm.store
-    // GFX950-COUNT-8: lvm.call_intrinsic "rocdl.ds.read.tr16.b64"
+    // GFX950-COUNT-8: rocdl.ds.read.tr16.b64
     %2 = ttg.convert_layout %1 : tensor<32x128xbf16, #linear> -> tensor<32x128xbf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
     tt.return
   }


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
This PR is related to a lds access scenario in the [HSTU attn backward kernel](https://github.com/meta-recsys/generative-recommenders/blob/9fe6a63d378ebcb47f1255077a7ca31beb2931da/generative_recommenders/ops/triton/triton_hstu_attention.py#L1760). When lds is used for a layout conversion and input of the convert_layout op is a `TransOp`, the `order` of the lds should be the same as the input rather than the output of `transOp`. This can make the lds write to be vectorized. Then for lds read, we can either use ds_read or ds_read_tr, so both lds write and read are vectorized. The PR can help uplift the hstu bwd kernel by 5%. 


# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
