### PR TITLE
[AMD] Fix vector size for padded encodings with direct to lds loads

### DIFF
--- a/test/Conversion/amd/async_ops_to_llvm.mlir
+++ b/test/Conversion/amd/async_ops_to_llvm.mlir
@@ -22,7 +22,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
 // -----
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 64], warpsPerCTA = [4, 1], order = [1, 0]}>
-#shared = #ttg.padded_shared<[4:+4] {order = [1, 0], shape = [32, 64]}>
+#shared = #ttg.padded_shared<[64:+4] {order = [1, 0], shape = [32, 64]}>
 #smem = #ttg.shared_memory
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shared = 8192 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: async_copy_padded

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CoalesceAsyncCopy.cpp
@@ -105,6 +105,11 @@ struct CoalesceAsyncCopyWrites
                                       dstTy.getAllocShape(), loadContig)) {
       return rewriter.notifyMatchFailure(copyOp, "already writes coalesced");
     }
+    // Check if we support load contig because canLoadDirectToLds can change it
+    if (!targetInfo.supportsDirectToLdsLoadBitWidth(loadContig * elemBitWidth))
+      return rewriter.notifyMatchFailure(copyOp,
+                                         "unable to find supported vector size "
+                                         "based on src and dst encodings");
 
     if (isa<ttg::SwizzledSharedEncodingAttr>(dstTy.getEncoding())) {
       // For swizzled layouts we apply the swizzling during lowering so we only


### PR DESCRIPTION
For architectures not supporting scattering (GFX9) we can only support padding intervals which are a multiple of `vectorWidth * warpSize` because we can only add padding at warp boundaries. This PR properly enforces this to bail out for such encodings.

Note that we do not create such layouts right now, but this came up when reviwing https://github.com/triton-lang/triton/pull/9074.