### PR TITLE
[AMD][BACKEND] Fix shared order selection for direct-to-LDS loads on GFX9

### DIFF
--- a/test/TritonGPU/loop-pipeline-hip.mlir
+++ b/test/TritonGPU/loop-pipeline-hip.mlir
@@ -252,8 +252,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 // COMMON: ttg.local_alloc {{.*}}, mutable>
 // COMMON: ttg.memdesc_trans {{.*}}, mutable> -> {{.*}}, mutable>
 
-#blocked = #ttg.blocked<{sizePerThread = [2, 2], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 2], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [1, 4], order = [0, 1]}>
 #shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
 #shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
 #smem = #ttg.shared_memory
@@ -702,13 +702,8 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 
 // -----
 
-// Check we do not get AsyncCopyGlobalToLocal because the vec width will be < 32bit.
-// The order of the shared memory will be getMemoryOrder(#linear1) == [0, 1]
-// which differs from the order [1, 0] of the blocked layout. Since we have to
-// gather into lds with AsyncCopyGlobalToLocal we have to fallback to registers
-
 // COMMON-LABEL: pipeline_scale_memory_order
-// COMMON-NOT: ttg.async_copy_global_to_local
+// ASYNC-2: ttg.async_copy_global_to_local
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [64, 1], warpsPerCTA = [8, 1], order = [1, 0]}>
 #linear = #ttg.linear<{register = [[0, 4], [16, 0], [32, 0], [64, 0]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 1], [0, 2]], warp = [[0, 0], [0, 0], [0, 0]], block = []}>

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -644,12 +644,7 @@ bool TargetInfo::supportsDirectToLDSScattering() const {
   switch (getISAFamily()) {
   case ISAFamily::GFX1250:
     return true;
-  case ISAFamily::CDNA3:
-  case ISAFamily::CDNA4:
-    return false;
   default:
-    llvm::report_fatal_error(
-        "Unsupported architecture for direct to lds loads");
     return false;
   }
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -180,8 +180,10 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
         auto regOrder = llEnc.getOrder();
         auto threadOrder = llEnc.getThreadOrder();
 
+        auto contig = llEnc.getElemsPerThread(srcTy.getShape());
         SetVector<unsigned> orderSet;
-        orderSet.insert(regOrder[0]);
+        if (contig[regOrder[0]] > 1)
+          orderSet.insert(regOrder[0]);
         orderSet.insert(threadOrder.begin(), threadOrder.end());
         order = orderSet.takeVector();
       }


### PR DESCRIPTION
On GFX9, direct-to-LDS loads must write coalesced to LDS. This requires that the distributed order and the shared order agree across all dimensions covered by a single warp.

This PR ensures that the shared order computed during pipelining preserves the fastest dimension based on getOrder, and then assigns remaining dimensions following the thread order. This approach guarantees that there are no gaps when writing to LDS for each warp.
We cannot directly use the `threadOrder` because contiguous registers may exhaust the fastest dimension. For example, consider a `4x64x4xi32` tensor with the following layout:

```
reg=[[0, 0, 1], [0, 0, 2], [0, 0, 4]]
lane = [[0, 1, 0], [0, 2, 0], [0, 4, 0], [0, 8, 0], [0, 16, 0], [0, 32, 0]]
warp= [[1, 0, 0], [2, 0, 0]]
```
Here:
- getOrder returns `[2, 0, 1]`
- getLaneOrder returns `[1, 0, 2]`

But the required order is `[2, 1, 0]`. We achieve this by taking `order[0]` (fastest dimension) and then using `laneOrder` for the remaining unassigned dimensions.

This PR fixes `language/test_tensor_descriptor.py:test_tensor_descriptor_reshape_matmul[float16]` when enabling `AsyncCopy`