### PR TITLE
[BACKEND] Improve and simplify ReduceOp's lowering

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -42,13 +42,7 @@ public:
     }
   }
 
-  ArrayRef<int64_t> getSrcShape() { return srcShape; }
-
-  Attribute getSrcLayout() { return srcEncoding; }
-
-  triton::ReduceOp getOperation() { return op; }
-
-  unsigned getThreadOffsetOnReductionAxis();
+  RankedTensorType getSrcTy() { return srcTy; }
 
   bool isWarpSynchronous();
 
@@ -56,16 +50,26 @@ public:
 
   unsigned getIntraWarpSizeWithUniqueData();
 
-  // The shape of the shared memory space needed for the reduction.
-  SmallVector<unsigned> getScratchRepShape();
-
-  SmallVector<unsigned> getOrderWithAxisAtBeginning();
-
-  unsigned getScratchSizeInBytes();
-
   bool isReduceWithinCTA();
 
   bool isAssociative();
+
+  static triton::ColumnAction
+  moveAxisBasesToFront(const triton::LinearLayout &layout, int axis);
+
+  static triton::LinearLayout
+  zeroBasesAlongDimAndReorder(const triton::LinearLayout &layout, unsigned axis,
+                              mlir::StringAttr dim);
+
+  static triton::LinearLayout getInterLayout(const triton::LinearLayout &layout,
+                                             unsigned axis);
+
+  static triton::LinearLayout reducedRegLaneLayout(RankedTensorType srcTy,
+                                                   unsigned axis);
+
+  SmallVector<unsigned>
+  getScratchBytesForCvt(const triton::LinearLayout &srcLayout,
+                        const triton::LinearLayout &dstLayout);
 
 private:
   triton::ReduceOp op;

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -2,6 +2,7 @@
 #define TRITON_CONVERSION_TRITONGPU_TO_LLVM_TARGETINFOBASE_H
 
 #include "triton/Conversion/MLIRTypes.h"
+#include "llvm/ADT/ArrayRef.h"
 
 namespace mlir::triton {
 enum class ProgramIDDim : uint32_t;
@@ -66,8 +67,7 @@ public:
 
   virtual bool warpReduce(RewriterBase &rewriter, Location loc,
                           SmallVector<Value> &acc, triton::ReduceOp op,
-                          unsigned numLaneToReduce,
-                          unsigned interleave) const = 0;
+                          unsigned reduceLaneIdMask) const = 0;
 
   virtual std::string getMulhiFuncName(Type resultElementTy) const = 0;
   // Emits LLVM code with |rewriter| to print a message following the given

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <numeric>
 
 #include "mlir/Analysis/Liveness.h"
 #include "mlir/Support/LLVM.h"
@@ -14,6 +15,7 @@
 #include "triton/Tools/LayoutUtils.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/MathExtras.h"
 #include "llvm/Support/raw_ostream.h"
 
 #define DEBUG_TYPE "allocation-shared-memory"
@@ -49,6 +51,36 @@ unsigned getNumScratchElemsSwizzledCvt(RankedTensorType srcTy,
   return smem.getTotalOutDimSize() / reps;
 }
 
+namespace {
+constexpr int64_t kReduceScratchAlign = 16;
+
+Type getReduceMemElemTy(Type elemTy, MLIRContext *ctx) {
+  if (elemTy.isIntOrFloat() && elemTy.getIntOrFloatBitWidth() < 8)
+    return IntegerType::get(ctx, 8);
+  return elemTy;
+}
+
+int64_t getReduceScratchSizeBytes(triton::ReduceOp op,
+                                  ArrayRef<unsigned> bytesPerOperand) {
+  std::vector<unsigned> indices(op.getNumOperands());
+  std::iota(indices.begin(), indices.end(), 0);
+  auto *ctx = op.getContext();
+  std::sort(indices.begin(), indices.end(), [&](unsigned i, unsigned j) {
+    auto lhsTy = getReduceMemElemTy(op.getElementTypes()[i], ctx);
+    auto rhsTy = getReduceMemElemTy(op.getElementTypes()[j], ctx);
+    return getIntOrFloatOrPtrBitWidth(lhsTy) >
+           getIntOrFloatOrPtrBitWidth(rhsTy);
+  });
+  // Aling to 16 bytes to allow for vectorisation
+  int64_t offset = 0;
+  for (unsigned idx : indices) {
+    offset += llvm::alignTo(bytesPerOperand[idx], kReduceScratchAlign);
+  }
+  return offset;
+}
+
+} // namespace
+
 // Both `atomic_cas` and `atomic_rmw` may need scratch memory to store values
 // because Triton's block-based programming model ensures that
 // all threads sharing the same partition of the tensor see the same values,
@@ -76,7 +108,14 @@ static SmallVector<unsigned> getRepShapeForAtomic(Value result) {
 unsigned defaultAllocationAnalysisScratchSizeFn(Operation *op) {
   if (auto reduceOp = dyn_cast<ReduceOp>(op)) {
     ReduceOpHelper helper(reduceOp);
-    return helper.getScratchSizeInBytes();
+    if (helper.isWarpSynchronous())
+      return 0;
+
+    auto regLl = ReduceOpHelper::reducedRegLaneLayout(helper.getSrcTy(),
+                                                      reduceOp.getAxis());
+    auto tmpLl = ReduceOpHelper::getInterLayout(regLl, reduceOp.getAxis());
+    auto bytesRegToTmp = helper.getScratchBytesForCvt(regLl, tmpLl);
+    return getReduceScratchSizeBytes(reduceOp, bytesRegToTmp);
   }
   if (auto scanOp = dyn_cast<ScanOp>(op)) {
     ScanLoweringHelper helper(scanOp);

--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -129,6 +129,46 @@ def test_scan_blocked_broadcast_layout_multiblock(device):
     torch.testing.assert_close(y, torch.cumsum(x, dim=0))
 
 
+def _funky_reduce_layouts():
+    # Broadcasting here and there and bases in a weird order
+    for axis in [0, 1]:
+        yield (ttgl.DistributedLinearLayout(
+            reg_bases=[[0, 8], [1, 0], [0, 0], [2, 0], [4, 0], [8, 0], [16, 0]],
+            lane_bases=[[0, 1], [0, 0], [64, 0], [0, 2], [0, 4]],
+            warp_bases=[[32, 0], [0, 16]],
+            block_bases=[],
+            shape=[128, 32],
+        ), axis)
+
+
+@pytest.mark.parametrize("src_layout, axis", list(_funky_reduce_layouts()))
+def test_reduce_funky_layout(src_layout, axis, device):
+    if not is_cuda():
+        pytest.skip("requires CUDA")
+    if THREADS_PER_WARP != 32:
+        pytest.skip("requires 32-thread warps")
+
+    shape = tuple(src_layout.shape)
+    num_warps = 2**len(src_layout.warp_bases)
+
+    torch.manual_seed(0)
+    x = torch.randn(shape, dtype=torch.float32, device=device)
+    y = torch.empty(shape[1 - axis], dtype=torch.float32, device=device)
+
+    @gluon.jit
+    def kernel(x_ptr, y_ptr, shape: ttgl.constexpr, axis: ttgl.constexpr, layout: ttgl.constexpr):
+        x_offs_m = ttgl.arange(0, shape[0], layout=ttgl.SliceLayout(1, layout))[:, None]
+        x_offs_n = ttgl.arange(0, shape[1], layout=ttgl.SliceLayout(0, layout))[None, :]
+        x = ttgl.load(x_ptr + x_offs_m * shape[1] + x_offs_n)
+        y = ttgl.sum(x, axis=axis)
+        y_offs = ttgl.arange(0, shape[1 - axis])
+        ttgl.store(y_ptr + y_offs, y)
+
+    kernel[(1, )](x, y, shape, axis, src_layout, num_warps=num_warps)
+
+    torch.testing.assert_close(y, torch.sum(x, dim=axis))
+
+
 def _reduce_linear_layouts():
     if THREADS_PER_WARP == 32:
         return [

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -219,7 +219,6 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
   // CHECK-LABEL: reduce_xor_max
   tt.func @reduce_xor_max(%arg0: tensor<32xf32, #blocked4>) {
     // CHECK: rocdl.ds_swizzle
-    // CHECK: llvm.intr.maxnum
 
     // CHECK: rocdl.update.dpp
     // CHECK-SAME: with 280, 15, 12, false : i32

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1827,9 +1827,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 //       CHECK:   nvvm.barrier0
 //       CHECK:   nvvm.shfl.sync bfly
 //       CHECK:   nvvm.shfl.sync bfly
-//       CHECK:   nvvm.barrier0
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @sum_reduction(%arg0: tensor<1x1024xi32, #blocked>) {
     %11 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
@@ -1918,10 +1916,8 @@ module attributes {"ttg.target" = "cuda:80", "ttg.num-ctas" = 1 : i32, "ttg.num-
 // -----
 
 //  CHECK-LABEL: reduce_md_slice
-//  CHECK: st.shared
-//  CHECK: st.shared
-//  CHECK: ld.shared
-//  CHECK: st.shared
+//  CHECK: llvm.store {{.*}} vector<2xi32>
+//  CHECK: llvm.load {{.*}} vector<2xi32>
 #blocked = #ttg.blocked<{sizePerThread = [1, 1, 1], threadsPerWarp = [1, 1, 32], warpsPerCTA = [1, 2, 2], order = [2, 1, 0]}>
 #sliced = #ttg.slice<{dim = 2, parent = #blocked}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:80", "ttg.threads-per-warp" = 32 : i32} {

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -727,9 +727,7 @@ tt.func @load_store_x1_unpacked(%arg0: !ttg.memdesc<128x2xf16, #tmem_x1_unpacked
 //       CHECK:   nvvm.barrier0
 //       CHECK:   nvvm.shfl.sync bfly
 //       CHECK:   nvvm.shfl.sync bfly
-//       CHECK:   nvvm.barrier0
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @max_reduction(%arg0: tensor<1x1024xf32, #blocked>) {
     %11 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({
@@ -749,9 +747,7 @@ module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num
 //       CHECK:   nvvm.barrier0
 //       CHECK:   nvvm.shfl.sync bfly
 //       CHECK:   nvvm.shfl.sync bfly
-//       CHECK:   nvvm.barrier0
 #blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
-#blocked1 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [4], order = [0]}>
 module attributes {"ttg.target" = "cuda:100", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
   tt.func public @maxnum_reduction(%arg0: tensor<1x1024xf32, #blocked>) {
     %11 = "tt.reduce"(%arg0) <{axis = 1 : i32}> ({

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -76,8 +76,8 @@ public:
                   ProgramIDDim axis) const override;
 
   bool warpReduce(RewriterBase &rewriter, Location loc, SmallVector<Value> &acc,
-                  triton::ReduceOp op, unsigned numLaneToReduce,
-                  unsigned interleave) const override;
+                  triton::ReduceOp op,
+                  unsigned reduceLaneIdMask) const override;
 
   std::string getMulhiFuncName(Type resultElementTy) const override;
 

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.cpp
@@ -464,48 +464,49 @@ Value TargetInfo::programId(RewriterBase &rewriter, Location loc,
 }
 bool TargetInfo::warpReduce(RewriterBase &rewriter, Location loc,
                             SmallVector<Value> &acc, triton::ReduceOp op,
-                            unsigned numLaneToReduce,
-                            unsigned interleave) const {
+                            unsigned reduceLaneIdMask) const {
+
+  // Based on benchmarking on A100 redux op gives a speed up only when doing
+  // a single reduction (not partitioned) and when the mask is static.
+  // Therefore we currently only enable it to reduce across all the lanes.
+  constexpr unsigned kWarpSize = 32;
+  unsigned fullMask = kWarpSize - 1;
+  if (reduceLaneIdMask != fullMask)
+    return false;
   auto b = TritonLLVMOpBuilder(loc, rewriter);
   bool useNanQualifier = false;
   if (auto kind = matchReduxKind(op, computeCapability, useNanQualifier)) {
-    // Based on benchmarking on A100 redux op gives a speed up only when doing
-    // a single reduction (not partitioned) and when the mask is static.
-    // Therefore we currently only enable it to reduce across all the lanes.
-    if (numLaneToReduce == 32) {
-      assert(acc.size() == 1);
-      Value mask = b.i32_val(0xFFFFFFFF);
-      // Even though we currently don't use redux for partitioned reduction
-      // the code below supports it in case we want to tweak the heuristic.
-      if (numLaneToReduce < 32) {
-        // For partitioned reduction we need to calculate the mask so that
-        // each group of numLaneToReduce threads has the correct mask.
-        unsigned bitmask = (1 << numLaneToReduce) - 1;
-        Value laneId = getLaneId(rewriter, loc);
-        mask = b.shl(b.i32_val(bitmask),
-                     b.and_(laneId, b.i32_val(~(numLaneToReduce - 1))));
-      }
-      for (unsigned i = 0; i < acc.size(); ++i) {
-        unsigned bitwidth = acc[i].getType().getIntOrFloatBitWidth();
-        if (acc[i].getType().isInteger()) {
-          if (bitwidth < 32) {
-            if (*kind == NVVM::ReductionKind::MIN ||
-                *kind == NVVM::ReductionKind::MAX)
-              acc[i] = b.sext(i32_ty, acc[i]);
-            else
-              acc[i] = b.zext(i32_ty, acc[i]);
-          }
-        }
-        acc[i] = NVVM::ReduxOp::create(rewriter, loc, acc[i].getType(), acc[0],
-                                       *kind, mask, /*abs=*/false,
-                                       /*nan=*/useNanQualifier);
-        if (acc[i].getType().isInteger()) {
-          if (bitwidth < 32)
-            acc[i] = b.trunc(int_ty(bitwidth), acc[i]);
-        }
-      }
-      return true;
+    assert(acc.size() == 1);
+    Value mask = b.i32_val(0xFFFFFFFF);
+    // Even though we currently don't use redux for partitioned reduction
+    // the code below supports it in case we want to tweak the heuristic.
+    if (reduceLaneIdMask != fullMask) {
+      // For partitioned reduction we need to calculate the mask so that
+      // each group of threads has the correct mask.
+      Value laneId = getLaneId(rewriter, loc);
+      mask = b.shl(b.i32_val(reduceLaneIdMask),
+                   b.and_(laneId, b.i32_val(~reduceLaneIdMask)));
     }
+    for (unsigned i = 0; i < acc.size(); ++i) {
+      unsigned bitwidth = acc[i].getType().getIntOrFloatBitWidth();
+      if (acc[i].getType().isInteger()) {
+        if (bitwidth < 32) {
+          if (*kind == NVVM::ReductionKind::MIN ||
+              *kind == NVVM::ReductionKind::MAX)
+            acc[i] = b.sext(i32_ty, acc[i]);
+          else
+            acc[i] = b.zext(i32_ty, acc[i]);
+        }
+      }
+      acc[i] = NVVM::ReduxOp::create(rewriter, loc, acc[i].getType(), acc[0],
+                                     *kind, mask, /*abs=*/false,
+                                     /*nan=*/useNanQualifier);
+      if (acc[i].getType().isInteger()) {
+        if (bitwidth < 32)
+          acc[i] = b.trunc(int_ty(bitwidth), acc[i]);
+      }
+    }
+    return true;
   }
   return false;
 }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -49,8 +49,8 @@ public:
                   ProgramIDDim axis) const override;
 
   bool warpReduce(RewriterBase &rewriter, Location loc, SmallVector<Value> &acc,
-                  triton::ReduceOp op, unsigned numLaneToReduce,
-                  unsigned interleave) const override;
+                  triton::ReduceOp op,
+                  unsigned reduceLaneIdMask) const override;
 
   std::string getMulhiFuncName(Type resultElementTy) const override;
 


### PR DESCRIPTION
Stacked PRs:
 * #9327
 * #9318
 * #9317
 * #9221
 * #9220
 * __->__#9219


--- --- ---

### [BACKEND] Improve and simplify ReduceOp's lowering


We implement a LinearLayout-based `ReduceOp` lowering. This has a
number of benefits:

- The logic is noticeably simpler as we barely have to implement anything. ConvertLayout and some LL helpers do all the heavy lifting
- We get shmem swizzling for free
- We sometimes save a shmem round-trip (before we did it unconditionally)
- It is now clear that we have a `tmpLl` variable we can carefully choose (we'll do so in a future PR)
- It opens the door to returning an arbitrary layout (fusing a `convert_layout` into this op)
- It is now really simple to generalise this op to perform cross-cluster reductions, provided that `convert_layout` supports them.
- We fix some latent issues the previous implementation had when run on arbitrary linear layouts. We add a funky regression test that used to fail and now passes.
- All this while being LOC-neutral!

In future PRs we will improve the choice fo `tmpLl` to avoid in many
cases the last `convert_layout`, and we will pack the inputs in shmem to
be able to vectorize the load/stores for full reductions with multiple inputs.

This PR was the result of quite a long (but rather successful) vibe-coding session together with `gpt-5.2-codex`. I found particularly useful being able to emit a ConvertLayout within this lowering rather than having to call the lowering of the function manually. This simplifies the code quite a bit and I would have struggled to convince MLIR to do so myself.
