### PR TITLE
Introduce Intel GPU specific Triton Exception

### DIFF
--- a/python/triton/runtime/errors.py
+++ b/python/triton/runtime/errors.py
@@ -47,4 +47,9 @@ class AutotunerError(TritonError):
 
 
 class IntelGPUError(TritonError):
+    """
+    Exception raised for Intel GPU/Level Zero errors.
+    This exception is used to indicate errors specific to Intel GPU backends,
+    particularly those related to Level Zero.
+    """
     pass


### PR DESCRIPTION
Issue caused by https://github.com/intel/intel-xpu-backend-for-triton/issues/5394#issuecomment-358762803 - the idea is to have Intel GPU specific error, that can be detected by PT runtime and (in this case) discard given autotuner config .