### PR TITLE
[Release specific] [BACKEND] Disable maybeDeduplicate for AMDWmma

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h
@@ -71,6 +71,12 @@ public:
       // the result must be a tensor
       return resultVals;
 
+    // Disable deduplicating for AMDWmma temporarily as it causes
+    // test failures. See: https://github.com/ROCm/triton/issues/909
+    Attribute encoding = rtType.getEncoding();
+    if (!encoding || isa<AMDWmmaEncodingAttr>(encoding))
+      return resultVals;
+
     // Bail out if we don't have the constancy analysis
     AxisInfo *axisInfo = axisAnalysisPass.getAxisInfo(result);
     if (!axisInfo)


### PR DESCRIPTION
Some tests fail on gfx1100 when deduplicated due to a potential optimization bug in LLVM. Disable it temporarily for AMDWmma.

(cherry picked from commit 05786c3ee95fb01cd46b749a56a648b98ff1e2c3)

Causing failures in inductor, landing as release specific, upstream triton will try to fix with latest LLVM update, which 3.6.x wouldn't be able to accept at this late stage