### PR TITLE
[AMD] Add PrepareIfCombining pass to enable scf.if combining

### DIFF
--- a/bin/RegisterTritonDialects.h
+++ b/bin/RegisterTritonDialects.h
@@ -113,6 +113,7 @@ inline void registerTritonDialects(mlir::DialectRegistry &registry) {
   mlir::registerTritonAMDGPUOptimizeEpilogue();
   mlir::registerTritonAMDGPUHoistLayoutConversions();
   mlir::registerTritonAMDGPUSinkLayoutConversions();
+  mlir::registerTritonAMDGPUPrepareIfCombining();
   mlir::registerTritonAMDGPUReorderInstructions();
   mlir::registerTritonAMDGPUBlockPingpong();
   mlir::registerTritonAMDGPUPipeline();

--- a/test/TritonGPU/amd/amd-prepare-if-combining.mlir
+++ b/test/TritonGPU/amd/amd-prepare-if-combining.mlir
@@ -1,0 +1,274 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-prepare-if-combining | FileCheck %s
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-prepare-if-combining -canonicalize | FileCheck %s --check-prefix=CANON
+
+
+// CHECK-LABEL: op_between_ifs
+//       CHECK: %[[LOAD:.+]] = ttg.local_load
+//  CHECK-NEXT: tt.trans %[[LOAD]]
+//  CHECK-NEXT: scf.if
+// CANON-LABEL: op_between_ifs
+//       CANON: scf.if
+//   CANON-NOT: scf.if
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_transposed = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @op_between_ifs(%cond: i1, %smem: !ttg.memdesc<32x32xf32, #shared, #smem>, %a: tensor<32x32xf32, #blocked>) -> tensor<32x32xf32, #blocked> {
+    %0 = ttg.local_load %smem : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #blocked>
+    %1 = scf.if %cond -> tensor<32x32xf32, #blocked> {
+      %mul = arith.mulf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %mul : tensor<32x32xf32, #blocked>
+    } else {
+      %div = arith.divf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %div : tensor<32x32xf32, #blocked>
+    }
+    %2 = tt.trans %0 {order = array<i32: 1, 0>} : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked_transposed>
+    %3 = scf.if %cond -> tensor<32x32xf32, #blocked_transposed> {
+      %add = arith.addf %2, %2 : tensor<32x32xf32, #blocked_transposed>
+      scf.yield %add : tensor<32x32xf32, #blocked_transposed>
+    } else {
+      %sub = arith.subf %2, %2 : tensor<32x32xf32, #blocked_transposed>
+      scf.yield %sub : tensor<32x32xf32, #blocked_transposed>
+    }
+    %4 = ttg.convert_layout %3 : tensor<32x32xf32, #blocked_transposed> -> tensor<32x32xf32, #blocked>
+    %5 = arith.addf %4, %1 : tensor<32x32xf32, #blocked>
+    tt.return %5 : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: multiple_ops_between_ifs
+//       CHECK: %[[LOAD:.+]] = ttg.local_load
+//  CHECK-NEXT: %[[CVT:.+]] = ttg.convert_layout %[[LOAD]]
+//  CHECK-NEXT: tt.trans %[[CVT]]
+//  CHECK-NEXT: scf.if
+// CANON-LABEL: multiple_ops_between_ifs
+//       CANON: scf.if
+//   CANON-NOT: scf.if
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_transposed = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @multiple_ops_between_ifs(%cond: i1, %smem: !ttg.memdesc<32x32xf32, #shared, #smem>, %a: tensor<32x32xf32, #blocked>) -> tensor<32x32xf32, #blocked> {
+    %0 = ttg.local_load %smem : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #blocked>
+    %1 = scf.if %cond -> tensor<32x32xf32, #blocked> {
+      %mul = arith.mulf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %mul : tensor<32x32xf32, #blocked>
+    } else {
+      %div = arith.divf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %div : tensor<32x32xf32, #blocked>
+    }
+    %2 = ttg.convert_layout %0 : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked_transposed>
+    %3 = tt.trans %2 {order = array<i32: 1, 0>} : tensor<32x32xf32, #blocked_transposed> -> tensor<32x32xf32, #blocked>
+    %4 = scf.if %cond -> tensor<32x32xf32, #blocked> {
+      %add = arith.addf %3, %3 : tensor<32x32xf32, #blocked>
+      scf.yield %add : tensor<32x32xf32, #blocked>
+    } else {
+      %sub = arith.subf %3, %3 : tensor<32x32xf32, #blocked>
+      scf.yield %sub : tensor<32x32xf32, #blocked>
+    }
+    %5 = arith.addf %4, %1 : tensor<32x32xf32, #blocked>
+    tt.return %5 : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: op_between_ifs_inside_for
+//       CHECK: %[[LOAD:.+]] = ttg.local_load
+//       CHECK: scf.for
+//  CHECK-NEXT: tt.trans %[[LOAD]]
+//  CHECK-NEXT: scf.if
+// CANON-LABEL: op_between_ifs_inside_for
+//       CANON: scf.for
+//       CANON: scf.if
+//   CANON-NOT: scf.if
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_transposed = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @op_between_ifs_inside_for(%cond: i1, %smem: !ttg.memdesc<32x32xf32, #shared, #smem>, %a: tensor<32x32xf32, #blocked>) -> tensor<32x32xf32, #blocked> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %x = ttg.local_load %smem : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #blocked>
+    %result = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %a) -> tensor<32x32xf32, #blocked> {
+      %0 = scf.if %cond -> tensor<32x32xf32, #blocked> {
+        %mul = arith.mulf %acc, %acc : tensor<32x32xf32, #blocked>
+        scf.yield %mul : tensor<32x32xf32, #blocked>
+      } else {
+        %div = arith.divf %acc, %acc : tensor<32x32xf32, #blocked>
+        scf.yield %div : tensor<32x32xf32, #blocked>
+      }
+      %1 = tt.trans %x {order = array<i32: 1, 0>} : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked_transposed>
+      %2 = scf.if %cond -> tensor<32x32xf32, #blocked_transposed> {
+        %add = arith.addf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+        scf.yield %add : tensor<32x32xf32, #blocked_transposed>
+      } else {
+        %sub = arith.subf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+        scf.yield %sub : tensor<32x32xf32, #blocked_transposed>
+      }
+      %3 = ttg.convert_layout %2 : tensor<32x32xf32, #blocked_transposed> -> tensor<32x32xf32, #blocked>
+      %4 = arith.addf %3, %0 : tensor<32x32xf32, #blocked>
+      scf.yield %4 : tensor<32x32xf32, #blocked>
+    }
+    tt.return %result : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// Negative test: ifs in different blocks
+// CHECK-LABEL: ifs_in_different_blocks
+//       CHECK: scf.if
+//       CHECK: scf.for
+//  CHECK-NEXT: tt.trans
+//  CHECK-NEXT: scf.if
+// CANON-LABEL: ifs_in_different_blocks
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_transposed = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @ifs_in_different_blocks(%cond: i1, %smem: !ttg.memdesc<32x32xf32, #shared, #smem>, %a: tensor<32x32xf32, #blocked>) -> tensor<32x32xf32, #blocked> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %x = ttg.local_load %smem : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #blocked>
+    %0 = scf.if %cond -> tensor<32x32xf32, #blocked> {
+      %mul = arith.mulf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %mul : tensor<32x32xf32, #blocked>
+    } else {
+      %div = arith.divf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %div : tensor<32x32xf32, #blocked>
+    }
+    %result = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %0) -> tensor<32x32xf32, #blocked> {
+      %1 = tt.trans %x {order = array<i32: 1, 0>} : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked_transposed>
+      %2 = scf.if %cond -> tensor<32x32xf32, #blocked_transposed> {
+        %add = arith.addf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+        scf.yield %add : tensor<32x32xf32, #blocked_transposed>
+      } else {
+        %sub = arith.subf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+        scf.yield %sub : tensor<32x32xf32, #blocked_transposed>
+      }
+      %3 = ttg.convert_layout %2 : tensor<32x32xf32, #blocked_transposed> -> tensor<32x32xf32, #blocked>
+      %4 = arith.addf %3, %acc : tensor<32x32xf32, #blocked>
+      scf.yield %4 : tensor<32x32xf32, #blocked>
+    }
+    tt.return %result : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// Negative test: nested ifs
+// CHECK-LABEL: nested_ifs
+//       CHECK: scf.if
+//  CHECK-NEXT: tt.trans
+//  CHECK-NEXT: scf.if
+// CANON-LABEL: nested_ifs
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_transposed = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @nested_ifs(%cond: i1, %cond2: i1, %smem: !ttg.memdesc<32x32xf32, #shared, #smem>, %a: tensor<32x32xf32, #blocked>) -> tensor<32x32xf32, #blocked> {
+    %x = ttg.local_load %smem : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #blocked>
+    %0 = scf.if %cond -> tensor<32x32xf32, #blocked> {
+      %1 = tt.trans %x {order = array<i32: 1, 0>} : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked_transposed>
+      %2 = scf.if %cond2 -> tensor<32x32xf32, #blocked_transposed> {
+        %add = arith.addf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+        scf.yield %add : tensor<32x32xf32, #blocked_transposed>
+      } else {
+        %sub = arith.subf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+        scf.yield %sub : tensor<32x32xf32, #blocked_transposed>
+      }
+      %3 = ttg.convert_layout %2 : tensor<32x32xf32, #blocked_transposed> -> tensor<32x32xf32, #blocked>
+      scf.yield %3 : tensor<32x32xf32, #blocked>
+    } else {
+      %div = arith.divf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %div : tensor<32x32xf32, #blocked>
+    }
+    tt.return %0 : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// Negative test: ifs with different conditions
+// CHECK-LABEL: different_conditions
+//       CHECK: scf.if
+//  CHECK-NEXT: arith.mulf
+//       CHECK: tt.trans
+//  CHECK-NEXT: scf.if
+// CANON-LABEL: different_conditions
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_transposed = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @different_conditions(%cond1: i1, %cond2: i1, %smem: !ttg.memdesc<32x32xf32, #shared, #smem>, %a: tensor<32x32xf32, #blocked>) -> tensor<32x32xf32, #blocked> {
+    %x = ttg.local_load %smem : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #blocked>
+    %0 = scf.if %cond1 -> tensor<32x32xf32, #blocked> {
+      %mul = arith.mulf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %mul : tensor<32x32xf32, #blocked>
+    } else {
+      %div = arith.divf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %div : tensor<32x32xf32, #blocked>
+    }
+    %1 = tt.trans %x {order = array<i32: 1, 0>} : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked_transposed>
+    %2 = scf.if %cond2 -> tensor<32x32xf32, #blocked_transposed> {
+      %add = arith.addf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+      scf.yield %add : tensor<32x32xf32, #blocked_transposed>
+    } else {
+      %sub = arith.subf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+      scf.yield %sub : tensor<32x32xf32, #blocked_transposed>
+    }
+    %3 = ttg.convert_layout %2 : tensor<32x32xf32, #blocked_transposed> -> tensor<32x32xf32, #blocked>
+    %4 = arith.addf %3, %0 : tensor<32x32xf32, #blocked>
+    tt.return %4 : tensor<32x32xf32, #blocked>
+  }
+}
+
+// -----
+
+// Negative test: non-pure op (local_store) between ifs
+// CHECK-LABEL: non_pure_op_between_ifs
+//       CHECK: scf.if
+//       CHECK: tt.trans
+//  CHECK-NEXT: ttg.local_store
+//  CHECK-NEXT: scf.if
+// CANON-LABEL: non_pure_op_between_ifs
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 8], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked_transposed = #ttg.blocked<{sizePerThread = [4, 1], threadsPerWarp = [8, 8], warpsPerCTA = [1, 4], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0]}>
+#shared_transposed = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func public @non_pure_op_between_ifs(%cond: i1, %smem: !ttg.memdesc<32x32xf32, #shared, #smem>, %smem_trans: !ttg.memdesc<32x32xf32, #shared_transposed, #smem, mutable>, %a: tensor<32x32xf32, #blocked>) -> tensor<32x32xf32, #blocked> {
+    %x = ttg.local_load %smem : !ttg.memdesc<32x32xf32, #shared, #smem> -> tensor<32x32xf32, #blocked>
+    %0 = scf.if %cond -> tensor<32x32xf32, #blocked> {
+      %mul = arith.mulf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %mul : tensor<32x32xf32, #blocked>
+    } else {
+      %div = arith.divf %a, %a : tensor<32x32xf32, #blocked>
+      scf.yield %div : tensor<32x32xf32, #blocked>
+    }
+    %1 = tt.trans %x {order = array<i32: 1, 0>} : tensor<32x32xf32, #blocked> -> tensor<32x32xf32, #blocked_transposed>
+    ttg.local_store %1, %smem_trans : tensor<32x32xf32, #blocked_transposed> -> !ttg.memdesc<32x32xf32, #shared_transposed, #smem, mutable>
+    %2 = scf.if %cond -> tensor<32x32xf32, #blocked_transposed> {
+      %add = arith.addf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+      scf.yield %add : tensor<32x32xf32, #blocked_transposed>
+    } else {
+      %sub = arith.subf %1, %1 : tensor<32x32xf32, #blocked_transposed>
+      scf.yield %sub : tensor<32x32xf32, #blocked_transposed>
+    }
+    %3 = ttg.convert_layout %2 : tensor<32x32xf32, #blocked_transposed> -> tensor<32x32xf32, #blocked>
+    %4 = arith.addf %3, %0 : tensor<32x32xf32, #blocked>
+    tt.return %4 : tensor<32x32xf32, #blocked>
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -263,6 +263,7 @@ class HIPBackend(BaseBackend):
             )
 
         amd.passes.ttgpuir.add_fold_true_cmpi(pm)
+        amd.passes.ttgpuir.add_prepare_if_combining(pm)
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)

--- a/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
+++ b/third_party/amd/include/TritonAMDGPUTransforms/Passes.td
@@ -99,6 +99,18 @@ def TritonAMDGPUSinkLayoutConversions
   let dependentDialects = [];
 }
 
+def TritonAMDGPUPrepareIfCombining
+    : Pass<"tritonamdgpu-prepare-if-combining", "mlir::triton::FuncOp"> {
+  let summary = "Move ops between scf.if pairs to enable combining";
+
+  let description = [{
+    Moves operations out from between scf.if pairs that share the same
+    condition, enabling canonicalization to combine them.
+  }];
+
+  let dependentDialects = [];
+}
+
 def TritonAMDGPUCanonicalizePointers : Pass<"tritonamdgpu-canonicalize-pointers", "mlir::triton::FuncOp"> {
   let summary = "Canonicalize pointers: rewrite pointers passed to load/store operation as a `<basePtr, offset>` pair.";
 

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CMakeLists.txt
@@ -8,6 +8,7 @@ add_triton_library(TritonAMDGPUTransforms
   OptimizeDotOperands.cpp
   HoistLayoutConversions.cpp
   SinkLayoutConversions.cpp
+  PrepareIfCombining.cpp
   ReorderInstructions.cpp
   Pipeline.cpp
   ScheduleLoops.cpp

--- a/third_party/amd/lib/TritonAMDGPUTransforms/PrepareIfCombining.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/PrepareIfCombining.cpp
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+// This pass enables combining of scf.if operations that share the same
+// condition by moving intervening operations out of the way.
+//
+// Example:
+//   %0 = ttg.local_load %smem : ...
+//   %1 = scf.if %cond -> tensor<...> { ... }
+//   %2 = tt.trans %0 : ...  // <-- blocking combining if ops
+//   %3 = scf.if %cond -> tensor<...> { ... }
+//
+// After this pass, %2 is moved before %1, making %1 and %3 adjacent so that
+// they can be combined by the canonicalizer.
+//===----------------------------------------------------------------------===//
+#include "TritonAMDGPUTransforms/Passes.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "mlir/Pass/PassManager.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+namespace mlir {
+
+#define GEN_PASS_DEF_TRITONAMDGPUPREPAREIFCOMBINING
+#include "TritonAMDGPUTransforms/Passes.h.inc"
+
+namespace {
+
+static void handleIfPair(scf::IfOp currentIf, scf::IfOp nextIf,
+                         DominanceInfo &domInfo) {
+  // Skip if they are not in the same block.
+  if (currentIf->getBlock() != nextIf->getBlock())
+    return;
+  // Skip if they have different conditions.
+  if (currentIf.getCondition() != nextIf.getCondition())
+    return;
+
+  // Collect ops between the two ifs and check if they are all
+  // pure (speculatable, does not touch memory) ops.
+  SetVector<Operation *> opsBetween;
+  for (Operation *op = currentIf->getNextNode(); op != nextIf.getOperation();
+       op = op->getNextNode()) {
+    if (!isPure(op))
+      return;
+    opsBetween.insert(op);
+  }
+  if (opsBetween.empty())
+    return;
+
+  // Check that all operands are either in opsBetween or dominate currentIf.
+  for (Operation *op : opsBetween) {
+    for (Value operand : op->getOperands()) {
+      auto *defOp = operand.getDefiningOp();
+      if (!defOp || opsBetween.contains(defOp))
+        continue;
+      if (!domInfo.properlyDominates(defOp, currentIf))
+        return;
+    }
+  }
+
+  // Move all ops before the current if.
+  for (Operation *op : opsBetween)
+    op->moveBefore(currentIf);
+}
+
+} // namespace
+
+struct TritonAMDGPUPrepareIfCombiningPass
+    : public impl::TritonAMDGPUPrepareIfCombiningBase<
+          TritonAMDGPUPrepareIfCombiningPass> {
+
+  void runOnOperation() override {
+    triton::FuncOp funcOp = getOperation();
+    DominanceInfo domInfo(funcOp);
+    SmallVector<scf::IfOp> ifOps;
+    funcOp.walk([&](scf::IfOp ifOp) { ifOps.push_back(ifOp); });
+    for (auto [currentIf, nextIf] : llvm::zip(ifOps, llvm::drop_begin(ifOps))) {
+      handleIfPair(currentIf, nextIf, domInfo);
+    }
+  }
+};
+
+} // namespace mlir

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ReorderInstructions.cpp
@@ -60,16 +60,6 @@ findEarlyInsertionPoint(Block *block, triton::LoadOp move) {
 // Reorder mechanisms
 //===----------------------------------------------------------------------===//
 
-// Move transpositions just after their definition.
-static void moveUpTranspose(triton::FuncOp funcOp) {
-  SmallVector<triton::TransposeOpInterface> transOps;
-  funcOp.walk([&](triton::TransposeOpInterface op) { transOps.push_back(op); });
-
-  for (auto op : transOps)
-    if (Operation *argOp = op.getSrc().getDefiningOp())
-      op->moveAfter(argOp);
-}
-
 // Schedule global load ops in prologue for better GEMM performance.
 static void moveUpGlobalLoadInPrologue(triton::FuncOp funcOp) {
   // Move global_load ops early to prefetch. This may increase
@@ -136,7 +126,6 @@ struct TritonAMDGPUReorderInstructionsPass
   void runOnOperation() override {
     ModuleOp m = getOperation();
     for (auto funcOp : m.getOps<triton::FuncOp>()) {
-      moveUpTranspose(funcOp);
       moveUpGlobalLoadInPrologue(funcOp);
     }
   }

--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -84,6 +84,10 @@ void init_triton_amd_passes_ttgpuir(py::module &&m) {
     pm.addNestedPass<mlir::triton::FuncOp>(
         mlir::createTritonAMDGPUSinkLayoutConversions());
   });
+  m.def("add_prepare_if_combining", [](mlir::PassManager &pm) {
+    pm.addNestedPass<mlir::triton::FuncOp>(
+        mlir::createTritonAMDGPUPrepareIfCombining());
+  });
   m.def("add_canonicalize_pointers", [](mlir::PassManager &pm) {
     pm.addNestedPass<mlir::triton::FuncOp>(
         mlir::createTritonAMDGPUCanonicalizePointers());


### PR DESCRIPTION
Add a new pass that moves operations out from between scf.if pairs that share the same condition. This enables the canonicalizer to combine adjacent if operations.

Also, remove moveUpTranspose optimization from the ReorderInstructions pass as we no longer need it with this new pass.