### PR TITLE
[AMD] NFC: include ArrayRef via mlir/support/LLVM

### DIFF
--- a/third_party/amd/include/Utils/Utility.h
+++ b/third_party/amd/include/Utils/Utility.h
@@ -1,7 +1,7 @@
 #ifndef TRITON_THIRD_PARTY_AMD_INCLUDE_UTILS_UTILITY_H_
 #define TRITON_THIRD_PARTY_AMD_INCLUDE_UTILS_UTILITY_H_
 
-#include "llvm/ADT/ArrayRef.h"
+#include "mlir/Support/LLVM.h"
 #include <cassert>
 #include <vector>
 namespace mlir::LLVM::AMD {


### PR DESCRIPTION
mlir/Support/LLVM.h introduces `using llvm::ArrayRef;`  to mlir namespace. Without it compilation with utility.h fails in some setups.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
  `pip install -e .` compiled without errors

- [x] This PR does not need a test because it is not a functional change.
- [x] I have not added any `lit` tests.
