### PR TITLE
[CMAKE] Canonicalize LLVM_BUILD_SHARED_LIBS before using it in lit.site.cfg.py.in

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(lib)
 
 llvm_canonicalize_cmake_booleans(
   MLIR_ENABLE_BINDINGS_PYTHON
+  LLVM_BUILD_SHARED_LIBS
 )
 
 configure_lit_site_cfg(


### PR DESCRIPTION
The `test/lit.site.cfg.py.in` template uses the newly added CMAKE option `LLVM_BUILD_SHARED_LIBS`
 ```
config.build_shared_libs = @LLVM_BUILD_SHARED_LIBS@
```

The default value of `LLVM_BUILD_SHARED_LIBS` is  `OFF` (defined in `/CMakeLists.txt`), which will cause a `NameError: OFF is not defined` in Python.

This PR canonicalizes  `LLVM_BUILD_SHARED_LIBS` with `llvm_canonicalize_cmake_booleans` before using it to configure the lit tests. This should make the value of `LLVM_BUILD_SHARED_LIBS` 0 or 1, which are legal in Python.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it's a cmake-only change`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
