### PR TITLE
Add is_maia() helper function in _internal_testing

### DIFF
--- a/python/triton/_internal_testing.py
+++ b/python/triton/_internal_testing.py
@@ -110,6 +110,17 @@ def is_xpu():
     return False if target is None else target.backend == "xpu"
 
 
+def is_maia(generation=None):
+    target = get_current_target()
+    if target is None:
+        return False
+    if target.backend != "maia":
+        return False
+    if generation is not None and generation != target.arch:
+        return False
+    return True
+
+
 def get_arch():
     target = get_current_target()
     return "" if target is None else str(target.arch)


### PR DESCRIPTION
Add a helper is_maia() function to _internal_testing on the same model as other platform is_X() functions. It returns true if the current accelerator used is [Microsoft Maia](https://azure.microsoft.com/en-us/blog/azure-maia-for-the-era-of-ai-from-silicon-to-software-to-systems).

This allows us to adapt the behavior of some Triton tests without relying on a custom fork of Triton.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it only adds a trivial internal function in tests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
