### PR TITLE
[Frontend] Revert deep copy when entering new scope

### DIFF
--- a/python/test/unit/language/test_frontend.py
+++ b/python/test/unit/language/test_frontend.py
@@ -152,9 +152,6 @@ class TypeWithBuiltinInitializer:
     def __init__(self, _semantic=None):
         self.value = tl.arange(0, 4, _semantic=_semantic)
 
-    def modify(self, value, _semantic=None):
-        self.value = value
-
 
 @filecheck_test
 @triton.jit
@@ -164,48 +161,6 @@ def test_aggregate_initializers():
     # CHECK: [[RANGE:%.*]] = tt.make_range {end = 4 : i32, start = 0 : i32}
     # CHECK: call @{{.*}}anchor{{.*}}([[RANGE]])
     anchor(value)
-    # CHECK: [[RANGE:%.*]] = tt.make_range {end = 8 : i32, start = 4 : i32}
-    # CHECK: call @{{.*}}anchor{{.*}}([[RANGE]])
-    value.modify(tl.arange(4, 8))
-    anchor(value)
-
-
-@filecheck_test
-@triton.jit
-def test_aggregate_modification_in_for_loop():
-    # CHECK-LABEL: test_aggregate_modification_in_for_loop
-    value = TypeWithBuiltinInitializer()
-    # CHECK: [[RANGE:%.*]] = tt.make_range {end = 4 : i32, start = 0 : i32}
-    for i in range(0, 2):
-        # CHECK: [[RET:%.*]] = scf.for
-        # CHECK-SAME: iter_args([[ITER:%.*]] = [[RANGE]])
-        value.modify(tl.arange(4, 8))
-        # CHECK: [[RANGE:%.*]] = tt.make_range {end = 8 : i32, start = 4 : i32}
-        # CHECK: yield [[RANGE]]
-
-    anchor(value)
-    # CHECK: call @{{.*}}anchor{{.*}}([[RET]])
-
-
-@filecheck_test
-@triton.jit
-def test_aggregate_modification_in_while_loop():
-    # CHECK-LABEL: test_aggregate_modification_in_while_loop
-    value = TypeWithBuiltinInitializer()
-    # CHECK: [[RANGE:%.*]] = tt.make_range {end = 4 : i32, start = 0 : i32}
-    i = 0
-    # CHECK: [[C0:%.*]] = arith.constant 0 :
-    while i < 1:
-        # CHECK: [[RET:%.*]]:2 = scf.while ([[ITER:%.*]] = [[RANGE]], [[IV:%.*]] = [[C0]])
-        # CHECK: do
-        i = 1
-        # CHECK: [[C1:%.*]] = arith.constant 1 :
-        value.modify(tl.arange(4, 8))
-        # CHECK: [[RANGE:%.*]] = tt.make_range {end = 8 : i32, start = 4 : i32}
-        # CHECK: yield [[RANGE]], [[C1]]
-
-    anchor(value)
-    # CHECK: call @{{.*}}anchor{{.*}}([[RET]]#0)
 
 
 @triton.jit

--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -104,17 +104,6 @@ def unflatten_ir_values(handles: List[ir.value], types: List[base_type]):
 _condition_types = {bool, int, type(None)}  # Python types accepted for conditionals inside kernels
 
 
-def _clone_triton_value(val):
-    handles = []
-    val._flatten_ir(handles)
-    clone, _ = val.type._unflatten_ir(handles, 0)
-    return clone
-
-
-def _clone_scope(scope):
-    return {name: _clone_triton_value(val) if _is_triton_value(val) else val for name, val in scope.items()}
-
-
 class enter_sub_region:
 
     def __init__(self, generator):
@@ -122,8 +111,8 @@ class enter_sub_region:
 
     def __enter__(self):
         # record lscope & local_defs in the parent scope
-        self.liveins = _clone_scope(self.generator.lscope)
-        self.prev_defs = _clone_scope(self.generator.local_defs)
+        self.liveins = dict(self.generator.lscope)
+        self.prev_defs = dict(self.generator.local_defs)
         self.generator.local_defs = {}
         self.insert_block = self.generator.builder.get_insertion_block()
         self.insert_point = self.generator.builder.get_insertion_point()


### PR DESCRIPTION
This was added when we were attempting to support mutations in the frontend. However, now that we ban mutations it's nothing but an added cost during compilation.

With this change I see a 250ms improvement in compilation time for the attention gluon example kernel.