### PR TITLE
[NFC]: Extract common warp specialization lowering utilities

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h
@@ -1,0 +1,78 @@
+#ifndef TRITON_CONVERSION_TRITONGPU_TO_LLVM_WARPSPECIALIZEUTILITY_H
+#define TRITON_CONVERSION_TRITONGPU_TO_LLVM_WARPSPECIALIZEUTILITY_H
+
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "llvm/ADT/SetVector.h"
+#include <functional>
+
+namespace mlir {
+namespace triton {
+
+// Forward declaration
+class TritonLLVMIRRewriter;
+
+//===----------------------------------------------------------------------===//
+// convertOpTypes
+//===----------------------------------------------------------------------===//
+
+/// Convert operand types, region argument types, and result types of a
+/// an operation using the provided type converter. This is used for
+/// WarpSpecializeOp and related operations during lowering to LLVM.
+void convertOpTypes(Operation *op, const TypeConverter &typeConverter);
+
+//===----------------------------------------------------------------------===//
+// elideTrivialCaptures
+//===----------------------------------------------------------------------===//
+
+/// Attempt to eliminate captures by rematerializing trivial computations into
+/// each partition region.
+void elideTrivialCaptures(LLVM::LLVMFuncOp func,
+                          ArrayRef<gpu::WarpSpecializeOp> wsOps);
+
+//===----------------------------------------------------------------------===//
+// lowerWarpSpecializeCommon
+//===----------------------------------------------------------------------===//
+
+/// Phase indicator for register reallocation during warp specialization.
+enum class RegisterReallocPhase {
+  SwitchLoopStart,       // Reallocate at the beginning of switch loop
+  WorkerPartitionStart,  // Reallocate at worker partition region start
+  WorkerPartitionEnd,    // Reallocate at worker partition region end
+  DefaultPartitionStart, // Reallocate at default partition region start
+  DefaultPartitionEnd    // Reallocate at default partition region end
+};
+
+/// Callbacks for backend-specific operations during warp specialization
+/// lowering.
+struct WarpSpecializeCallbacks {
+  /// Create a barrier to synchronize threads across the whole CTA
+  std::function<void(TritonLLVMIRRewriter &, unsigned barIdx)> createAllBarrier;
+
+  /// Reallocate registers.
+  /// regionNumber is only used for WorkerPartitionStart and WorkerPartitionEnd
+  /// phases.
+  std::function<void(TritonLLVMIRRewriter &, gpu::WarpSpecializeOp,
+                     RegisterReallocPhase, unsigned regionNumber)>
+      reallocRegisters;
+};
+
+/// Common implementation of warp specialize lowering.
+/// Uses callbacks for backend-specific barrier and register reallocation
+/// operations.
+LogicalResult lowerWarpSpecializeCommon(
+    LLVM::LLVMFuncOp func, ArrayRef<gpu::WarpSpecializeOp> wsOps, Block *entry,
+    Block *header, Block *switchLoop, Value wid, MLIRContext *ctx,
+    unsigned defaultNumWarps, unsigned totalNumWarps,
+    const TargetInfoBase &targetInfo, const WarpSpecializeCallbacks &callbacks,
+    unsigned switchLoopBarrierIdx);
+
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_CONVERSION_TRITONGPU_TO_LLVM_WARPSPECIALIZEUTILITY_H

--- a/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonGPUToLLVM/CMakeLists.txt
@@ -21,6 +21,7 @@ add_triton_library(TritonGPUToLLVM
     TypeConverter.cpp
     Utility.cpp
     ViewOpToLLVM.cpp
+    WarpSpecializeUtility.cpp
 
     DEPENDS
     TritonGPUConversionPassIncGen

--- a/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.cpp
@@ -1,0 +1,368 @@
+#include "triton/Conversion/TritonGPUToLLVM/WarpSpecializeUtility.h"
+#include "mlir/Analysis/TopologicalSortUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/OperationSupport.h"
+#include "triton/Conversion/TritonGPUToLLVM/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+
+//===----------------------------------------------------------------------===//
+// convertOpTypes
+//===----------------------------------------------------------------------===//
+
+void mlir::triton::convertOpTypes(Operation *op,
+                                  const TypeConverter &typeConverter) {
+  ImplicitLocOpBuilder b(op->getLoc(), op);
+  SmallVector<Value> operands = llvm::to_vector(op->getOperands());
+  for (Value &operand : operands) {
+    Type type = typeConverter.convertType(operand.getType());
+    if (type != operand.getType()) {
+      operand =
+          UnrealizedConversionCastOp::create(b, type, operand).getResult(0);
+    }
+  }
+  op->setOperands(operands);
+
+  for (Region &region : op->getRegions()) {
+    b.setInsertionPointToStart(&region.front());
+    for (BlockArgument arg : llvm::to_vector(region.getArguments())) {
+      Type type = typeConverter.convertType(arg.getType());
+      BlockArgument newArg = region.addArgument(type, arg.getLoc());
+      auto cast = UnrealizedConversionCastOp::create(b, arg.getType(), newArg);
+      arg.replaceAllUsesWith(cast.getResult(0));
+      region.eraseArgument(0);
+    }
+  }
+
+  SmallVector<Type> resultTypes;
+  (void)typeConverter.convertTypes(op->getResultTypes(), resultTypes);
+  if (TypeRange(resultTypes) == op->getResultTypes())
+    return;
+  OperationState state(op->getLoc(), op->getName(), op->getOperands(),
+                       resultTypes, op->getAttrs());
+  for (Region &region : op->getRegions())
+    state.addRegion()->takeBody(region);
+  b.setInsertionPoint(op);
+  Operation *newOp = b.create(state);
+
+  SmallVector<Value> results;
+  for (auto [i, result, type] :
+       llvm::enumerate(newOp->getResults(), op->getResultTypes())) {
+    auto cast = UnrealizedConversionCastOp::create(b, type, result);
+    op->getResult(i).replaceAllUsesWith(cast.getResult(0));
+  }
+  op->erase();
+}
+
+//===----------------------------------------------------------------------===//
+// elideTrivialCaptures
+//===----------------------------------------------------------------------===//
+
+static LogicalResult findTrivialSubcomputation(LLVM::LLVMFuncOp func,
+                                               Value capture,
+                                               SetVector<Operation *> &ops) {
+  SetVector<Value> worklist;
+  worklist.insert(capture);
+  for (unsigned i = 0; i != worklist.size(); ++i) {
+    Value capture = worklist[i];
+    // Check for a kernel argument.
+    if (auto arg = dyn_cast<BlockArgument>(capture)) {
+      if (arg.getOwner() == &func.getBody().front())
+        continue;
+      // Otherwise, this is some other block argument that cannot be elided.
+      return failure();
+    }
+
+    Operation *op = capture.getDefiningOp();
+    // Check if the defining op can be rematerialized. At the LLVM level,
+    // checking for pure is probably a good enough heuristic.
+    if (isPure(op)) {
+      ops.insert(op);
+      worklist.insert(op->operand_begin(), op->operand_end());
+      continue;
+    }
+    // The op cannot be rematerialized.
+    return failure();
+  }
+
+  // Cap the number of ops that can be rematerialized.
+  // FIXME: This is arbitrary.
+  return success(ops.size() <= 16);
+}
+
+void mlir::triton::elideTrivialCaptures(LLVM::LLVMFuncOp func,
+                                        ArrayRef<WarpSpecializeOp> wsOps) {
+  // The goal is to completely eliminate captures by hoisting or rematerializing
+  // computations. We could minimize captures by rematerializing
+  // subcomputations, but that is much more complicated. Prefer rematerializing
+  // because that reduces liveranges. If subgraphs are duplicated more than
+  // once, we will rely on CSE to clean them up.
+  SetVector<Operation *> subgraph;
+  for (WarpSpecializeOp wsOp : wsOps) {
+    llvm::BitVector toErase(wsOp.getNumOperands());
+    for (auto [i, capture] : llvm::enumerate(wsOp.getExplicitCaptures())) {
+      subgraph.clear();
+      if (failed(findTrivialSubcomputation(func, capture, subgraph)))
+        continue;
+      toErase.set(i);
+      subgraph = topologicalSort(subgraph);
+
+      for (Region *region : wsOp.getPartitionRegions()) {
+        OpBuilder b(region);
+        IRMapping mapping;
+        for (Operation *op : subgraph) {
+          b.clone(*op, mapping);
+        }
+        Value remat = capture;
+        if (!subgraph.empty()) {
+          unsigned resultIdx = cast<OpResult>(capture).getResultNumber();
+          remat = mapping.lookup(subgraph.back())->getResult(resultIdx);
+        }
+        region->getArgument(i).replaceAllUsesWith(remat);
+      }
+    }
+
+    wsOp->eraseOperands(toErase);
+    for (Region *region : wsOp.getPartitionRegions()) {
+      region->front().eraseArguments(toErase);
+    }
+  }
+}
+
+/// Disable LICM (Loop Invariant Code Motion) for a loop. This prevents LLVM
+/// from hoisting code out of the switch loop generated by the
+/// `ttg.warp_specialize` lowering, which could result in long liveranges and
+/// cause register spilling in partition regions.
+static void disableLICM(LLVM::BrOp latchBr) {
+  Builder b(latchBr.getContext());
+  MLIRContext *ctx = b.getContext();
+  auto licmMD = LLVM::LoopLICMAttr::get(ctx, b.getBoolAttr(true), {});
+  auto loopMD =
+      LLVM::LoopAnnotationAttr::get(b.getContext(), {}, {}, {}, {}, {}, licmMD,
+                                    {}, {}, {}, {}, {}, {}, {}, {}, {});
+  latchBr.setLoopAnnotationAttr(loopMD);
+}
+
+//===----------------------------------------------------------------------===//
+// lowerWarpSpecializeCommon
+//===----------------------------------------------------------------------===//
+
+static void rewritePartitionRegions(WarpSpecializeOp ws, Block *switchLoop,
+                                    const TargetInfoBase &targetInfo,
+                                    const WarpSpecializeCallbacks &callbacks,
+                                    unsigned switchLoopBarrierIdx) {
+  TritonLLVMIRRewriter b(ws.getLoc(), ws.getContext());
+  for (Region *partition : ws.getPartitionRegions()) {
+    // Load the explicit captures from shared memory and replace the block args
+    // if there are any.
+    b.setInsertionPointToStart(&partition->front());
+
+    callbacks.reallocRegisters(b, ws,
+                               RegisterReallocPhase::WorkerPartitionStart,
+                               partition->getRegionNumber());
+
+    if (partition->getNumArguments()) {
+      auto captureType = LLVM::LLVMStructType::getLiteral(
+          b.getContext(), llvm::to_vector(partition->getArgumentTypes()),
+          /*isPacked=*/true);
+      Value capturePtr =
+          LLVM::getSharedMemoryBase(b.getLoc(), b, targetInfo, ws);
+      LLVM::LLVMPointerType ptrTy = ptr_ty(b.getContext(), 3);
+      for (auto [i, arg] :
+           llvm::zip(llvm::seq<int32_t>(partition->getNumArguments()),
+                     partition->getArguments())) {
+        Value ptr =
+            b.gep(ptrTy, captureType, capturePtr, ArrayRef<LLVM::GEPArg>{0, i});
+        // Each thread in the warp group needs a copy of the value.
+        Value value = b.load(arg.getType(), ptr, /*align=*/1);
+        arg.replaceAllUsesWith(value);
+      }
+      partition->front().eraseArguments([](auto) { return true; });
+    }
+
+    // The shared memory is only live for the entry into the region, so put
+    // another barrier here.
+    callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+
+    // Rewrite all warp returns.
+    partition->walk([&](WarpReturnOp op) {
+      TritonLLVMIRRewriter b(op.getLoc(), op);
+      callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+      callbacks.reallocRegisters(b, ws,
+                                 RegisterReallocPhase::WorkerPartitionEnd,
+                                 partition->getRegionNumber());
+      b.replaceOpWithNewOp<LLVM::BrOp>(op, switchLoop);
+    });
+  }
+}
+
+LogicalResult mlir::triton::lowerWarpSpecializeCommon(
+    LLVM::LLVMFuncOp func, ArrayRef<WarpSpecializeOp> wsOps, Block *entry,
+    Block *header, Block *switchLoop, Value wid, MLIRContext *ctx,
+    unsigned defaultNumWarps, unsigned totalNumWarps,
+    const TargetInfoBase &targetInfo, const WarpSpecializeCallbacks &callbacks,
+    unsigned switchLoopBarrierIdx) {
+
+  TritonLLVMIRRewriter b(func.getLoc(), ctx);
+  Type int8Type = b.getIntegerType(8);
+  LLVM::LLVMPointerType ptrTy = ptr_ty(ctx, 3);
+
+  b.setInsertionPointToStart(switchLoop);
+  callbacks.reallocRegisters(b, wsOps[0], RegisterReallocPhase::SwitchLoopStart,
+                             0);
+  callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+  Value statePtr = LLVM::getSharedMemoryBase(b.getLoc(), b, targetInfo, func);
+  Value relWid = b.sub(wid, b.i32_val(defaultNumWarps));
+
+  // The default warp group will populate the state pointer with the state ID
+  // for all warps.
+  // %warp_state_ptr = getelementptr ptr %state_tr[%rel_wid]
+  // %warp_state = load i8 %warp_state_ptr
+  Value warpStatePtr = b.gep(ptrTy, int8Type, statePtr, relWid);
+  // All threads in a warp reading from the same smem address will not create
+  // bank conflicts and is better than predicated load.
+  Value warpState = b.load(int8Type, warpStatePtr);
+
+  // Pull the partition regions out. Switch based on the state ID to the right
+  // partition.
+  SmallVector<Block *> partitionBlocks;
+  SmallVector<int32_t> partitionStates;
+  int32_t partitionStateCounter = 0;
+  // This represents the data that the default warp group will fill into the
+  // state pointer before entering each `warp_specialize` region, which maps
+  // a warp ID to a state ID in the switch.
+  int32_t maxNumWarps = totalNumWarps - defaultNumWarps;
+  SmallVector<SmallVector<int32_t>> warpToState(
+      wsOps.size(), SmallVector<int32_t>(maxNumWarps, -1));
+
+  for (size_t i = 0; i < wsOps.size(); ++i) {
+    WarpSpecializeOp op = wsOps[i];
+    auto &stateMap = warpToState[i];
+    rewritePartitionRegions(op, switchLoop, targetInfo, callbacks,
+                            switchLoopBarrierIdx);
+    for (auto [partition, partitionNumWarps, startId] :
+         llvm::zip(op.getPartitionRegions(), op.getPartitionNumWarps(),
+                   *op.getWarpGroupStartIds())) {
+      partitionStates.push_back(partitionStateCounter++);
+      partitionBlocks.push_back(&partition->front());
+      for (int32_t &stateId : MutableArrayRef(stateMap).slice(
+               startId - defaultNumWarps, partitionNumWarps))
+        stateId = partitionStates.back();
+    }
+  }
+
+  if (partitionStateCounter > std::numeric_limits<uint8_t>::max()) {
+    return mlir::emitError(func.getLoc(),
+                           "FIXME: too many warp group partitions");
+  }
+
+  // Splice them in reverse order so the IR is easier to read.
+  Region::BlockListType &funcBlocks = func.getBody().getBlocks();
+  for (Block *block : llvm::reverse(partitionBlocks)) {
+    Region *region = block->getParent();
+    funcBlocks.splice(std::next(switchLoop->getIterator()),
+                      region->getBlocks());
+  }
+
+  // Default destination.
+  Block *defaultBlock = new Block;
+  funcBlocks.insert(std::next(switchLoop->getIterator()), defaultBlock);
+  b.setInsertionPointToStart(defaultBlock);
+  callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+  callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+  auto latchBr = LLVM::BrOp::create(b, b.getLoc(), switchLoop);
+  disableLICM(latchBr);
+
+  // Exit state.
+  Block *switchExit = new Block;
+  funcBlocks.insert(std::next(defaultBlock->getIterator()), switchExit);
+  partitionBlocks.push_back(switchExit);
+  partitionStates.push_back(partitionStateCounter);
+
+  // Create the switch.
+  b.setInsertionPointToEnd(switchLoop);
+  SmallVector<APInt> caseValues;
+  for (int32_t state : partitionStates)
+    caseValues.push_back(APInt(8, state));
+  LLVM::SwitchOp::create(b, b.getLoc(), warpState, defaultBlock, ValueRange(),
+                         caseValues, partitionBlocks,
+                         SmallVector<ValueRange>(partitionBlocks.size()));
+
+  // Now add synchronization around the default regions.
+  for (size_t i = 0; i < wsOps.size(); ++i) {
+    WarpSpecializeOp ws = wsOps[i];
+    auto &stateMap = warpToState[i];
+    Block *before = ws->getBlock();
+    Block *after = b.splitBlock(before, ws->getIterator());
+    TritonLLVMIRRewriter b(ws.getLoc(), OpBuilder::atBlockEnd(before));
+    Type int8Type = b.getIntegerType(8);
+    Value statePtrWs =
+        LLVM::getSharedMemoryBase(b.getLoc(), b, targetInfo, func);
+    for (auto [j, state] : llvm::enumerate(stateMap)) {
+      Value stateVal = b.i8_val(state);
+      b.store(stateVal, b.gep(ptrTy, int8Type, statePtrWs, LLVM::GEPArg(j)));
+    }
+
+    // Store the captures if there are any.
+    if (ws.getNumOperands()) {
+      auto captureType = LLVM::LLVMStructType::getLiteral(
+          b.getContext(), llvm::to_vector(ws.getOperandTypes()),
+          /*isPacked=*/true);
+      Value capturePtr =
+          LLVM::getSharedMemoryBase(b.getLoc(), b, targetInfo, ws);
+      for (auto [j, arg] : llvm::zip(llvm::seq<int32_t>(ws.getNumOperands()),
+                                     ws.getOperands())) {
+        Value ptr =
+            b.gep(ptrTy, captureType, capturePtr, ArrayRef<LLVM::GEPArg>{0, j});
+        b.store(arg, ptr, /*align=*/1);
+      }
+    }
+
+    // First barrier releases the waiting warpgroups. The second barrier ensures
+    // they have read the captures before the memory is released upon entry.
+    callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+    callbacks.reallocRegisters(b, ws,
+                               RegisterReallocPhase::DefaultPartitionStart, 0);
+    callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+    LLVM::BrOp::create(b, b.getLoc(), &ws.getDefaultRegion().front());
+
+    ws.getDefaultRegion().walk([&, ws = ws](WarpYieldOp op) mutable {
+      TritonLLVMIRRewriter b(op.getLoc(), op);
+      callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+      callbacks.reallocRegisters(b, ws,
+                                 RegisterReallocPhase::DefaultPartitionEnd, 0);
+      b.replaceOpWithNewOp<LLVM::BrOp>(op, op.getOperands(), after);
+    });
+    after->getParent()->getBlocks().splice(after->getIterator(),
+                                           ws.getDefaultRegion().getBlocks());
+
+    // Replace the results.
+    auto outputs = after->addArguments(
+        ws.getResultTypes(),
+        SmallVector<Location>(ws.getNumResults(), ws.getLoc()));
+    ws.replaceAllUsesWith(outputs);
+    ws.erase();
+  }
+
+  // Signal all warp groups to exit.
+  func.walk([&](LLVM::ReturnOp op) {
+    TritonLLVMIRRewriter b(op.getLoc(), op);
+    Type int8Type = b.getIntegerType(8);
+    Value statePtrExit =
+        LLVM::getSharedMemoryBase(b.getLoc(), b, targetInfo, func);
+    Value cst = b.i8_val(partitionStateCounter);
+    for (int32_t i : llvm::seq(maxNumWarps))
+      b.store(cst, b.gep(ptrTy, int8Type, statePtrExit, LLVM::GEPArg(i)));
+    callbacks.createAllBarrier(b, switchLoopBarrierIdx);
+  });
+  b.setInsertionPointToStart(switchExit);
+  LLVM::ReturnOp::create(b, b.getLoc(), ValueRange());
+
+  return success();
+}

--- a/python/triton/experimental/gluon/language/_core.py
+++ b/python/triton/experimental/gluon/language/_core.py
@@ -490,7 +490,7 @@ def fp4_to_fp(src, elem_type, axis, _semantic=None):
 
 
 @builtin
-def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _semantic=None, _generator=None):
+def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs=None, _semantic=None, _generator=None):
     """
     Create a warp-specialized execution region, partitioning work across warps.
 
@@ -504,13 +504,15 @@ def warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _sema
     Args:
         functions_and_args (List[Tuple[Callable, Any]]): List of functions and arguments for each partition. The first of which is the default partition.
         worker_num_warps (List[int]): Number of warps used for each worker partition.
-        worker_num_regs (List[int]): Number of registers for each worker partition.
+        worker_num_regs (List[int], optional): Number of registers for each worker partition.
+            If not None, will be used by backend for dynamic register reallocation.
 
     Returns:
         Tuple[Any, ...]: Results from the default partition.
     """
     worker_num_warps = [_unwrap_if_constexpr(w) for w in worker_num_warps]
-    worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
+    if worker_num_regs is not None:
+        worker_num_regs = [_unwrap_if_constexpr(r) for r in worker_num_regs]
     return _semantic.warp_specialize(functions_and_args, worker_num_warps, worker_num_regs, _generator)
 
 

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -518,9 +518,11 @@ class GluonSemantic(TritonSemantic[TensorTy]):
         assert num_partitions == len(
             worker_num_warps
         ), f"warp specialize got {num_partitions} partitions but {len(worker_num_warps)} warp counts"
-        assert num_partitions == len(
-            worker_num_regs
-        ), f"warp specialize got {num_partitions} partitions but {len(worker_num_regs)} register counts"
+
+        if worker_num_regs is not None:
+            assert num_partitions == len(
+                worker_num_regs
+            ), f"warp specialize got {num_partitions} partitions but {len(worker_num_regs)} register counts"
 
         builder = self.builder
         insert_pt = builder.get_insertion_point()
@@ -541,7 +543,9 @@ class GluonSemantic(TritonSemantic[TensorTy]):
         builder.restore_insertion_point(insert_pt)
         ws_op = builder.create_warp_specialize(result_types, mlir_args, worker_num_warps)
         ws_op.get_default_region().push_back(default_block)
-        ws_op.set_requested_registers(worker_num_regs)
+
+        if worker_num_regs is not None:
+            ws_op.set_requested_registers(worker_num_regs)
 
         # Emit the partition regions.
         builder.create_block_with_parent(ws_op.get_partition_op_holder(), [])


### PR DESCRIPTION
Extract common warp specialization lowering utilities that will be shared between NVIDIA and AMD backends. This refactoring is a prelude to adding warp specialization support for AMD gfx1250.
Ref: https://github.com/ROCm/triton-internal/issues/1338