### PR TITLE
Move the CallGraph utility to the mlir::triton namespace

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -59,7 +59,7 @@ public:
   /// A unique identifier for shared memory buffers
   using BufferId = size_t;
   using BufferIdSetT = DenseSet<BufferId>;
-  using FuncAllocMapT = CallGraph<Allocation>::FuncDataMapT;
+  using FuncAllocMapT = triton::CallGraph<Allocation>::FuncDataMapT;
 
   static constexpr BufferId InvalidBufferId =
       std::numeric_limits<BufferId>::max();
@@ -216,14 +216,14 @@ private:
 /// Each call op is treated like convert_layout that allocates a scratch buffer.
 /// At each call, we compute the start offset of the scratch buffer and pass it
 /// as an argument to the callee.
-class ModuleAllocation : public CallGraph<Allocation> {
+class ModuleAllocation : public triton::CallGraph<Allocation> {
 public:
   using FuncOffsetMapT = DenseMap<FunctionOpInterface, Value>;
 
   ModuleAllocation(ModuleOp moduleOp,
                    triton::AllocationAnalysisScratchSizeFn scratchSizeGetter =
                        triton::defaultAllocationAnalysisScratchSizeFn)
-      : CallGraph<Allocation>(moduleOp) {
+      : triton::CallGraph<Allocation>(moduleOp) {
     walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
         // Pre-order edge walk callback
         [](CallOpInterface callOp, FunctionOpInterface funcOp) {},

--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -101,7 +101,7 @@ class MembarOrFenceAnalysis {
   using VirtualBlock = std::pair<Block *, Block::iterator>;
 
 public:
-  using FuncBlockInfoMapT = CallGraph<BlockInfo>::FuncDataMapT;
+  using FuncBlockInfoMapT = triton::CallGraph<BlockInfo>::FuncDataMapT;
   /// Creates a new Membar analysis that generates the shared memory barrier
   /// in the following circumstances:
   /// - RAW: If a shared memory write is followed by a shared memory read, and
@@ -179,11 +179,11 @@ private:
 /// after returning. This way users do not have to explicitly insert membars
 /// before and after function calls, but might be a bit conservative.
 template <typename AnalysisType>
-class ModuleMembarOrFenceAnalysis : public CallGraph<BlockInfo> {
+class ModuleMembarOrFenceAnalysis : public triton::CallGraph<BlockInfo> {
 public:
   ModuleMembarOrFenceAnalysis(ModuleAllocation *moduleAllocation,
                               MembarFilterFn filter = nullptr)
-      : CallGraph<BlockInfo>(moduleAllocation->getModuleOp()),
+      : triton::CallGraph<BlockInfo>(moduleAllocation->getModuleOp()),
         moduleAllocation(moduleAllocation), filter(filter) {}
 
   void run() {

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -271,6 +271,8 @@ bool shouldUseDistSmem(Attribute srcLayout, Attribute dstLayout);
 /// Create a basic DataFlowSolver with constant and dead code analysis included.
 std::unique_ptr<DataFlowSolver> createDataFlowSolver();
 
+namespace triton {
+
 /// This class represents a call graph for a given ModuleOp and holds
 /// data of type T associated with each FunctionOpInterface.
 template <typename T> class CallGraph {
@@ -409,6 +411,9 @@ protected:
   FuncDataMapT funcMap;
   SmallVector<FunctionOpInterface> roots;
 };
+
+} // namespace triton
+
 // Create a basic DataFlowSolver with constant and dead code analysis included.
 std::unique_ptr<DataFlowSolver> createDataFlowSolver();
 

--- a/third_party/proton/Dialect/include/Analysis/ScopeIdAllocation.h
+++ b/third_party/proton/Dialect/include/Analysis/ScopeIdAllocation.h
@@ -59,7 +59,7 @@ private:
   ScopeIdParent scopeParentIds;
 };
 
-class ModuleScopeIdAllocation : public CallGraph<ScopeIdAllocation> {
+class ModuleScopeIdAllocation : public triton::CallGraph<ScopeIdAllocation> {
 public:
   using FuncOffsetMapT =
       llvm::DenseMap<FunctionOpInterface, ScopeIdAllocation::ScopeId>;


### PR DESCRIPTION
Upstream MLIR defines its own `mlir::CallGraph` class, so adding another one is an ODR violation.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because: this is an NFC fixing a normally hidden ODR violation.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
