### PR TITLE
[llvm-head] Fix warp spec op successor input determination

### DIFF
--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUOps.td
@@ -540,7 +540,7 @@ def TTG_GlobalScratchAllocOp : TTG_Op<"global_scratch_alloc"> {
 
 def TTG_WarpSpecializeOp : TTG_Op<"warp_specialize", [
   RecursiveMemoryEffects, RecursivelySpeculatable, AsyncRegions,
-  DeclareOpInterfaceMethods<RegionBranchOpInterface>
+  DeclareOpInterfaceMethods<RegionBranchOpInterface, ["getSuccessorInputs"]>
 ]> {
   let summary = "asynchronously execute code on multiple warpgroups";
   let description = [{
@@ -616,7 +616,8 @@ def TTG_WarpSpecializePartitionsOp
               RecursivelySpeculatable, Terminator,
               HasParent<"WarpSpecializeOp">,
               DeclareOpInterfaceMethods<
-                  RegionBranchOpInterface, ["getEntrySuccessorOperands"]>]> {
+                  RegionBranchOpInterface, ["getEntrySuccessorOperands",
+                                            "getSuccessorInputs"]>]> {
   let summary = "container op for `ttg.warp_specialize`";
   let description = [{
     Because MLIR requires entire operations be isolated from above, this op

--- a/lib/Dialect/TritonGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonGPU/IR/Ops.cpp
@@ -1056,6 +1056,11 @@ void WarpSpecializeOp::getSuccessorRegions(
     successors.push_back(RegionSuccessor::parent());
 }
 
+ValueRange WarpSpecializeOp::getSuccessorInputs(RegionSuccessor successor) {
+  // When returning to parent, the successor inputs are the op results.
+  return successor.isParent() ? getResults() : ValueRange();
+}
+
 void WarpSpecializePartitionsOp::getSuccessorRegions(
     RegionBranchPoint src, SmallVectorImpl<RegionSuccessor> &successors) {
   // The parent branches to each of the partition regions, but nothing flows out
@@ -1069,6 +1074,13 @@ OperandRange
 WarpSpecializePartitionsOp::getEntrySuccessorOperands(RegionSuccessor) {
   // Pass through the explicit captures from the enclosing WarpSpecializeOp.
   return getExplicitCaptures();
+}
+
+ValueRange
+WarpSpecializePartitionsOp::getSuccessorInputs(RegionSuccessor successor) {
+  // The successor inputs are the block arguments of the partition region.
+  Region *region = successor.getSuccessor();
+  return region ? region->getArguments() : ValueRange();
 }
 
 LogicalResult WarpSpecializeOp::verify() {


### PR DESCRIPTION
The new LLVM pin requires these operations to implement `getSuccessorInputs`, since `getSuccessRegions` no longer also provides the successor inputs.