### PR TITLE
Sanitize non-kernel function names

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -320,9 +320,9 @@ class CodeGenerator(ast.NodeVisitor):
         self.lscope = {}
         self.jit_fn = jit_fn
         # TODO: we currently generate illegal names for non-kernel functions involving constexprs!
-        if is_kernel:
-            function_name = function_name[function_name.rfind('.') + 1:]
-            function_name = check_identifier_legality(function_name, "function")
+        # ensure function name is legal
+        function_name = function_name[function_name.rfind('.') + 1:]
+        function_name = check_identifier_legality(function_name, "function")
         self.function_name = function_name
         self.is_kernel = is_kernel
         self.cur_node = None


### PR DESCRIPTION
Applies check_identifier_legality to all function names in CodeGenerator, not just kernels, ensuring valid LLVM IR identifiers.