### PR TITLE
[LLVM-HEAD] Stop building LLVM/MLIR tests to work around relocation linker error for ARM64 

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -215,6 +215,8 @@ jobs:
         -DCMAKE_RANLIB="/usr/bin/aarch64-linux-gnu-ranlib" \
         -DCMAKE_STRIP="/usr/bin/aarch64-linux-gnu-strip" \
         -DCMAKE_SYSROOT=$SYSROOT \
+        -DLLVM_INCLUDE_TESTS=OFF \
+        -DMLIR_INCLUDE_TESTS=OFF \
         -DLLVM_ENABLE_TERMINFO=OFF \
         llvm-project/llvm
         ninja -C llvm-project/build install


### PR DESCRIPTION
After the llvm bump in https://github.com/triton-lang/triton/pull/9239 the build failed because the linker failed to keep jumps below the hardware limit of ARM64 (without increase the code model).

This PR disables building LLVM/MLIR tests, which we will not run, which makes the binary smaller and avoids the linker error. We could also disable it for other OS'es/architectures to make our packages smaller?