### PR TITLE
[Frontend] Fix setting attr on constexpr argument

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -5477,6 +5477,15 @@ def test_constexpr_assignment(literal, tensor_ty):
     kernel_patched[(1, )](literal, tensor_ty)
 
 
+def test_constexpr_arg_str_attr():
+
+    @triton.jit
+    def cst_str_attr(c_s_arg: tl.constexpr):
+        pass
+
+    cst_str_attr.warmup('SD', grid=(1, ))
+
+
 @triton.jit
 def return_poison(x):
     a = False

--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -693,7 +693,7 @@ class JITFunction(JITCallable, KernelInterface[T]):
         constexprs = find_paths_if(sigvals, lambda _, val: val == "constexpr")
         constexprs = {path: get_iterable_path(list(bound_args.values()), path) for path in constexprs}
         # attributes
-        attrvals = [x[1] for x in specialization]
+        attrvals = ['' if x[0] == 'constexpr' else x[1] for x in specialization]
         attrs = find_paths_if(attrvals, lambda _, x: isinstance(x, str))
         attrs = {k: backend.parse_attr(get_iterable_path(attrvals, k)) for k in attrs}
 


### PR DESCRIPTION
Specialization contains a pair for each argument, the first of which is
the argument's type (e.g. int/ptr/constexpr). For dynamic
(non-constexpr) argument, the second element is a string describing the
attribute of the argument (e.g. 'D' means divisibility by 16), for
constexpr argument, second element is the argument's compiling time
value. For example:

```
[(i32, 'D'), (float, ''), (constexpr, 'CDNA'), (constexpr, 128)]
```

For MLIR func-op's arguments, only dynamic arguments have
correspondence, constexpr arguments are already propagated/inlined and
not passed as runtime arguments. So when determining func-op arguments'
attrs from specialization, we should filter-out constexpr arguments