### PR TITLE
[AMD][Test] Fix Triton gather test to skip CDNA2 when shape too large.

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6383,7 +6383,7 @@ def gather_test_kernel_1d(src_ptr, idx_ptr, out_ptr, axis: tl.constexpr, src_dim
     ([128, 64], [128, 128], 1),
 ])
 def test_gather(src_shape, indices_shape, axis, device):
-    if is_hip_cdna3() and src_shape == [128, 64] and indices_shape == [256, 64]:
+    if (is_hip_cdna2() or is_hip_cdna3()) and src_shape == [128, 64] and indices_shape == [256, 64]:
         # This could be solved by reducing vectorization in general swizzling algorithm.
         # We will do this if any relevant workload suffers from large LDS consumption of the algorithm.
         pytest.skip('Not enough LDS.')


### PR DESCRIPTION
Currently CI is failing for CDNA2 on test_core's gather test when shape is too large. We are skipping for CDNA3 to resolve this but did not skip on CDNA2. This PR adds a skip for CDNA2 as well to turn CI green.