### PR TITLE
Fix two issues for matmul directly output mxfp format

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -176,6 +176,11 @@ def _build_test_op_cases():
         Case(*even_shape, "ragged", "bfloat16", "bfloat16", epilogue_subtile=val, swiglu_opts=(1.1, 1.4))
         for val in (1, 2, 4)
     ])
+    # swiglu together with mxfp8 downcastepilogue
+    test_cases.extend([
+        Case(*shape, mode, "mxfloat8_e4m3fn", "mxfloat4_e2m1", b_hbm_swizzling=True, split_k=split_k, swiglu_opts=(1.1, 7))
+     for shape in [odd_shape2, even_shape] for mode in ["ragged", "batched"] for split_k in [1, 5]
+    ])
 
     return test_cases
 

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -434,7 +434,6 @@ def _p_matmul(
 
         if is_out_microscaled:
             MX_SCALE_BLOCK_N: tl.constexpr = OUT_BLOCK_N // MXFP_BLOCK_SIZE
-            N_MX_BLOCK = tl.cdiv(N, MXFP_BLOCK_SIZE)
 
         for a_i in tl.static_range(len(accs)):
             acc_tile = accs[a_i]
@@ -490,7 +489,7 @@ def _p_matmul(
                 out, out_scale = EPILOGUE_FN(out, mask_m[:, None] & mask_n[None, :], *epilogue_fn_args)
                 tl.static_assert(BLOCK_N % MX_SCALE_BLOCK_N == 0, "")
                 offs_y_n_scale = off_n1 // ACTIVATION_REDUCTION_N // MXFP_BLOCK_SIZE + a_i * MX_SCALE_BLOCK_N + tl.arange(0, MX_SCALE_BLOCK_N)
-                mask_n_scale = offs_y_n_scale < N_MX_BLOCK
+                mask_n_scale = offs_y_n_scale < tl.cdiv(yN, MXFP_BLOCK_SIZE)
                 offs_y_mx_k = 0
                 if USE_SCATTER_TMA:
                     # Convert -1 offsets to INT_MAX. We do this by clearing the leading bit. Note that

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -215,6 +215,9 @@ def make_default_opt_flags_nvidia(
                 block_m = max(16, min(triton.next_power_of_2(8 * slice_size), 128))
             else:
                 block_m = max(16, min(triton.next_power_of_2(2 * slice_size), 64))
+            if block_m == 64 and precision_config.c_mx_scale is not None and rhs_dtype == FP4 and torch.cuda.get_device_capability()[0] >= 10:
+                # when having both fused_activation and mxfp8 downcast in epilogue, block_m=64 causing shared memory overflow
+                block_m = 128
         else:
             block_m = max(16, min(triton.next_power_of_2(slice_size), 128))
     # block n


### PR DESCRIPTION
Encountered two issues when directly having mxfp8 output from matmul:
- SMEM out of memory: this only happens for block_m=64. num_stages is over estimated in this case. Temporary fix in this PR to use block_m=128 instead and will need to fix num_stages estimation in next step. 
- Numerics off for some shapes when fusing swiglu from unit test: there is a bug in mask_n_scale which should use yN (N // ACTIVATION_REDUCTION_N) instead N. 

```
pytest ./python/triton_kernels/tests/test_matmul.py -rs -vv -k "True-False-True-False-None-128-720-576-768-ragged-mxfloat8_e4m3fn-mxfloat4_e2m1-10-1-False-True-None-False-False-False-True-swiglu_opts"
```

```
pytest ./python/triton_kernels/tests/test_matmul.py -rs -vv -k "True-False-True-False-None-128-768-512-1024-ragged-mxfloat8_e4m3fn-mxfloat4_e2m1-10-1-False-True-None-False-False-False-True-swiglu_opts"
```