### PR TITLE
[Testing] Propagate err_msg to np in triton's assert_close

### DIFF
--- a/python/triton/testing.py
+++ b/python/triton/testing.py
@@ -235,7 +235,7 @@ def assert_close(x, y, atol=None, rtol=None, err_msg=''):
     # we handle size==1 case separately as we can
     # provide better error message there
     if x.size > 1 or y.size > 1:
-        np.testing.assert_allclose(x, y, atol=atol, rtol=rtol, equal_nan=True)
+        np.testing.assert_allclose(x, y, atol=atol, rtol=rtol, equal_nan=True, err_msg=err_msg)
         return
     if not np.allclose(x, y, atol=atol, rtol=rtol):
         raise AssertionError(f'{err_msg} {x} is not close to {y} (atol={atol}, rtol={rtol})')


### PR DESCRIPTION
Pass `err_msg` arg to `np.testing.assert_allclose` for richer error message