### PR TITLE
[AMD] Fixing waitcnt for gfx1250

### DIFF
--- a/third_party/amd/language/hip/utils.py
+++ b/third_party/amd/language/hip/utils.py
@@ -7,29 +7,20 @@ def memrealtime(_semantic=None):
     Returns a 64-bit real time-counter value
     """
     target_arch = _semantic.builder.options.arch
-    if 'gfx11' in target_arch or 'gfx12' in target_arch:
-        return core.inline_asm_elementwise(
-            """
-            s_sendmsg_rtn_b64 $0, sendmsg(MSG_RTN_GET_REALTIME)
-            s_waitcnt lgkmcnt(0)
-            """,
-            "=r",
-            [],
-            dtype=core.int64,
-            is_pure=False,
-            pack=1,
-            _semantic=_semantic,
-        )
-    else:
-        return core.inline_asm_elementwise(
-            """
-            s_memrealtime $0
-            s_waitcnt vmcnt(0)
-            """,
-            "=r",
-            [],
-            dtype=core.int64,
-            is_pure=False,
-            pack=1,
-            _semantic=_semantic,
-        )
+    asm_str = """s_memrealtime $0
+                 s_waitcnt vmcnt(0)"""
+    if 'gfx11' in target_arch:
+        asm_str = """s_sendmsg_rtn_b64 $0, sendmsg(MSG_RTN_GET_REALTIME)
+                     s_waitcnt lgkmcnt(0)"""
+    elif 'gfx12' in target_arch:
+        asm_str = """s_sendmsg_rtn_b64 $0, sendmsg(MSG_RTN_GET_REALTIME)
+                     s_wait_kmcnt 0"""
+    return core.inline_asm_elementwise(
+        asm_str,
+        "=r",
+        [],
+        dtype=core.int64,
+        is_pure=False,
+        pack=1,
+        _semantic=_semantic,
+    )

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1761,9 +1761,10 @@ struct AtomicCASOpConversion
           return success();
         }
 
-        GCNBuilder BuilderMemfenceLDS;
-        BuilderMemfenceLDS.create("s_waitcnt lgkmcnt(0)")->operator()();
-        BuilderMemfenceLDS.launch(rewriter, loc, void_ty(ctx));
+        auto dsCount = rewriter.getI32IntegerAttr(0);
+        amdgpu::MemoryCounterWaitOp::create(rewriter, op->getLoc(),
+                                            /*load=*/nullptr, /*store=*/nullptr,
+                                            /*ds=*/dsCount);
         b.barrier();
         Value atomPtr =
             getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());


### PR DESCRIPTION
AMD gfx1250 deprecates "s_waitcnt lgkmcnt(N)" where the lgkm stands for lds, gds, constant and messages. Instead there are different wait instructions for some different types. Therefore updating some hard-coded waitcnts to (1) MemoryCounterWaitOp which is arch aware and uses the different wait types, and (2) fixing REALTIME's wait for message count (which is an edge case) to use s_wait_kmcnt which is new for gfx1250.
