### PR TITLE
[Tests] Disable stack traces in performance remark tests

### DIFF
--- a/python/test/unit/test_perf_warning.py
+++ b/python/test/unit/test_perf_warning.py
@@ -83,18 +83,18 @@ def test_mma_remark(capfd, fresh_triton_cache):
     assert ("due to unsupported shapes or data types" in captured.err), "expect explanation in the remark"
     assert "note: see current operation:" not in captured.err
 
-    with enable_diagnostics_context('remarks,operations,stacktraces'):
+    with enable_diagnostics_context('remarks,operations'):
         triton.compile(triton.compiler.ASTSource(
             fn=matmul_kernel,
             signature=signature,
             constexprs={},
         ))
     captured = capfd.readouterr()
-    assert "note: diagnostic emitted with trace:" in captured.err
+    # Stack traces disabled as it adds several minutes to compile time
+    # assert "note: diagnostic emitted with trace:" in captured.err
     assert "note: see current operation:" in captured.err
 
 
-@pytest.mark.skip(reason="Hangs when running `make NUM_PROCS=24 test-unit`")
 def test_remark_vectorization(capfd, fresh_triton_cache):
     if is_hip():
         pytest.skip("currently failing on HIP")
@@ -147,7 +147,7 @@ def test_remark_vectorization(capfd, fresh_triton_cache):
     assert ("remark: Warning: vectorization fails" in err), "expect vectorization failure remark"
     assert "note: see current operation:" not in err
 
-    with enable_diagnostics_context('remarks,operations,stacktraces'):
+    with enable_diagnostics_context('remarks,operations'):
         triton.compile(
             triton.compiler.ASTSource(**astsource_args),
             options={"num_warps": 1},
@@ -155,7 +155,8 @@ def test_remark_vectorization(capfd, fresh_triton_cache):
 
     _, err = capfd.readouterr()
     assert "note: see current operation:" in err
-    assert "note: diagnostic emitted with trace:" in err
+    # Stack traces disabled as it adds several minutes to compile time
+    # assert "note: diagnostic emitted with trace:" in err
 
 
 def test_remark_swp_op_before_operands(capfd, fresh_triton_cache):


### PR DESCRIPTION
For some reason generating the stack traces is extremely slow, taking the test runtime from under a second up to 15 minutes.