### PR TITLE
[BACKEND] Remove synchronisation in 2CTA mma

### DIFF
--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -29,6 +29,7 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     TensorMemoryLayout,
     TensorMemoryScalesLayout,
     allocate_tensor_memory,
+    cluster_sync,
     get_tmem_reg_layout,
     tcgen05_mma,
     tcgen05_mma_scaled,
@@ -251,6 +252,10 @@ def mma_kernel(a, b, out, M: ttgl.constexpr, N: ttgl.constexpr, K: ttgl.constexp
         assert mma_barrier_layout is not None, "Expected an mbarrier layout for TCGen05 MMA execution"
         mma_barrier = ttgl.allocate_shared_memory(ttgl.int64, [1], mma_barrier_layout)
         mbarrier.init(mma_barrier, count=1)
+        # Need to synchronise all the CTAs after the mbarrier initialisation
+        # so that they all see it
+        if two_ctas:
+            cluster_sync()
 
         acc_tmem = allocate_tensor_memory(acc_dtype, [M, N], acc_layout)
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/MMAv5.cpp
@@ -376,11 +376,6 @@ LogicalResult convertDotImpl(const LLVMTypeConverter &typeConverter,
   Value warpId = mlir::triton::gpu::WarpIdOp::create(rewriter, loc);
   Value isWarp0 = tb.icmp_eq(warpId, tb.i32_val(0));
   if (twoCTAs) {
-    // TODO: we have to sync the two CTAs because we currently don't use remove
-    // barriers for the copies.
-    ttng::ClusterArriveOp::create(rewriter, loc, false);
-    ttng::ClusterWaitOp::create(rewriter, loc);
-
     Value leftClusterId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
     leftClusterId = tb.and_(leftClusterId, tb.i32_val(1));
     Value cluster0 = tb.icmp_eq(leftClusterId, tb.i32_val(0));


### PR DESCRIPTION
[BACKEND] Remove synchronisation in 2CTA mma

We have now disabled 2CTA mode in Triton, and this should now works as expected
in Gluon, so no need for the workaround