### PR TITLE
[AMD] Fix a bug about TDM when dim > 2

### DIFF
--- a/third_party/amd/backend/include/TDMCommon.h
+++ b/third_party/amd/backend/include/TDMCommon.h
@@ -1,6 +1,10 @@
 #ifndef TRITON_THIRD_PARTY_AMD_BACKEND_INCLUDE_TDMCOMMON_H
 #define TRITON_THIRD_PARTY_AMD_BACKEND_INCLUDE_TDMCOMMON_H
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 //===----------------------------------------------------------------------===//
 // C-compatible TDM utilities shared between host-side (driver.c) and
 // device-side (TDMUtility.cpp) code.
@@ -41,15 +45,16 @@ static inline void tdmGetAdjustedBlockShape(const int64_t *blockShape,
   tdmGetWarpDistribution(blockShape, numDims, numWarps, warps);
 
   if (numDims >= 2) {
-    adjustedOut[0] = (blockShape[0] + warps[0] - 1) / warps[0];
-    adjustedOut[1] = (blockShape[1] + warps[1] - 1) / warps[1];
+    for (int i = 0; i < numDims; i++) {
+      int warpDiv = warps[i];
+      adjustedOut[i] = (blockShape[i] + warpDiv - 1) / warpDiv;
+    }
   } else {
     adjustedOut[0] = (blockShape[0] + numWarps - 1) / numWarps;
   }
-
-  // Higher dimensions are not divided by warps
-  for (int i = 2; i < numDims; ++i)
-    adjustedOut[i] = blockShape[i];
 }
 
+#if defined(__cplusplus)
+}
+#endif
 #endif // TRITON_THIRD_PARTY_AMD_BACKEND_INCLUDE_TDMCOMMON_H

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -215,13 +215,11 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   }
 
   // Distribute block among warps
-  if (numDims >= 2) {
-    auto warps = getWarpDistribution(blockShape, numWarps);
-    blockShape[0] = ceil(blockShape[0], int64_t(warps[0]));
-    blockShape[1] = ceil(blockShape[1], int64_t(warps[1]));
-  } else {
-    // For 1D case, all warps work on the single dimension
-    blockShape[0] = ceil(blockShape[0], int64_t(numWarps));
+  {
+    int64_t blkShapePerWarp[5];
+    tdmGetAdjustedBlockShape(blockShape.data(), numDims, numWarps,
+                             &blkShapePerWarp[0]);
+    blockShape.assign(blkShapePerWarp, blkShapePerWarp + blockShape.size());
   }
 
   // group0 (128 bits / 4 dwords) effective bit encoding:
@@ -235,17 +233,48 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
   group0[3] = b.trunc(i32_ty, b.lshr(globalAddr, v32));
   group0[3] = b.or_(group0[3], b.i32_val(1 << 31));
 
-  // group1 (256 bits / 8 dwords) effective bit encoding:
-  // [15:0]:    multicast mask
-  // [17:16]:   data size - log2(element size in bytes)
-  // [20]:      enable padding
-  // [24:22]:   pad interval - log2(pad interval in dwords) - 1
-  // [31:25]:   pad amount - pad amount in dwords - 1
-  // [79:48]:   tensor shape dim inner
-  // [111:80]:  tensor shape dim outer
-  // [127:112]: block shape dim inner
-  // [143:128]: block shape dim outer
-  // [207:160]: tensor stride dim outer (we only use 32 bits)
+  /* group1 bit-field definition:
+
+    NOTE that in this chart
+    - {tensor|tile}-dim0 for means innermost dimension.
+    - stride-dim0 refers to the stride of the 2nd innermost dimension.
+      FIXME: Is the stride for innermost dimension always 1, and hence no
+      need to set in the descriptor
+
+    ================================================================
+     dword | dword     | bit-size | field
+           | -bit-ofst |
+     ------------------------------------------------
+      0      0          16         multicast mask
+             16         2          data size - log2(element size in bytes)
+             18         1          atomic barrier enable
+             19         1          iterate enable
+             20         1          pad enable
+             22         3          pad interval
+                                   (log2(pad interval in dwords) - 1)
+             25         7          pad amount - pad amount in dwords - 1
+                                   (pad amount in dwords - 1)
+     ---------------------------------------------------------
+     1       0          16         atomic barrier address
+             16         16         tensor_dim0 (low-16-bit)
+     --------------------------------------------------------
+     2       0           16        tensor_dim0 (high-16-bit)
+             16          16        tensor_dim1 (low-16-bit)
+     ----------------------------------------------------------
+     3       0           16        tensor_dim1 (high-16-bit)
+             16          16        tile_dim0
+     -------------------------------------------------------
+     4       0           16        tile_dim1
+             16          16        tile_dim2
+     -------------------------------------------------------
+     5       0           32        tensor_dim0_stride(low-32-bit)
+     -------------------------------------------------------
+     6       0           16        tensor_dim0_stride(high-16-bit)
+            16           16        tensor_dim1_stride(low-16-bit)
+     -------------------------------------------------------------
+     7       0           32        tensor_dim1_stride(high-16-bit)
+     ================================================================
+  */
   SmallVector<Value> group1(8, b.i32_val(0));
   int32_t dataSize = log2(elementSizeInBytes);
   unsigned dwordSize = 32;
@@ -318,11 +347,19 @@ TDMDescriptor createTDMDescriptor(RewriterBase &rewriter, Location loc,
     }
   }
 
-  // group3 (128 bits / 4 dwords) effective bit encoding:
-  // [47:0]:    tensor_dim3_stride (4th dimension from the end)
-  // [79:48]:   tensor_dim4 (5th dimension from the end)
-  // [95:80]:   tile_dim4
-  // [127:96]:  reserved
+  /* group3 bit-field definition
+    ================================================================
+     dword | dword     | bit-size | field
+           | -bit-ofst |
+     ---------------------------------------------------------------
+         0           0          32 tensor_dim3_stride LSB-32
+         1           0          16 tensor_dim3_stride MSB-16
+                    16          16 tensor_dim4 LSB-16
+         2          00          16 tensor_dim4 MSB-16
+                    16          16 tile_dim4
+         3           0          32 reserved
+    ================================================================
+  */
   SmallVector<Value> group3(4, b.i32_val(0));
   if (numDims >= 4) {
 


### PR DESCRIPTION
Fix https://github.com/ROCm/triton-internal/issues/1512.

The bug is about warp distribution about TDM mistakenly omitting dimensions whose id >= 2.