### PR TITLE
[Kernels] Use ex2.approx.ftz in swiglu

### DIFF
--- a/python/triton_kernels/triton_kernels/swiglu_details/_swiglu.py
+++ b/python/triton_kernels/triton_kernels/swiglu_details/_swiglu.py
@@ -36,8 +36,10 @@ def swiglu_launch_metadata(grid, kernel, args):
 
 
 @triton.jit
-def exp2_ftz(x):
+def exp_ftz(x):
     if tl.target_info.is_cuda():
+        log2_e: tl.constexpr = 1.4426950408889634
+        x *= log2_e
         return tl.inline_asm_elementwise(
             "ex2.approx.ftz.f32 $0, $1;",
             "=r, r",
@@ -47,7 +49,7 @@ def exp2_ftz(x):
             pack=1,
         )
     else:
-        return tl.exp2(x)
+        return tl.exp(x)
 
 
 @triton.jit
@@ -58,14 +60,7 @@ def compute_swiglu(gelu, linear, scale, alpha, limit):
     linear = linear.to(tl.float32) * scale
     if limit is not None:
         linear = clip(linear, limit, clip_lower=True)
-    s = gelu / (1 + tl.exp(-alpha * gelu))
-
-    # TODO: Instead of using tl.exp(-alpha * gelu), there is potential way to reduce instructions:
-    # But we need to further understand its impact on model numerics.
-    # exp(x) becomes exp2(log2(e) * x) in ptx. By expanding it early, we can factor
-    # (-alpha * log2_e) into a single scalar factor.
-    # log2_e: tl.constexpr = 1.4426950408889634
-    # s = gelu / (1 + exp2_ftz((-alpha * log2_e) * gelu))
+    s = gelu / (1 + exp_ftz(-alpha * gelu))
     return tl.fma(s, linear, s)  # (s * (linear + 1))
 
 


### PR DESCRIPTION
This seems to get most of the speedup of the other version but without compromising numerics. Since we add 1 after the exponential, any denormal values would be lost to rounding anyway.

It's worth about 1-2 GBps, or around 0.1% in bf16 x mxfp4 moe. Not world-changing, but it is repeatable.