### PR TITLE
[TOOLS] Add hip support for link.py

### DIFF
--- a/python/triton/tools/compile.py
+++ b/python/triton/tools/compile.py
@@ -173,6 +173,7 @@ def compile_kernel(args: CompileArgs):
     hex_ = str(binascii.hexlify(asm))[2:-1]
 
     ty_to_cpp = triton.runtime.driver.active.map_python_to_cpp_type
+    backend_name = target.backend
 
     params = {
         "kernel_name": func_name,
@@ -192,9 +193,9 @@ def compile_kernel(args: CompileArgs):
         "gridZ": grid[2],
         "_placeholder": "",
         "warp_size": target.warp_size,
+        "backend_name": backend_name,
     }
     output_files = []
-    backend_name = target.backend
     template_dir = Path(__file__).parent / "extra" / backend_name
     for template_path in template_dir.glob('compile.*'):
         ext = template_path.suffix

--- a/python/triton/tools/link.py
+++ b/python/triton/tools/link.py
@@ -39,8 +39,11 @@ class HeaderParser:
         self.c_sig = re.compile("[\\s]*(\\w+)\\s(\\w+)[,]?")
         # [d|c]
         self.arg_suffix = re.compile("[c,d]")
+        # [backend_name]
+        self.backend_name_re = re.compile("//[\\s]*tt-linker-backend:[\\s]*([\\w]+)")
 
         self.kernels = defaultdict(list)
+        self.backend_name = None
 
     def extract_linker_meta(self, header: str):
         for ln in header.splitlines():
@@ -64,6 +67,14 @@ class HeaderParser:
                             num_specs=num_specs,
                         ),
                     )
+                else:
+                    m = self.backend_name_re.match(ln)
+                    if _exists(m):
+                        backend_name = m.group(1)
+                        if self.backend_name is None:
+                            self.backend_name = backend_name
+                        elif self.backend_name != backend_name:
+                            raise RuntimeError(f"differing backend {self.backend_name} vs. {backend_name}")
 
     def _match_name(self, ker_name: str):
         m = self.kernel_name.match(ker_name)
@@ -135,7 +146,7 @@ def gen_signature(m):
 # generate declarations of kernels with meta-parameter and constant values
 def make_algo_decls(name: str, metas: Sequence[KernelLinkerMeta]) -> str:
     return f"""
-CUresult {name}(CUstream stream, {gen_signature_with_full_args(metas[-1])});
+TT_ResultTy {name}(TT_StreamTy stream, {gen_signature_with_full_args(metas[-1])});
 void load_{name}();
 void unload_{name}();
     """
@@ -144,8 +155,8 @@ void unload_{name}();
 # generate declarations of kernels with meta-parameter and constant values
 def make_global_decl(meta: KernelLinkerMeta) -> str:
     return f"""
-CUresult {meta.orig_kernel_name}_default(CUstream stream, {gen_signature_with_full_args(meta)});
-CUresult {meta.orig_kernel_name}(CUstream stream, {gen_signature_with_full_args(meta)}, int algo_id);
+TT_ResultTy {meta.orig_kernel_name}_default(TT_StreamTy stream, {gen_signature_with_full_args(meta)});
+TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id);
 void load_{meta.orig_kernel_name}();
 void unload_{meta.orig_kernel_name}();
     """
@@ -153,7 +164,7 @@ void unload_{meta.orig_kernel_name}();
 
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_default_algo_kernel(meta: KernelLinkerMeta) -> str:
-    src = f"CUresult {meta.orig_kernel_name}_default(CUstream stream, {gen_signature_with_full_args(meta)}){{\n"
+    src = f"TT_ResultTy {meta.orig_kernel_name}_default(TT_StreamTy stream, {gen_signature_with_full_args(meta)}){{\n"
     src += (f"  return {meta.orig_kernel_name}(stream, {', '.join(meta.arg_names)}, 0);\n")
     src += "}\n"
     return src
@@ -163,14 +174,14 @@ def make_default_algo_kernel(meta: KernelLinkerMeta) -> str:
 def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -> str:
     src = f"// launcher for: {name}\n"
     for meta in sorted(metas, key=lambda m: -m.num_specs):
-        src += f"CUresult {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(CUstream stream, {gen_signature(meta)});\n"
+        src += f"TT_ResultTy {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(TT_StreamTy stream, {gen_signature(meta)});\n"
     src += "\n"
 
-    src += (f"CUresult {name}(CUstream stream, {gen_signature_with_full_args(metas[-1])}){{")
+    src += (f"TT_ResultTy {name}(TT_StreamTy stream, {gen_signature_with_full_args(metas[-1])}){{")
     src += "\n"
     for meta in sorted(metas, key=lambda m: -m.num_specs):
         cond_fn = (  #
-            lambda val, hint: f"({val} % {hint} == 0)"  #
+            lambda val, hint: f"((uintptr_t){val} % {hint} == 0)"  #
             if hint == 16  #
             else f"({val} == {hint})"  #
             if hint == 1  #
@@ -185,7 +196,7 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
         arg_names = [arg for arg, hint in zip(meta.arg_names, meta.sizes) if hint != 1]
         src += f"    return {meta.orig_kernel_name}_{meta.sig_hash}_{meta.suffix}(stream, {', '.join(arg_names)});\n"
     src += "\n"
-    src += "  return CUDA_ERROR_INVALID_VALUE;\n"
+    src += "  return TT_ERROR_INVALID_VALUE;\n"
     src += "}\n"
 
     for mode in ["load", "unload"]:
@@ -202,7 +213,7 @@ def make_kernel_hints_dispatcher(name: str, metas: Sequence[KernelLinkerMeta]) -
 
 # generate dispatcher function for kernels with different meta-parameter and constant values
 def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
-    src = f"CUresult {meta.orig_kernel_name}(CUstream stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
+    src = f"TT_ResultTy {meta.orig_kernel_name}(TT_StreamTy stream, {gen_signature_with_full_args(meta)}, int algo_id){{\n"
     src += f"  assert (algo_id < (int)sizeof({meta.orig_kernel_name}_kernels));\n"
     src += f"  return {meta.orig_kernel_name}_kernels[algo_id](stream, {', '.join(meta.arg_names)});\n"
     src += "}\n"
@@ -212,7 +223,7 @@ def make_kernel_meta_const_dispatcher(meta: KernelLinkerMeta) -> str:
 # generate definition of function pointers of kernel dispatchers based on meta-parameter and constant values
 def make_func_pointers(names: str, meta: KernelLinkerMeta) -> str:
     # the table of hint dispatchers
-    src = f"typedef CUresult (*kernel_func_t)(CUstream stream, {gen_signature_with_full_args(meta)});\n"
+    src = f"typedef TT_ResultTy (*kernel_func_t)(TT_StreamTy stream, {gen_signature_with_full_args(meta)});\n"
     src += f"kernel_func_t {meta.orig_kernel_name}_kernels[] = {{\n"
     for name in names:
         src += f"  {name},\n"
@@ -287,8 +298,9 @@ if __name__ == "__main__":
     meta = meta_lists[0][0]
     get_num_algos_decl = make_get_num_algos_decl(meta)
     global_decl = make_global_decl(meta)
+    backend_prelude = (Path(__file__).parent / "extra" / parser.backend_name / "link.h").read_text()
     with args.out.with_suffix(".h").open("w") as fp:
-        out = "#include <cuda.h>\n"
+        out = backend_prelude
         out += "\n".join(algo_decls)
         out += "\n"
         out += get_num_algos_decl
@@ -305,8 +317,7 @@ if __name__ == "__main__":
     get_num_algos_def = make_get_num_algos_def(meta)
     default_algo_kernel = make_default_algo_kernel(meta)
     with args.out.with_suffix(".c").open("w") as fp:
-        out = ""
-        out += "#include <cuda.h>\n"
+        out = backend_prelude
         out += "#include <stdint.h>\n"
         out += "#include <assert.h>\n"
         out += "\n"

--- a/third_party/amd/tools/hip/compile.c
+++ b/third_party/amd/tools/hip/compile.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <string.h>
+#define __HIP_PLATFORM_AMD__
 #include <hip/hip_runtime.h>
 
 // helpers to check for hip errors
@@ -28,8 +29,8 @@ static inline void gpuAssert(hipError_t code, const char *file, int line) {{
 
 // globals
 #define HSACO_NAME {kernel_name}_hsaco
-hipModule_t {kernel_name}_mod = nullptr;
-hipFunction_t {kernel_name}_func = nullptr;
+hipModule_t {kernel_name}_mod = NULL;
+hipFunction_t {kernel_name}_func = NULL;
 unsigned char HSACO_NAME[{bin_size}] = {{ {bin_data} }};
 
 
@@ -50,7 +51,7 @@ void load_{kernel_name}() {{
 {kernel_docstring}
 */
 hipError_t {kernel_name}(hipStream_t stream, {signature}) {{
-    if ({kernel_name}_func == nullptr)
+    if ({kernel_name}_func == NULL)
        load_{kernel_name}();
     unsigned int gX = {gridX};
     unsigned int gY = {gridY};
@@ -61,7 +62,7 @@ hipError_t {kernel_name}(hipStream_t stream, {signature}) {{
 
     // TODO: shared memory
     if(gX * gY * gZ > 0)
-      return hipModuleLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * {warp_size}, 1, 1, {shared}, stream, args, nullptr);
+      return hipModuleLaunchKernel({kernel_name}_func, gX, gY, gZ, {num_warps} * {warp_size}, 1, 1, {shared}, stream, args, NULL);
     else
       return hipErrorInvalidValue;
 }}

--- a/third_party/amd/tools/hip/compile.h
+++ b/third_party/amd/tools/hip/compile.h
@@ -3,11 +3,16 @@
 
 #pragma once
 
+#define __HIP_PLATFORM_AMD__
+
 #include <hip/hip_runtime.h>
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
 
+// tt-linker-backend: {backend_name}
+
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
+// tt-linker: {kernel_name}:{full_signature}:{algo_info}
 hipError_t{_placeholder} {kernel_name}(hipStream_t stream, {signature});

--- a/third_party/amd/tools/hip/link.h
+++ b/third_party/amd/tools/hip/link.h
@@ -1,0 +1,14 @@
+#ifndef TT_LINK_INCLUDES
+#define TT_LINK_INCLUDES
+
+#include <stdint.h>
+
+#define __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime.h>
+
+typedef hipStream_t TT_StreamTy;
+typedef hipError_t TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE hipErrorInvalidValue
+
+#endif

--- a/third_party/nvidia/tools/cuda/compile.h
+++ b/third_party/nvidia/tools/cuda/compile.h
@@ -8,6 +8,8 @@
 
 #endif
 
+// tt-linker-backend: {backend_name}
+
 void unload_{kernel_name}(void);
 void load_{kernel_name}(void);
 // tt-linker: {kernel_name}:{full_signature}:{algo_info}

--- a/third_party/nvidia/tools/cuda/link.h
+++ b/third_party/nvidia/tools/cuda/link.h
@@ -1,0 +1,13 @@
+#ifndef TT_LINK_INCLUDES
+#define TT_LINK_INCLUDES
+
+#include <stdint.h>
+
+#include <cuda.h>
+
+typedef CUstream TT_StreamTy;
+typedef CUresult TT_ResultTy;
+
+#define TT_ERROR_INVALID_VALUE CUDA_ERROR_INVALID_VALUE
+
+#endif


### PR DESCRIPTION
* Use the same link cpp scr except hipStrean/CUstream etc.
* Add a link.h prelude for AMD/Nvidia to adapt for the difference.
* Enable test_aot.py for AMD.
* Also rename AMD's compile.cpp to compile.c.

Fixes https://github.com/ROCm/triton-internal/issues/953