### PR TITLE
[LinearLayout][tt.scan] Ignore broadcast bases in contig helpers

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/Dialect.h
+++ b/include/triton/Dialect/TritonGPU/IR/Dialect.h
@@ -127,7 +127,17 @@ inline SmallVector<unsigned> getWarpsPerCTA(RankedTensorType type) {
 // for thread 0 would be [A_{0, 0}, A_{0, 0}, A_{0, 0}, A_{0, 0}], returns [1,
 // 1]. Whereas for a tensor shape [128, 128], the elements for thread 0 would be
 // [A_{0, 0}, A_{0, 1}, A_{0, 2}, A_{0, 3}], returns [1, 4].
-SmallVector<unsigned> getContigPerThread(RankedTensorType tensorType);
+// The logic to find contiguity extent fails in the presence of zero basis
+// vectors. These are created due to the presence of broadcast dimensions along
+// which several registers and lanes might share the same value. We can simply
+// ignore these zero basis vectors when we want to find true contiguity in the
+// presence of broadcast dimensions (controlled by `handleBroadcastDims`).
+// TODO: Consider enabling this in the general case for finding contiguity after
+// considering observed effects on e2e performance (heuristics not accounting
+// for this can be one of the reasons for performance difference).
+SmallVector<unsigned>
+getContigPerThread(RankedTensorType tensorType,
+                   const bool handleBroadcastDims = false);
 
 // Returns the number of threads per warp that have access to non-replicated
 // elements of the tensor. E.g. for a blocked layout with sizePerThread = [1,

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -671,14 +671,23 @@ def LinearEncodingAttr : DistributedEncoding<"LinearEncoding", "linear_encoding"
 
   let parameters = (ins LinearLayoutParam:$linearLayout);
 
-  let extraClassDeclaration = extraDistributedDeclaration # [{
+  let extraClassDeclaration = extraDistributedDeclaration#[{
     // Generic distributed encoding methods
     unsigned getTotalElemsPerThread(ArrayRef<int64_t> shape) const;
     SmallVector<unsigned> getElemsPerThread(ArrayRef<int64_t> shape) const;
 
-    SmallVector<unsigned int> getContig(const char *, SmallVector<unsigned int>) const;
-    SmallVector<unsigned> getContigPerThread() const;
-    SmallVector<unsigned> getContigPerWarp() const;
+    // The logic to find contiguity extent fails in the presence of zero basis
+    // vectors. These are created due to the presence of broadcast dimensions along
+    // which several registers and lanes might share the same value. We can simply
+    // ignore these zero basis vectors when we want to find true contiguity in the
+    // presence of broadcast dimensions (controlled by `handleBroadcastDims`).
+    // TODO: Consider enabling this in the general case for finding contiguity after
+    // considering observed effects on e2e performance (heuristics not accounting
+    // for this can be one of the reasons for performance difference).
+    SmallVector<unsigned int> getContig(const char *, SmallVector<unsigned int>, const bool handleBroadcastDims = false) const;
+    SmallVector<unsigned> getContigPerThread(const bool handleBroadcastDims = false) const;
+    SmallVector<unsigned> getContigPerWarp(const bool handleBroadcastDims = false) const;
+
     SmallVector<unsigned> getOrder() const;
     SmallVector<unsigned> getWarpOrder() const;
     SmallVector<unsigned> getThreadOrder() const;

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -158,11 +158,13 @@ bool ReduceOpHelper::isAssociative() {
 }
 
 unsigned ScanLoweringHelper::getAxisNumElementsPerThread() {
-  return getEncoding().getContigPerThread()[getAxis()];
+  return getEncoding().getContigPerThread(
+      /*handleBroadcastDims=*/true)[getAxis()];
 }
 
 unsigned ScanLoweringHelper::getNonAxisNumElementsPerThread() {
-  auto contigPerThread = getEncoding().getContigPerThread();
+  auto contigPerThread =
+      getEncoding().getContigPerThread(/*handleBroadcastDims=*/true);
   contigPerThread[getAxis()] = 1;
   return product<unsigned>(contigPerThread);
 }
@@ -190,7 +192,8 @@ unsigned ScanLoweringHelper::getAxisNumWarpsWithUniqueData() {
 }
 
 unsigned ScanLoweringHelper::getAxisNumBlocks() {
-  auto contigPerThread = getEncoding().getContigPerThread();
+  auto contigPerThread =
+      getEncoding().getContigPerThread(/*handleBroadcastDims=*/true);
   auto threadsPerWarp = getEncoding().getThreadsPerWarp();
   auto warpsPerCTA = getEncoding().getWarpsPerCTA();
   unsigned axis = getAxis();
@@ -200,7 +203,8 @@ unsigned ScanLoweringHelper::getAxisNumBlocks() {
 }
 
 unsigned ScanLoweringHelper::getNonAxisNumBlocks() {
-  auto contigPerThread = getEncoding().getContigPerThread();
+  auto contigPerThread =
+      getEncoding().getContigPerThread(/*handleBroadcastDims=*/true);
   auto threadsPerWarp = getEncoding().getThreadsPerWarp();
   auto warpsPerCTA = getEncoding().getWarpsPerCTA();
   auto rank = contigPerThread.size();
@@ -734,11 +738,13 @@ getReshapeDecomposition(ArrayRef<int64_t> srcShape,
 
 unsigned ScanLoweringHelper::getAxisElementStride() {
   auto order = getOrder();
+  auto contigPerThread =
+      getEncoding().getContigPerThread(/*handleBroadcastDims=*/true);
   unsigned stride = 1;
   for (unsigned dim : order) {
     if (dim == getAxis())
       return stride;
-    stride *= getEncoding().getContigPerThread()[dim];
+    stride *= contigPerThread[dim];
   }
   llvm_unreachable("Axis not found in order");
 }
@@ -762,7 +768,8 @@ unsigned ScanLoweringHelper::getAxisThreadStride() {
 unsigned ScanLoweringHelper::getAxisBlockStride() {
   auto order = getOrder();
   unsigned stride = 1;
-  auto contigPerThread = getEncoding().getContigPerThread();
+  auto contigPerThread =
+      getEncoding().getContigPerThread(/*handleBroadcastDims=*/true);
   auto threadsPerWarp = getEncoding().getThreadsPerWarp();
   auto warpsPerCTA = getEncoding().getWarpsPerCTA();
   for (unsigned dim : order) {

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -1,5 +1,7 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
 
+#include "mlir/Parser/Parser.h"
+#include "triton/Analysis/Utility.h"
 #include "llvm/Support/Signals.h"
 #include <gtest/gtest.h>
 
@@ -21,6 +23,50 @@ TEST(Analysis, reorder) {
     EXPECT_EQ(reordered[1], 10);
     EXPECT_EQ(reordered[2], 30);
   }
+}
+
+TEST(Analysis, ScanIgnoreBroadcastBasis) {
+  // Exercise elem_count, num_blocks, and stride helpers when a broadcasted
+  // register basis appears before a non-broadcast basis in the register order.
+  mlir::DialectRegistry registry;
+  registry
+      .insert<mlir::triton::TritonDialect, mlir::triton::gpu::TritonGPUDialect,
+              mlir::arith::ArithDialect>();
+  mlir::MLIRContext ctx(registry);
+  ctx.getOrLoadDialect<mlir::triton::TritonDialect>();
+  ctx.getOrLoadDialect<mlir::triton::gpu::TritonGPUDialect>();
+  ctx.getOrLoadDialect<mlir::arith::ArithDialect>();
+
+  // sizePerThread[2] exceeds shape[2], so the register base for dim 2 is
+  // broadcasted and should not affect contiguity or stride computation.
+  const char *mlirText = R"mlir(
+#layout_axis_bcast_3d = #ttg.blocked<{sizePerThread = [2, 2, 2], threadsPerWarp = [2, 4, 1], warpsPerCTA = [2, 1, 1], order = [2, 1, 0]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 8 : i32} {
+  tt.func public @axis_scan(%arg0: tensor<8x8x1xf32, #layout_axis_bcast_3d>) -> tensor<8x8x1xf32, #layout_axis_bcast_3d> {
+    %0 = "tt.scan"(%arg0) <{axis = 0 : i32, reverse = false}> ({
+    ^bb0(%arg1: f32, %arg2: f32):
+      %1 = arith.addf %arg1, %arg2 : f32
+      tt.scan.return %1 : f32
+    }) : (tensor<8x8x1xf32, #layout_axis_bcast_3d>) -> tensor<8x8x1xf32, #layout_axis_bcast_3d>
+    tt.return %0 : tensor<8x8x1xf32, #layout_axis_bcast_3d>
+  }
+}
+)mlir";
+
+  auto module = mlir::parseSourceString<mlir::ModuleOp>(mlirText, &ctx);
+  ASSERT_TRUE(module);
+
+  mlir::triton::ScanOp scanOp;
+  module->walk([&](mlir::triton::ScanOp op) { scanOp = op; });
+  ASSERT_TRUE(scanOp);
+
+  mlir::ScanLoweringHelper helper(scanOp);
+  EXPECT_EQ(helper.getAxisNumElementsPerThread(), 2u);
+  EXPECT_EQ(helper.getNonAxisNumElementsPerThread(), 2u);
+  EXPECT_EQ(helper.getAxisNumBlocks(), 1u);
+  EXPECT_EQ(helper.getNonAxisNumBlocks(), 1u);
+  EXPECT_EQ(helper.getAxisElementStride(), 2u);
+  EXPECT_EQ(helper.getAxisBlockStride(), 1u);
 }
 
 } // namespace mlir


### PR DESCRIPTION
The logic to find contiguity extent fails in the presence of zero basis vectors (due to broadcast dims). Add a handleBroadcastDims option to LinearEncodingAttr contig helpers and use it in scan lowering so broadcasted register bases don’t distort the axis/non-axis contiguity or elements, stride, block counts.

Add a unit test that builds a scan with a broadcasted register base and verify ScanLoweringHelper returns the expected axis/non-axis specific relevant counts. The observed behavior is difficult to reproduce in LIT tests without causing another crash mentioned in #7817, hence adding a gtest-based unit test to keep this solution separate from the next fix for the issue (to help with the review and feedback addressal process).

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
