### PR TITLE
Properly expose arguments to WS partitions

### DIFF
--- a/include/triton/Analysis/Alias.h
+++ b/include/triton/Analysis/Alias.h
@@ -89,11 +89,6 @@ public:
   visitOperation(Operation *op,
                  ArrayRef<const dataflow::Lattice<AliasInfo> *> operands,
                  ArrayRef<dataflow::Lattice<AliasInfo> *> results) override;
-
-  void visitNonControlFlowArguments(
-      Operation *op, const RegionSuccessor &successor,
-      ArrayRef<dataflow::Lattice<AliasInfo> *> argLattices,
-      unsigned firstIndex) override;
 };
 
 } // namespace mlir

--- a/include/triton/Analysis/BufferRegion.h
+++ b/include/triton/Analysis/BufferRegion.h
@@ -152,11 +152,6 @@ public:
       llvm::ArrayRef<const dataflow::Lattice<RegionInfo> *> operands,
       llvm::ArrayRef<dataflow::Lattice<RegionInfo> *> results) override;
 
-  void visitNonControlFlowArguments(
-      Operation *op, const RegionSuccessor &successor,
-      llvm::ArrayRef<dataflow::Lattice<RegionInfo> *> argLattices,
-      unsigned firstIndex) override;
-
   LogicalResult initialize(Operation *top) override;
 
 private:

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -548,7 +548,8 @@ def TTG_WarpSpecializePartitionsOp
              [IsolatedFromAbove, RecursiveMemoryEffects,
               RecursivelySpeculatable, Terminator,
               HasParent<"WarpSpecializeOp">,
-              DeclareOpInterfaceMethods<RegionBranchOpInterface>]> {
+              DeclareOpInterfaceMethods<
+                  RegionBranchOpInterface, ["getEntrySuccessorOperands"]>]> {
   let summary = "container op for `ttg.warp_specialize`";
   let description = [{
     Because MLIR requires entire operations be isolated from above, this op

--- a/lib/Analysis/Alias.cpp
+++ b/lib/Analysis/Alias.cpp
@@ -58,30 +58,6 @@ LogicalResult SharedMemoryAliasAnalysis::visitOperation(
   return success();
 }
 
-void SharedMemoryAliasAnalysis::visitNonControlFlowArguments(
-    Operation *op, const RegionSuccessor &successor,
-    ArrayRef<dataflow::Lattice<AliasInfo> *> argLattices, unsigned firstIndex) {
-  auto wsOp = dyn_cast<triton::gpu::WarpSpecializePartitionsOp>(op);
-  if (!wsOp) {
-    setAllToEntryStates(argLattices.take_front(firstIndex));
-    setAllToEntryStates(argLattices.drop_front(
-        firstIndex + successor.getSuccessorInputs().size()));
-    return;
-  }
-
-  // Propagate aliases from the parent operation's operands to the block
-  // arguments.
-  assert(!successor.isParent());
-  ProgramPoint *point = getProgramPointAfter(wsOp);
-
-  for (auto [capture, argLattice] :
-       llvm::zip(wsOp.getParentOp().getExplicitCaptures(), argLattices)) {
-    propagateIfChanged(
-        argLattice,
-        argLattice->join(getLatticeElementFor(point, capture)->getValue()));
-  }
-}
-
 AliasResult SharedMemoryAliasAnalysis::alias(Value lhs, Value rhs) {
   // TODO: implement
   return AliasResult::MayAlias;

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -964,7 +964,13 @@ void WarpSpecializePartitionsOp::getSuccessorRegions(
   // of the partition regions.
   if (src.isParent())
     for (Region &region : getPartitionRegions())
-      successors.emplace_back(&region);
+      successors.emplace_back(&region, region.getArguments());
+}
+
+OperandRange
+WarpSpecializePartitionsOp::getEntrySuccessorOperands(RegionSuccessor) {
+  // Pass through the explicit captures from the enclosing WarpSpecializeOp.
+  return getParentOp().getExplicitCaptures();
 }
 
 LogicalResult WarpSpecializeOp::verify() {


### PR DESCRIPTION
While we explicitly expose the region relationships between the WS operations and the regions they enclose, we do not expose how the operands to the `WarpSpecializeOp` are passed to the partition regions. Doing so allows us to eliminate the remaining explicit handling of `WarpSpecializeOp` in dataflow analyses.