### PR TITLE
Fix must_use_result check for methods

### DIFF
--- a/python/test/unit/language/test_compile_errors.py
+++ b/python/test/unit/language/test_compile_errors.py
@@ -475,6 +475,62 @@ def test_unused_result():
     assert expected_err_msg == obtained_err_msg
 
 
+@tl.core._aggregate
+class Square:
+    x: tl.tensor
+
+    @triton.constexpr_function
+    def __init__(self, x):
+        self.x = x
+
+    @triton.must_use_result
+    @triton.constexpr_function
+    def power(self):
+        return 2
+
+    @triton.must_use_result
+    @triton.jit
+    def compute(self):
+        return self.x * self.x
+
+
+def test_bound_unused_result():
+
+    @triton.jit
+    def evil_square_kernel():
+        a = Square(tl.full((64, 64), 0.0, tl.float32))
+        a.compute()
+
+    @triton.jit
+    def good_square_kernel():
+        a = Square(tl.full((64, 64), 0.0, tl.float32))
+        a = a.compute()
+
+    triton.compile(triton.compiler.ASTSource(fn=good_square_kernel, signature={}, constexprs={}))
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=evil_square_kernel, signature={}, constexprs={}))
+
+    assert "The result of a.compute is not being used" in str(e.value)
+
+    @triton.jit
+    def evil_power_kernel():
+        a = Square(tl.full((64, 64), 0.0, tl.float32))
+        a.power()
+
+    @triton.jit
+    def good_power_kernel():
+        a = Square(tl.full((64, 64), 0.0, tl.float32))
+        a = a.power()
+
+    triton.compile(triton.compiler.ASTSource(fn=good_power_kernel, signature={}, constexprs={}))
+
+    with pytest.raises(CompilationError) as e:
+        triton.compile(triton.compiler.ASTSource(fn=evil_power_kernel, signature={}, constexprs={}))
+
+    assert "The result of a.power is not being used" in str(e.value)
+
+
 def test_err_constexpr_and_do_not_specialize():
 
     @triton.jit(do_not_specialize=["N"])


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [X] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
