### PR TITLE
[Frontend] Lazily compute tuple_type.name

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -75,7 +75,7 @@ def test_err_in_unary_op():
     # ok, but the error message needs to point to the correct spot.
     @triton.jit
     def kernel():
-        not (0, 0)
+        -(0, 0)
 
     with pytest.raises(CompilationError) as e:
         triton.compile(triton.compiler.ASTSource(fn=kernel, signature={}, constexprs={}))

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1280,7 +1280,10 @@ class tuple(base_value):
             return tuple(self.values[idx.start:idx.stop:idx.step])
 
     def __getattr__(self, name):
-        return self.values[self.type.fields.index(name)]
+        fields = self.type.fields
+        if fields is None or name not in fields:
+            raise AttributeError(f"'tuple' object has no attribute {name}")
+        return self.values[fields.index(name)]
 
     # TODO: remove
     def _setitem(self, idx, value):


### PR DESCRIPTION
This saves ~40 ms in gluon attention which both uses tuples a lot and holds layouts inside, which can be relatively expensive to print.