### PR TITLE
[Backend] Separate out additive kReg smem padding contribution calculation

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -200,7 +200,6 @@ struct ConvertLayoutOpConversion
     SmallVector<Value> outVals;
     auto affineOffset = b.i32_val(0);
     auto maskSpanAffineOffset = 0;
-    auto noPaddingOffset = [](Value v) { return v; };
 
     bool isWarpSync = mlir::isCvtWarpSync(srcLayout, dstLayout);
     for (int i = 0; i < nReps; ++i) {
@@ -215,7 +214,7 @@ struct ConvertLayoutOpConversion
           ArrayRef<Value>(permutedInVals).slice(i * tileSize, tileSize);
       // Store
       lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
-                      noPaddingOffset, affineOffset, maskSpanAffineOffset,
+                      /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset,
                       rewriter, targetInfo);
       if (isWarpSync) {
         targetInfo.warpSync(loc, rewriter);
@@ -224,7 +223,7 @@ struct ConvertLayoutOpConversion
       }
       // Load
       SmallVector<Value> tileOutVals = lowerLdStShared(
-          loc, ctx, loadCvt, {}, llvmElemTy, smemBase, noPaddingOffset,
+          loc, ctx, loadCvt, {}, llvmElemTy, smemBase, /*paddingShifts=*/{},
           affineOffset, maskSpanAffineOffset, rewriter, targetInfo);
       llvm::append_range(outVals, tileOutVals);
     }

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -104,10 +104,10 @@ SmallVector<Value> lowerLocalScGt(Location loc, MLIRContext *ctx,
     if (paddedEnc) {
       // Convert offset to bytes for padding calculation
       Value offsetBytes = b.mul(offset, b.i32_val(bitwidth / 8));
-      Value padOffset = emitPadding(loc, rewriter, paddedEnc, bitwidth,
-                                    offsetBytes, /*offsetInBytes=*/true);
+      auto shifts = getPaddedSharedShifts(paddedEnc, bitwidth,
+                                          /*offsetInBytes=*/true);
       // GEP in bytes: base + offset*elemSize + padOffset
-      Value totalOffset = b.add(offsetBytes, padOffset);
+      Value totalOffset = applyPadding(loc, rewriter, offsetBytes, shifts);
       ptr = b.gep(smemObj.getBase().getType(), i8_ty, smemObj.getBase(),
                   totalOffset);
     } else {

--- a/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ViewOpToLLVM.cpp
@@ -546,9 +546,9 @@ struct MemDescIndexOpConversion
     // Apply padding based on the amount we move the base ptr
     if (auto padEnc = dyn_cast<PaddedSharedEncodingAttr>(dstTy.getEncoding())) {
       auto bitwidth = dstTy.getElementTypeBitWidth();
-      Value padOffset = emitPadding(loc, rewriter, padEnc, bitwidth, offset,
-                                    /*offsetInBytes=*/false);
-      offset = b.add(offset, padOffset);
+      auto paddingShifts = getPaddedSharedShifts(padEnc, bitwidth,
+                                                 /*offsetInBytes=*/false);
+      offset = applyPadding(loc, rewriter, offset, paddingShifts);
     }
 
     // Advance the pointer and keep the opOffsets as the new shape

--- a/test/Conversion/amd/ds_transpose.mlir
+++ b/test/Conversion/amd/ds_transpose.mlir
@@ -696,12 +696,13 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.thr
 
   //  CHECK-LABEL: ds_transpose_with_padding
   tt.func @ds_transpose_with_padding(%arg0: !ttg.memdesc<128x64xf16, #padding, #smem, mutable>, %arg2: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
-    // CHECK: [[ADD1:%.*]] = llvm.add [[VAL1:%.*]], [[VAL2:%.*]] : i32
-    // CHECK-NEXT: [[ASHR:%.*]] = llvm.ashr [[ADD1]], [[SHIFT_AMT1:%.*]] : i32
-    // CHECK-NEXT: [[SHL:%.*]] = llvm.shl [[ASHR]], [[SHIFT_AMT2:%.*]] : i32
-    // CHECK-NEXT: [[ADD2:%.*]] = llvm.add [[SHL]], [[VAL3:%.*]] : i32
-    // CHECK-NEXT: [[ADD3:%.*]] = llvm.add [[ADD1]], [[ADD2]] : i32
-    // CHECK-NEXT: [[GEP:%.*]] = llvm.getelementptr inbounds [[BASE:%.*]]{{\[}}[[ADD3]]] : (!llvm.ptr<3>, i32) -> !llvm.ptr<3>, i8
+    // CHECK:      [[CST0:%.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:      [[SHR:%.*]]  = llvm.lshr [[OFF:%.*]], [[SHIFT_AMT0:%.*]] : i32
+    // CHECK-NEXT: [[SHL:%.*]]  = llvm.shl [[SHR]], [[SHIFT_AMT1:%.*]] : i32
+    // CHECK-NEXT: [[ADD0:%.*]] = llvm.add [[SHL:%.*]], [[CST0:%.*]] : i32
+    // CHECK-NEXT: [[ADD1:%.*]] = llvm.add [[OFF]], [[ADD0:%.*]] : i32
+    // CHECK-NEXT: [[ADD2:%.*]] = llvm.add [[ADD1]], [[CST0]] : i32
+    // CHECK-NEXT: [[GEP:%.*]] = llvm.getelementptr inbounds [[BASE:%.*]]{{\[}}[[ADD2]]] : (!llvm.ptr<3>, i32) -> !llvm.ptr<3>, i8
     // CHECK-NEXT: [[RESULT:%.*]] = rocdl.ds.read.tr16.b64 [[GEP]] : <3> -> vector<4xf16>
     // CHECK-COUNT-15: rocdl.ds.read.tr16.b64 %{{.*}} : <3> -> vector<4xf16>
     // CHECK-NOT: rocdl.ds.read.tr16.b64

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -432,14 +432,15 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
     // CHECK-DAG: %[[CST8:.+]] = llvm.mlir.constant(8 : i32)
     // CHECK-DAG: %[[CST9:.+]] = llvm.mlir.constant(9 : i32)
 
-    //      CHECK: %[[SHR0:.+]] = llvm.ashr %[[ADD:.+]], %[[CST8]] : i32
+    //      CHECK: %[[SHR0:.+]] = llvm.lshr %[[ADD:.+]], %[[CST8]] : i32
     // CHECK-NEXT: %[[SHL0:.+]] = llvm.shl %[[SHR0]], %[[CST3]] : i32
     // CHECK-NEXT: %[[ADD0:.+]] = llvm.add %[[SHL0]], %[[CST0]] : i32
-    // CHECK-NEXT: %[[SHR1:.+]] = llvm.ashr %[[ADD]], %[[CST9]] : i32
+    // CHECK-NEXT: %[[SHR1:.+]] = llvm.lshr %[[ADD]], %[[CST9]] : i32
     // CHECK-NEXT: %[[SHL1:.+]] = llvm.shl %[[SHR1]], %[[CST4]] : i32
     // CHECK-NEXT: %[[ADD1:.+]] = llvm.add %[[ADD0]], %[[SHL1]] : i32
     // CHECK-NEXT: %[[ADD2:.+]] = llvm.add %[[ADD]], %[[ADD1]] : i32
-    // CHECK: llvm.getelementptr inbounds %{{.+}}[%[[ADD2]]]
+    // CHECK-NEXT: %[[ADD3:.+]] = llvm.add %[[ADD2]], %[[CST0]] : i32
+    // CHECK: llvm.getelementptr inbounds %{{.+}}[%[[ADD3]]]
 
     // CHECK-COUNT-16: llvm.store {{.*}} : vector<1xf16>, !llvm.ptr<3>
     %0 = ttg.local_alloc %arg0 : (tensor<64x64xf16, #blocked>) -> !ttg.memdesc<64x64xf16, #shared, #smem, mutable>
@@ -484,7 +485,7 @@ module attributes {"ttg.target" = "hip:gfx942", "ttg.num-ctas" = 1 : i32, "ttg.n
     // GFX950-DAG: %[[CST7:.+]] = llvm.mlir.constant(7 : i32)
     // GFX950-DAG: %[[CST2:.+]] = llvm.mlir.constant(2 : i32)
 
-    // GFX950: %[[SHR0:.+]] = llvm.ashr %[[ADD:.+]], %[[CST7]] : i32
+    // GFX950-DAG: %[[SHR0:.+]] = llvm.lshr %[[ADD:.+]], %[[CST7]] : i32
     // GFX950-NEXT: %[[SHL0:.+]] = llvm.shl %[[SHR0]], %[[CST2]] : i32
     // GFX950-NEXT: %[[ADD1:.+]] = llvm.add %[[CST0]], %[[SHL0]] : i32
     // GFX950-NEXT: %[[ADD2:.+]] = llvm.add %[[ADD]], %[[ADD1]] : i32

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -66,22 +66,14 @@ public:
     auto smemBase = smemObj.getBase();
     auto affineOffset = smemObj.getShmemOffset(loc, rewriter, srcTy);
     auto maskSpanAffineOffset = smemObj.getMaskSpanOffsets(srcTy);
-    auto calcPaddedOffset = [&](Value smemOffset) {
-      TritonLLVMOpBuilder b(loc, rewriter);
-      if (paddedEnc) {
-        // Apply the offset needed for padding.
-        Value padOffset = emitPadding(loc, rewriter, paddedEnc, bitWidth,
-                                      smemOffset, /*offsetInBytes=*/true);
-        smemOffset = b.add(smemOffset, padOffset);
-      }
-      return smemOffset;
-    };
+    auto paddingShifts = getPaddedSharedShifts(srcTy.getEncoding(),
+                                               srcTy.getElementTypeBitWidth(),
+                                               /*offsetInBytes=*/true);
 
     llvm::SmallVector<Value> values;
-    auto result =
-        lowerDsReadTr(op, ldsParams.value(), loc, cvtDstLL, values, smemBase,
-                      affineOffset, maskSpanAffineOffset, calcPaddedOffset,
-                      llvmElemTy, rewriter, targetInfo);
+    auto result = lowerDsReadTr(
+        op, ldsParams.value(), loc, cvtDstLL, values, smemBase, affineOffset,
+        maskSpanAffineOffset, paddingShifts, llvmElemTy, rewriter, targetInfo);
     if (failed(result)) {
       return failure();
     }
@@ -101,7 +93,7 @@ private:
       LinearLayout cvt,
       SmallVector<Value> &vals, // Input for stmatrix, output for ldmatrix
       Value smemBase, Value affineOffset, uint64_t maskSpanAffineOffset,
-      std::function<Value(Value)> calcPaddedOffset, Type llvmElemTy,
+      ArrayRef<std::pair<unsigned, unsigned>> paddingShifts, Type llvmElemTy,
       ConversionPatternRewriter &rewriter,
       const ::triton::AMD::TargetInfo &targetInfo) const {
 
@@ -293,15 +285,19 @@ private:
       auto regIdx = reps.apply({{kReg, i}, {kLane, 0}, {kWarp, 0}})[0].second;
       auto regIdxI8 = regIdx * (bitWidth / 8);
       Value offset = b.xor_(regBase, b.i32_val(regIdxI8));
+      offset = applyPadding(loc, rewriter, offset, paddingShifts);
       for (int i2 = 0; i2 < nAdditive; i2 += elemsPerInstr) {
         // all these constants will go as immediate values to ds_read_tr
         auto regIdxAdd =
             reps.apply({{kReg, i2}, {kLane, 0}, {kWarp, 0}})[0].second;
         auto regIdxAddI8 = regIdxAdd * (bitWidth / 8);
+        // `actionAdditiveStrides` forces `regIdxAddI8` and `offset` to be
+        // bitwise disjoint, so we can calculate their padding contributions
+        // separately.
+        regIdxAddI8 = applyPadding(regIdxAddI8, paddingShifts);
         Value innerOffset = b.add(offset, b.i32_val(regIdxAddI8));
-        auto vecAddr =
-            b.gep(smemPtrTy, i8_ty, smemBase, calcPaddedOffset(innerOffset),
-                  LLVM::GEPNoWrapFlags::inbounds);
+        auto vecAddr = b.gep(smemPtrTy, i8_ty, smemBase, innerOffset,
+                             LLVM::GEPNoWrapFlags::inbounds);
         llvm::append_range(vals,
                            lowerInst(rewriter, loc, vecAddr, i + i2, vecTy));
       }
@@ -375,18 +371,8 @@ private:
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
     auto affineOffset = smemObj.getShmemOffset(loc, rewriter, srcTy);
     auto maskSpanAffineOffset = smemObj.getMaskSpanOffsets(srcTy);
-    auto calcPaddedOffset = [&](Value smemOffset) {
-      TritonLLVMOpBuilder b(loc, rewriter);
-      auto bitWidth = llvmElemTy.getIntOrFloatBitWidth();
-      if (auto paddedLayout = dyn_cast<triton::gpu::PaddedSharedEncodingAttr>(
-              srcTy.getEncoding())) {
-        // Apply the offset needed for padding.
-        Value padOffset = emitPadding(loc, rewriter, paddedLayout, bitWidth,
-                                      smemOffset, /*offsetInBytes=*/true);
-        smemOffset = b.add(smemOffset, padOffset);
-      }
-      return smemOffset;
-    };
+    auto paddingShifts = getPaddedSharedShifts(srcTy.getEncoding(), bitWidth,
+                                               /*offsetInBytes=*/true);
 
     auto shape = srcTy.getShape();
     auto ldsTransLoadParams = targetInfo.queryLDSTransLoadParams(bitWidth);
@@ -447,7 +433,7 @@ private:
 
     SmallVector<Value> outVals = lowerLdSt(
         loc, rewriter.getContext(), cvt, {}, // Input for store, output for load
-        llvmElemTy, smemObj.getBase(), calcPaddedOffset, affineOffset,
+        llvmElemTy, smemObj.getBase(), paddingShifts, affineOffset,
         maskSpanAffineOffset, laneId, warpId, rewriter, targetInfo,
         ldsTransLoadParams->tileSize, lowerInst);
     Value result = packLLElements(loc, typeConverter, outVals, rewriter, retTy);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -171,7 +171,6 @@ struct ConvertLayoutOpSwizzlingConversion
     SmallVector<Value> outVals;
     auto affineOffset = b.i32_val(0);
     auto maskSpanAffineOffset = 0;
-    auto noPaddingOffset = [](Value v) { return v; };
     bool isWarpSync = mlir::isCvtWarpSync(srcLayout, dstLayout);
     for (int i = 0; i < nReps; ++i) {
       if (i > 0) {
@@ -188,8 +187,8 @@ struct ConvertLayoutOpSwizzlingConversion
       // idxSrc 0: st.shared, idxSrc 1: stmatrix, idxSrc 2: stmatrix.trans
       if (idxSrc == 0) {
         lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
-                        noPaddingOffset, affineOffset, maskSpanAffineOffset,
-                        rewriter, targetInfo);
+                        /*paddingShifts=*/{}, affineOffset,
+                        maskSpanAffineOffset, rewriter, targetInfo);
       } else {
         assert(idxSrc == 1 || idxSrc == 2);
         bool transpose = idxSrc == 2;
@@ -208,7 +207,7 @@ struct ConvertLayoutOpSwizzlingConversion
       // idxDst 0: ld.shared, idxDst 1: ldmatrix, idxDst 2: ldmatrix.trans
       if (idxDst == 0) {
         tileOutVals = lowerLdStShared(
-            loc, ctx, loadCvt, {}, llvmElemTy, smemBase, noPaddingOffset,
+            loc, ctx, loadCvt, {}, llvmElemTy, smemBase, /*paddingShifts=*/{},
             affineOffset, maskSpanAffineOffset, rewriter, targetInfo);
       } else {
         assert(idxDst == 1 || idxDst == 2);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1248,10 +1248,9 @@ struct AsyncCopyGlobalToLocalOpConversion
     auto affineOffset = smemObj.getShmemOffset(loc, rewriter, dstTy);
     auto maskSpanAffineOffset = SharedMemoryObject::getMaskSpanOffsets(dstTy);
     auto [laneId, warpId] = getLaneAndWarpId(rewriter, loc);
-    lowerLdSt(
-        loc, ctx, cvt, vals, resElemTy, smemObj.getBase(),
-        [](Value v) { return v; }, affineOffset, maskSpanAffineOffset, laneId,
-        warpId, rewriter, targetInfo, maxVec, emitCpAsync);
+    lowerLdSt(loc, ctx, cvt, vals, resElemTy, smemObj.getBase(),
+              /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset, laneId,
+              warpId, rewriter, targetInfo, maxVec, emitCpAsync);
 
     // Drop the result token.
     Value zero = LLVM::ConstantOp::create(rewriter, op.getLoc(),


### PR DESCRIPTION
LLVM was struggling to use immediate values in the padded offset calculation. This change makes things easier for LLVM, and we get a nice reduction in register usage. For non-padded pathways, there should be no difference in the LLVM IR generated. 