### PR TITLE
Add x scale swizzling for blackwell + batched matmul

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -19,6 +19,7 @@ from triton_kernels.testing import assert_close, make_random_tensor
 from triton_kernels.target_info import is_hip, is_hip_cdna3, is_cuda, is_hip_cdna4
 from triton_kernels.swiglu import swiglu, swiglu_fn
 from triton_kernels.swiglu import PrecisionConfig as SwiGLUPrecisionConfig
+from triton_kernels.tensor_details import layout
 
 # ---------------
 # numerics stuff
@@ -73,8 +74,8 @@ class Case:
     weight_dtype_str: str
     n_slices: int = None
     split_k: int = 1
-    w_hbm_swizzling: bool = False
-    x_hbm_swizzling: bool = False
+    a_hbm_swizzling: bool = False
+    b_hbm_swizzling: bool = False
     epilogue_subtile: Union[int, None] = None
     a_transpose: bool = False
     b_transpose: bool = False
@@ -115,37 +116,37 @@ def _build_test_op_cases():
     for shape in [odd_shape2, even_shape]:
         test_cases.extend([
             Case(*shape, "plain", "bfloat16", "mxfloat4_e2m1"),
-            Case(*shape, "plain", "bfloat16", "mxfloat4_e2m1", w_hbm_swizzling=True),
+            Case(*shape, "plain", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True),
             Case(*shape, "batched", "bfloat16", "mxfloat4_e2m1"),
-            Case(*shape, "batched", "bfloat16", "mxfloat4_e2m1", w_hbm_swizzling=True),
+            Case(*shape, "batched", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True),
             Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1"),
-            Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1", w_hbm_swizzling=True),
+            Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1", b_hbm_swizzling=True),
             Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1", split_k=9),
-            Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1", split_k=9, w_hbm_swizzling=True),
+            Case(*shape, "ragged", "bfloat16", "mxfloat4_e2m1", split_k=9, b_hbm_swizzling=True),
             Case(*shape, "ragged", "bfloat16", "mxfloat8_e4m3fn"),
-            Case(*shape, "ragged", "bfloat16", "mxfloat8_e4m3fn", w_hbm_swizzling=True)
+            Case(*shape, "ragged", "bfloat16", "mxfloat8_e4m3fn", b_hbm_swizzling=True)
         ])
     # float8 x mxfloat
     test_cases.extend([
-        Case(16, 256, 256, "ragged", "float8_e5m2", "mxfloat4_e2m1", w_hbm_swizzling=True),
-        Case(1024, 1024, 1024, "batched", "float8_e5m2", "mxfloat4_e2m1", w_hbm_swizzling=True),
+        Case(16, 256, 256, "ragged", "float8_e5m2", "mxfloat4_e2m1", b_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "batched", "float8_e5m2", "mxfloat4_e2m1", b_hbm_swizzling=True),
         Case(1024, 1024, 1024, "batched", "float8_e5m2", "mxfloat4_e2m1"),
         Case(1024, 1024, 1024, "ragged", "float8_e5m2", "mxfloat4_e2m1", split_k=9),
-        Case(1024, 1024, 1024, "ragged", "float8_e5m2", "mxfloat4_e2m1", split_k=9, w_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "ragged", "float8_e5m2", "mxfloat4_e2m1", split_k=9, b_hbm_swizzling=True),
         Case(300, 400, 400, "ragged", "float8_e5m2", "mxfloat8_e4m3fn"),
         Case(300, 400, 832, "ragged", "float8_e5m2", "mxfloat4_e2m1"),
         Case(300, 400, 400, "batched", "float8_e5m2", "mxfloat8_e4m3fn"),
     ])
     # mxfloat x mxfloat
     test_cases.extend([
-        Case(16, 256, 256, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", w_hbm_swizzling=True),
-        Case(1024, 1024, 1024, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", split_k=9, w_hbm_swizzling=True),
+        Case(16, 256, 256, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", split_k=9, b_hbm_swizzling=True),
         Case(1024, 1024, 1024, "ragged", "mxfloat8_e4m3fn", "mxfloat4_e2m1", split_k=9, colmajor_mxfp_weight=False),
-        Case(1000, 704, 800, "batched", "mxfloat8_e4m3fn", "mxfloat4_e2m1", w_hbm_swizzling=True, x_hbm_swizzling=True),
+        Case(1000, 704, 800, "batched", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True, a_hbm_swizzling=True),
         Case(300, 400, 400, "ragged", "mxfloat8_e4m3fn", "mxfloat8_e4m3fn"),
-        Case(300, 400, 400, "ragged", "mxfloat8_e4m3fn", "mxfloat8_e4m3fn", w_hbm_swizzling=True),
+        Case(300, 400, 400, "ragged", "mxfloat8_e4m3fn", "mxfloat8_e4m3fn", b_hbm_swizzling=True),
         Case(300, 400, 400, "batched", "mxfloat8_e4m3fn", "mxfloat8_e4m3fn"),
-        Case(1024, 1024, 1024, "batched", "mxfloat8_e4m3fn", "mxfloat4_e2m1", w_hbm_swizzling=True),
+        Case(1024, 1024, 1024, "batched", "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True),
     ])
     # amd-specific float8
     test_cases.extend([
@@ -194,10 +195,10 @@ def _build_test_op_cases():
     (False, False, "pad_b"),
     (False, False, "pad_a"),
 ])
-@pytest.mark.parametrize("do_gamma", [False, True])
-@pytest.mark.parametrize("is_persistent", [False, True])
+@pytest.mark.parametrize("do_gamma", [False,True])
+@pytest.mark.parametrize("is_persistent", [False,True])
 def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, n_slices,
-            mode, act_dtype_str, weight_dtype_str, block_m, w_hbm_swizzling, x_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
+            mode, act_dtype_str, weight_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
             a_transpose, b_transpose, c_transpose,
             swiglu_opts, device, opt_flags_scope):
     # We catch and re-invoke pytest.skip(), because otherwise pytest may hold a reference to
@@ -205,7 +206,7 @@ def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, i
     skip_message = None
     try:
         _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, n_slices,
-                 mode, act_dtype_str, weight_dtype_str, block_m, w_hbm_swizzling, x_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
+                 mode, act_dtype_str, weight_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
                  a_transpose, b_transpose, c_transpose,
                  swiglu_opts, device, opt_flags_scope)
     except pytest.skip.Exception as e:
@@ -215,7 +216,7 @@ def test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, i
         pytest.skip(skip_message)
 
 def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, is_persistent, n_slices,
-            mode, act_dtype_str, weight_dtype_str, block_m, w_hbm_swizzling, x_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
+            mode, act_dtype_str, weight_dtype_str, block_m, b_hbm_swizzling, a_hbm_swizzling, colmajor_mxfp_weight, epilogue_subtile,
             a_transpose, b_transpose, c_transpose,
             swiglu_opts, device, opt_flags_scope):
     # TODO: remove when Triton FP8 supports proper RTNE
@@ -248,7 +249,7 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
     if "float8_e4m3fnuz" in (weight_dtype_str, act_dtype_str) and not is_hip_cdna3():
         pytest.skip("float8_e4m3fnuz only tested on AMD CDNA3 Platform")
 
-    if w_hbm_swizzling:
+    if b_hbm_swizzling:
         if is_hip():
             if not is_hip_cdna4():
                 pytest.skip("Scale preshuffling on AMD GPU has not been emulated on non-CDNA4 arch yet.")
@@ -260,8 +261,10 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
             if "mxfloat4" not in weight_dtype_str:
                 pytest.skip("NYI. Hopper swizzling just implemented for mxfp4.")
 
-    if x_hbm_swizzling:
+    if a_hbm_swizzling:
         # current x scale swizzling requires B200, batched input, mxfloat8 act and is persistent case
+        if is_hip():
+            pytest.skip("NYI. X swizzling not tested on AMD GPU yet.")
         if torch.cuda.get_device_capability()[0] < 10:
             pytest.skip("NYI. X swizzling only implemented for B200 for now.")
         if mode != "batched":
@@ -282,12 +285,12 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         if "mx" in weight_dtype_str:
             if inner_expt_opt != "pad_b":
                 pytest.skip("inner_expt_opt and weight mx only supported with pad_b")
-            if is_persistent and not w_hbm_swizzling:
+            if is_persistent and not b_hbm_swizzling:
                 pytest.skip("FIXME: Fatal Python error: Aborted")
             if is_hip():
                 if act_dtype_str == "bfloat16":
                     pytest.skip("FIXME: failed to translate module to LLVM IR")
-                if w_hbm_swizzling:
+                if b_hbm_swizzling:
                     pytest.skip("NYI: nner_expt_opt and HBM swizzling")
     if not colmajor_mxfp_weight:
         if torch.cuda.get_device_capability()[0] < 10:
@@ -301,7 +304,7 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
     torch.manual_seed(0)
 
     # set opt flags constraints
-    constraints = make_constraints(block_m, split_k, is_persistent, epilogue_subtile, w_hbm_swizzling, weight_dtype_str)
+    constraints = make_constraints(block_m, split_k, is_persistent, epilogue_subtile, b_hbm_swizzling, weight_dtype_str)
     opt_flags.update_opt_flags_constraints(constraints)
 
     a_dtype = DType(act_dtype_str)
@@ -324,7 +327,8 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         transpose = a_transpose,
         ragged_padding = inner_expt_opt is not None and "pad_a" in inner_expt_opt,
         squeeze_batch_dim = mode == "plain",
-        hbm_swizzling = x_hbm_swizzling,
+        scale_hbm_swizzling = layout.make_default_matmul_mxfp8_act_scale_layout if a_hbm_swizzling else None,
+        scale_hbm_swizzling_args = {},
     )
     b, b_scale_tri, b_ragged_metadata = make_random_tensor(
         shape=(k, n),
@@ -336,8 +340,11 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         transpose = b_transpose,
         ragged_padding = inner_expt_opt is not None and "pad_b" in inner_expt_opt,
         squeeze_batch_dim = mode == "plain",
-        hbm_swizzling = w_hbm_swizzling,
         is_mx_rowmajor = not colmajor_mxfp_weight,
+        value_hbm_swizzling = layout.make_default_matmul_mxfp4_w_layout if b_hbm_swizzling and colmajor_mxfp_weight and b_dtype.is_mxfloat4 else None,
+        value_hbm_swizzling_args = {"mx_axis":-2},
+        scale_hbm_swizzling = layout.make_default_matmul_mxfp4_w_scale_layout if b_hbm_swizzling and colmajor_mxfp_weight and b_dtype.is_mxfloat4 else None,
+        scale_hbm_swizzling_args = {"mx_axis":-2, "num_warps":8},
     )
     gather_indx  = None if not do_gather  else torch.randint(0, max(m, 1), (m, ), dtype=torch.int32, device=device)
     scatter_indx = None if not do_scatter else torch.randperm(m, dtype=torch.int32, device=device)

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -1,6 +1,6 @@
 # isort: off
 # fmt: off
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 import itertools
 import torch
 import triton
@@ -22,46 +22,6 @@ from .tensor import Storage, Tensor, FP4, bitwidth, wrap_torch_tensor, RaggedTen
 from .reduce import reduce
 from .reduce import PostprocessFn as ReducePostprocessFn
 from .tensor_details.ragged_tensor import ragged_metadata_fields
-
-@dataclass
-class GatherIndx:
-    """
-    Indices for an operation that performs:
-    Y = X[src_idx, :]
-    """
-    # array such that `dst_idx[src_idx] = arange(0, N)`
-    src_indx: torch.Tensor
-    dst_indx: torch.Tensor
-
-
-@dataclass
-class ScatterIndx:
-    """
-    Indices for an operation that performs:
-    Y[dst_idx, :] = X
-    """
-    # array such that `dst_idx[src_idx] = arange(0, N)`
-    src_indx: torch.Tensor
-    dst_indx: torch.Tensor
-
-@dataclass
-class RoutingData:
-    gate_scal: torch.Tensor = field()
-    expt_hist: torch.Tensor = field()
-    n_expts_tot: int = field()
-    n_expts_act: int = field()
-    expt_data: RaggedTensorMetadata = None
-
-    # Used to make perf annotation cleaner: when we use expert sharding, we can
-    # use this to tell the "expected" number of local tokens per expert, because
-    # the actual number can vary per each input.
-    expected_tokens_per_expt: int = field(default=None)
-
-    def n_blocks(self, n_rows, block_m):
-        if n_rows <= self.n_expts_tot:
-            return n_rows
-        else:
-            return triton.cdiv(max(n_rows - self.n_expts_tot + 1, 0), block_m) + self.n_expts_tot - 1
 
 @dataclass(frozen=True)
 class FusedActivation:
@@ -278,7 +238,7 @@ def matmul(a, b, bias,
     if epilogue is None:
         epilogue = Epilogue(FnSpecs.default(), tuple(), tuple(), False)
     n_slices = max(1, b.shape[0]) if a_ragged_metadata is None else a_ragged_metadata.n_slices
-    # unpack scales
+    # unpack b scale
     b_scale = precision_config.b_mx_scale
     b_has_mx = b_scale is not None
     is_hopper_fp8 = is_cuda() and not target_info.cuda_capability_geq(10, 0) and bitwidth(b.dtype) == 8
@@ -294,14 +254,12 @@ def matmul(a, b, bias,
     if b_scale is not None:
         b_scale.storage.data = b_scale.data.view(torch.uint8)
         b_scale.dtype = torch.uint8
+    # unpack a scale
     a_scale = precision_config.a_mx_scale
     a_has_mx = a_scale is not None
     if a_has_mx: assert a.stride(-1) == 1, "'x' must be row-major when it has data-type mxfp"
     if a_scale is not None and not isinstance(a_scale, Tensor):
         a_scale = Tensor(a_scale)
-    if a_scale is not None:
-        a_scale.storage.data = a_scale.data.view(torch.uint8)
-        a_scale.dtype = torch.uint8
     if not isinstance(a, Tensor):
         a = Tensor(a, dtype=a.dtype)
     a_transpose = a.stride(-1) != 1
@@ -474,7 +432,7 @@ def matmul(a, b, bias,
     else:
         b_scale_tensor_or_tma = b_scale
     # create tma descriptor for x_scale
-    a_scale_has_tma = opt_flags.is_persistent and a_scale is not None
+    a_scale_has_tma = opt_flags.is_persistent and a_has_mx
     if a_scale_has_tma:
         # temporary limitation for x scale tma: only support act scale layout is BlackwellActMXScaleLayout and input batched case
         if not isinstance(a_scale.storage.layout, BlackwellActMXScaleLayout):
@@ -484,12 +442,13 @@ def matmul(a, b, bias,
         if opt_flags.block_m < 128 or opt_flags.block_k < 128: # need to be at least 128 for TMA
             a_scale_has_tma = False
     if a_scale_has_tma:
-        a_scale_storage = a_scale.storage
+        a_scale.storage.data = a_scale.storage.data.view(torch.uint8)
+        a_scale.dtype = torch.uint8
         scale_block_k = opt_flags.block_k // int(MXFP_BLOCK_SIZE)
         a_scale_tma_block_size = [opt_flags.block_m, scale_block_k]
-        a_scale_tensor_or_tma = a_scale_storage.make_tma(a_scale_tma_block_size, "dense", is_scale=True)
+        a_scale_tensor_or_tma = a_scale.storage.make_tma(a_scale_tma_block_size, "dense", is_scale=True)
     else:
-        a_scale_tensor_or_tma = a_scale
+        a_scale_tensor_or_tma = None if a_scale is None else a_scale.data.view(torch.uint8)
     # canonicalize strides
     a_strides = [0]*(3 - a_storage.data.ndim) + list(a_storage.data.stride())
     a_scale_strides = a_scale.stride() if a_has_mx and not a_scale_has_tma else (None, None, None)

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -283,7 +283,7 @@ def _p_matmul(
             # --- load x_scale ---
             x_format: tl.constexpr = get_scaled_dot_format_string(x.dtype)
             if is_x_microscaled:
-                if XMxScalePtrs is not None: # not using TAM for x scale load
+                if XMxScalePtrs is not None: # not using TMA for x scale load
                     off_k_mx = off_k_w // (MX_PACK_DIVISOR // W_PACK_DIVISOR)
                     if EVEN_K:
                         mask_k_scale = tl.full([MX_SCALE_BLOCK_K], True, dtype=tl.int1)
@@ -320,7 +320,7 @@ def _p_matmul(
                     w_scales = WMxScale.load([off_w_z, off_k_mx, off_n])
                     w_scales = tl.reshape(w_scales, *w_scales.shape[1:]).T
 
-            # # --- update accumulator ---
+            # --- update accumulator ---
             if is_w_microscaled:
                 if SWAP_XW:
                     acc = tl.dot_scaled(w.T, w_scales, w_format, x.T, x_scales, x_format, acc=acc, fast_math=True)

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -199,7 +199,25 @@ def make_default_opt_flags_nvidia(
     group_m = 8
     xcd_swizzle = 1
     # block_m
-    block_m, block_m_tma = opt_flags_nvidia.compute_block_m(m, constraints, enforce_bitwise_invariance, slice_size, routing_data, lhs_dtype, rhs_dtype, precision_config)
+    if constraints.get("block_m", None):
+        block_m = constraints["block_m"]
+    elif enforce_bitwise_invariance:
+        block_m = 128
+    else:
+        if slice_size <= 64 and routing_data is not None and routing_data.slice_sizes is not None:
+            # Ragged and likely memory bound; set the block size higher to minimize loading weights more than once.
+            if (
+                lhs_dtype == torch.bfloat16
+                and rhs_dtype == FP4
+                and slice_size >= 16
+                and torch.cuda.get_device_capability()[0] >= 10
+            ):
+                block_m = max(16, min(triton.next_power_of_2(8 * slice_size), 128))
+            else:
+                block_m = max(16, min(triton.next_power_of_2(2 * slice_size), 64))
+        else:
+            block_m = max(16, min(triton.next_power_of_2(slice_size), 128))
+    # block n
     arch = None
     block_n, block_n_tma = opt_flags_nvidia.compute_block_n(n, arch, precision_config)
     # is_persistent

--- a/python/triton_kernels/triton_kernels/tensor_details/layout.py
+++ b/python/triton_kernels/triton_kernels/tensor_details/layout.py
@@ -43,5 +43,5 @@ def make_default_matmul_mxfp4_w_scale_layout(mx_axis: int, num_warps: int = 8):
 
 def make_default_matmul_mxfp8_act_scale_layout():
     if cuda_capability_geq(10):
-        return BlackwellActMXScaleLayout
-    return StridedLayout
+        return BlackwellActMXScaleLayout, dict()
+    return StridedLayout, dict()

--- a/python/triton_kernels/triton_kernels/testing.py
+++ b/python/triton_kernels/triton_kernels/testing.py
@@ -7,7 +7,6 @@ import torch
 from triton_kernels.numerics import MAX_FINITE_FLOAT8E4B8, MAX_FINITE_FLOAT8E4NV, MAX_FINITE_FLOAT8E5
 from triton_kernels.tensor import convert_layout, wrap_torch_tensor, FP4, make_ragged_tensor_metadata
 from triton_kernels.numerics_details.mxfp import downcast_to_mxfp, MXFP_BLOCK_SIZE
-from triton_kernels.tensor_details import layout
 import itertools
 from dataclasses import replace
 
@@ -289,7 +288,8 @@ def pad_ragged_tensor(x, x_ragged_metadata, hbm_swizzling, transpose):
 
 
 def make_random_tensor(shape, n_slices, ragged_dim, ragged_padding, device, dtype, mxfp_dim, transpose,
-                       squeeze_batch_dim, hbm_swizzling=False, is_mx_rowmajor=False):
+                       squeeze_batch_dim, is_mx_rowmajor=False, value_hbm_swizzling=None, value_hbm_swizzling_args={},
+                       scale_hbm_swizzling=None, scale_hbm_swizzling_args={}):
     # allocate buffer
     buffer_shape = ((n_slices, ) if ragged_dim is None else tuple()) + shape
     buffer_dtype = torch.bfloat16 if dtype.has_mx_scale else dtype.torch_dtype
@@ -302,7 +302,8 @@ def make_random_tensor(shape, n_slices, ragged_dim, ragged_padding, device, dtyp
         slice_sizes = make_slice_sizes(n_slices, shape[ragged_dim], device=device)
         ragged_metadata = make_ragged_tensor_metadata(slice_sizes, shape[ragged_dim])
     if ragged_padding:
-        buffer, ragged_metadata = pad_ragged_tensor(buffer, ragged_metadata, hbm_swizzling, ragged_dim == 1)
+        buffer, ragged_metadata = pad_ragged_tensor(buffer, ragged_metadata, value_hbm_swizzling is not None
+                                                    or scale_hbm_swizzling is not None, ragged_dim == 1)
     # handle transpose
     if transpose:
         buffer = buffer.mT.contiguous().mT
@@ -318,18 +319,12 @@ def make_random_tensor(shape, n_slices, ragged_dim, ragged_padding, device, dtyp
             buffer, scales = downcast_to_mxfp(buffer, buffer_dtype, axis=mxfp_dim)
         buffer = wrap_torch_tensor(buffer, FP4 if dtype.is_mxfloat4 else buffer_dtype)
         scales = wrap_torch_tensor(scales)
-        if dtype.is_mxfloat4 and hbm_swizzling and not is_mx_rowmajor:
+        if value_hbm_swizzling is not None:
             # convert buffer to swizzled hbm layout
-            buffer_layout, buffer_layout_opts = layout.make_default_matmul_mxfp4_w_layout(mx_axis=mxfp_dim)
+            buffer_layout, buffer_layout_opts = value_hbm_swizzling(**value_hbm_swizzling_args)
             buffer = convert_layout(buffer, buffer_layout, **buffer_layout_opts)
+        if scale_hbm_swizzling is not None:
             # convert scales to swizzled hbm layout
-            scale_layout, scale_layout_opts = layout.make_default_matmul_mxfp4_w_scale_layout(
-                mx_axis=mxfp_dim, num_warps=8)
+            scale_layout, scale_layout_opts = scale_hbm_swizzling(**scale_hbm_swizzling_args)
             scales = convert_layout(scales, scale_layout, **scale_layout_opts)
-        if dtype.is_mxfloat8 and hbm_swizzling:
-            # # convert buffer to swizzled hbm layout
-            # buffer_layout, buffer_layout_opts = layout.make_default_matmul_mxfp8_w_layout(mx_axis=mxfp_dim)
-            # buffer = convert_layout(buffer, buffer_layout, **buffer_layout_opts)
-            # convert scales to swizzled hbm layout
-            scales = convert_layout(scales, layout.make_default_matmul_mxfp8_act_scale_layout(), **{})
     return buffer, scales, ragged_metadata


### PR DESCRIPTION
What:
This PR adds the scale tensor swizzling for mxfp8 x input. And this initial version only supports blackwell, batched input (batched matmul where x and w all are 3 dim input), and persistent mamtul (_p_matmul_orgs). Will address the other hardware and ragged case in following PRs.

Why:
Current matmul with mxfp8 x is 1.7x slower than fp8 x. After swizzling x scale and use TMA to load x scale, the latency difference is dropped to 1.1x.

B=M=N=K=1024

before
├─ 219902325555200.000 143856876.000 _p_matmul_ogs_NNT_bf16xfp8e4nvxmxfp4_128x256x128x1 [B = 1024, M = 1024, N = 1024, K = 1024] stg4 ep/4
└─ 219902325555200.000 84351383.000 _p_matmul_ogs_NNT_fp8e4nvxfp8e4nvxmxfp4_128x256x128x1 [B = 1024, M = 1024, N = 1024, K = 1024] stg4 ep/2

after
├─ 219902325555200.000 102593357.000 _p_matmul_ogs_NNT_bf16xfp8e4nvxmxfp4_128x256x128x1 [B = 1024, M = 1024, N = 1024, K = 1024] stg4 ep/4
└─ 219902325555200.000 88714864.000 _p_matmul_ogs_NNT_fp8e4nvxfp8e4nvxmxfp4_128x256x128x1 [B = 1024, M = 1024, N = 1024, K = 1024] stg4 ep/2

Main changes are:

Add swizzling and unswizzle logics
Revise matmul_ogs and _p_matmul_ogs to adopt TMA for x scale load: swizzle x scale before load, load, then unswizzle for dot operation.

New test for a scale swizzling:
```
pytest ./python/triton_kernels/tests/test_matmul.py -rs -vv -k "True-False-False-False-None-128-1000-704-800-batched-mxfloat8_e4m3fn-mxfloat4_e2m1-10-1-True-True-None-False-False-False-True-None"
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
