### PR TITLE
[WS] Variable naming fix in `LowerAref`

### DIFF
--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerAref.cpp
@@ -160,7 +160,7 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
         case AsyncOp::TC5MMA:
         case AsyncOp::TMALoad:
         case AsyncOp::NONE:
-          count.consumerPendingCount += 1;
+          count.producerPendingCount += 1;
           break;
         default:
           llvm_unreachable("unsupported producer kind");
@@ -176,7 +176,7 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
         case AsyncOp::TC5MMA:
         case AsyncOp::WGMMA:
         case AsyncOp::NONE:
-          count.producerPendingCount += 1;
+          count.consumerPendingCount += 1;
           break;
         default:
           llvm_unreachable("unsupported consumer kind");
@@ -186,10 +186,10 @@ BarrierCount getArrivalCount(ArefCreateOp op) {
   }
   // If the aref is not used within a warp-specialized loop, the pending counts
   // will be equal 0. Set them to 1.
-  if (count.producerPendingCount == 0)
-    count.producerPendingCount = 1;
   if (count.consumerPendingCount == 0)
     count.consumerPendingCount = 1;
+  if (count.producerPendingCount == 0)
+    count.producerPendingCount = 1;
 
   return count;
 }
@@ -227,8 +227,8 @@ ArefValue createAndInitMbar(ArefCreateOp op, PatternRewriter &rewriter) {
   auto op1 = op->getBlock()->findAncestorOpInBlock(*sorted.back());
   b2.setInsertionPointAfter(op1);
 
-  auto emptyMbars = createBarriers(b1, b2, depth, count.producerPendingCount);
-  auto fullMbars = createBarriers(b1, b2, depth, count.consumerPendingCount);
+  auto emptyMbars = createBarriers(b1, b2, depth, count.consumerPendingCount);
+  auto fullMbars = createBarriers(b1, b2, depth, count.producerPendingCount);
 
   return ArefValue{emptyMbars, fullMbars, static_cast<int>(depth),
                    op.getOperands()};


### PR DESCRIPTION
rename `pending{Producer<->Consumer}Count`  to match name with meaning.

naming error in two places, that cancelled each other and produced correct logic. this PR fixes this.