### PR TITLE
[LAYOUTS] Tighten LinearEncoding checks

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -948,6 +948,15 @@ LinearEncodingAttr::verify(function_ref<InFlightDiagnostic()> emitError,
     }
   }
 
+  LinearLayout withoutBroadcast = linearLayout;
+  for (auto inDim : linearLayout.getInDimNames()) {
+    withoutBroadcast = withoutBroadcast.removeZeroBasesAlongDim(inDim);
+  }
+  if (!withoutBroadcast.isInvertible()) {
+    return emitError()
+           << "After removing the zero bases the layout must be bijective";
+  }
+
   return success();
 }
 

--- a/test/TritonNvidiaGPU/invalid.mlir
+++ b/test/TritonNvidiaGPU/invalid.mlir
@@ -196,3 +196,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// expected-error @+1 {{After removing the zero bases the layout must be bijective}}
+#linear = #ttg.linear<{register = [[0, 2], [0, 4], [0, 8], [0, 16], [0, 32]], lane = [[1, 0], [2, 0], [4, 0], [8, 0], [0, 1]], warp = [[16, 0], [8, 0]], block = []}>
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @invalid_linear_layout(%arg0: tensor<32x64xi32, #linear>) {
+    tt.return
+  }
+}


### PR DESCRIPTION
Before, we mistakenly allowed repeated non-zero bases
