### PR TITLE
Fix flakiness in test_line_info_ir_source

### DIFF
--- a/python/test/unit/language/test_line_info.py
+++ b/python/test/unit/language/test_line_info.py
@@ -224,7 +224,7 @@ def test_line_info_env(monkeypatch, status: str):
 
 
 @pytest.mark.parametrize("status", ["ttir", ""])
-def test_line_info_ir_source(monkeypatch, status, tmp_path):
+def test_line_info_ir_source(monkeypatch, status, tmp_path, fresh_triton_cache):
     try:
         obj_kind, command, anchor, separator = get_disassembler_command_and_debug_line_format()
     except BaseException:


### PR DESCRIPTION
This test fails if run twice because a new temp path is created for each run, but the cache entry was generated with the path of the first run. This causes the debug info to not match the current path.

Fix this by using `fresh_triton_cache`. It may also be worth considering using the full original path as part of the cache key.