### PR TITLE
Remove stale JIT hash TODO

### DIFF
--- a/python/triton/runtime/jit.py
+++ b/python/triton/runtime/jit.py
@@ -497,7 +497,6 @@ class JITCallable:
 
     @property
     def cache_key(self) -> str:
-        # TODO : hash should be attribute of `self`
         with self._hash_lock:
             if self.hash is not None:
                 return self.hash


### PR DESCRIPTION
Removes a stale TODO in jit.py regarding cache_key. The current property-based implementation is correct.