### PR TITLE
Enforce stride constraint in tensor descriptors

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -6699,4 +6699,18 @@ def test_dot_multidim(rank, trans_a, trans_b, device):
 
     d = a.to(torch.float32) @ b.to(torch.float32)
 
+
     assert torch.allclose(c, d, rtol=1e-3, atol=1e-2)
+
+
+def test_stride_constraint():
+    from triton.language import str_to_ty, constexpr_type, int64
+
+    # Test that the last stride is constrained to 1
+    desc_str = "tensordesc<float32, [128, 64], 0>"
+    ty = str_to_ty(desc_str, None)
+    
+    assert ty.strides_type[-1] == constexpr_type(1)
+    
+    # Verify we can make a descriptor with this type
+    assert ty.block_type.element_ty.name == 'fp32'

--- a/python/triton/language/__init__.py
+++ b/python/triton/language/__init__.py
@@ -311,10 +311,11 @@ def str_to_ty(name, c):
         dtype = str_to_ty(dtype, None)
         ndim = len(block_shape)
         shape_type = tuple_type([int32] * ndim)
-        # FIXME: Last dim stride should be constexpr(1)
-        if stride_type[-1] != 1:
-            raise ValueError("Last dim stride must be 1")
-        stride_type = tuple_type(([int64] * ndim))
+        # Last dim stride should be constexpr(1)
+        stride_type_list = [int64] * ndim
+        if ndim > 0:
+            stride_type_list[-1] = constexpr_type(1)
+        stride_type = tuple_type(stride_type_list)
         block = block_type(dtype, block_shape)
         if is_gluon:
             from triton.experimental.gluon.language._layouts import NVMMASharedLayout, PaddedSharedLayout, SwizzledSharedLayout


### PR DESCRIPTION
This PR addresses the FIXME in python/triton/language/__init__.py by correctly enforcing that the last dimension stride of a tensor descriptor is a constexpr(1).

Previously, the code attempted a runtime check if stride_type[-1] != 1 which was incorrect effectively (as stride_type was undefined at that point) and conceptually (we want to define the type, not check values).

This change:

Explicitly sets the last element of stride_type to constexpr_type(1).

Removes the erroneous runtime check.

Adds a unit test test_stride_constraint in python/test/unit/language/test_core.py to verify this behavior.

New contributor declaration

 I am not making a trivial change, such as fixing a typo in a comment.
 I have written a PR description following these rules.
 I have run pre-commit run --from-ref origin/main --to-ref HEAD.

Tests
 I have added tests.
/python/test

Lit Tests
 I have not added any lit tests.