### PR TITLE
[AMD][BACKEND] Make sure `tt.dot` dominates its predecessors when pingpong'ing

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/BlockPingpong.cpp
@@ -897,7 +897,7 @@ Pingponger::transformTwoClusterWithLocalLoadAndAll(OpBuilder &builder,
 
   appendOp(asyncCopyOps[1]);
   appendOp(asyncCommitOps[1]);
-  appendOp(dotOps[0]);
+  moveOpAndPredecessorsUpSameBlock(dotOps[0]);
 
   appendOp(ROCDL::SchedBarrier::create(builder, loc, 0));
   appendOp(ROCDL::SBarrierOp::create(builder, loc));


### PR DESCRIPTION
Make sure we place all predecessor of the dot before the dot. This PR fixes `language/test_tensor_descriptor.py/test_tensor_descriptor_batched_gemm_2d_tma` when enabling `AsyncCopy` on `gfx950`.

cc: @jungpark-mlir 