### PR TITLE
[NIC][AMD] Renamed gfx11 and gfx12 to RDNA3 and RDNA4, respectively

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -10,8 +10,8 @@ import triton.language as tl
 from triton._internal_testing import (
     is_ampere_or_newer,
     is_blackwell,
-    is_hip_gfx11,
-    is_hip_gfx12,
+    is_hip_rdna3,
+    is_hip_rdna4,
     is_hip_cdna3,
     is_hip_cdna4,
     is_hopper_or_newer,
@@ -788,7 +788,7 @@ def test_amd_direct_load_to_shared(use_buffer_load):
     assert 'vmcnt(0)' in pgm.asm['amdgcn']
 
 
-@pytest.mark.skipif(not (is_hip_gfx11() or is_hip_gfx12()), reason="Requires RDNA3 or RDNA4")
+@pytest.mark.skipif(not (is_hip_rdna3() or is_hip_rdna4()), reason="Requires RDNA3 or RDNA4")
 @pytest.mark.parametrize("M, N, K", [(64, 64, 64)])
 @pytest.mark.parametrize("in_dtype", ['float16', 'bfloat16'])
 def test_amd_wmma(M, N, K, in_dtype):
@@ -838,8 +838,8 @@ def test_amd_wmma(M, N, K, in_dtype):
     c = torch.empty((M, N), device=a.device, dtype=elem_type)
 
     blocked = ttgl.BlockedLayout([1, 8], [4, 8], [4, 1], [1, 0])
-    wmma_version = 1 if is_hip_gfx11() else 2
-    k_width = 16 if is_hip_gfx11() else 8
+    wmma_version = 1 if is_hip_rdna3() else 2
+    k_width = 16 if is_hip_rdna3() else 8
     wmma = ttgl.amd.AMDWMMALayout(wmma_version, True, [2, 2])
     kernel[1, 1](a, b, c, a.stride(0), a.stride(1), b.stride(0), b.stride(1), c.stride(0), c.stride(1), BLOCK_SIZE_M=M,
                  BLOCK_SIZE_N=N, BLOCK_SIZE_K=K, BLOCKED_LAYOUT=blocked, WMMA_LAYOUT=wmma, K_WIDTH=k_width, num_warps=4)

--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -7,7 +7,7 @@ import pytest
 import triton
 import triton.language as tl
 
-from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_gfx12
+from triton._internal_testing import is_cuda, is_hip, is_hip_cdna2, is_hip_cdna3, is_hip_cdna4, is_hip_rdna4
 
 
 def matching_int(dtype):
@@ -290,7 +290,7 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
                 launch_exhaustive_populate(getattr(tl, src_dtype), 0, 65536, False, 8, 0x7f, device=device)
             return
-        if src_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_gfx12()):
+        if src_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4()):
             pytest.skip(f"{src_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias, max_repr)
@@ -343,7 +343,7 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU CDNA3")
 
     if is_hip():
-        if dst_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_gfx12()):
+        if dst_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4()):
             pytest.skip(f"{dst_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
 
     # dtype : (exponent_bits, mantissa_bits, exponent_bias)
@@ -373,7 +373,7 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
         if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
-    if mode in ('inf', '-inf') and is_hip_gfx12():
+    if mode in ('inf', '-inf') and is_hip_rdna4():
         pytest.skip(f"clamping from `{mode}` is not supported on AMDGPU GFX12")
 
     converter = {

--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -78,12 +78,12 @@ def is_hip_cdna4():
     return target is not None and target.backend == 'hip' and target.arch == 'gfx950'
 
 
-def is_hip_gfx11():
+def is_hip_rdna3():
     target = get_current_target()
     return target is not None and target.backend == 'hip' and 'gfx11' in target.arch
 
 
-def is_hip_gfx12():
+def is_hip_rdna4():
     target = get_current_target()
     return target is not None and target.backend == 'hip' and 'gfx12' in target.arch
 


### PR DESCRIPTION
The PR removes confusion between gfx12 and gfx1250. We make it explicit that gfx12 refers to RDNA4 arch. family. Also gfx11 gets renamed to RDNA3