### PR TITLE
Use fresh_knobs_except_libraries for some tests when setting `TRITON_PTXAS_BLACKWELL_PATH`

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5732,7 +5732,7 @@ def test_dot_max_num_imprecise_acc(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, in_type_s
 
 @pytest.mark.parametrize("enable_fp_fusion", [False, True])
 @pytest.mark.parametrize("default_override", [False, True])
-def test_enable_fp_fusion(enable_fp_fusion, default_override, device, fresh_knobs):
+def test_enable_fp_fusion(enable_fp_fusion, default_override, device, fresh_knobs_except_libraries):
     # Sequential multiply add can be fused by backend
     @triton.jit
     def mul_add(data):
@@ -5741,7 +5741,7 @@ def test_enable_fp_fusion(enable_fp_fusion, default_override, device, fresh_knob
 
     data = torch.randn((128, ), device=device, dtype=torch.float32)
     if default_override:
-        fresh_knobs.language.default_fp_fusion = enable_fp_fusion
+        fresh_knobs_except_libraries.language.default_fp_fusion = enable_fp_fusion
         h = mul_add.warmup(data, grid=(1, ))
     else:
         h = mul_add.warmup(data, grid=(1, ), enable_fp_fusion=enable_fp_fusion)
@@ -5759,7 +5759,7 @@ def test_enable_fp_fusion(enable_fp_fusion, default_override, device, fresh_knob
 
 @pytest.mark.skipif(not is_cuda(), reason="Requires CUDA")
 @pytest.mark.parametrize("enable_reflect_ftz", [False, True])
-def test_enable_reflect_ftz(enable_reflect_ftz, device, fresh_knobs):
+def test_enable_reflect_ftz(enable_reflect_ftz, device, fresh_knobs_except_libraries):
 
     @triton.jit
     def exp2(data):
@@ -5780,7 +5780,7 @@ def test_enable_reflect_ftz(enable_reflect_ftz, device, fresh_knobs):
 
 @pytest.mark.parametrize("arch", ["sm70", "sm80", "sm90", "gfx942", "gfx950", "gfx1200"])
 @pytest.mark.parametrize("env_var_override", [False, True])
-def test_override_arch(arch, env_var_override, device, fresh_knobs):
+def test_override_arch(arch, env_var_override, device, fresh_knobs_except_libraries):
     if arch.startswith("sm") and not is_cuda():
         pytest.skip(f"{arch} arch only for CUDA")
     elif arch.startswith("gfx") and not is_hip():
@@ -5797,7 +5797,7 @@ def test_override_arch(arch, env_var_override, device, fresh_knobs):
 
     if is_cuda():
         if env_var_override:
-            fresh_knobs.runtime.override_arch = str(arch)
+            fresh_knobs_except_libraries.runtime.override_arch = str(arch)
             h = simple.warmup(data, out, grid=(1, ))
         else:
             h = simple.warmup(data, out, arch=arch, grid=(1, ))
@@ -5807,7 +5807,7 @@ def test_override_arch(arch, env_var_override, device, fresh_knobs):
         # For HIP, the generated kernel is a binary containing the final ISA. So we cannot run
         # them like CUDA side if the chip doesn't match. Here we just check generated ISA.
         if env_var_override:
-            fresh_knobs.runtime.override_arch = str(arch)
+            fresh_knobs_except_libraries.runtime.override_arch = str(arch)
             h = simple.warmup(data, out, grid=(1, ))
         else:
             h = simple.warmup(data, out, arch=arch, grid=(1, ))

--- a/python/test/unit/language/test_tuple.py
+++ b/python/test/unit/language/test_tuple.py
@@ -269,7 +269,7 @@ def test_passing_nested_tuple_with_constexpr(device):
     _nested_tuple_kernel[(1, )](((1, ), (tl.constexpr(2), )))
 
 
-def test_passing_nested_tuple_with_constexpr_and_jit_hook(device, fresh_knobs):
+def test_passing_nested_tuple_with_constexpr_and_jit_hook(device, fresh_knobs_except_libraries):
     # get the serialized specialization data
     specialization_data = None
 
@@ -277,7 +277,7 @@ def test_passing_nested_tuple_with_constexpr_and_jit_hook(device, fresh_knobs):
         nonlocal specialization_data
         specialization_data = kwargs["compile"]["specialization_data"]
 
-    fresh_knobs.runtime.jit_cache_hook = cache_hook
+    fresh_knobs_except_libraries.runtime.jit_cache_hook = cache_hook
 
     device = getattr(torch, device).current_device()
 


### PR DESCRIPTION
When using the `TRITON_PTXAS_BLACKWELL_PATH` envvar to override the default `ptxas-blackwell` some tests still look for the hardcoded path and binary name for `ptxas-blackwell`. This PR fixes those tests to use `fresh_knobs_except_libraries` so that the proper environment variable value is used.




# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it is fixing tests`

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
