### PR TITLE
[BACKEND][AMD] Use addOccurrence for LLVM options to properly disable…

### DIFF
--- a/python/test/backend/test_mir_stage.py
+++ b/python/test/backend/test_mir_stage.py
@@ -152,3 +152,145 @@ def test_mir_swap_pipeline(tmp_path, monkeypatch):
     copy_kernel[grid](x, output2, size, BLOCK_SIZE=128)
 
     torch.testing.assert_close(output2, x)
+
+
+def test_mir_swap_pipeline_passes(tmp_path):
+    """Test that MIR swap pipeline starts before machine-scheduler and disables schedulers."""
+    import re
+    import os
+    import subprocess
+
+    # Write test script to a file (required for @triton.jit to get source)
+    test_script = '''
+import triton
+import triton.language as tl
+import torch
+
+@triton.jit
+def simple_kernel(x_ptr, output_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(output_ptr + offsets, x, mask=mask)
+
+size = 128
+x = torch.randn(size, device='cuda')
+output = torch.empty_like(x)
+grid = lambda meta: (triton.cdiv(size, meta['BLOCK_SIZE']), )
+simple_kernel[grid](x, output, size, BLOCK_SIZE=128)
+'''
+
+    script_file = tmp_path / "test_kernel.py"
+    script_file.write_text(test_script)
+
+    # Phase 1: Dump MIR
+    env = os.environ.copy()
+    env["TRITON_DUMP_MIR"] = str(tmp_path)
+    env["TRITON_ALWAYS_COMPILE"] = "1"
+
+    result = subprocess.run(["python", str(script_file)], capture_output=True, text=True, env=env, timeout=120)
+
+    assert result.returncode == 0, \
+        f"Dump phase should succeed. stderr: {result.stderr[:1000]}"
+
+    # Verify MIR file was created
+    mir_files = list(tmp_path.glob("simple_kernel_*.txt"))
+    assert len(mir_files) == 1, "Exactly one MIR file should have been dumped"
+
+    # Strip scheduling DAG and trailing "..." from MIR file (they break YAML parsing)
+    mir_file = mir_files[0]
+    mir_content = mir_file.read_text()
+    dag_marker = "\n---\n=========="
+    if dag_marker in mir_content:
+        mir_content = mir_content.split(dag_marker)[0]
+    # Remove trailing "..." which LLVM MIR parser doesn't accept
+    if mir_content.rstrip().endswith("..."):
+        mir_content = mir_content.rstrip()[:-3]
+    mir_file.write_text(mir_content)
+
+    # Phase 2: Swap MIR with LLVM_IR_ENABLE_DUMP to capture pass sequence
+    env = os.environ.copy()
+    env["TRITON_SWAP_MIR"] = str(tmp_path)
+    env["TRITON_ALWAYS_COMPILE"] = "1"
+    env["LLVM_IR_ENABLE_DUMP"] = "1"
+
+    result = subprocess.run(["python", str(script_file)], capture_output=True, text=True, env=env, timeout=120)
+
+    assert result.returncode == 0, \
+        f"Swap phase should succeed. stderr: {result.stderr[:1000]}"
+
+    all_output = result.stderr
+
+    # Find the first "# Machine code for function" line and check the preceding IR Dump
+    lines = all_output.split('\n')
+    machine_code_indices = [i for i, line in enumerate(lines) if "# Machine code for function" in line]
+    assert len(machine_code_indices) > 0, \
+        f"Should find '# Machine code for function' in output. Stderr length: {len(all_output)}"
+
+    first_machine_code_idx = machine_code_indices[0]
+
+    # Find the immediately preceding "IR Dump After" line
+    ir_dump_pattern = r"# \*\*\* IR Dump After (.+) \*\*\*"
+    preceding_ir_dump = None
+    for i in range(first_machine_code_idx - 1, -1, -1):
+        match = re.search(ir_dump_pattern, lines[i])
+        if match:
+            preceding_ir_dump = match.group(1).strip()
+            break
+
+    assert preceding_ir_dump is not None, \
+        f"Should find 'IR Dump After' before first Machine code. Lines before: {lines[max(0, first_machine_code_idx-10):first_machine_code_idx]}"
+
+    assert "slotindexes" in preceding_ir_dump.lower() or "slot index" in preceding_ir_dump.lower(), \
+        f"First MIR pass should be slotindexes, got: '{preceding_ir_dump}'"
+
+    # Verify machine-scheduler pass does NOT modify MIR (disabled via enable-misched=false).
+    # The scheduler passes still appear in the pipeline output but return early without
+    # making changes when enable-misched=false is set. This is the expected LLVM behavior -
+    # we verify the MIR is unchanged rather than checking for pass absence.
+    dumps = re.split(r'# \*\*\* IR Dump After ([^*]+) \*\*\*', all_output)
+
+    machine_sched_idx = None
+    for i, part in enumerate(dumps):
+        if 'Machine Instruction Scheduler' in part and 'PostRA' not in part:
+            machine_sched_idx = i
+            break
+
+    if machine_sched_idx and machine_sched_idx >= 1 and machine_sched_idx + 1 < len(dumps):
+        before_content = dumps[machine_sched_idx - 1]
+        after_content = dumps[machine_sched_idx + 1]
+
+        # Extract machine code sections
+        def extract_machine_code(text):
+            match = re.search(r'# Machine code for function.*', text, re.DOTALL)
+            return match.group(0).strip() if match else text.strip()
+
+        before_mc = extract_machine_code(before_content)
+        after_mc = extract_machine_code(after_content)
+
+        assert before_mc == after_mc, \
+            "machine-scheduler should not modify MIR when disabled, but MIR changed"
+
+    # Verify post-RA machine scheduler does NOT modify MIR (disabled via enable-post-misched=false).
+    # Same as above - the pass appears but returns early without changes.
+    post_ra_idx = None
+    for i, part in enumerate(dumps):
+        if 'PostRA Machine Instruction Scheduler' in part:
+            post_ra_idx = i
+            break
+
+    if post_ra_idx and post_ra_idx >= 1 and post_ra_idx + 1 < len(dumps):
+        before_content = dumps[post_ra_idx - 1]
+        after_content = dumps[post_ra_idx + 1]
+
+        def extract_machine_code(text):
+            match = re.search(r'# Machine code for function.*', text, re.DOTALL)
+            return match.group(0).strip() if match else text.strip()
+
+        before_mc = extract_machine_code(before_content)
+        after_mc = extract_machine_code(after_content)
+
+        assert before_mc == after_mc, \
+            "post-RA scheduler should not modify MIR when disabled, but MIR changed"


### PR DESCRIPTION
… schedulers

Use addOccurrence instead of setValue when setting LLVM command-line options like enable-misched=false. This is necessary because LLVM's scheduler passes check getNumOccurrences() to determine if the option was explicitly set on the command line (see llvm/lib/CodeGen/MachineScheduler.cpp).

Also add test to verify the MIR swap pipeline starts before machine-scheduler and that both machine-scheduler and post-RA scheduler are disabled.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
