### PR TITLE
Avoid data race in test_core.py::test_num_programs

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6187,12 +6187,13 @@ def test_num_programs(device):
 
     @triton.jit
     def kernel(input):
-        num_programs_0 = tl.num_programs(0)
-        num_programs_1 = tl.num_programs(1)
-        num_programs_2 = tl.num_programs(2)
-        tl.store(input, num_programs_0)
-        tl.store(input + 1, num_programs_1)
-        tl.store(input + 2, num_programs_2)
+        if tl.program_id(0) == 0 and tl.program_id(1) == 0 and tl.program_id(2) == 0:
+            num_programs_0 = tl.num_programs(0)
+            num_programs_1 = tl.num_programs(1)
+            num_programs_2 = tl.num_programs(2)
+            tl.store(input, num_programs_0)
+            tl.store(input + 1, num_programs_1)
+            tl.store(input + 2, num_programs_2)
 
     kernel[grid](input)
     assert torch.all(input == torch.tensor(grid, device=device))


### PR DESCRIPTION
test_core.py::test_num_programs contains a data race. The `tl.store` write to the same addresses for every program id. While all program ids write the same value, it is still a race for them to write to the same location without synchronization. The proposed fix is to guard the `tl.store` so that only pid 0 writes.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it is editing an existing test

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
