### PR TITLE
Fix matmul metadata n_token dtype

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/_common.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_common.py
@@ -188,7 +188,7 @@ def matmul_launch_metadata(grid, kernel, args):
     n_tokens = None
     if slice_sizes is not None:
         if launch_metadata_allow_sync():
-            n_tokens = float(slice_sizes.sum())
+            n_tokens = int(slice_sizes.sum())
         else:
             n_tokens = slice_sizes.sum()  # n_tokens can stay in gpu
 


### PR DESCRIPTION
As title to avoid breaking existing tests - K printed dtype is based on n_tokens and it used int before