### PR TITLE
Pass explicit captures to WarpSpecializePartitionsOp

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -507,13 +507,10 @@ def TTG_WarpSpecializeOp : TTG_Op<"warp_specialize", [
     ```
   }];
 
-  let arguments = (ins
-    Variadic<AnyType>:$explicitCaptures,
-    DenseI32ArrayAttr:$partitionNumWarps,
-    OptionalAttr<DenseI32ArrayAttr>:$warpGroupStartIds,
-    OptionalAttr<DenseI32ArrayAttr>:$requestedRegisters,
-    OptionalAttr<DenseI32ArrayAttr>:$actualRegisters
-  );
+  let arguments = (ins DenseI32ArrayAttr:$partitionNumWarps,
+      OptionalAttr<DenseI32ArrayAttr>:$warpGroupStartIds,
+      OptionalAttr<DenseI32ArrayAttr>:$requestedRegisters,
+      OptionalAttr<DenseI32ArrayAttr>:$actualRegisters);
   let results = (outs Variadic<AnyType>:$defaultPassthrough);
 
   let regions = (region
@@ -523,6 +520,7 @@ def TTG_WarpSpecializeOp : TTG_Op<"warp_specialize", [
 
   let extraClassDeclaration = [{
     RegionRange getPartitionRegions();
+    WarpSpecializePartitionsOp getPartitionOp();
 
     // Get the size and alignment of the capture list.
     std::pair<uint64_t, uint64_t> getCaptureSizeAlign();
@@ -530,12 +528,11 @@ def TTG_WarpSpecializeOp : TTG_Op<"warp_specialize", [
     unsigned getTotalPartitionWarps();
   }];
 
-  let builders = [
-    OpBuilder<(ins "TypeRange":$resultTypes,
-                   "ArrayRef<int32_t>":$partitionNumWarps,
-                   "unsigned":$numPartitionRegions)>,
-    OpBuilder<(ins "TypeRange":$resultTypes, "ValueRange":$explicitCaptures,
-                   "ArrayRef<int32_t>":$partitionNumWarps)>,
+  let builders = [OpBuilder<(ins "TypeRange":$resultTypes,
+                      "ArrayRef<int32_t>":$partitionNumWarps,
+                      "unsigned":$numPartitionRegions)>,
+                  OpBuilder<(ins "TypeRange":$resultTypes,
+                      "ArrayRef<int32_t>":$partitionNumWarps)>,
   ];
 
   let hasVerifier = 1;
@@ -556,7 +553,11 @@ def TTG_WarpSpecializePartitionsOp
     contains the actual isolated from above regions of `ttg.warp_specialize`.
   }];
 
+  let arguments = (ins Variadic<AnyType>:$explicitCaptures);
   let regions = (region VariadicRegion<MinSizedRegion<1>>:$partitionRegions);
+
+  let hasVerifier = 1;
+  let hasCanonicalizeMethod = 1;
 }
 
 def TTG_WarpYieldOp : TTG_Op<"warp_yield", [

--- a/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateWarpGroups.cpp
@@ -30,7 +30,8 @@ static void padToMaxWarpGroups(WarpSpecializeOp op, int numExtraWarpGroups) {
 
   auto partitions = cast<WarpSpecializePartitionsOp>(
       op.getPartitionOpHolder().front().front());
-  OperationState state(partitions.getLoc(), partitions.getOperationName());
+  OperationState state(partitions.getLoc(), partitions.getOperationName(),
+                       partitions.getOperands(), /*types=*/{});
   for (Region *region : partitions.getRegions())
     state.addRegion()->takeBody(*region);
 
@@ -39,7 +40,7 @@ static void padToMaxWarpGroups(WarpSpecializeOp op, int numExtraWarpGroups) {
     partitionNumWarps.push_back(paddingSize);
 
     Block &body = state.addRegion()->emplaceBlock();
-    for (Value capture : op.getExplicitCaptures())
+    for (Value capture : op.getPartitionOp().getExplicitCaptures())
       body.addArgument(capture.getType(), capture.getLoc());
     OpBuilder b(op.getContext());
     b.setInsertionPointToStart(&body);

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1404,13 +1404,14 @@ Value dot(RewriterBase &rewriter, Location loc, ArrayRef<Value> offsets,
 static void
 makeWarpGroupsIsolatedFromAbove(triton::gpu::WarpSpecializeOp wsOp) {
   SetVector<Value> captures;
-  getUsedValuesDefinedAbove(wsOp.getPartitionOpHolder(), captures);
+  auto partOp = wsOp.getPartitionOp();
+  getUsedValuesDefinedAbove(partOp.getPartitionRegions(), captures);
   for (Value capture : captures) {
-    wsOp->insertOperands(wsOp.getNumOperands(), capture);
-    for (Region *region : wsOp.getPartitionRegions()) {
+    partOp->insertOperands(partOp.getNumOperands(), capture);
+    for (Region &region : partOp.getPartitionRegions()) {
       BlockArgument arg =
-          region->addArgument(capture.getType(), capture.getLoc());
-      replaceAllUsesInRegionWith(capture, arg, *region);
+          region.addArgument(capture.getType(), capture.getLoc());
+      replaceAllUsesInRegionWith(capture, arg, region);
     }
   }
 }

--- a/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
+++ b/lib/Dialect/Gluon/Transforms/Canonicalize.cpp
@@ -58,6 +58,7 @@ void Canonicalize::runOnOperation() {
   BroadcastOp::getCanonicalizationPatterns(patterns, ctx);
   ExpandDimsOp::getCanonicalizationPatterns(patterns, ctx);
   ttg::WarpSpecializeOp::getCanonicalizationPatterns(patterns, ctx);
+  ttg::WarpSpecializePartitionsOp::getCanonicalizationPatterns(patterns, ctx);
 
   (void)applyPatternsGreedily(getOperation(), std::move(patterns));
 }

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -939,9 +939,12 @@ LogicalResult MemDescSubsliceOp::verify() {
 // -- WarpSpecializeOp --
 
 RegionRange WarpSpecializeOp::getPartitionRegions() {
+  return getPartitionOp().getPartitionRegions();
+}
+
+WarpSpecializePartitionsOp WarpSpecializeOp::getPartitionOp() {
   return cast<WarpSpecializePartitionsOp>(
-             getPartitionOpHolder().front().front())
-      .getPartitionRegions();
+      getPartitionOpHolder().front().front());
 }
 
 void WarpSpecializeOp::getSuccessorRegions(
@@ -970,7 +973,7 @@ void WarpSpecializePartitionsOp::getSuccessorRegions(
 OperandRange
 WarpSpecializePartitionsOp::getEntrySuccessorOperands(RegionSuccessor) {
   // Pass through the explicit captures from the enclosing WarpSpecializeOp.
-  return getParentOp().getExplicitCaptures();
+  return getExplicitCaptures();
 }
 
 LogicalResult WarpSpecializeOp::verify() {
@@ -1004,22 +1007,6 @@ LogicalResult WarpSpecializeOp::verify() {
     }
   }
 
-  for (auto [i, region] : llvm::enumerate(getPartitionRegions())) {
-    if (region->getNumArguments() != getNumOperands()) {
-      return emitOpError("partition region #")
-             << i << " has " << region->getNumArguments()
-             << " arguments but expected " << getNumOperands();
-    }
-    for (auto [argIdx, argType, capType] : llvm::enumerate(
-             region->getArgumentTypes(), getExplicitCaptures().getTypes())) {
-      if (argType == capType)
-        continue;
-      return emitOpError("partition region #")
-             << i << " argument #" << argIdx << " has type " << argType
-             << " but corresponding capture has type " << capType;
-    }
-  }
-
   // This op cannot be nested inside itself.
   if ((*this)->getParentOfType<WarpSpecializeOp>()) {
     return emitOpError(
@@ -1038,71 +1025,38 @@ LogicalResult WarpSpecializeOp::verify() {
 LogicalResult WarpSpecializeOp::canonicalize(WarpSpecializeOp op,
                                              PatternRewriter &b) {
   // Propagate unused results and captures by removing them from the op.
-  llvm::BitVector unusedArgs(op.getNumOperands());
   llvm::BitVector unusedResults(op.getNumResults());
   for (auto [i, result] : llvm::enumerate(op.getResults())) {
     if (result.use_empty())
       unusedResults.set(i);
   }
-  // Remove duplicate captures.
-  DenseMap<Value, unsigned> uniqueCaptures;
-  for (auto [i, capture] : llvm::enumerate(op.getExplicitCaptures())) {
-    auto noUseInRegion = [i = i](Region *region) {
-      return region->getArgument(i).use_empty();
-    };
-    if (llvm::all_of(op.getPartitionRegions(), noUseInRegion)) {
-      unusedArgs.set(i);
-      continue;
-    }
 
-    auto [it, inserted] = uniqueCaptures.try_emplace(capture, i);
-    if (!inserted) {
-      unsigned duplicateIdx = it->second;
-      b.modifyOpInPlace(op, [&, i = i] {
-        for (Region *region : op.getPartitionRegions()) {
-          b.replaceAllUsesWith(region->getArgument(i),
-                               region->getArgument(duplicateIdx));
-        }
-      });
-      unusedArgs.set(i);
-    }
-  }
-  if (unusedArgs.none() && unusedResults.none())
+  if (unusedResults.none())
     return failure();
 
-  if (unusedArgs.any()) {
-    b.modifyOpInPlace(op, [&] {
-      for (Region *region : op.getPartitionRegions())
-        region->front().eraseArguments(unusedArgs);
-      op->eraseOperands(unusedArgs);
-    });
+  for (Block &block : op.getDefaultRegion()) {
+    if (auto yield = dyn_cast<WarpYieldOp>(block.getTerminator())) {
+      b.modifyOpInPlace(yield, [&] { yield->eraseOperands(unusedResults); });
+    }
   }
 
-  if (unusedResults.any()) {
-    for (Block &block : op.getDefaultRegion()) {
-      if (auto yield = dyn_cast<WarpYieldOp>(block.getTerminator())) {
-        b.modifyOpInPlace(yield, [&] { yield->eraseOperands(unusedResults); });
-      }
-    }
-
-    SmallVector<Type> newTypes;
-    for (auto [i, type] : llvm::enumerate(op.getResultTypes())) {
-      if (!unusedResults.test(i))
-        newTypes.push_back(type);
-    }
-    OperationState state(op.getLoc(), op->getName(), op.getOperands(), newTypes,
-                         op->getAttrs());
-    state.addRegion()->takeBody(op.getDefaultRegion());
-    state.addRegion()->takeBody(op.getPartitionOpHolder());
-    auto newOp = cast<WarpSpecializeOp>(b.create(state));
-    unsigned newResultIdx = 0;
-    for (auto [i, result] : llvm::enumerate(op.getResults())) {
-      if (!unusedResults.test(i))
-        result.replaceAllUsesWith(newOp.getResult(newResultIdx++));
-    }
-    assert(newResultIdx == newOp.getNumResults());
-    b.eraseOp(op);
+  SmallVector<Type> newTypes;
+  for (auto [i, type] : llvm::enumerate(op.getResultTypes())) {
+    if (!unusedResults.test(i))
+      newTypes.push_back(type);
   }
+  OperationState state(op.getLoc(), op->getName(), {}, newTypes,
+                       op->getAttrs());
+  state.addRegion()->takeBody(op.getDefaultRegion());
+  state.addRegion()->takeBody(op.getPartitionOpHolder());
+  auto newOp = cast<WarpSpecializeOp>(b.create(state));
+  unsigned newResultIdx = 0;
+  for (auto [i, result] : llvm::enumerate(op.getResults())) {
+    if (!unusedResults.test(i))
+      result.replaceAllUsesWith(newOp.getResult(newResultIdx++));
+  }
+  assert(newResultIdx == newOp.getNumResults());
+  b.eraseOp(op);
 
   return success();
 }
@@ -1111,19 +1065,18 @@ void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
                              TypeRange resultTypes,
                              ArrayRef<int32_t> partitionNumWarps,
                              unsigned partitionNumRegions) {
-  build(builder, state, resultTypes, /*explicitCaptures=*/ValueRange(),
-        partitionNumWarps, {}, {}, {});
+  build(builder, state, resultTypes, partitionNumWarps, {}, {}, {});
   OpBuilder::InsertionGuard guard(builder);
   Block *container = builder.createBlock(state.regions.back().get());
   WarpSpecializePartitionsOp::create(builder, state.location,
+                                     /*explicitCaptures=*/ValueRange(),
                                      partitionNumRegions);
 }
 
 void WarpSpecializeOp::build(OpBuilder &builder, OperationState &state,
-                             TypeRange resultTypes, ValueRange explicitCaptures,
+                             TypeRange resultTypes,
                              ArrayRef<int32_t> partitionNumWarps) {
-  build(builder, state, resultTypes, explicitCaptures, partitionNumWarps, {},
-        {}, {});
+  build(builder, state, resultTypes, partitionNumWarps, {}, {}, {});
 }
 
 ParseResult WarpSpecializeOp::parse(OpAsmParser &p, OperationState &result) {
@@ -1155,7 +1108,7 @@ ParseResult WarpSpecializeOp::parse(OpAsmParser &p, OperationState &result) {
   FunctionType types;
   if (p.parseColon() || p.parseType(types) ||
       p.resolveOperands(operands, types.getInputs(), operandLoc,
-                        result.operands))
+                        partitionOpState.operands))
     return failure();
 
   result.addTypes(types.getResults());
@@ -1171,7 +1124,7 @@ ParseResult WarpSpecializeOp::parse(OpAsmParser &p, OperationState &result) {
 
 void WarpSpecializeOp::print(OpAsmPrinter &p) {
   p << '(';
-  p.printOperands(getOperands());
+  p.printOperands(getPartitionOp().getOperands());
   p << ')';
   p.printOptionalAttrDictWithKeyword(getOperation()->getAttrs(),
                                      {getPartitionNumWarpsAttrName()});
@@ -1191,7 +1144,69 @@ void WarpSpecializeOp::print(OpAsmPrinter &p) {
     p.printRegion(*region, /*printEntryBlockArgs=*/false);
   }
   p << " : ";
-  p.printFunctionalType(*this);
+  SmallVector<Type> captureTypes;
+  for (auto val : getPartitionOp().getExplicitCaptures())
+    captureTypes.push_back(val.getType());
+  p.printFunctionalType(captureTypes, getResultTypes());
+}
+
+LogicalResult WarpSpecializePartitionsOp::verify() {
+  for (auto [i, region] : llvm::enumerate(getPartitionRegions())) {
+    if (region.getNumArguments() != getNumOperands()) {
+      return emitOpError("partition region #")
+             << i << " has " << region.getNumArguments()
+             << " arguments but expected " << getNumOperands();
+    }
+    for (auto [argIdx, argType, capType] : llvm::enumerate(
+             region.getArgumentTypes(), getExplicitCaptures().getTypes())) {
+      if (argType == capType)
+        continue;
+      return emitOpError("partition region #")
+             << i << " argument #" << argIdx << " has type " << argType
+             << " but corresponding capture has type " << capType;
+    }
+  }
+  return success();
+}
+
+LogicalResult
+WarpSpecializePartitionsOp::canonicalize(WarpSpecializePartitionsOp op,
+                                         PatternRewriter &b) {
+  llvm::BitVector unusedArgs(op.getNumOperands());
+
+  // Remove duplicate captures.
+  DenseMap<Value, unsigned> uniqueCaptures;
+  for (auto [i, capture] : llvm::enumerate(op.getExplicitCaptures())) {
+    auto noUseInRegion = [i = i](Region &region) {
+      return region.getArgument(i).use_empty();
+    };
+    if (llvm::all_of(op.getPartitionRegions(), noUseInRegion)) {
+      unusedArgs.set(i);
+      continue;
+    }
+
+    auto [it, inserted] = uniqueCaptures.try_emplace(capture, i);
+    if (!inserted) {
+      unsigned duplicateIdx = it->second;
+      b.modifyOpInPlace(op, [&, i = i] {
+        for (Region &region : op.getPartitionRegions()) {
+          b.replaceAllUsesWith(region.getArgument(i),
+                               region.getArgument(duplicateIdx));
+        }
+      });
+      unusedArgs.set(i);
+    }
+  }
+
+  if (unusedArgs.none())
+    return failure();
+
+  b.modifyOpInPlace(op, [&] {
+    for (Region &region : op.getPartitionRegions())
+      region.front().eraseArguments(unusedArgs);
+    op->eraseOperands(unusedArgs);
+  });
+  return success();
 }
 
 LogicalResult WarpYieldOp::verify() {
@@ -1230,7 +1245,7 @@ static size_t getSharedMemorySize(Type type) {
 std::pair<uint64_t, uint64_t> WarpSpecializeOp::getCaptureSizeAlign() {
   uint64_t captureSize = 0;
   // Tightly pack the captures in memory.
-  for (Type type : getOperandTypes()) {
+  for (Type type : getPartitionOp().getOperandTypes()) {
     captureSize += getSharedMemorySize(type);
   }
   // Align the captures to 8 bytes.

--- a/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/WarpSpecialization/OptimizePartitionWarps.cpp
@@ -53,7 +53,8 @@ static OwningOpRef<ModuleOp> takeIntoFunction(ModuleAxisInfoAnalysis &axisInfo,
   auto *funcInfo =
       axisInfo.getFuncData(wsOp->getParentOfType<FunctionOpInterface>());
   assert(funcInfo && "expected to find function axis info");
-  for (auto [i, capture] : llvm::enumerate(wsOp.getExplicitCaptures())) {
+  for (auto [i, capture] :
+       llvm::enumerate(wsOp.getPartitionOp().getExplicitCaptures())) {
     AxisInfo info = funcInfo->lookup(capture);
     containerFunc.setArgAttr(i, "tt.contiguity",
                              b.getI64IntegerAttr(info.getContiguity(0)));

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/FenceInsertion.cpp
@@ -136,8 +136,8 @@ private:
 
     // look through `ttg.warp_specialize`.
     if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(argOwner)) {
-      findCopyRegToSharedOps(wsOp.getParentOp().getExplicitCaptures()[argNum],
-                             visited, result);
+      findCopyRegToSharedOps(wsOp.getExplicitCaptures()[argNum], visited,
+                             result);
       return;
     }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/InterleaveTMem.cpp
@@ -124,8 +124,7 @@ std::pair<Value, AccessRange> findBufferAccess(Value a) {
 
     // Look through `ttg.warp_specialize` explicit captures.
     if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(parentOp)) {
-      return findBufferAccess(
-          wsOp.getParentOp().getExplicitCaptures()[arg.getArgNumber()]);
+      return findBufferAccess(wsOp.getExplicitCaptures()[arg.getArgNumber()]);
     }
 
     // Unknown block argument.

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/TensorMemoryAllocation.cpp
@@ -217,8 +217,7 @@ static SmallVector<Operation *> getAlloc(Value value) {
 
       // Handle region entry arguments.
       if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(parentOp)) {
-        worklist.push_back(
-            wsOp.getParentOp().getExplicitCaptures()[arg.getArgNumber()]);
+        worklist.push_back(wsOp.getExplicitCaptures()[arg.getArgNumber()]);
       } else if (auto forOp = dyn_cast<scf::ForOp>(parentOp)) {
         unsigned idx = arg.getArgNumber() - 1;
         worklist.push_back(forOp.getYieldedValues()[idx]);

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -845,15 +845,16 @@ void init_gluon_ir(py::module &&m) {
              return self.create<ttg::WarpYieldOp>(values);
            })
       .def("create_warp_specialize_partitions",
-           [](GluonOpBuilder &self, int numPartitions) -> Operation * {
-             return self.create<ttg::WarpSpecializePartitionsOp>(numPartitions);
+           [](GluonOpBuilder &self, std::vector<Value> &explicitCaptures,
+              int numPartitions) -> Operation * {
+             return self.create<ttg::WarpSpecializePartitionsOp>(
+                 explicitCaptures, numPartitions);
            })
       .def("create_warp_specialize",
            [](GluonOpBuilder &self, std::vector<Type> &resultTypes,
-              std::vector<Value> &explicitCaptures,
               std::vector<int> &partitionNumWarps) {
-             return self.create<ttg::WarpSpecializeOp>(
-                 resultTypes, explicitCaptures, partitionNumWarps);
+             return self.create<ttg::WarpSpecializeOp>(resultTypes,
+                                                       partitionNumWarps);
            })
       .def("create_buffer_load",
            [](GluonOpBuilder &self, Type resultType, Value ptr, Value offsets,

--- a/python/triton/experimental/gluon/language/_semantic.py
+++ b/python/triton/experimental/gluon/language/_semantic.py
@@ -539,7 +539,7 @@ class GluonSemantic(TritonSemantic[TensorTy]):
         worker_args = [flatten_values_to_ir(args) for _, args in workers]
         mlir_args = sum(worker_args, [])
         builder.restore_insertion_point(insert_pt)
-        ws_op = builder.create_warp_specialize(result_types, mlir_args, worker_num_warps)
+        ws_op = builder.create_warp_specialize(result_types, worker_num_warps)
         ws_op.get_default_region().push_back(default_block)
 
         if worker_num_regs is not None:
@@ -547,7 +547,7 @@ class GluonSemantic(TritonSemantic[TensorTy]):
 
         # Emit the partition regions.
         builder.create_block_with_parent(ws_op.get_partition_op_holder(), [])
-        partitions_op = builder.create_warp_specialize_partitions(num_partitions)
+        partitions_op = builder.create_warp_specialize_partitions(mlir_args, num_partitions)
         arg_types = [arg.get_type() for arg in mlir_args]
         arg_it = 0
         for i, (func, args) in enumerate(workers):

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -917,6 +917,56 @@ tt.func @two_different_ws() {
   tt.return
 }
 
+// expected-remark @below {{default_partition_outside_alloc_interference}}
+// expected-remark @below {{size = 36}}
+// expected-remark @below {{offset = 32, size = 4}}
+tt.func @default_partition_outside_alloc_interference() {
+  // expected-remark @below {{offset = 0, size = 16}}
+  %0 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>
+  // expected-remark @below {{offset = 16, size = 12}}
+  ttg.warp_specialize(%0)
+  default {
+    // Ensure that we do not reuse the memory for %0 even though we are done
+    // with it in this partition.
+    // expected-remark @below {{offset = 16, size = 16}}
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>
+    "use"(%1) : (!ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) -> ()
+    ttg.warp_yield
+  }
+  partition0(%arg0: !ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) num_warps(4) {
+    "use"(%arg0) : (!ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) -> ()
+    ttg.warp_return
+  } : (!ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) -> ()
+  tt.return
+}
+
+// expected-remark @below {{partition_outside_alloc_interference}}
+// expected-remark @below {{size = 36}}
+// expected-remark @below {{offset = 32, size = 4}}
+tt.func @partition_outside_alloc_interference() {
+  // expected-remark @below {{offset = 0, size = 16}}
+  %0 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>
+  // expected-remark @below {{offset = 16, size = 12}}
+  ttg.warp_specialize(%0)
+  default {
+    ttg.warp_yield
+  }
+  partition0(%arg0: !ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) num_warps(2) {
+    "use"(%arg0) : (!ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) -> ()
+    ttg.warp_return
+  }
+  partition1(%arg1: !ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) num_warps(2) {
+    "use"(%arg1) : (!ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) -> ()
+    // Ensure that we do not reuse the memory for %0 even though we are done
+    // with it in this partition.
+    // expected-remark @below {{offset = 16, size = 16}}
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>
+    "use"(%1) : (!ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) -> ()
+    ttg.warp_return
+  } : (!ttg.memdesc<2xi64, #A_SHARED_1D, #smem, mutable>) -> ()
+  tt.return
+}
+
 // expected-remark @below {{ptr_allocation_datalayout}}
 // expected-remark @below {{size = 8}}
 tt.func @ptr_allocation_datalayout(%arg0: !tt.ptr<i32>) {

--- a/test/TritonGPU/invalid.mlir
+++ b/test/TritonGPU/invalid.mlir
@@ -223,11 +223,11 @@ tt.func @not_power_of_2() {
 // -----
 
 tt.func @bad_argument_count() {
-  // expected-error @below {{'ttg.warp_specialize' op partition region #0 has 1 arguments but expected 0}}
   ttg.warp_specialize()
   default {
     ttg.warp_yield
   }
+  // expected-error @below {{'ttg.warp_specialize.partitions' op partition region #0 has 1 arguments but expected 0}}
   partition0(%arg0: i32) num_warps(4) {
     ttg.warp_return
   } : () -> ()
@@ -237,11 +237,11 @@ tt.func @bad_argument_count() {
 // -----
 
 tt.func @bad_argument_type(%arg0: i32) {
-  // expected-error @below {{'ttg.warp_specialize' op partition region #0 argument #0 has type 'i64' but corresponding capture has type 'i32'}}
   ttg.warp_specialize(%arg0)
   default {
     ttg.warp_yield
   }
+  // expected-error @below {{'ttg.warp_specialize.partitions' op partition region #0 argument #0 has type 'i64' but corresponding capture has type 'i32'}}
   partition0(%arg1: i64) num_warps(4) {
     ttg.warp_return
   } : (i32) -> ()

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -209,13 +209,13 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
       auto loc = user->getLoc();
       builder.setInsertionPoint(user);
       bool handled = handleOneUser(user);
-      if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+      if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(user)) {
         unsigned opndNum = use.getOperandNumber();
         // Handle the regions. Trace uses of the argument corresponding to the
         // captured value.
-        for (Region *region : wsOp.getPartitionRegions()) {
-          LDBG("-- region " << region->getNumArguments());
-          auto tArg = region->getArgument(opndNum);
+        for (Region &region : wsOp.getPartitionRegions()) {
+          LDBG("-- region " << region.getNumArguments());
+          auto tArg = region.getArgument(opndNum);
           for (Operation *tUser : tArg.getUsers()) {
             builder.setInsertionPoint(tUser);
             // Use of TokenOp via capture of warp_specialize.
@@ -253,7 +253,7 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
       // eraseArgument.
       for (OpOperand &use : llvm::make_early_inc_range(tokenOp->getUses())) {
         Operation *user = use.getOwner();
-        if (auto wsOp = dyn_cast<ttg::WarpSpecializeOp>(user)) {
+        if (auto wsOp = dyn_cast<ttg::WarpSpecializePartitionsOp>(user)) {
           unsigned opndNum = use.getOperandNumber();
           LDBG("wsOp user numOperands: " << wsOp->getNumOperands() << " idx "
                                          << opndNum);
@@ -268,22 +268,22 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
           wsOp->insertOperands(wsOp.getNumOperands(), full);
           wsOp->insertOperands(wsOp.getNumOperands(), empty);
           // Handle the regions.
-          for (Region *region : wsOp.getPartitionRegions()) {
-            LDBG("-- region " << region->getNumArguments());
-            auto tArg = region->getArgument(opndNum);
+          for (Region &region : wsOp.getPartitionRegions()) {
+            LDBG("-- region " << region.getNumArguments());
+            auto tArg = region.getArgument(opndNum);
             for (Operation *tUser : tArg.getUsers()) {
               LLVM_DEBUG({
                 LDBG("user for arg");
                 tUser->dump();
               });
             }
-            region->eraseArgument(opndNum);
+            region.eraseArgument(opndNum);
             BlockArgument arg =
-                region->addArgument(full.getType(), full.getLoc());
-            replaceAllUsesInRegionWith(full, arg, *region);
+                region.addArgument(full.getType(), full.getLoc());
+            replaceAllUsesInRegionWith(full, arg, region);
             BlockArgument arg2 =
-                region->addArgument(empty.getType(), empty.getLoc());
-            replaceAllUsesInRegionWith(empty, arg2, *region);
+                region.addArgument(empty.getType(), empty.getLoc());
+            replaceAllUsesInRegionWith(empty, arg2, region);
           }
         }
       }

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSSpecialize.cpp
@@ -463,7 +463,8 @@ void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters) {
                         "FIXME: capturing tensor values into warp "
                         "partitions is not supported");
     }
-    wsOp->insertOperands(wsOp.getNumOperands(), capture);
+    auto partOp = wsOp.getPartitionOp();
+    partOp->insertOperands(partOp.getNumOperands(), capture);
     for (Region *region : wsOp.getPartitionRegions()) {
       // Does this include default region?
       BlockArgument arg =

--- a/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerWarpGroup.cpp
+++ b/third_party/nvidia/lib/Dialect/NVWS/Transforms/LowerWarpGroup.cpp
@@ -155,10 +155,8 @@ class LowerWarpGroup : public OpRewritePattern<WarpGroupOp> {
       }
     }
 
-    auto wsOp = WarpSpecializeOp::create(rewriter, loc,
-                                         warpGroupOp.getResultTypes(), inputs);
-
-    wsOp.setPartitionNumWarps(numWarps);
+    auto wsOp = WarpSpecializeOp::create(
+        rewriter, loc, warpGroupOp.getResultTypes(), numWarps);
 
     auto &defaultBlock = wsOp.getDefaultRegion().emplaceBlock();
     rewriter.setInsertionPointToEnd(&defaultBlock);
@@ -178,8 +176,8 @@ class LowerWarpGroup : public OpRewritePattern<WarpGroupOp> {
 
     auto &block = wsOp.getPartitionOpHolder().emplaceBlock();
     rewriter.setInsertionPointToStart(&block);
-    auto wspOp =
-        WarpSpecializePartitionsOp::create(rewriter, loc, partitions.size());
+    auto wspOp = WarpSpecializePartitionsOp::create(rewriter, loc, inputs,
+                                                    partitions.size());
     auto regions = wspOp.getPartitionRegions();
 
     for (auto [in, out, mapping] : zip(partitions, regions, mappings))

--- a/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
+++ b/third_party/proton/Dialect/lib/ProtonToProtonGPU/ProtonToProtonGPUPass.cpp
@@ -61,7 +61,8 @@ void instrumentWarpSpecializeOps(FuncOp func, Value buffer, Value profileMem) {
   for (auto wsOp : func.getOps<triton::gpu::WarpSpecializeOp>()) {
     auto loc = wsOp.getLoc();
     if (hasOperator<Operation, proton::RecordOp>(wsOp.getOperation())) {
-      wsOp->insertOperands(wsOp->getNumOperands(), {buffer, profileMem});
+      auto partOp = wsOp.getPartitionOp();
+      partOp->insertOperands(partOp->getNumOperands(), {buffer, profileMem});
       for (Region *region : wsOp.getPartitionRegions()) {
         region->addArgument(buffer.getType(), loc);
         region->addArgument(profileMem.getType(), loc);


### PR DESCRIPTION
Explicit captures are currently operands on `WarpSpecializeOp` but the regions that consume them are owned by the `WarpSpecializePartitionsOp` in the enclosed holder region. That is, the block arguments to the actual partitions do not get their values from an immediate parent region.

This has been mostly fine, but some MLIR common code assumes that the operands of a `RegionBranchOpInterface` operation flow directly into the regions that it encloses. For example, attempting to use a `SparseBackwardDataFlowAnalysis` will trigger a crash.

To address this, move the explicit captures to be operands on the operation that holds the non-default partition regions.