### PR TITLE
[Kernels] Don't flatten persistent hopper mixed precision matmul

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -74,6 +74,7 @@ def _matmul(
              UPCAST_INDICES: tl.constexpr = False,
              SWAP_XW: tl.constexpr = False,
              IS_EPILOGUE_QUANT_MXFP8: tl.constexpr = False,
+             FLATTEN_LOOPS: tl.constexpr = True, # Only relevant to persistent kernel
              pYPtrs=None,
              map_dst_coord=None,
              all_writes_issued=None,

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -103,6 +103,7 @@ def _p_matmul(
              UPCAST_INDICES: tl.constexpr=False,
              SWAP_XW: tl.constexpr = False,
              IS_EPILOGUE_QUANT_MXFP8: tl.constexpr = False,
+             FLATTEN_LOOPS: tl.constexpr = True,
              pYPtrs=None,
              map_dst_coord=None,
              all_writes_issued=None,
@@ -207,7 +208,12 @@ def _p_matmul(
 
     DISALLOW_ACC_MULTI_BUFFER: tl.constexpr = is_w_microscaled and BLOCK_M * BLOCK_N >= 128 * 256
 
-    for block_id in tl.range(tl.program_id(0), num_blocks, NUM_SMS, flatten=True, disallow_acc_multi_buffer=DISALLOW_ACC_MULTI_BUFFER, warp_specialize=True):
+    for block_id in tl.range(
+        tl.program_id(0), num_blocks, NUM_SMS,
+        flatten=FLATTEN_LOOPS,
+        disallow_acc_multi_buffer=DISALLOW_ACC_MULTI_BUFFER,
+        warp_specialize=True,
+    ):
 
         pid_z, pid_m, pid_n, pid_k = compute_pids(block_id, useful_grid_m, grid_n, num_blocks, XCD_SWIZZLE, GROUP_M, SPLIT_K)
 

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -300,7 +300,8 @@ def make_default_opt_flags_nvidia(
 
     # Occupancy target and maxnreg (for Hopper)
     occupancy_target = 1
-    if isinstance(b_mx_scale_layout, HopperMXScaleLayout):
+    is_hopper_scale = isinstance(b_mx_scale_layout, HopperMXScaleLayout)
+    if is_hopper_scale:
         occupancy_target = 16 // num_warps
     threads_per_warp = 32
     reg_per_sm = 64 * 1024
@@ -339,7 +340,11 @@ def make_default_opt_flags_nvidia(
         is_persistent=is_persistent,
         epilogue_subtile=epilogue_subtile,
         arch=arch,
-        target_kernel_kwargs=dict(maxnreg=maxnreg),
+        target_kernel_kwargs=dict(
+            maxnreg=maxnreg,
+            # For some reason, overlapping the epilogue is slower for hopper bf16 x mxfp4
+            FLATTEN_LOOPS=not is_hopper_scale,
+        ),
         idle_sms=constraints.get("idle_sms", 0),
         occupancy_target=occupancy_target,
     )


### PR DESCRIPTION
For some reason, overlapping the epilogue with the prologue of the next tile is actually slower here. Disabling it gives a 150 GBps speedup on h200, from 2650 GBps -> 2800 GBps.

My hypothesis is that because we use occupancy here, it allows the other block in the SM to better utilise the tensor cores while we process the epilogue. Similar to a ping-pong schedule but done by the warp scheduler.