### PR TITLE
[CUDA][PTXAS] Make TRITON_PTXAS_BLACKWELL_PATH work to overwrite ptxas-blackwell binary

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -196,7 +196,8 @@ class env_nvidia_tool(env_base[str, NvidiaTool]):
         binary += sysconfig.get_config_var("EXE")
         self.binary = binary
         self.default_path = os.path.join(os.path.dirname(__file__), "backends", "nvidia", "bin", binary)
-        super().__init__(f"TRITON_{binary.upper()}_PATH")
+        # Convert ptxas-blackwell to PTXAS_BLACKWELL, not PTXAS-BLACKWELL
+        super().__init__(f"TRITON_{binary.upper().replace('-', '_')}_PATH")
 
     def get(self) -> NvidiaTool:
         return self.transform(getenv(self.key))


### PR DESCRIPTION
Mainly for THOR as by default ptxas-blackwell (cuda 12.9) would be used and it would go "I don't understand sm110a".

Context: There is an environment variable TRITON_PTXAS_BLACKWELL_PATH that was designed for users to overwrite this ptxas-blackwell, via the lines noted in https://github.com/triton-lang/triton/pull/8945#pullrequestreview-3562216960. 
But: `export TRITON_PTXAS-BLACKWELL_PATH=/usr/local/cuda/bin/ptxas` is NOT a valid bash script, but 
`export TRITON_PTXAS_BLACKWELL_PATH` is. So this PR maps `ptxas-blackwell` binary to look for `TRITON_PTXAS_BLACKWELL_PATH`. IF set, the ptxas-blackwell would use the provided "path" (nit: it is call a "path" but we should supply the binary, like "TRITON_PTXAS_BLACKWELL_PATH_AND_BINARY". 

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [X] I am not making a trivial change, such as fixing a typo in a comment.

- [X] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [X] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
But I got: 
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
==> At Config()
==> At key: default_stages
==> At index 0
=====> Expected one of commit, commit-msg, manual, merge-commit, post-checkout, post-commit, post-merge, post-rewrite, prepare-commit-msg, push but got: 'pre-commit'

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [X] This PR does not need a test because this PR is fixing a regression.

- Select one of the following.
  - [X] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
