### PR TITLE
[AMD] Persistent subtiled variant for WS f16 GEMM 

### DIFF
--- a/third_party/amd/python/examples/gluon/f16_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_gfx1250.py
@@ -606,6 +606,58 @@ class PersistentPartitionArgs:
         self.c_dtype = ttgl.constexpr(c_dtype)
 
 
+# Helper class for passing arguments around persistent warp-specialization partitions (subtiled variant).
+@aggregate
+class PersistentPartitionSubtiledArgs:
+    a_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
+    b_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
+    c_desc: ttgl.amd.gfx1250.tdm.tensor_descriptor
+    a_buffer: ttgl.shared_memory_descriptor
+    b_buffer: ttgl.shared_memory_descriptor
+    acc_buffer: ttgl.shared_memory_descriptor
+    load_empty_bars: ttgl.shared_memory_descriptor
+    load_ready_bars: ttgl.shared_memory_descriptor
+    acc_empty_bars: ttgl.shared_memory_descriptor
+    acc_ready_bars: ttgl.shared_memory_descriptor
+    BLOCK_K: ttgl.constexpr
+    NUM_BUFFERS: ttgl.constexpr
+    NUM_ACC_BUFFERS: ttgl.constexpr
+    TRANSPOSE_B: ttgl.constexpr
+    WMMA_LAYOUT: ttgl.constexpr
+    c_dtype: ttgl.constexpr
+    NUM_QUADS: ttgl.constexpr
+    NUM_QUADS_M: ttgl.constexpr
+    NUM_QUADS_N: ttgl.constexpr
+    QUADRANT_M: ttgl.constexpr
+    QUADRANT_N: ttgl.constexpr
+
+    @gluon.constexpr_function
+    def __init__(self, a_desc, b_desc, c_desc, a_buffer, b_buffer, acc_buffer, load_empty_bars, load_ready_bars,
+                 acc_empty_bars, acc_ready_bars, BLOCK_K, NUM_BUFFERS, NUM_ACC_BUFFERS, TRANSPOSE_B, WMMA_LAYOUT,
+                 c_dtype, NUM_QUADS, NUM_QUADS_M, NUM_QUADS_N, QUADRANT_M, QUADRANT_N):
+        self.a_desc = a_desc
+        self.b_desc = b_desc
+        self.c_desc = c_desc
+        self.a_buffer = a_buffer
+        self.b_buffer = b_buffer
+        self.acc_buffer = acc_buffer
+        self.load_empty_bars = load_empty_bars
+        self.load_ready_bars = load_ready_bars
+        self.acc_empty_bars = acc_empty_bars
+        self.acc_ready_bars = acc_ready_bars
+        self.BLOCK_K = ttgl.constexpr(BLOCK_K)
+        self.NUM_BUFFERS = ttgl.constexpr(NUM_BUFFERS)
+        self.NUM_ACC_BUFFERS = ttgl.constexpr(NUM_ACC_BUFFERS)
+        self.TRANSPOSE_B = ttgl.constexpr(TRANSPOSE_B)
+        self.WMMA_LAYOUT = ttgl.constexpr(WMMA_LAYOUT)
+        self.c_dtype = ttgl.constexpr(c_dtype)
+        self.NUM_QUADS = ttgl.constexpr(NUM_QUADS)
+        self.NUM_QUADS_M = ttgl.constexpr(NUM_QUADS_M)
+        self.NUM_QUADS_N = ttgl.constexpr(NUM_QUADS_N)
+        self.QUADRANT_M = ttgl.constexpr(QUADRANT_M)
+        self.QUADRANT_N = ttgl.constexpr(QUADRANT_N)
+
+
 @aggregate
 class PhaseCounter:
     """Tracks iteration count and computes phase."""
@@ -836,6 +888,82 @@ def test_runtime_gemm_tdm_warp_specialized(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFER
     torch.testing.assert_close(c_triton, c_torch, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(128, 128, 256), (256, 256, 128)])
+@pytest.mark.parametrize("NUM_BUFFERS", [2, 4])
+@pytest.mark.parametrize("TRANSPOSE_B", [True])
+@pytest.mark.parametrize("PERSISTENT", [True])
+@pytest.mark.parametrize("M,N,K", [(1024, 1024, 512)])
+@pytest.mark.parametrize("NUM_TOTAL_WARPS", [12])
+def test_runtime_gemm_tdm_warp_specialized_subtiled(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, PERSISTENT, M,
+                                                    N, K, NUM_TOTAL_WARPS):
+    """Test warp specialized GEMM kernel (subtiled variant for large blocks)."""
+    if triton.cdiv(K, BLOCK_K) < NUM_BUFFERS:
+        pytest.skip("Skip tests where K/BLOCK_K < NUM_BUFFERS")
+
+    torch.manual_seed(42)
+
+    a = torch.randn((M, K), dtype=torch.float16)
+    b = torch.randn((K, N), dtype=torch.float16)
+    if TRANSPOSE_B:
+        b = b.T.contiguous()
+    c = torch.zeros((M, N), dtype=torch.float32)
+
+    stride_am, stride_ak = a.stride(0), a.stride(1)
+    stride_bk, stride_bn = (b.stride(0), b.stride(1)) if not TRANSPOSE_B else (b.stride(1), b.stride(0))
+    stride_cm, stride_cn = c.stride(0), c.stride(1)
+
+    a_device = a.cuda()
+    b_device = b.cuda()
+    c_device = c.cuda()
+
+    num_tiles = triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N)
+    # num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
+    # NOTE: Explicitly set num_sms to small number to ensure that each CU will compute multiple tiles.
+    num_sms = 8
+    grid = (min(num_sms, num_tiles), 1)
+
+    persistent_gemm_tdm_warp_specialized_subtiled_kernel[grid](
+        a_device, b_device, c_device,  #
+        M, N, K,  #
+        stride_am, stride_ak,  #
+        stride_bk, stride_bn,  #
+        stride_cm, stride_cn,  #
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N, BLOCK_K=BLOCK_K,  #
+        NUM_BUFFERS=NUM_BUFFERS, TRANSPOSE_B=TRANSPOSE_B, NUM_WARPS=NUM_TOTAL_WARPS,  #
+        num_warps=NUM_TOTAL_WARPS // 3)
+
+    c_triton = c_device.cpu()
+    c_torch = a.to(torch.float32) @ (b.to(torch.float32) if not TRANSPOSE_B else b.T.to(torch.float32))
+    torch.testing.assert_close(c_triton, c_torch, rtol=1e-3, atol=1e-3)
+
+
+@gluon.jit
+def split_accumulator_quadrant(acc):
+    """Split an accumulator into 4 subtiles.
+
+    Returns a tuple of 4 subtiles in row-major order: (top-left, top-right, bottom-left, bottom-right)
+    """
+    BLOCK_M: ttgl.constexpr = acc.shape[0]
+    BLOCK_N: ttgl.constexpr = acc.shape[1]
+    SUBTILE_M: ttgl.constexpr = BLOCK_M // 2
+    SUBTILE_N: ttgl.constexpr = BLOCK_N // 2
+
+    # Reshape [BLOCK_M, BLOCK_N] -> [2, SUBTILE_M, 2, SUBTILE_N]
+    acc_4d = acc.reshape([2, SUBTILE_M, 2, SUBTILE_N])
+
+    # Permute to [SUBTILE_M, SUBTILE_N, 2, 2] so split dimensions are at the end
+    acc_4d = acc_4d.permute(1, 3, 0, 2)
+
+    # Split along last dimension (split_n = 2) -> two tensors of [SUBTILE_M, SUBTILE_N, 2]
+    acc_n0, acc_n1 = acc_4d.split()
+
+    # Split each along last dimension (split_m = 2) -> four tensors of [SUBTILE_M, SUBTILE_N]
+    acc_00, acc_10 = acc_n0.split()
+    acc_01, acc_11 = acc_n1.split()
+
+    return acc_00, acc_01, acc_10, acc_11
+
+
 @gluon.jit
 def persistent_producer_partition(args, scheduler):
     """Persistent Producer partition: Issues TDM async loads for A and B matrices."""
@@ -933,7 +1061,7 @@ def persistent_compute_partition(args, scheduler):
 
 
 @gluon.jit
-def persistent_epilogue_partition(args, c_ptr, M, N, stride_cm, stride_cn, scheduler):
+def persistent_epilogue_partition(args, scheduler):
     """Epilogue partition: Waits for accumulator, issues TDM async store from shared to global memory."""
     BLOCK_M: ttgl.constexpr = args.a_desc.block_shape[0]
     BLOCK_N: ttgl.constexpr = args.b_desc.block_shape[0] if args.TRANSPOSE_B else args.b_desc.block_shape[1]
@@ -955,6 +1083,163 @@ def persistent_epilogue_partition(args, c_ptr, M, N, stride_cm, stride_cn, sched
                                          args.acc_buffer.index(acc_buffer_idx), mbarrier=acc_empty_bar)
 
         acc_ready_phase_counter = acc_ready_phase_counter.next()
+
+    ttgl.amd.gfx1250.tdm.async_wait(0)
+
+
+@gluon.jit
+def persistent_producer_subtiled_partition(args, scheduler):
+    """Persistent Producer partition: Issues TDM async loads for A and B matrices."""
+    K = args.a_desc.shape[1]
+    QUADRANT_M: ttgl.constexpr = args.QUADRANT_M
+    QUADRANT_N: ttgl.constexpr = args.QUADRANT_N
+    BLOCK_M: ttgl.constexpr = args.QUADRANT_M * args.NUM_QUADS_M
+    BLOCK_N: ttgl.constexpr = args.QUADRANT_N * args.NUM_QUADS_N
+    NUM_QUADS: ttgl.constexpr = args.NUM_QUADS
+    NUM_QUADS_N: ttgl.constexpr = args.NUM_QUADS_N
+
+    num_k_tiles = ttgl.cdiv(K, args.BLOCK_K)
+    num_tiles = scheduler.get_num_tiles()
+
+    # Assume phase 0 is already completed as the buffers are initially empty; start from phase 1
+    load_empty_phase_counter = PhaseCounter.create(args.NUM_BUFFERS, args.NUM_BUFFERS)
+
+    for tile_idx in range(num_tiles):
+        pid_m, pid_n = scheduler.get_tile(tile_idx)
+
+        for quad_idx in ttgl.static_range(NUM_QUADS):
+            quad_m = quad_idx // NUM_QUADS_N
+            quad_n = quad_idx % NUM_QUADS_N
+
+            off_am = pid_m * BLOCK_M + quad_m * QUADRANT_M
+            off_bn = pid_n * BLOCK_N + quad_n * QUADRANT_N
+
+            for k_tile_idx in range(num_k_tiles):
+                k_offset = k_tile_idx * args.BLOCK_K
+                buffer_idx = k_tile_idx % args.NUM_BUFFERS
+
+                empty_bar = args.load_empty_bars.index(buffer_idx)
+                ready_bar = args.load_ready_bars.index(buffer_idx)
+
+                # Wait for the buffers to be consumed before loading
+                ttgl.amd.gfx1250.mbarrier.wait(empty_bar, load_empty_phase_counter.phase())
+
+                # Only attach mbarrier to the last load so we signal once after both loads complete
+                ttgl.amd.gfx1250.tdm.async_load(args.a_desc, [off_am, k_offset], args.a_buffer.index(buffer_idx))
+                if args.TRANSPOSE_B:
+                    ttgl.amd.gfx1250.tdm.async_load(args.b_desc, [off_bn, k_offset], args.b_buffer.index(buffer_idx),
+                                                    mbarrier=ready_bar)
+                else:
+                    ttgl.amd.gfx1250.tdm.async_load(args.b_desc, [k_offset, off_bn], args.b_buffer.index(buffer_idx),
+                                                    mbarrier=ready_bar)
+
+                load_empty_phase_counter = load_empty_phase_counter.next()
+
+
+@gluon.jit
+def persistent_compute_subtiled_partition(args, scheduler):
+    """Persistent Compute partition: Waits for loaded data, performs WMMA operations, and writes accumulator to shared memory."""
+    K = args.a_desc.shape[1]
+    OPERAND_LAYOUT_A: ttgl.constexpr = ttgl.DotOperandLayout(0, args.WMMA_LAYOUT, 8)
+    OPERAND_LAYOUT_B: ttgl.constexpr = ttgl.DotOperandLayout(1, args.WMMA_LAYOUT, 8)
+
+    QUADRANT_M: ttgl.constexpr = args.QUADRANT_M
+    QUADRANT_N: ttgl.constexpr = args.QUADRANT_N
+    NUM_QUADS: ttgl.constexpr = args.NUM_QUADS
+    SUBTILES_PER_ACC: ttgl.constexpr = 4
+
+    num_k_tiles = ttgl.cdiv(K, args.BLOCK_K)
+    num_tiles = scheduler.get_num_tiles()
+
+    load_ready_phase_counter = PhaseCounter.create(0, args.NUM_BUFFERS)
+    # Assume phase 0 is already completed as the buffers are initially empty; start from phase 1
+    acc_empty_phase_counter = PhaseCounter.create(args.NUM_ACC_BUFFERS, args.NUM_ACC_BUFFERS)
+
+    for tile_idx in range(num_tiles):
+        for quad_idx in ttgl.static_range(NUM_QUADS):
+            # Process accumulator quadrants (1/4 of full accumulator tile) to avoid register spilling
+            accumulator = ttgl.zeros((QUADRANT_M, QUADRANT_N), dtype=args.c_dtype, layout=args.WMMA_LAYOUT)
+
+            for k_tile_idx in range(num_k_tiles):
+                buffer_idx = k_tile_idx % args.NUM_BUFFERS
+                ready_bar = args.load_ready_bars.index(buffer_idx)
+                empty_bar = args.load_empty_bars.index(buffer_idx)
+
+                # Wait for the buffers to be filled by the producer
+                ttgl.amd.gfx1250.mbarrier.wait(ready_bar, load_ready_phase_counter.phase())
+
+                a = args.a_buffer.index(buffer_idx).load(layout=OPERAND_LAYOUT_A)
+                if args.TRANSPOSE_B:
+                    b = args.b_buffer.index(buffer_idx).permute([1, 0]).load(layout=OPERAND_LAYOUT_B)
+                else:
+                    b = args.b_buffer.index(buffer_idx).load(layout=OPERAND_LAYOUT_B)
+
+                accumulator = ttgl.amd.gfx1250.wmma(a, b, accumulator)
+
+                # Signal that we're done with these buffers (producer can reuse them)
+                ttgl.amd.gfx1250.mbarrier.arrive(empty_bar, count=1)
+
+                load_ready_phase_counter = load_ready_phase_counter.next()
+
+            # Split accumulator quadrant into subtiles to reduce shared memory usage
+            subtiles = split_accumulator_quadrant(accumulator)
+
+            for subtile_idx in ttgl.static_range(SUBTILES_PER_ACC):
+                subtile = subtiles[subtile_idx]
+                acc_buffer_idx = subtile_idx % args.NUM_ACC_BUFFERS
+                acc_empty_bar = args.acc_empty_bars.index(acc_buffer_idx)
+                acc_ready_bar = args.acc_ready_bars.index(acc_buffer_idx)
+                # Wait for the accumulator subtile buffer to be empty (consumed by epilogue partition)
+                ttgl.amd.gfx1250.mbarrier.wait(acc_empty_bar, acc_empty_phase_counter.phase())
+                # Store buffer to shared memory for epilogue partition
+                args.acc_buffer.index(acc_buffer_idx).store(subtile)
+                # Signal epilogue partition that accumulator subtile is ready to be consumed
+                ttgl.amd.gfx1250.mbarrier.arrive(acc_ready_bar, count=1)
+                acc_empty_phase_counter = acc_empty_phase_counter.next()
+
+
+@gluon.jit
+def persistent_epilogue_subtiled_partition(args, scheduler):
+    """Epilogue partition: Waits for accumulator, issues TDM async store from shared to global memory."""
+    QUADRANT_M: ttgl.constexpr = args.QUADRANT_M
+    QUADRANT_N: ttgl.constexpr = args.QUADRANT_N
+    BLOCK_M: ttgl.constexpr = args.QUADRANT_M * args.NUM_QUADS_M
+    BLOCK_N: ttgl.constexpr = args.QUADRANT_N * args.NUM_QUADS_N
+    NUM_QUADS: ttgl.constexpr = args.NUM_QUADS
+    NUM_QUADS_N: ttgl.constexpr = args.NUM_QUADS_N
+    ACC_SUBTILE: ttgl.constexpr = 64  # Each subtile is 64x64
+    SUBTILES_PER_QUAD: ttgl.constexpr = 4
+
+    num_tiles = scheduler.get_num_tiles()
+
+    acc_ready_phase_counter = PhaseCounter.create(0, args.NUM_ACC_BUFFERS)
+
+    for tile_idx in range(num_tiles):
+        pid_m, pid_n = scheduler.get_tile(tile_idx)
+
+        for quad_idx in ttgl.static_range(NUM_QUADS):
+            quad_m = quad_idx // NUM_QUADS_N
+            quad_n = quad_idx % NUM_QUADS_N
+
+            quad_m_offset = quad_m * QUADRANT_M
+            quad_n_offset = quad_n * QUADRANT_N
+
+            for subtile_idx in ttgl.static_range(SUBTILES_PER_QUAD):
+                local_subtile_m = subtile_idx // 2
+                local_subtile_n = subtile_idx % 2
+
+                acc_buffer_idx = subtile_idx % args.NUM_ACC_BUFFERS
+                acc_ready_bar = args.acc_ready_bars.index(acc_buffer_idx)
+                acc_empty_bar = args.acc_empty_bars.index(acc_buffer_idx)
+
+                ttgl.amd.gfx1250.mbarrier.wait(acc_ready_bar, acc_ready_phase_counter.phase())
+
+                offs_m = pid_m * BLOCK_M + quad_m_offset + local_subtile_m * ACC_SUBTILE
+                offs_n = pid_n * BLOCK_N + quad_n_offset + local_subtile_n * ACC_SUBTILE
+
+                ttgl.amd.gfx1250.tdm.async_store(args.c_desc, [offs_m, offs_n], args.acc_buffer.index(acc_buffer_idx),
+                                                 mbarrier=acc_empty_bar)
+                acc_ready_phase_counter = acc_ready_phase_counter.next()
 
     ttgl.amd.gfx1250.tdm.async_wait(0)
 
@@ -1039,9 +1324,108 @@ def persistent_gemm_tdm_warp_specialized_kernel(a_ptr, b_ptr, c_ptr,  #
                                    NUM_ACC_BUFFERS, TRANSPOSE_B, WMMA_LAYOUT, c_ptr.type.element_ty)
 
     ttgl.warp_specialize([
-        (persistent_epilogue_partition, (args, c_ptr, M, N, stride_cm, stride_cn, scheduler)),
+        (persistent_epilogue_partition, (args, scheduler)),
         (persistent_compute_partition, (args, scheduler)),
         (persistent_producer_partition, (args, scheduler)),
+    ], [COMPUTE_WARPS, PRODUCER_WARPS])
+
+
+@gluon.jit
+def persistent_gemm_tdm_warp_specialized_subtiled_kernel(a_ptr, b_ptr, c_ptr,  #
+                                                         M, N, K,  #
+                                                         stride_am, stride_ak,  #
+                                                         stride_bk, stride_bn,  #
+                                                         stride_cm, stride_cn,  #
+                                                         BLOCK_M: ttgl.constexpr, BLOCK_N: ttgl.constexpr,
+                                                         BLOCK_K: ttgl.constexpr,  #
+                                                         NUM_BUFFERS: ttgl.constexpr,  #
+                                                         TRANSPOSE_B: ttgl.constexpr,  #
+                                                         NUM_WARPS: ttgl.constexpr):
+    """Persistent warp specialized GEMM kernel with quadrant-based subtiling (three partitions: producer, compute, epilogue)."""
+    a_dtype: ttgl.constexpr = a_ptr.type.element_ty
+    b_dtype: ttgl.constexpr = b_ptr.type.element_ty
+    ttgl.static_assert(a_dtype.is_fp16() or a_dtype.is_bf16(), "Only fp16/bf16 supported for A")
+    ttgl.static_assert(b_dtype.is_fp16() or b_dtype.is_bf16(), "Only fp16/bf16 supported for B")
+    ttgl.static_assert(NUM_BUFFERS >= 2, "NUM_BUFFERS must be at least 2")
+    ttgl.static_assert(NUM_WARPS == 12, "NUM_WARPS must be 12 for this kernel")
+
+    # WS kernels require num_warps to be a multiple of 4; default partition (epilogue) must have multiple of 4 warps.
+    PRODUCER_WARPS: ttgl.constexpr = 4
+    COMPUTE_WARPS: ttgl.constexpr = 4
+    EPILOGUE_WARPS: ttgl.constexpr = 4
+    WARP_SIZE: ttgl.constexpr = 32
+
+    # accumulator buffers used for double-buffering to overlap epilogue with load of the next tile
+    NUM_ACC_BUFFERS: ttgl.constexpr = 2
+
+    # Accumulator subtile size for shared memory (fixed at 64x64)
+    ACC_SUBTILE_M: ttgl.constexpr = 64
+    ACC_SUBTILE_N: ttgl.constexpr = 64
+
+    QUADRANT_M: ttgl.constexpr = 128
+    QUADRANT_N: ttgl.constexpr = 128
+    NUM_QUADS_M: ttgl.constexpr = BLOCK_M // QUADRANT_M
+    NUM_QUADS_N: ttgl.constexpr = BLOCK_N // QUADRANT_N
+    NUM_QUADS: ttgl.constexpr = NUM_QUADS_M * NUM_QUADS_N
+
+    WMMA_LAYOUT: ttgl.constexpr = ttgl.amd.AMDWMMALayout(3, True, [COMPUTE_WARPS // 2, 2], [16, 16, 32])
+    shared_layouts: ttgl.constexpr = create_shared_layouts(QUADRANT_M, QUADRANT_N, BLOCK_K, TRANSPOSE_B)
+    SHARED_LAYOUT_A: ttgl.constexpr = shared_layouts[0]
+    SHARED_LAYOUT_B: ttgl.constexpr = shared_layouts[1]
+
+    SHARED_LAYOUT_ACC: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, [1, 0])
+
+    a_desc, b_desc = create_tensor_descriptors(a_ptr, b_ptr, 0, 0, stride_am, stride_ak, stride_bn, stride_bk,
+                                               SHARED_LAYOUT_A, SHARED_LAYOUT_B, M, N, K, QUADRANT_M, QUADRANT_N,
+                                               BLOCK_K, TRANSPOSE_B)
+
+    c_desc = ttgl.amd.gfx1250.tdm.make_tensor_descriptor(base=c_ptr, shape=(M, N), strides=(stride_cm, stride_cn),
+                                                         block_shape=(ACC_SUBTILE_M, ACC_SUBTILE_N),
+                                                         layout=SHARED_LAYOUT_ACC)
+
+    scheduler = PersistentTileScheduler.initialize(M, N, BLOCK_M, BLOCK_N)
+
+    a_buffer = ttgl.allocate_shared_memory(a_desc.dtype, shape=[NUM_BUFFERS] + a_desc.block_shape, layout=a_desc.layout)
+    b_buffer = ttgl.allocate_shared_memory(b_desc.dtype, shape=[NUM_BUFFERS] + b_desc.block_shape, layout=b_desc.layout)
+    acc_buffer = ttgl.allocate_shared_memory(c_ptr.type.element_ty,
+                                             shape=[NUM_ACC_BUFFERS, ACC_SUBTILE_M,
+                                                    ACC_SUBTILE_N], layout=SHARED_LAYOUT_ACC)
+
+    load_empty_bars = ttgl.allocate_shared_memory(ttgl.int64, [NUM_BUFFERS, 1],
+                                                  ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+    load_ready_bars = ttgl.allocate_shared_memory(ttgl.int64, [NUM_BUFFERS, 1],
+                                                  ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+    acc_empty_bars = ttgl.allocate_shared_memory(ttgl.int64, [NUM_ACC_BUFFERS, 1],
+                                                 ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+    acc_ready_bars = ttgl.allocate_shared_memory(ttgl.int64, [NUM_ACC_BUFFERS, 1],
+                                                 ttgl.amd.gfx1250.mbarrier.MBarrierLayout())
+
+    # Initialize mbarriers
+    # load_empty_bars: signals when compute partition has consumed the shared memory buffers for matrices A and B
+    # load_ready_bars: signals when producer partition has filled the shared memory buffer for matrices A and B
+    # acc_empty_bars: signals when epilogue partition has stored the accumulator provided by the compute partition
+    # acc_ready_bars: signals when compute partition has filled the accuumulator to be consumed by the epilogue partition
+    for i in ttgl.static_range(NUM_BUFFERS):
+        # load_empty_bars: arrive on barrier once per thread, so use compute thread count
+        ttgl.amd.gfx1250.mbarrier.init(load_empty_bars.index(i), count=COMPUTE_WARPS * WARP_SIZE)
+        # load_ready_bars: TDM arrives on barrier once per warp, so use producer warp count
+        ttgl.amd.gfx1250.mbarrier.init(load_ready_bars.index(i), count=PRODUCER_WARPS)
+
+    for i in ttgl.static_range(NUM_ACC_BUFFERS):
+        # acc_empty_bars: TDM arrives on barrier once per warp, so use epilogue warp count
+        ttgl.amd.gfx1250.mbarrier.init(acc_empty_bars.index(i), count=EPILOGUE_WARPS)
+        # acc_ready_bars: arrive on barrier once per thread, so use compute thread count
+        ttgl.amd.gfx1250.mbarrier.init(acc_ready_bars.index(i), count=COMPUTE_WARPS * WARP_SIZE)
+
+    args = PersistentPartitionSubtiledArgs(a_desc, b_desc, c_desc, a_buffer, b_buffer, acc_buffer, load_empty_bars,
+                                           load_ready_bars, acc_empty_bars, acc_ready_bars, BLOCK_K, NUM_BUFFERS,
+                                           NUM_ACC_BUFFERS, TRANSPOSE_B, WMMA_LAYOUT, c_ptr.type.element_ty, NUM_QUADS,
+                                           NUM_QUADS_M, NUM_QUADS_N, QUADRANT_M, QUADRANT_N)
+
+    ttgl.warp_specialize([
+        (persistent_epilogue_subtiled_partition, (args, scheduler)),
+        (persistent_compute_subtiled_partition, (args, scheduler)),
+        (persistent_producer_subtiled_partition, (args, scheduler)),
     ], [COMPUTE_WARPS, PRODUCER_WARPS])
 
 
@@ -1059,6 +1443,7 @@ if __name__ == "__main__":
     parser.add_argument("--prefetch-lds", action="store_true", help="Enable prefetch LDS")
     parser.add_argument("--single-warp-schedule", action="store_true", help="Use single warp per SIMD schedule variant")
     parser.add_argument("--warp-specialized", action="store_true", help="Use warp specialized variant")
+    parser.add_argument("--subtiled", action="store_true", help="Use subtiled quadrant processing")
     args = parser.parse_args()
 
     assert not (args.persistent and args.single_warp_schedule)
@@ -1082,13 +1467,23 @@ if __name__ == "__main__":
     PREFETCH = args.prefetch_lds
 
     if args.warp_specialized:
-        BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 128
-        print(
-            f"({M=}, {N=}, {K=}), ({BLOCK_M=}, {BLOCK_N=}, {BLOCK_K=}), {TRANSPOSE_B=}, NUM_TOTAL_WARPS={NUM_WARPS}, {NUM_BUFFERS=}, {PERSISTENT=}"
-        )
-        test_runtime_gemm_tdm_warp_specialized(BLOCK_M, BLOCK_N, BLOCK_K,  #
-                                               NUM_BUFFERS, TRANSPOSE_B, PERSISTENT,  #
-                                               M, N, K, NUM_WARPS)
+        # For warp specialized, allow larger blocks with subtiled variant
+        if args.subtiled:
+            BLOCK_M, BLOCK_N, BLOCK_K = 256, 256, 128
+            print(
+                f"({M=}, {N=}, {K=}), ({BLOCK_M=}, {BLOCK_N=}, {BLOCK_K=}), {TRANSPOSE_B=}, NUM_TOTAL_WARPS={NUM_WARPS}, {NUM_BUFFERS=}, {PERSISTENT=}"
+            )
+            test_runtime_gemm_tdm_warp_specialized_subtiled(BLOCK_M, BLOCK_N, BLOCK_K,  #
+                                                            NUM_BUFFERS, TRANSPOSE_B, PERSISTENT,  #
+                                                            M, N, K, NUM_WARPS)
+        else:
+            BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 128
+            print(
+                f"({M=}, {N=}, {K=}), ({BLOCK_M=}, {BLOCK_N=}, {BLOCK_K=}), {TRANSPOSE_B=}, NUM_TOTAL_WARPS={NUM_WARPS}, {NUM_BUFFERS=}, {PERSISTENT=}"
+            )
+            test_runtime_gemm_tdm_warp_specialized(BLOCK_M, BLOCK_N, BLOCK_K,  #
+                                                   NUM_BUFFERS, TRANSPOSE_B, PERSISTENT,  #
+                                                   M, N, K, NUM_WARPS)
     elif args.single_warp_schedule:
         print(
             f"({M=}, {N=}, {K=}), ({BLOCK_M=}, {BLOCK_N=}, {BLOCK_K=}), {TRANSPOSE_B=}, {NUM_WARPS=}, {NUM_BUFFERS=}, {PERSISTENT=}, {PREFETCH=}"


### PR DESCRIPTION
Increase supported block size by using subtiling techniques to reduce shared memory usage and eliminate register spills.
Ref: https://github.com/ROCm/triton-internal/issues/1338