### PR TITLE
[AMD][gluon] Expose in_thread_transpose operation

### DIFF
--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -97,6 +97,10 @@ def is_hip_cdna():
     return is_hip_cdna2() or is_hip_cdna3() or is_hip_cdna4()
 
 
+def is_hip_rdna():
+    return is_hip_rdna3() or is_hip_rdna4()
+
+
 def get_hip_lds_size():
     return 163840 if is_hip_cdna4() else 65536
 


### PR DESCRIPTION
This PR exposes in_thread_transpose operation in gluon. This operation is used in shared memory optimizations, for example, when register order is different from shared memory order.

