### PR TITLE
[AMD] Add TritonAMDGPUSinkLayoutConversions pass

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -112,6 +112,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUAccelerateMatmul();
   mlir::registerTritonAMDGPUOptimizeEpilogue();
   mlir::registerTritonAMDGPUHoistLayoutConversions();
+  mlir::registerTritonAMDGPUSinkLayoutConversions();
   mlir::registerTritonAMDGPUReorderInstructions();
   mlir::registerTritonAMDGPUBlockPingpong();
   mlir::registerTritonAMDGPUPipeline();

--- a/test/TritonGPU/amd/amd-reorder-instructions.mlir
+++ b/test/TritonGPU/amd/amd-reorder-instructions.mlir
@@ -26,27 +26,6 @@ module attributes {"ttg.num-warps" = 8 : i32, "ttg.threads-per-warp" = 64 : i32}
 
 // -----
 
-//   CHECK-LABEL: sink_convert_dealloc
-// CHECK-COUNT-2: ttg.local_dealloc %{{.+}} : !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
-//         CHECK: ttg.convert_layout %arg0 : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked1>
-#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
-#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
-#smem = #ttg.shared_memory
-module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
-  tt.func public @sink_convert_dealloc(%arg0: tensor<32x32xf32, #blocked>) {
-    %0 = ttg.local_alloc : () -> !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
-    %1 = ttg.local_alloc : () -> !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
-    %2 = ttg.convert_layout %arg0 : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked1>
-    ttg.local_dealloc %0 : !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
-    ttg.local_dealloc %1 : !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
-    %3 = arith.addf %2, %2 : tensor<32x32xf32, #blocked1>
-    tt.return
-  }
-}
-
-// -----
-
 //   CHECK-LABEL: anchor_barrier
 //         CHECK: gpu.barrier
 //         CHECK: tt.load %arg0 : tensor<32x32x!tt.ptr<f16>, #blocked>

--- a/test/TritonGPU/amd/amd-sink-layout-conversions.mlir
+++ b/test/TritonGPU/amd/amd-sink-layout-conversions.mlir
@@ -1,0 +1,21 @@
+// RUN: triton-opt %s -tritonamdgpu-sink-layout-conversions | FileCheck %s
+
+//   CHECK-LABEL: sink_layout_conversion
+// CHECK-COUNT-2: ttg.local_dealloc %{{.+}} : !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
+//         CHECK: ttg.convert_layout %arg0 : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked1>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [0, 1]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [32, 1], warpsPerCTA = [1, 4], order = [1, 0]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 1, maxPhase = 4, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @sink_layout_conversion(%arg0: tensor<32x32xf32, #blocked>, %arg1: tensor<32x32xf32, #blocked1>, %arg2: tensor<32x32x!tt.ptr<f32>, #blocked1>) {
+    %0 = ttg.local_alloc : () -> !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
+    %1 = ttg.local_alloc : () -> !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
+    %2 = ttg.convert_layout %arg0 : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked1>
+    ttg.local_dealloc %0 : !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
+    ttg.local_dealloc %1 : !ttg.memdesc<4x128x64xf16, #shared, #smem, mutable>
+    %3 = arith.addf %2, %arg1 : tensor<32x32xf32, #blocked1>
+    tt.store %arg2, %3 : tensor<32x32x!tt.ptr<f32>, #blocked1>
+    tt.return
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -225,6 +225,7 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_optimize_epilogue(pm)
         amd.passes.ttgpuir.add_optimize_dot_operands(pm, options.arch)
         amd.passes.ttgpuir.add_hoist_layout_conversions(pm)
+        amd.passes.ttgpuir.add_sink_layout_conversions(pm)
 
         passes.ttgpuir.add_fuse_nested_loops(pm)
         passes.common.add_canonicalizer(pm)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -87,6 +87,18 @@ def TritonAMDGPUHoistLayoutConversions : Pass<"tritonamdgpu-hoist-layout-convers
 
 }
 
+def TritonAMDGPUSinkLayoutConversions
+    : Pass<"tritonamdgpu-sink-layout-conversions", "mlir::triton::FuncOp"> {
+  let summary = "Sink layout conversions to reduce shared memory allocation";
+
+  let description = [{
+    This pass sinks layout conversions after the last dealloc but before the first use in their block.
+    This helps to avoid unnecessary shared memory allocation.
+  }];
+
+  let dependentDialects = [];
+}
+
 def TritonAMDGPUCanonicalizePointers : Pass<"tritonamdgpu-canonicalize-pointers", "mlir::triton::FuncOp"> {
   let summary = "Canonicalize pointers: rewrite pointers passed to load/store operation as a `<basePtr, offset>` pair.";
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -7,6 +7,7 @@ add_triton_library(TritonAMDGPUTransforms
   OptimizeEpilogue.cpp
   OptimizeDotOperands.cpp
   HoistLayoutConversions.cpp
+  SinkLayoutConversions.cpp
   ReorderInstructions.cpp
   Pipeline.cpp
   ScheduleLoops.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -56,40 +56,9 @@ findEarlyInsertionPoint(Block *block, triton::LoadOp move) {
   return ipnt;
 }
 
-// Return the first user in the same block of the given op. If the user is in a
-// nested block then return the op owning the block. Return nullptr if not
-// existing.
-static Operation *getFirstUseInSameBlock(Operation *op) {
-  SmallVector<Operation *> usersInSameBlock;
-  for (auto user : op->getUsers()) {
-    if (Operation *ancestor = op->getBlock()->findAncestorOpInBlock(*user))
-      usersInSameBlock.push_back(ancestor);
-  }
-  auto minOpIt =
-      llvm::min_element(usersInSameBlock, [](Operation *a, Operation *b) {
-        return a->isBeforeInBlock(b);
-      });
-  return minOpIt != usersInSameBlock.end() ? *minOpIt : nullptr;
-}
-
 //===----------------------------------------------------------------------===//
 // Reorder mechanisms
 //===----------------------------------------------------------------------===//
-
-// Sink conversion after the last dealloc but before the first use in its block.
-// This helps to avoid unnecessary shared memory allocation.
-static void moveDownCoversion(triton::FuncOp funcOp) {
-  SmallVector<ttg::ConvertLayoutOp> convertOps;
-  funcOp.walk([&](ttg::ConvertLayoutOp op) { convertOps.push_back(op); });
-
-  for (auto op : convertOps) {
-    Operation *user = getFirstUseInSameBlock(op);
-    for (auto it = Block::iterator(op), ie = op->getBlock()->end();
-         it != ie && &*it != user; ++it)
-      if (isa<ttg::LocalDeallocOp>(&*it))
-        op->moveAfter(&*it);
-  }
-}
 
 // Move transpositions just after their definition.
 static void moveUpTranspose(triton::FuncOp funcOp) {
@@ -167,7 +136,6 @@ struct TritonAMDGPUReorderInstructionsPass
   void runOnOperation() override {
     ModuleOp m = getOperation();
     for (auto funcOp : m.getOps<triton::FuncOp>()) {
-      moveDownCoversion(funcOp);
       moveUpTranspose(funcOp);
       moveUpGlobalLoadInPrologue(funcOp);
     }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/SinkLayoutConversions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/SinkLayoutConversions.cpp
@@ -1,0 +1,54 @@
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/Pass/PassManager.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+
+namespace ttg = mlir::triton::gpu;
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONAMDGPUSINKLAYOUTCONVERSIONS
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+namespace {
+
+// Return the first user in the same block of the given op. If the user is in a
+// nested block then return the op owning the block. Return nullptr if not
+// existing.
+static Operation *getFirstUseInSameBlock(Operation *op) {
+  SmallVector<Operation *> usersInSameBlock;
+  for (auto user : op->getUsers()) {
+    if (Operation *ancestor = op->getBlock()->findAncestorOpInBlock(*user))
+      usersInSameBlock.push_back(ancestor);
+  }
+  auto minOpIt =
+      llvm::min_element(usersInSameBlock, [](Operation *a, Operation *b) {
+        return a->isBeforeInBlock(b);
+      });
+  return minOpIt != usersInSameBlock.end() ? *minOpIt : nullptr;
+}
+
+// Sink conversion after the last dealloc but before the first use in its block.
+// This helps to avoid unnecessary shared memory allocation.
+static void sinkLayoutConversions(triton::FuncOp funcOp) {
+  SmallVector<ttg::ConvertLayoutOp> convertOps;
+  funcOp.walk([&](ttg::ConvertLayoutOp op) { convertOps.push_back(op); });
+  for (auto op : convertOps) {
+    Operation *user = getFirstUseInSameBlock(op);
+    for (auto it = Block::iterator(op), ie = op->getBlock()->end();
+         it != ie && &*it != user; ++it)
+      if (isa<ttg::LocalDeallocOp>(&*it))
+        op->moveAfter(&*it);
+  }
+}
+
+} // namespace
+
+struct TritonAMDGPUSinkLayoutConversionsPass
+    : public impl::TritonAMDGPUSinkLayoutConversionsBase<
+          TritonAMDGPUSinkLayoutConversionsPass> {
+
+  void runOnOperation() override { sinkLayoutConversions(getOperation()); }
+};
+
+} // namespace mlir

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -80,6 +80,10 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
     pm.addNestedPass<mlir::triton::FuncOp>(
         mlir::createTritonAMDGPUHoistLayoutConversions());
   });
+  m.def("add_sink_layout_conversions", [](mlir::PassManager &pm) {
+    pm.addNestedPass<mlir::triton::FuncOp>(
+        mlir::createTritonAMDGPUSinkLayoutConversions());
+  });
   m.def("add_canonicalize_pointers", [](mlir::PassManager &pm) {
     pm.addNestedPass<mlir::triton::FuncOp>(
         mlir::createTritonAMDGPUCanonicalizePointers());


### PR DESCRIPTION
Add a new pass to sink LayoutConversion operations instead of using ReorderInstructions pass to do that. Eventually, we want each pass to have a clear purpose and ability to run/test separately.