### PR TITLE
[AMD] Added missing f64.16x16x4.f64 v3 to wmma database

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -351,3 +351,27 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [1, 32], warpsPerCTA = [8, 1], order = [1, 0]}>
+#op0 = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#op1 = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+
+// CHECK{LITERAL}: #mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [0, 2], [1, 0]]}, instrShape = [16, 16, 4]}>
+// CHECK-LABEL: wmma_dot_i8_i32
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @wmma_dot_i8_i32(
+      %arg0: tensor<64x128x!tt.ptr<f64>, #op0>,
+      %arg1: tensor<128x128x!tt.ptr<f64>, #op1>,
+      %arg2: tensor<64x128x!tt.ptr<f64>, #blocked>
+      ) {
+    %a = tt.load %arg0 : tensor<64x128x!tt.ptr<f64>, #op0>
+    %b = tt.load %arg1 : tensor<128x128x!tt.ptr<f64>, #op1>
+    %c = arith.constant dense<0.000> : tensor<64x128xf64, #blocked>
+
+    %res = tt.dot %a, %b, %c : tensor<64x128xf64, #op0> * tensor<128x128xf64, #op1> -> tensor<64x128xf64, #blocked>
+    tt.store %arg2, %res : tensor<64x128x!tt.ptr<f64>, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -337,8 +337,8 @@ selectMatrixCoreOperandTypes(tt::DotOp dot,
 
 OperandTypesVector getOperandTypesForWmmaOp(PatternRewriter &rewriter,
                                             tt::DotOp dot, int version) {
-  Type f16 = rewriter.getF16Type();
   Type f32 = rewriter.getF32Type();
+  Type f16 = rewriter.getF16Type();
   Type bf16 = rewriter.getBF16Type();
   Type i8 = rewriter.getIntegerType(8);
   Type i32 = rewriter.getIntegerType(32);
@@ -362,6 +362,14 @@ OperandTypesVector getOperandTypesForWmmaOp(PatternRewriter &rewriter,
         {fp8e4nv, fp8e5, f32, f32},
         {fp8e5, fp8e4nv, f32, f32},
         {fp8e5, fp8e5, f32, f32},
+        // clang-format on
+    });
+  }
+  if (version == 3) {
+    Type f64 = rewriter.getF64Type();
+    applicableTypes.append({
+        // clang-format off
+        {f64, f64, f64, f64},
         // clang-format on
     });
   }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/WmmaGroup.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/WmmaGroup.cpp
@@ -72,6 +72,7 @@ WmmaDatabase::WmmaDatabase(MLIRContext *context) {
                       symbol2, k2, kBase2)
 
   Builder b(context);
+  auto f64T = b.getF64Type();
   auto f32T = b.getF32Type();
   auto f16T = b.getF16Type();
   auto bf16T = b.getBF16Type();
@@ -83,6 +84,10 @@ WmmaDatabase::WmmaDatabase(MLIRContext *context) {
   auto ocpBf8T = b.getType<Float8E5M2Type>();
 
   wmmaMap = {
+      // f64 inputs
+      TRITON_WMMA_v(3, 16, 16, f64T, f64T, 64, f64T,
+                    "llvm.amdgcn.wmma.f64.16x16x4.f64", 4, 1),
+
       // f32 inputs
       // wmma_f32_16x16x4_f32
       TRITON_WMMA_v(3, 16, 16, f32T, f32T, 32, f32T,


### PR DESCRIPTION
Added support for f64 case for GFX1250 arch.

Note, 

- we are skipping `llvm.amdgcn.wmma.f32.32x16x128.f4` support because there is no fp4 builtin type in Triton.
- `llvm.amdgcn.wmma.f32.16x16x128.f8f6f4` can be added to the WMMA database as well. This requires refactoring; currently it is hard-codded and bypasses the database