### PR TITLE
Default _semantic parameter to None

### DIFF
--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -237,7 +237,7 @@ class tensor_memory_descriptor(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, layout, _semantic: GluonSemantic) -> ttgl.tensor:
+    def load(self, layout, _semantic: GluonSemantic = None) -> ttgl.tensor:
         """
         Load a tensor from tensor memory.
 
@@ -269,7 +269,7 @@ class tensor_memory_descriptor(base_value):
         _semantic.builder.create_tmem_store(self.handle, value.handle, pred.handle)
 
     @builtin
-    def slice(self, start, length, _semantic: GluonSemantic) -> None:
+    def slice(self, start, length, _semantic: GluonSemantic = None) -> None:
         """
         Create a slice of the tensor memory descriptor along the last dimension.
 

--- a/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/hopper/__init__.py
@@ -58,7 +58,7 @@ class warpgroup_mma_accumulator(_core.base_value):
 
 
 @_core.builtin
-def warpgroup_mma_init(value, _semantic):
+def warpgroup_mma_init(value, _semantic=None):
     assert isinstance(value, _core.tensor)
     return warpgroup_mma_accumulator(value.handle, value.type)
 


### PR DESCRIPTION
This doesn't really have any effect on the resulting code but it helps with type checking.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because `it's NFC`.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
