### PR TITLE
[hopper][WS] Support tt.split/join in data partition (#456)

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -124,10 +124,11 @@ struct DataPartitionScheme {
     return dim < numPartitions || dim == DataPartitionScheme::noOpPartitionDim;
   }
 
-  unsigned flipPartitionDim(unsigned dim) const {
+  unsigned flipPartitionDim(unsigned dim, const ArrayRef<int32_t> &order,
+                            bool forward) const {
     if (dim == DataPartitionScheme::noOpPartitionDim)
       return dim;
-    return numPartitions - 1 - dim;
+    return forward ? order[dim] : llvm::find(order, dim) - order.begin();
   }
 
   bool isPartitioned(Operation *op) const {
@@ -256,8 +257,13 @@ static bool getBackwardSliceToPartition(Value v,
     partitionScheme.opPartitionDims[op] = currentDim;
 
     // Flip dim when op is trans
-    if (isa<TransOp, MemDescTransOp>(op))
-      currentDim = partitionScheme.flipPartitionDim(currentDim);
+    if (auto transOp = dyn_cast<TransOp>(op)) {
+      currentDim = partitionScheme.flipPartitionDim(currentDim,
+                                                    transOp.getOrder(), false);
+    } else if (auto memDescTransOp = dyn_cast<MemDescTransOp>(op)) {
+      currentDim = partitionScheme.flipPartitionDim(
+          currentDim, memDescTransOp.getOrder(), false);
+    }
 
     if (auto expandDimsOp = dyn_cast<ExpandDimsOp>(op)) {
       // currentDim is the dim after expansion.
@@ -274,7 +280,8 @@ static bool getBackwardSliceToPartition(Value v,
             BroadcastOp, ExpandDimsOp, MakeRangeOp, SplatOp, ConvertLayoutOp,
             triton::gpu::LocalAllocOp, LoadOp, TransOp, MemDescTransOp,
             AtomicRMWOp, triton::AddPtrOp, DescriptorLoadOp,
-            nvidia_gpu::TMEMAllocOp, nvidia_gpu::TMEMLoadOp, FpToFpOp>(op)) {
+            nvidia_gpu::TMEMAllocOp, nvidia_gpu::TMEMLoadOp, FpToFpOp, SplitOp,
+            JoinOp, ReshapeOp>(op)) {
       for (Value operand : op->getOperands())
         if (!getBackwardSliceToPartition(operand, partitionScheme, currentDim))
           return false;
@@ -358,8 +365,13 @@ static bool getForwardSliceToPartition(Value v,
   for (Operation *depOp : v.getUsers()) {
     currentDim = originalDim;
     // Flip dim when op is trans
-    if (isa<TransOp, MemDescTransOp>(depOp))
-      currentDim = partitionScheme.flipPartitionDim(currentDim);
+    if (auto transOp = dyn_cast<TransOp>(depOp)) {
+      currentDim = partitionScheme.flipPartitionDim(currentDim,
+                                                    transOp.getOrder(), true);
+    } else if (auto memDescTransOp = dyn_cast<MemDescTransOp>(depOp)) {
+      currentDim = partitionScheme.flipPartitionDim(
+          currentDim, memDescTransOp.getOrder(), true);
+    }
 
     // Check dim compatibility
     if (!partitionScheme.ops.insert(depOp)) {
@@ -698,9 +710,12 @@ static void rewriteRematerializedOps(triton::FuncOp &funcOp,
         assert(partitionScheme.opPartitionDims.contains(user) &&
                "user not partitioned");
         unsigned userDim = partitionScheme.opPartitionDims[user];
-        if (isa<TransOp, MemDescTransOp>(user)) {
-          // flip userDim for trans
-          userDim = partitionScheme.flipPartitionDim(userDim);
+        if (auto transOp = dyn_cast<TransOp>(user)) {
+          userDim = partitionScheme.flipPartitionDim(userDim,
+                                                     transOp.getOrder(), true);
+        } else if (auto memDescTransOp = dyn_cast<MemDescTransOp>(user)) {
+          userDim = partitionScheme.flipPartitionDim(
+              userDim, memDescTransOp.getOrder(), true);
         } else if (auto dotOp = dyn_cast<nvidia_gpu::WarpGroupDotOp>(user)) {
           // infer userDim for dot
           assert(partitionScheme.dotPartitionOperand.contains(user) &&
@@ -770,10 +785,10 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     setAsyncTaskIds(newOp, sliceTaskIds);
     mappings.map(op, newOp);
     reverseMappings.map(newOp, op);
-    // set result shape
-    if (!op->getResults().empty()) {
-      auto v = op->getResult(0);
-      auto newV = newOp->getResult(0);
+    // set result shape for all results
+    for (unsigned resultIdx = 0; resultIdx < op->getNumResults(); ++resultIdx) {
+      auto v = op->getResult(resultIdx);
+      auto newV = newOp->getResult(resultIdx);
       bool needRetype = true;
       if (dim == DataPartitionScheme::noOpPartitionDim) {
         // Just duplicate the op for noOpPartitionDim
@@ -845,7 +860,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
   if ((dim == DataPartitionScheme::noOpPartitionDim) ||
       op->hasTrait<OpTrait::Elementwise>() ||
       isa<ConvertLayoutOp, BroadcastOp, SplatOp, ExpandDimsOp, FpToFpOp,
-          AtomicRMWOp, LocalAllocOp>(op)) {
+          AtomicRMWOp, LocalAllocOp, SplitOp, JoinOp, ReshapeOp>(op)) {
     for (Value operand : op->getOperands())
       sliceOp(operand, offset, mappings, reverseMappings, partitionScheme);
     newOp = cloneAndSetResultType(op);


### PR DESCRIPTION
Add support for `SplitOp` and `JoinOp` operations in the WSDataPartition pass. This enables data partitioning for tensor split and join operations along the M dimension during warp specialization.

Key changes:
- Add `SplitOp` and `JoinOp` to `getBackwardSliceToPartition` to include them in backward slice traversal
- Add handling for `SplitOp` and `JoinOp` in `sliceOp` function to correctly partition these operations
- Fix a bug where multi-result operations (like `SplitOp` which returns two tensors) were not having all their results sliced correctly - the `cloneAndSetResultType` lambda now iterates over all results instead of just the first one
- changes to backward slice traversal and sliceOp function

Also adds a lit test that covers partitioning of:
- `tt.trans` (transpose)
- `tt.reshape` (reshape with allow_reorder)
- `tt.join` (join two tensors)
- `tt.split` (split into two tensors)

