### PR TITLE
Preserve named tuples in constexpr_functions

### DIFF
--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -364,3 +364,22 @@ def test_tuple_float():
         x, y = float("-inf"), float("inf")  # noqa: F841
 
     _namedtuple_float_tuple_kernel[(1, )]()
+
+
+@triton.constexpr_function
+def passthrough_constexpr(x):
+    return x
+
+
+class TrivialTuple(NamedTuple):
+    foo: tl.constexpr
+
+
+@pytest.mark.interpreter
+def test_tuple_constexpr_function():
+
+    @triton.jit
+    def kernel():
+        tl.static_assert(passthrough_constexpr(TrivialTuple(0)).foo == 0)
+
+    kernel[(1, )]()

--- a/python/triton/_utils.py
+++ b/python/triton/_utils.py
@@ -146,3 +146,12 @@ def get_primitive_bitwidth(dtype: str) -> int:
 
 def is_namedtuple(val):
     return isinstance(val, type) and issubclass(val, tuple) and hasattr(val, "_fields")
+
+
+def _tuple_create(arg, contents):
+    # NamedTuples and tuples have different construction semantics. NamedTuple
+    # has a constructor that takes individual arguments, while tuple takes an
+    # iterable. Both have type "tuple" making it difficult to distinguish
+    # between them, but only NamedTuple has "_fields" and apparently this is how
+    # everyone does the check.
+    return type(arg)(*contents) if hasattr(arg, "_fields") else type(arg)(contents)

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -14,7 +14,7 @@ from ..runtime.jit import JITCallable
 import inspect
 
 from .._C.libtriton import ir
-from .._utils import TRITON_MAX_TENSOR_NUMEL, validate_block_shape, get_primitive_bitwidth
+from .._utils import TRITON_MAX_TENSOR_NUMEL, validate_block_shape, get_primitive_bitwidth, _tuple_create
 
 T = TypeVar('T')
 
@@ -353,9 +353,9 @@ def _unwrap_if_constexpr(o):
     if isinstance(o, list):
         return [_unwrap_if_constexpr(x) for x in o]
     if isinstance(o, builtins.tuple):
-        return builtins.tuple(_unwrap_if_constexpr(x) for x in o)
+        return _tuple_create(o, [_unwrap_if_constexpr(x) for x in o])
     if isinstance(o, tuple):
-        return tuple(_unwrap_if_constexpr(x) for x in o)
+        return tuple([_unwrap_if_constexpr(x) for x in o], o.type)
     return o.value if isinstance(o, constexpr) else o
 
 

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -19,6 +19,7 @@ from .errors import InterpreterError
 from functools import partial
 from .._C.libtriton import interpreter as _interpreter
 from .._C.libtriton import ir as _ir
+from .._utils import _tuple_create
 
 T = TypeVar("T")
 
@@ -1191,15 +1192,6 @@ def _patch_lang(fn):
         _patch_lang_core(lang, scope)
     _patch_builtin(tl.core.tensor_descriptor_base, interpreter_builder, scope)
     return scope
-
-
-def _tuple_create(arg, contents):
-    # NamedTuples and tuples have different construction semantics. NamedTuple
-    # has a constructor that takes individual arguments, while tuple takes an
-    # iterable. Both have type "tuple" making it difficult to distinguish
-    # between them, but only NamedTuple has "_fields" and apparently this is how
-    # everyone does the check.
-    return type(arg)(*contents) if hasattr(arg, "_fields") else type(arg)(contents)
 
 
 # TODO: wrap everything in triton tensors


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
