### PR TITLE
[DO NOT MERGE!!!] Depricate AMDMfmaEncodingAttr

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
+++ b/include/triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h
@@ -13,6 +13,7 @@ enum class ScaleDotElemType : uint32_t;
 } // namespace mlir::triton
 
 namespace mlir::triton::gpu {
+class LinearEncodingAttr;
 class SwizzledSharedEncodingAttr;
 class NVMMASharedEncodingAttr;
 class TensorOrMemDesc;
@@ -117,12 +118,30 @@ chooseDsReadTrLayout(Attribute enc, ArrayRef<int64_t> shape,
                      int32_t elemBitWidth, unsigned instBitWidth,
                      unsigned numLanesInShuffleGroup);
 
+LinearLayout chooseMfmaTileLinearLayout(MLIRContext *ctx, ArrayRef<long> shape,
+                                        int mDim, int nDim, int kDim,
+                                        bool isTransposed,
+                                        unsigned elementBitWidth);
+
+LinearLayout chooseMfmaWarpLinearLayout(MLIRContext *ctx, unsigned rank,
+                                        ArrayRef<unsigned> warpsPerCTA,
+                                        ArrayRef<unsigned> tilesPerWarp);
+
+LinearLayout chooseMfmaLinearLayout(MLIRContext *ctx, ArrayRef<long> shape,
+                                    int mDim, int nDim, int kDim,
+                                    bool isTransposed, unsigned elementBitWidth,
+                                    ArrayRef<unsigned> warpsPerCTA,
+                                    ArrayRef<unsigned> tilesPerWarp);
+
+SmallVector<unsigned> findMfmaMNFromLL(LinearEncodingAttr mfmaLayout);
+LinearLayout getWarpMfmaLayout(LinearLayout mfmaLayout, int mDim, int nDim,
+                               MLIRContext *ctx);
+
 // Create LinearLayout for scale in scaled mfma.
 LinearLayout chooseScaledMfmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                          ArrayRef<int64_t> dotOperandShape,
                                          unsigned mfmaMDim,
-                                         ArrayRef<unsigned> tilesPerWarp,
-                                         ArrayRef<unsigned> warpsPerCTA);
+                                         LinearLayout warpLay);
 
 LinearLayout chooseScaledWmmaScaleLayout(MLIRContext *ctx, int dotOperandIdx,
                                          ArrayRef<int64_t> dotOperandShape,

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2456,6 +2456,8 @@ SmallVector<unsigned> DotOperandEncodingAttr::getRepOrder() const {
     return mma.getRepOrderForOperand(getOpIdx());
   } else if (auto blocked = mlir::dyn_cast<BlockedEncodingAttr>(getParent())) {
     return to_vector(blocked.getOrder());
+  } else if (auto linear = mlir::dyn_cast<LinearEncodingAttr>(getParent())) {
+    return to_vector(linear.getRepOrder());
   }
   llvm::report_fatal_error(
       "getRepOrder not implemented for DotOperandEncodingAttr");
@@ -2522,6 +2524,13 @@ LogicalResult DotOperandEncodingAttr::verify(
   }
 
   if (auto parentAttr = mlir::dyn_cast<AMDMfmaEncodingAttr>(parent)) {
+    if (kWidth == 0)
+      return emitError() << "ttg.dot_op kWidth parameter is mandatory for "
+                            "MFMA parent";
+    return success();
+  }
+
+  if (auto parentAttr = mlir::dyn_cast<LinearEncodingAttr>(parent)) {
     if (kWidth == 0)
       return emitError() << "ttg.dot_op kWidth parameter is mandatory for "
                             "MFMA parent";

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -30,9 +30,14 @@ DecomposeScaledBlocked::matchAndRewrite(DotScaledOp scaledDotOp,
           scaledDotOp.getResult().getType().getEncoding()))
     return failure();
 
+  if (isa_and_nonnull<LinearEncodingAttr>(
+          scaledDotOp.getResult().getType().getEncoding()))
+    return failure();
+
   // TODO: add support for m/n packed formats.
   if (!scaledDotOp.getLhsKPack() || !scaledDotOp.getRhsKPack())
     return failure();
+
   // Types
   auto computeType = getComputeType(scaledDotOp.getAElemType(),
                                     scaledDotOp.getBElemType(), rewriter);

--- a/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Prefetch.cpp
@@ -166,7 +166,7 @@ LogicalResult Prefetcher::initialize() {
       auto dstMmaEnc =
           dyn_cast<NvidiaMmaEncodingAttr>(getEncoding(dotOp.getResult()));
       auto dstMfmaEnc =
-          dyn_cast<AMDMfmaEncodingAttr>(getEncoding(dotOp.getResult()));
+          dyn_cast<LinearEncodingAttr>(getEncoding(dotOp.getResult()));
       if (!dstMfmaEnc && (!dstMmaEnc || dstMmaEnc.getVersionMajor() != 2))
         // Don't rewrite if any other type is found.
         return failure();

--- a/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/RemoveLayoutConversions.cpp
@@ -353,7 +353,7 @@ void LayoutPropagation::resolveConflicts() {
         op && isa<LoadOp, StoreOp, AtomicRMWOp, AtomicCASOp>(op);
     for (Attribute e : info.encodings) {
       if ((isLoadOrStore && isa<BlockedEncodingAttr>(e)) ||
-          (!isLoadOrStore && isa<MmaEncodingTrait>(e))) {
+          (!isLoadOrStore && isa<LinearEncodingAttr>(e))) {
         encoding = e;
         break;
       }
@@ -1294,7 +1294,7 @@ void LayoutRematerialization::hoistConvertDotOperand(
       auto dotEnc = dyn_cast<DotOperandEncodingAttr>(opType.getEncoding());
       if (!dotEnc)
         return;
-      if (isa<MmaEncodingTrait>(dotEnc.getParent()))
+      if (isa<LinearEncodingAttr>(dotEnc.getParent()))
         dotLikeOps.push_back(op);
     });
     if (dotLikeOps.empty())

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -939,9 +939,10 @@ void init_gluon_ir(py::module &&m) {
           MLIRContext ctx(MLIRContext::Threading::DISABLED);
           ctx.appendDialectRegistry(registry);
           ctx.loadAllAvailableDialects();
-
-          auto ll = ttg::chooseScaledMfmaScaleLayout(
-              &ctx, opIdx, shape, mfmaMDim, tilesPerWarp, warpsPerCTA);
+          auto warpMfmaLayout = ttg::chooseMfmaWarpLinearLayout(
+              &ctx, warpsPerCTA.size(), warpsPerCTA, tilesPerWarp);
+          auto ll = ttg::chooseScaledMfmaScaleLayout(&ctx, opIdx, shape,
+                                                     mfmaMDim, warpMfmaLayout);
           auto attr = ttg::LinearEncodingAttr::get(&ctx, ll);
           return layoutToGluon(attr);
         });

--- a/python/test/unit/language/test_matmul.py
+++ b/python/test/unit/language/test_matmul.py
@@ -731,10 +731,6 @@ def test_preshuffle_scale_mxfp_cdna4(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, DTYPE_A
     torch.testing.assert_close(torch_out, triton_out, atol=2e-5, rtol=1e-4)
     if is_hip() and preshuffle:
         assert "ds_read_u8" not in k.asm["amdgcn"]
-        if mfma_nonkdim == 16:
-            assert "tilesPerWarp = [2, 2]" in k.asm["ttgir"]
-        elif mfma_nonkdim == 32:  # default tilesPerWarp = [1, 1]
-            assert "tilesPerWarp" not in k.asm["ttgir"]
 
 
 @pytest.mark.parametrize("M, N, K", [(1024, 512, 512), (998, 111, 512), (63, 128, 512)])

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TargetUtils.h
@@ -29,6 +29,8 @@ bool isCDNA(ISAFamily isaFamily);
 
 bool isRDNA(ISAFamily isaFamily);
 
+int getMfmaVersion(ISAFamily isaFamily);
+
 // Here is a partial definition of DppCtrl enums. For the complete definition,
 // please check:
 // https://github.com/llvm/llvm-project/blob/8c75290/llvm/lib/Target/AMDGPU/SIDefines.h#L939

--- a/third_party/amd/include/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Utility.h
@@ -1,6 +1,7 @@
 #ifndef TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTRANSFORMS_UTILITY_H_
 #define TRITON_THIRD_PARTY_AMD_LIB_TRITONAMDGPUTRANSFORMS_UTILITY_H_
 
+#include "TritonAMDGPUTransforms/MfmaGroup.h"
 #include "amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/Value.h"
@@ -25,5 +26,18 @@ composePaddedLayout(const triton::AMD::TargetInfo &targetInfo,
                     triton::gpu::DotOperandEncodingAttr dotOpEnc,
                     triton::gpu::TensorOrMemDesc srcTy,
                     ArrayRef<unsigned> sharedOrder, bool useAsyncCopy);
+
+FailureOr<MfmaIntrinsic> chooseMfmaInstruction(triton::DotOp dot,
+                                               int mfmaVersion, int nonKDim,
+                                               bool withScale = false);
+FailureOr<MfmaIntrinsic> chooseMfmaInstruction(triton::DotScaledOp dot,
+                                               int mfmaVersion, int nonKDim);
+FailureOr<MfmaIntrinsic> chooseMfmaInstruction(triton::DotScaledOp dot,
+                                               int mfmaVersion, int nonKDim,
+                                               bool useFp16);
+FailureOr<MfmaIntrinsic>
+chooseMfmaInstruction(Location loc, int mfmaVersion, RankedTensorType cType,
+                      Type aElemType, Type bElemType, int inputKSize,
+                      int enforcedNonKDim, bool withScale, bool allowXF32);
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -20,7 +20,7 @@ void populateMemoryOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
 void populateDotOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                  RewritePatternSet &patterns,
                                  ModuleAxisInfoAnalysis &axisInfoAnalysis,
-                                 PatternBenefit benefit);
+                                 int mfmaVersion, PatternBenefit benefit);
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns, bool ftz,
     ModuleAxisInfoAnalysis &axisInfoAnalysis, ModuleAllocation &allocation,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetUtils.cpp
@@ -39,6 +39,22 @@ ISAFamily deduceISAFamily(llvm::StringRef arch) {
   return ISAFamily::Unknown;
 }
 
+int getMfmaVersion(ISAFamily isaFamily) {
+  switch (isaFamily) {
+  case ISAFamily::CDNA1:
+    return 1;
+  case ISAFamily::CDNA2:
+    return 2;
+  case ISAFamily::CDNA3:
+    return 3;
+  case ISAFamily::CDNA4:
+    return 4;
+  default:
+    break;
+  }
+  return 0;
+}
+
 bool supportsVDot(llvm::StringRef arch) {
   switch (deduceISAFamily(arch)) {
   case AMD::ISAFamily::CDNA1:

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -4,6 +4,7 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "TargetInfo.h"
 #include "TritonAMDGPUToLLVM/MembarUtility.h"
+#include "TritonAMDGPUToLLVM/TargetUtils.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h"
@@ -198,8 +199,12 @@ struct ConvertTritonAMDGPUToLLVM
                                                patterns, AMDBenefit);
     mlir::triton::populateConvertLayoutOpToLLVMPatterns(
         typeConverter, targetInfo, patterns, commonBenefit);
+
+    auto isaFamily = mlir::triton::AMD::deduceISAFamily(this->arch);
+    auto mfmaVersion = mlir::triton::AMD::getMfmaVersion(isaFamily);
+
     AMD::populateDotOpToLLVMPatterns(typeConverter, patterns, axisInfoAnalysis,
-                                     AMDBenefit);
+                                     mfmaVersion, AMDBenefit);
     AMD::populateElementwiseOpToLLVMPatterns(typeConverter, patterns, ftz,
                                              axisInfoAnalysis, allocation,
                                              targetInfo, AMDBenefit);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/UpcastMXFPToLLVM.cpp
@@ -11,6 +11,7 @@
 #include "triton/Conversion/TritonGPUToLLVM/Utility.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Attributes.h"
+#include "triton/Dialect/TritonGPU/IR/LinearLayoutConversions.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
@@ -201,12 +202,13 @@ public:
 
     auto dotEncoding =
         cast<DotOperandEncodingAttr>(op.getSrc().getType().getEncoding());
-    auto mfmaEncoding = dyn_cast<AMDMfmaEncodingAttr>(dotEncoding.getParent());
+    auto mfmaEncoding = dyn_cast<LinearEncodingAttr>(dotEncoding.getParent());
     if (!mfmaEncoding)
       return rewriter.notifyMatchFailure(op, "NYI: non-mfma dot operand");
-    LDBG("mfma: " << mfmaEncoding);
+    // LDBG("mfma: " << mfmaEncoding);
 
-    int mDim = mfmaEncoding.getInstrShape()[0];
+    int mDim =
+        findMfmaMNFromLL(mfmaEncoding)[0]; // mfmaEncoding.getInstrShape()[0];
     if (mDim != 32 && mDim != 16)
       return rewriter.notifyMatchFailure(op, "NYI: non-mfma32/16 intrinsics");
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -1064,9 +1064,9 @@ void Pingponger::getDotPingponged() {
   auto encoding = cast<RankedTensorType>(aType).getEncoding();
   auto srcEncoding = cast<ttg::DotOperandEncodingAttr>(encoding);
   kWidth = srcEncoding.getKWidth();
-  auto mfmaEncoding = cast<ttg::AMDMfmaEncodingAttr>(srcEncoding.getParent());
+  auto mfmaEncoding = cast<ttg::LinearEncodingAttr>(srcEncoding.getParent());
   SmallVector<int64_t> intShape;
-  auto mnkDim = mfmaEncoding.getInstrShape();
+  auto mnkDim = findMfmaMNFromLL(mfmaEncoding); // mfmaEncoding.getInstrShape();
   intShape.push_back(mnkDim[0]);
   intShape.push_back(mnkDim[1]);
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/InThreadTranspose.cpp
@@ -591,7 +591,7 @@ matchInThreadTransposePattern(ttg::LocalLoadOp lLoad) {
 
   int kDimNum = opDotOpEnc.getOpIdx() == 0 ? 1 : 0;
   // TODO: support wmma
-  if (!isa<ttg::AMDMfmaEncodingAttr, ttg::AMDWmmaEncodingAttr>(
+  if (!isa<ttg::LinearEncodingAttr, ttg::AMDWmmaEncodingAttr>(
           opDotOpEnc.getParent())) {
     LDBG("Operand's parent encoding is not MFMA");
     return failure();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -1,5 +1,5 @@
 #include "TritonAMDGPUTransforms/Passes.h"
-#include "Utility.h"
+#include "TritonAMDGPUTransforms/Utility.h"
 #include "amd/lib/TritonAMDGPUToLLVM/AsyncUtility.h"
 #include "amd/lib/TritonAMDGPUToLLVM/TargetInfo.h"
 #include "amd/lib/TritonAMDGPUTransforms/PipelineUtility.h"

--- a/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/OptimizeEpilogue.cpp
@@ -151,8 +151,8 @@ public:
       return mlir::failure();
 
     auto encoding = cvtOp.getSrc().getType().getEncoding();
-    if (!isa<triton::gpu::MmaEncodingTrait>(encoding))
-      return mlir::failure();
+    // if (!isa<triton::gpu::MmaEncodingTrait>(encoding))
+    //   return mlir::failure();
 
     if (!cvtOp.getResult().hasOneUse())
       return mlir::failure();

--- a/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/UpdateAsyncWaitCount.cpp
@@ -1,7 +1,7 @@
 #include "Dialect/TritonAMDGPU/IR/Dialect.h"
 #include "TritonAMDGPUTransforms/Passes.h"
+#include "TritonAMDGPUTransforms/Utility.h"
 #include "amd/lib/TritonAMDGPUToLLVM/Utility.h"
-#include "amd/lib/TritonAMDGPUTransforms/Utility.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "triton/Analysis/AxisInfo.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -267,9 +267,9 @@ public:
     RankedTensorType dstTy = op.getType();
     Attribute srcLayout = srcTy.getEncoding();
     Attribute dstLayout = dstTy.getEncoding();
-    if (isa<MmaEncodingTrait, BlockedEncodingAttr, SliceEncodingAttr>(
+    if (isa<LinearEncodingAttr, BlockedEncodingAttr, SliceEncodingAttr>(
             srcLayout) &&
-        isa<MmaEncodingTrait, BlockedEncodingAttr, SliceEncodingAttr>(
+        isa<BlockedEncodingAttr, BlockedEncodingAttr, SliceEncodingAttr>(
             dstLayout)) {
       if (shouldUseDistSmem(srcLayout, dstLayout))
         return lowerDistToDistWithDistSmem(op, adaptor, rewriter, targetInfo);


### PR DESCRIPTION
This patch rewrites DOT lowering with MFMA encoding attribute by using linear layouts instead.
This is both generalization and refactoring of current lowering.

Lowering now doesn't assume particular warp distribution across the tensor, instead it works correctly with arbitrary
warp distribution by analyzing LL during lowering.

TODO: Do a lot of cleanup. For example, references to AMDMfmaEncodingAttr/MMEncodingTrait can't simply be
replaced with LinearEncodingAttr as it is in current patch. I will add additional checks to see it particular LL is "MFMA like", by checking if it matches MFMA layout for a single tile (layout without warp dim and "repetition" registers).