### PR TITLE
[KERNELS] Add unary_swiglu fused activation

### DIFF
--- a/python/triton_kernels/triton_kernels/unary_geglu.py
+++ b/python/triton_kernels/triton_kernels/unary_geglu.py
@@ -1,9 +1,0 @@
-import torch
-
-from .unary_geglu_details._unary_geglu import _unary_geglu_fn
-
-unary_geglu_fn = _unary_geglu_fn
-
-
-def unary_geglu_torch(x: torch.Tensor, alpha: float) -> torch.Tensor:
-    return x * torch.sigmoid(alpha * x) * (x + 1)

--- a/python/triton_kernels/triton_kernels/unary_geglu_details/_unary_geglu.py
+++ b/python/triton_kernels/triton_kernels/unary_geglu_details/_unary_geglu.py
@@ -1,9 +1,0 @@
-import triton
-import triton.language as tl
-
-
-@triton.jit(repr=lambda _: "_unary_geglu")
-def _unary_geglu_fn(x, alpha):
-    x = x.to(tl.float32)
-    s = x / (1 + tl.exp(-alpha * x))
-    return tl.fma(s, x, s)

--- a/python/triton_kernels/triton_kernels/unary_swiglu.py
+++ b/python/triton_kernels/triton_kernels/unary_swiglu.py
@@ -1,0 +1,12 @@
+import torch
+
+from .swiglu import PrecisionConfig as SwiGLUPrecisionConfig
+from .swiglu import swiglu_torch
+from .unary_swiglu_details._unary_swiglu import _unary_swiglu_fn
+
+unary_swiglu_fn = _unary_swiglu_fn
+
+
+def unary_swiglu_torch(x: torch.Tensor, alpha: float) -> torch.Tensor:
+    packed = torch.repeat_interleave(x, 2, dim=-1)
+    return swiglu_torch(packed, alpha, SwiGLUPrecisionConfig(limit=None))

--- a/python/triton_kernels/triton_kernels/unary_swiglu_details/_unary_swiglu.py
+++ b/python/triton_kernels/triton_kernels/unary_swiglu_details/_unary_swiglu.py
@@ -1,0 +1,8 @@
+import triton
+
+from triton_kernels.swiglu_details._swiglu import compute_swiglu
+
+
+@triton.jit(repr=lambda _: "_unary_swiglu")
+def _unary_swiglu_fn(x, alpha):
+    return compute_swiglu(x, x, 1.0, alpha, None)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.
- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).
- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)


## PR Description

  Why

  - Add unary GEGLU fused activation support for matmul
    path), and make test selection clearer for unary GEGLU cases.

  What

  - Introduce a unary GEGLU Triton activation and torch reference.
  - Wire unary GEGLU into matmul fused activation selection and refactor test cases to a single activation tuple with
    stable ids.
  - Guard unsupported fused_activation + gammas + split_k > 1 combos and skip those in tests.

  Tests

  - pytest triton/python/triton_kernels/tests/test_matmul.py
  - pytest triton/python/triton_kernels/tests/test_matmul.py -k unary_geglu

