### PR TITLE
[AMD] NFC: drop last dead getShapePerCTATile declaration

### DIFF
--- a/third_party/amd/include/Dialect/TritonAMDGPU/Utility/CommonUtils.h
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/Utility/CommonUtils.h
@@ -10,9 +10,6 @@ using ElemLocationKey = SmallVector<std::pair<StringAttr, int32_t>>;
 
 SmallVector<scf::ForOp> getLeafForOps(triton::FuncOp funcOp);
 
-// [FIXME LL] Kill this function
-SmallVector<unsigned> getShapePerCTATile(RankedTensorType tensorTy);
-
 // Build element coordinates for a given register ID.
 // All other hardware dimensions (lane, warp, block) are set to 0.
 ElemLocationKey getElemCoordinatesFromRegisters(LinearLayout ll, unsigned regId,


### PR DESCRIPTION
We already removed all usage of it with prior pull requests https://github.com/triton-lang/triton/pull/8184 and https://github.com/triton-lang/triton/pull/8282.