### PR TITLE
Fix division by zero in do_bench when estimate_ms is zero

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -163,8 +163,12 @@ def do_bench(fn, warmup=25, rep=100, grad_to_none=None, quantiles=None, return_m
     estimate_ms = start_event.elapsed_time(end_event) / 5
 
     # compute number of warmup and repeat
-    n_warmup = max(1, int(warmup / estimate_ms))
-    n_repeat = max(1, int(rep / estimate_ms))
+    if estimate_ms == 0:
+        n_warmup = 1
+        n_repeat = 1
+    else:
+        n_warmup = max(1, int(warmup / estimate_ms))
+        n_repeat = max(1, int(rep / estimate_ms))
     start_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
     end_event = [di.Event(enable_timing=True) for i in range(n_repeat)]
     # Warm-up


### PR DESCRIPTION
When the benchmark function runs in simulated environment, estimate_ms is 0 for executing any kernels, causing a ZeroDivisionError when computing n_warmup and n_repeat. (This happens in particular for next generation hardware). This fix adds a defensive check similar to what already exists in do_bench_cudagraph.

CC: @guacamoleo 