### PR TITLE
[release/3.6] [Revert] [Coalesce] Fix the default order to be row major (#5707) #7143

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/Utility.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/Utility.h
@@ -35,11 +35,9 @@ SmallVector<unsigned, 3> mmaVersionToInstrShape(int version,
 // Return true if the Load uses block pointer.
 bool isLoadFromTensorPtr(triton::LoadOp op);
 
-// Gets the order of a tensor from its contiguity. Places the dimensions with
-// the largest contiguity as the inner most dimension. If the contiguity is
-// all ones, returns the order {dim - 1, dim - 2, ..., 0}
-SmallVector<unsigned, 4>
-getOrderFromContiguity(const SmallVector<int64_t> &contiguity);
+// Return an array of indices enumerating the elements of 'arr' in descending
+// order (so that result[i] is the index of the i-th largest element of 'arr')
+SmallVector<unsigned, 4> argSort(const SmallVector<int64_t> &arr);
 
 // Return the operand used to access the memory in the operation
 Value getMemAccessPtr(Operation *op);

--- a/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/CoalesceUtils.cpp
@@ -28,7 +28,7 @@ BlockedEncodingAttr buildCoalescedEncoding(
   });
 
   auto contiguity = axisInfoAnalysis.getAxisInfo(ptr)->getContiguity();
-  SmallVector<unsigned> order = getOrderFromContiguity(contiguity);
+  SmallVector<unsigned> order = argSort(contiguity);
   LDBG("order=[" << triton::join(order, ", ") << "]");
 
   auto matchesShape = [&refTensorType](const Value &val) {
@@ -45,8 +45,8 @@ BlockedEncodingAttr buildCoalescedEncoding(
       Value val = getMemAccessPtr(use);
       if (!val || !matchesShape(val) || memAccessesSameOrder.contains(use))
         continue;
-      auto currOrder = getOrderFromContiguity(
-          axisInfoAnalysis.getAxisInfo(val)->getContiguity());
+      auto currOrder =
+          argSort(axisInfoAnalysis.getAxisInfo(val)->getContiguity());
       if (order == currOrder) {
         LDBG("multi-root-slice: insert to memAccessesSameOrder " << *use);
         memAccessesSameOrder.insert(use);

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -90,11 +90,9 @@ bool isLoadFromTensorPtr(triton::LoadOp op) {
   return mlir::triton::isTensorPointerType(op.getPtr().getType());
 }
 
-SmallVector<unsigned, 4>
-getOrderFromContiguity(const SmallVector<int64_t> &arr) {
+SmallVector<unsigned, 4> argSort(const SmallVector<int64_t> &arr) {
   SmallVector<unsigned, 4> ret(arr.size());
   std::iota(ret.begin(), ret.end(), 0);
-  std::reverse(ret.begin(), ret.end());
   std::stable_sort(ret.begin(), ret.end(),
                    [&](unsigned x, unsigned y) { return arr[x] > arr[y]; });
   return ret;

--- a/test/TritonGPU/coalesce.mlir
+++ b/test/TritonGPU/coalesce.mlir
@@ -202,20 +202,6 @@ tt.func @coalesce_poison(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1
 
 // -----
 
-#blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [2, 4, 4], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
-module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @load_3D_contig_1(%arg: !tt.ptr<i8> {tt.divisibility = 16 : i32}) {
-    %50 = tt.splat %arg : !tt.ptr<i8> -> tensor<32x4x4x!tt.ptr<i8>, #blocked>
-    // This checks that the pass picks the row-major ordering by default for elements with contiguity 1.
-    // CHECK: #blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [2, 4, 4], warpsPerCTA = [4, 1, 1], order = [2, 1, 0]}>
-    // CHECK:  tt.load %1 : tensor<32x4x4x!tt.ptr<i8>, #blocked>
-    %108 = tt.load %50 : tensor<32x4x4x!tt.ptr<i8>, #blocked>
-    tt.return
-  }
-}
-
-// -----
-
 // CHECK: #[[$LAYOUT:.*]] = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {


### PR DESCRIPTION
Duplicates the work in https://github.com/triton-lang/triton/commit/2d06bd2a03130d40a00b49c8db0ecfbb64989bab for the 3.5 release to remove the change that makes the default ordering row major. This is due to this PyTorch issue https://github.com/pytorch/pytorch/issues/169492#issuecomment-3612342260, which is a hang encountered in certain tests due to this change.

At this time it unclear if this is a bug in the Triton implementation or just an incompatibility in implicit layout assumptions in the generated Triton code for the reduction. Either way this will let us unblock the issues in the release while we investigate the proper fix across the two code bases.