### PR TITLE
[Docs] Clarify divisibility reset logic for contiguous dimensions in AxisInfo

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -364,13 +364,11 @@ private:
                           const AxisInfo &rhs, int dim) override {
     auto lhsDivisibility = lhs.getDivisibility(dim);
     if (lhs.getContiguity(dim) > 1 && rhs.getConstantValue() != 1) {
-      // If the operand is contiguous (e.g., [base, base+1, ...]), the divisibility 
-      // of the entire sequence drops to 1, regardless of the base's divisibility.
-      // Example: Input [4, 5, 6, 7]. Base 4 is divisible by 4.
-      // If we preserve divisibility=4 and multiply by 2, we might incorrectly 
-      // infer result divisibility as 8. Real result: [8, 10, 12, 14] (GCD=2).
-      // Therefore, we explicitly reset input divisibility to 1 for contiguous dims 
-      // to prevent over-estimating the alignment of the result.
+      // If the operand is contiguous, the divisibility of the
+      // sequence drops to 1.
+      // Example: [4, 5, 6, 7] (base 4 divisible by 4).
+      // Multiplying by 2 yields [8, 10, 12, 14] (GCD=2).
+      // Preserving divisibility=4 implies result align 8 (unsafe).
       lhsDivisibility = 1;
     }
     auto rhsDivisibility = rhs.getDivisibility(dim);


### PR DESCRIPTION
## What does this PR do?
This PR improves the code documentation in `AxisInfo.cpp`, specifically within `MulIOp` visitor.

## Why is it important?
The logic `lhsDivisibility = 1` when `contiguity > 1` is a critical safety guardrail. Without explicit explanation, it looks like an arbitrary pessimization.

This change clarifies that:
1. Contiguous sequences (e.g., `range(0, N)`) inherently have a GCD of 1 across the dimension.
2. Propagating the base value's divisibility would lead to incorrect alignment assumptions in downstream passes (like `Coalesce` or `LoadStoreOp` vectorization), potentially causing illegal memory accesses or miscompiled code.

This documentation helps future contributors understand the interaction between `Contiguity` and `Divisibility` without needing to derive the number theory from scratch.