### PR TITLE
[NFC] Prepare utilities for warp specialization lowering on AMD

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -469,6 +469,10 @@ Value mxfpScaleBf16(RewriterBase &rewriter, Location loc, Value v, Value scale,
 // -----------------------------------------------------------------------
 
 // If an operation is contained within a warp specialize region, this returns
+// the warp ID offset of that warpgroup.
+std::optional<int> getWarpGroupStartWarpId(Block *block);
+
+// If an operation is contained within a warp specialize region, this returns
 // the thread ID offset of that warpgroup.
 std::optional<int> getWarpGroupStartThreadId(Block *block);
 

--- a/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/TypeConverter.h
@@ -1,0 +1,43 @@
+#ifndef TRITON_CONVERSION_TRITONAMDGPU_TO_LLVM_TYPECONVERTER_H
+#define TRITON_CONVERSION_TRITONAMDGPU_TO_LLVM_TYPECONVERTER_H
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "triton/Conversion/MLIRTypes.h"
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
+#include "triton/Conversion/TritonGPUToLLVM/TypeConverter.h"
+#include "triton/Dialect/Triton/IR/Types.h"
+#include "triton/Dialect/TritonGPU/IR/Types.h"
+
+using namespace mlir;
+using namespace mlir::triton;
+
+class TritonAMDGPUToLLVMTypeConverter : public TritonGPUToLLVMTypeConverter {
+public:
+  TritonAMDGPUToLLVMTypeConverter(MLIRContext *ctx,
+                                  const LowerToLLVMOptions &options,
+                                  const TargetInfoBase &targetInfo,
+                                  const DataLayoutAnalysis *analysis = nullptr)
+      : TritonGPUToLLVMTypeConverter(ctx, options, targetInfo, analysis) {
+    addConversion([&](TensorDescType type) -> std::optional<Type> {
+      return convertTensorDescType(type);
+    });
+  }
+
+  Type convertTensorDescType(triton::TensorDescType type) {
+    auto ctx = type.getContext();
+    auto blockType = type.getBlockType();
+    auto shape = blockType.getShape();
+
+    // Determine the number of dwords based on tensor dimensions
+    // 2D tensors: group0 (4) + group1 (8) = 12 dwords
+    // 3D-5D tensors: group0 (4) + group1 (8) + group2 (4) + group3 (4) = 20
+    // dwords
+    int numDwords = (shape.size() > 2) ? (4 + 8 + 4 + 4) : (4 + 8);
+
+    auto types = SmallVector<Type>(numDwords, IntegerType::get(ctx, 32));
+    return LLVM::LLVMStructType::getLiteral(ctx, types);
+  }
+};
+
+#endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -4,6 +4,7 @@
 #include "PatternTritonGPUOpToLLVM.h"
 #include "TargetInfo.h"
 #include "TritonAMDGPUToLLVM/MembarUtility.h"
+#include "TritonAMDGPUToLLVM/TypeConverter.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/GPUToNVVM/GPUToNVVMPass.h"
@@ -60,34 +61,6 @@ public:
     addIllegalDialect<mlir::gpu::GPUDialect>();
     addLegalOp<mlir::UnrealizedConversionCastOp>();
     addLegalOp<triton::amdgpu::InstructionSchedHint>();
-  }
-};
-
-class TritonAMDGPUToLLVMTypeConverter : public TritonGPUToLLVMTypeConverter {
-public:
-  TritonAMDGPUToLLVMTypeConverter(MLIRContext *ctx,
-                                  const LowerToLLVMOptions &options,
-                                  const TargetInfoBase &targetInfo,
-                                  const DataLayoutAnalysis *analysis = nullptr)
-      : TritonGPUToLLVMTypeConverter(ctx, options, targetInfo, analysis) {
-    addConversion([&](TensorDescType type) -> std::optional<Type> {
-      return convertTensorDescType(type);
-    });
-  }
-
-  Type convertTensorDescType(triton::TensorDescType type) {
-    auto ctx = type.getContext();
-    auto blockType = type.getBlockType();
-    auto shape = blockType.getShape();
-
-    // Determine the number of dwords based on tensor dimensions
-    // 2D tensors: group0 (4) + group1 (8) = 12 dwords
-    // 3D-5D tensors: group0 (4) + group1 (8) + group2 (4) + group3 (4) = 20
-    // dwords
-    int numDwords = (shape.size() > 2) ? (4 + 8 + 4 + 4) : (4 + 8);
-
-    auto types = SmallVector<Type>(numDwords, IntegerType::get(ctx, 32));
-    return LLVM::LLVMStructType::getLiteral(ctx, types);
   }
 };
 


### PR DESCRIPTION
Exposes additional utilities needed for warp specialization lowering on AMD.
Ref: https://github.com/ROCm/triton-internal/issues/1338