### PR TITLE
[BACKEND] Perform tree reductions on in-thread values

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -136,7 +136,7 @@ private:
     if (values.front().size() != 1)
       return nullptr;
     auto elemTy = values.front().front().getType();
-    if ((!elemTy.isF16() && !elemTy.isF32()) || isa<VectorType>(elemTy))
+    if (!(elemTy.isF16() || elemTy.isBF16() || elemTy.isF32()))
       return nullptr;
     Operation *combiner = nullptr;
     if (!combineOp.empty()) {


### PR DESCRIPTION
We generate ternary trees for suitable integer ops that would lower to `IADD3`
or `LOP3` and binary trees for everything else.

We manually generate `{add,mul}.{f16,f32}x2` ops. This brings a speed-up
to some gluon attention kernels.
