### PR TITLE
[AMD] NFC: remove std::move(temporary)

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/SchedInstructions.cpp
@@ -105,7 +105,7 @@ struct TritonAMDGPULowerInstructionSchedHints
 
   explicit TritonAMDGPULowerInstructionSchedHints(StringRef arch,
                                                   int32_t numStages) {
-    this->arch = std::move(arch.str());
+    this->arch = arch.str();
     this->numStages = numStages;
   }
 
@@ -138,7 +138,7 @@ struct TritonAMDGPUInsertInstructionSchedHints
           TritonAMDGPUInsertInstructionSchedHints> {
 
   explicit TritonAMDGPUInsertInstructionSchedHints(StringRef variant) {
-    this->variant = std::move(variant.str());
+    this->variant = variant.str();
   }
 
   void runOnOperation() override {


### PR DESCRIPTION
In both cases here we have moved a temporary, which is not needed. Clang also complains that "moving a temporary object prevents copy elision".

- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD` (running).

- [x] This PR does not need a test because NFC.
- [x] I have not added any `lit` tests.