### PR TITLE
[AMD] ReorderInstructions: Remove moveUpTranspose optimization

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -60,16 +60,6 @@ findEarlyInsertionPoint(Block *block, triton::LoadOp move) {
 // Reorder mechanisms
 //===----------------------------------------------------------------------===//
 
-// Move transpositions just after their definition.
-static void moveUpTranspose(triton::FuncOp funcOp) {
-  SmallVector<triton::TransposeOpInterface> transOps;
-  funcOp.walk([&](triton::TransposeOpInterface op) { transOps.push_back(op); });
-
-  for (auto op : transOps)
-    if (Operation *argOp = op.getSrc().getDefiningOp())
-      op->moveAfter(argOp);
-}
-
 // Schedule global load ops in prologue for better GEMM performance.
 static void moveUpGlobalLoadInPrologue(triton::FuncOp funcOp) {
   // Move global_load ops early to prefetch. This may increase
@@ -136,7 +126,6 @@ struct TritonAMDGPUReorderInstructionsPass
   void runOnOperation() override {
     ModuleOp m = getOperation();
     for (auto funcOp : m.getOps<triton::FuncOp>()) {
-      moveUpTranspose(funcOp);
       moveUpGlobalLoadInPrologue(funcOp);
     }
   }


### PR DESCRIPTION
This optimization moves TransOps closer to their defs, but that doesn't actually have any impact on the generated code because the actual transpose code generated by ConvertLayout ops.