### PR TITLE
[PROTON] Capture traces even if code exits with error

### DIFF
--- a/third_party/proton/proton/proton.py
+++ b/third_party/proton/proton/proton.py
@@ -26,6 +26,7 @@ def parse_arguments():
     args = parser.parse_args()
     return args, args.target_args
 
+
 def is_pytest(script):
     return os.path.basename(script) == 'pytest'
 


### PR DESCRIPTION
This updates the proton command line interface to call finalize even if an exception occurred or sys.exit was called. I find this useful as if I only want to profile a single kernel call within a larger script I can simply insert a sys.exit(0) call after the relevant kernel has launched.

This also updates `execute_as_main` to use `runpy` which is the implementation of the `python -c` command. This simplifies things a bit.