### PR TITLE
[AMD] Fix extract_element type error by bitcasting pkVals to v2i32 in else branch

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -772,6 +772,11 @@ SmallVector<Value> upcast8xMxfp4_SW(RewriterBase &rewriter, Operation *op,
         Value pkScaled = b.fmul(pkScale, b.bitcast(pkVals[i], v2f32));
         pkVals[i] = (b.bitcast(pkScaled, v2i32));
       }
+    } else {
+      // bitcast to v2i32
+      for (unsigned i = 0; i < 4; i++) {
+        pkVals[i] = b.bitcast(pkVals[i], vec_ty(i32_ty, 2));
+      }
     }
     Value e0 = b.extract_element(pkVals[0], b.i32_val(0));
     Value e1 = b.extract_element(pkVals[2], b.i32_val(0));


### PR DESCRIPTION
[AMD] Fix extract_element type error by bitcasting pkVals to v2i32 in else branch

The subsequent `b.extract_element` requires an aggregate type (e.g. vector) as input. In the else branch (when `scale` is false), we bitcast each element of `pkVals` to `v2i32` (2-element i32 vector) to match the type requirement of `extract_element`, aligning with the type handling logic in the `scale` branch.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
