### PR TITLE
[Membar] Membar pass for clusters

### DIFF
--- a/include/triton/Analysis/Allocation.h
+++ b/include/triton/Analysis/Allocation.h
@@ -5,7 +5,6 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <limits>
 
@@ -143,6 +142,11 @@ public:
   /// Returns if the given buffer is a virtual buffer.
   bool isVirtualBuffer(BufferId bufferId) const {
     return bufferSet.at(bufferId).kind == BufferT::BufferKind::Virtual;
+  }
+
+  /// Returns if the given buffer is an explicit buffer.
+  bool isExplicitBuffer(BufferId bufferId) const {
+    return bufferSet.at(bufferId).kind == BufferT::BufferKind::Explicit;
   }
 
   /// Returns the size of total shared memory allocated

--- a/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h
+++ b/include/triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h
@@ -1,0 +1,19 @@
+#ifndef TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERINSERTION_H_
+#define TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERINSERTION_H_
+
+#include "triton/Analysis/Allocation.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+/// Inserts cluster barriers (cluster_arrive + cluster_wait) using the provided
+/// shared-memory allocation analysis.
+void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
+                                int computeCapability);
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir
+
+#endif // TRITON_DIALECT_TRITONNVIDIAGPU_TRANSFORMS_CLUSTERBARRIERINSERTION_H_

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -10,8 +10,9 @@
 namespace mlir {
 
 AllocationSlice::AllocationSlice(Value value,
-                                 Interval<size_t> allocationInterval)
-    : allocationInterval(allocationInterval) {
+                                 Interval<size_t> allocationInterval,
+                                 Allocation::BufferId bufferId)
+    : allocationInterval(allocationInterval), bufferId(bufferId) {
   auto accessTy = cast<triton::gpu::MemDescType>(value.getType());
   this->accessTy = accessTy;
 
@@ -68,6 +69,9 @@ bool AllocationSlice::intersects(const AllocationSlice &other) const {
 void AllocationSlice::print(raw_ostream &os) const {
   os << "interval=[" << allocationInterval.start() << ","
      << allocationInterval.end() << ")";
+
+  if (bufferId != Allocation::InvalidBufferId)
+    os << " buffer=" << bufferId;
 
   os << " offsets=[";
   if (!subsliceOffsets.empty()) {
@@ -244,6 +248,8 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
   auto containsLocalBarrier = [](Operation *op) {
     if (isa<gpu::BarrierOp>(op))
       return true;
+    if (isa<triton::nvidia_gpu::ClusterWaitOp>(op))
+      return true;
     if (isa<triton::gpu::WarpSpecializePartitionsOp>(op))
       return true;
     if (auto barrier = dyn_cast<triton::gpu::BarrierOp>(op))
@@ -287,7 +293,7 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
           for (auto bufferId : allocation->getAllBufferIdsWithAliases(value)) {
             if (bufferId != Allocation::InvalidBufferId) {
               auto interval = allocation->getAllocatedInterval(bufferId);
-              auto slice = AllocationSlice(value, interval);
+              auto slice = AllocationSlice(value, interval, bufferId);
 
               if (isa<MemoryEffects::Write>(effectInstance.getEffect()))
                 curBlockInfo.syncWriteSlices[slice].insert(op);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_triton_library(TritonNvidiaGPUTransforms
+  ClusterBarrierInsertion.cpp
   CheckMatmulTwoCTAs.cpp
   FenceInsertion.cpp
   InterleaveTMem.cpp

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -1,0 +1,188 @@
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
+#include "triton/Analysis/Allocation.h"
+#include "triton/Analysis/Membar.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/ErrorHandling.h"
+
+namespace mlir {
+namespace triton {
+namespace nvidia_gpu {
+
+namespace {
+
+namespace ttg = mlir::triton::gpu;
+namespace ttng = mlir::triton::nvidia_gpu;
+
+static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
+  if (auto cvt = dyn_cast<ttg::ConvertLayoutOp>(op)) {
+    if (!isRead)
+      return false;
+    auto srcTy = cvt.getSrc().getType();
+    auto dstTy = cvt.getType();
+    auto kBlock = StringAttr::get(op->getContext(), "block");
+    auto conversion = minimalCvtLayout(srcTy, dstTy);
+    return conversion.hasInDim(kBlock);
+  }
+  if (auto reduce = dyn_cast<triton::ReduceOp>(op)) {
+    if (!isRead)
+      return false;
+    auto srcTy = reduce.getInputTypes()[0];
+    auto splitNum = ttg::getCTASplitNum(srcTy.getEncoding());
+    return splitNum[reduce.getAxis()] > 1;
+  }
+  if (auto mma = dyn_cast<ttng::TCGen5MMAOp>(op)) {
+    return mma.getTwoCtas();
+  } else if (auto mmaScaled = dyn_cast<ttng::TCGen5MMAScaledOp>(op)) {
+    // TODO: Change when we support scaled MMA with 2CTAs
+    assert(!ttng::getModuleTwoCTAs(op->getParentOfType<ModuleOp>()) &&
+           "Scaled MMA with 2CTAs not supported");
+    return false;
+  } else if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
+    return tma.getMulticast();
+  }
+  return false;
+}
+
+static bool isPreAllocAliasSliceFilter(const AllocationSlice &lhsSlice,
+                                       const AllocationSlice &rhsSlice,
+                                       bool /*lhsIsRead*/, bool /*rhsIsRead*/,
+                                       Allocation *allocation) {
+  auto bufferId = lhsSlice.getBufferId();
+  return bufferId != Allocation::InvalidBufferId &&
+         bufferId == rhsSlice.getBufferId() &&
+         allocation->isExplicitBuffer(bufferId);
+}
+
+class ClusterBarrierAnalysis : public MembarOrFenceAnalysis {
+public:
+  ClusterBarrierAnalysis() = default;
+  explicit ClusterBarrierAnalysis(Allocation *allocation, MembarFilterFn filter)
+      : MembarOrFenceAnalysis(allocation, filter) {}
+
+private:
+  void update(Operation *op, BlockInfo *blockInfo,
+              FuncBlockInfoMapT *funcBlockInfoMap, OpBuilder *builder) override;
+
+  void insertClusterBarrier(Operation *op, OpBuilder *builder);
+};
+
+void ClusterBarrierAnalysis::insertClusterBarrier(Operation *op,
+                                                  OpBuilder *builder) {
+  OpBuilder::InsertionGuard guard(*builder);
+  ttng::ClusterArriveOp::create(*builder, op->getLoc(), /*relaxed=*/false);
+  ttng::ClusterWaitOp::create(*builder, op->getLoc());
+}
+
+void ClusterBarrierAnalysis::update(Operation *op, BlockInfo *blockInfo,
+                                    FuncBlockInfoMapT *funcBlockInfoMap,
+                                    OpBuilder *builder) {
+  if (isa<ttng::ClusterWaitOp>(op)) {
+    blockInfo->sync();
+    return;
+  }
+
+  BlockInfo curBlockInfo;
+  auto scratchBufferId = Allocation::InvalidBufferId;
+  if (isa<triton::CallOp>(op)) {
+    auto callOpInterface = dyn_cast<CallOpInterface>(op);
+    if (auto callee =
+            dyn_cast<FunctionOpInterface>(callOpInterface.resolveCallable()))
+      curBlockInfo = funcBlockInfoMap->lookup(callee);
+  } else {
+    if (auto memEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
+      SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>>
+          effectInstances;
+      memEffects.getEffects(effectInstances);
+      for (auto effectInstance : effectInstances) {
+        if (auto value = effectInstance.getValue()) {
+          for (auto bufferId : allocation->getBufferIds(value)) {
+            if (bufferId != Allocation::InvalidBufferId) {
+              auto interval = allocation->getAllocatedInterval(bufferId);
+              auto slice = AllocationSlice(value, interval, bufferId);
+              if (isa<MemoryEffects::Write>(effectInstance.getEffect()))
+                curBlockInfo.syncWriteSlices[slice].insert(op);
+              else if (isa<MemoryEffects::Read>(effectInstance.getEffect()))
+                curBlockInfo.syncReadSlices[slice].insert(op);
+            }
+          }
+        }
+      }
+    }
+    scratchBufferId = allocation->getBufferId(op);
+  }
+
+  // Scratch buffer operations consist of a series of shared memory operations
+  // starting from a shared memory write, followed by a series of shared memory
+  // read/write operations, and ending with a shared memory read, i.e., shared
+  // memory write -> ... -> shared memory read.
+  if (scratchBufferId != Allocation::InvalidBufferId) {
+    if (!curBlockInfo.syncReadSlices.empty() ||
+        !curBlockInfo.syncWriteSlices.empty()) {
+      llvm::report_fatal_error(
+          "scratch buffer operations should not have any shared memory "
+          "dependencies");
+    }
+
+    auto interval = allocation->getAllocatedInterval(scratchBufferId);
+    auto scratchSlice = AllocationSlice(interval);
+    curBlockInfo.syncWriteSlices[scratchSlice].insert(op);
+
+    auto insertClusterBarrierNeeded = blockInfo->isIntersected(
+        curBlockInfo, filter, allocation, isPreAllocAliasSliceFilter);
+    if (insertClusterBarrierNeeded) {
+      builder->setInsertionPoint(op);
+      insertClusterBarrier(op, builder);
+    }
+
+    // Clear prior distributed dependencies if we have inserted a cluster
+    // barrier, or if the scratch op itself performs a cluster-level sync.
+    bool hasClusterSync = isDistributedMultiCTAOp(op, /*isRead=*/true);
+    if (insertClusterBarrierNeeded || hasClusterSync)
+      blockInfo->sync();
+
+    curBlockInfo.syncReadSlices[scratchSlice].insert(op);
+  } else if (blockInfo->isIntersected(curBlockInfo, filter, allocation,
+                                      isPreAllocAliasSliceFilter)) {
+    builder->setInsertionPoint(op);
+    insertClusterBarrier(op, builder);
+    blockInfo->sync();
+  }
+
+  blockInfo->join(curBlockInfo);
+}
+
+} // namespace
+
+void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
+                                int computeCapability) {
+  ModuleOp mod = moduleAllocation.getModuleOp();
+  if (computeCapability < 90)
+    return;
+  if (ttg::TritonGPUDialect::getNumCTAs(mod) == 1)
+    return;
+
+  MembarFilterFn filterFn = [](Operation *lhs, Operation *rhs, bool lhsIsRead,
+                               bool rhsIsRead, Allocation * /*allocation*/) {
+    // Filter ops that do not touch distributed shared memory. Whether the
+    // aliasing was already present in TTGIR is handled per-allocation slice.
+    bool lhsDist = isDistributedMultiCTAOp(lhs, lhsIsRead);
+    bool rhsDist = isDistributedMultiCTAOp(rhs, rhsIsRead);
+    if (!lhsDist && !rhsDist)
+      return true;
+    return false;
+  };
+
+  ModuleMembarOrFenceAnalysis<ClusterBarrierAnalysis> analysis(
+      &moduleAllocation, filterFn);
+  analysis.run();
+}
+
+} // namespace nvidia_gpu
+} // namespace triton
+} // namespace mlir

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -1,6 +1,5 @@
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
-#include "triton/Analysis/Utility.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/Passes.h"
@@ -65,7 +64,8 @@ bool ignoreOpForProxyFence(Operation *op) {
              triton::nvidia_gpu::InvalBarrierOp>(op);
 }
 
-bool filterFn(Operation *op, Operation *other, Allocation *allocation) {
+bool filterFn(Operation *op, Operation *other, bool /*opIsRead*/,
+              bool /*otherIsRead*/, Allocation *allocation) {
   return ignoreOpForProxyFence(other);
 }
 
@@ -126,7 +126,7 @@ void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
               // FenceInsertionPass where it can generate better placement for
               // the fence. But we should support a safe fallback here.
               auto interval = allocation->getAllocatedInterval(bufferId);
-              auto slice = AllocationSlice(value, interval);
+              auto slice = AllocationSlice(value, interval, bufferId);
 
               if (isAsyncProxyWrite(op)) {
                 if (value == getSmemDest(op)) {

--- a/test/TritonNvidiaGPU/membar-cluster.mlir
+++ b/test/TritonNvidiaGPU/membar-cluster.mlir
@@ -1,0 +1,567 @@
+// RUN: triton-opt %s -split-input-file --triton-nvidia-tma-lowering --allocate-shared-memory -test-print-membar | FileCheck --dump-input=fail --dump-input-context=30 %s
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedSplitN = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @convert_layout_cluster_barrier
+  // CHECK: ttg.convert_layout
+  // CHECK-NEXT: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttg.local_alloc
+  tt.func @convert_layout_cluster_barrier() -> tensor<256x128xf16, #blockedSplitM> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSplitM> -> tensor<256x128xf16, #blockedSplitN>
+    %buf = ttg.local_alloc %cvt : (tensor<256x128xf16, #blockedSplitN>) -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    ttg.local_store %cvt, %buf : tensor<256x128xf16, #blockedSplitN> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blockedSplitM>
+    tt.return %ld : tensor<256x128xf16, #blockedSplitM>
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[0, 1]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blocked}>
+#slice1 = #ttg.slice<{dim = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // First reduction does not cross CTAs; second one does.
+  // There should be no cluster barrier between them as tt.reduce always syncs internally before touching distributed shared memory.
+  // but there should be a cluster barrier after the reduction that touches distributed shared memory
+  // CHECK-LABEL: @reduce_nocross_then_cross
+  // CHECK: "tt.reduce"{{.*}}axis = 0
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: ttg.barrier local
+  // CHECK: "tt.reduce"{{.*}}axis = 1
+  // CHECK: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: "tt.reduce"{{.*}}axis = 0
+  tt.func @reduce_nocross_then_cross(%t1: tensor<256x128xf16, #blocked>, %t2: tensor<256x128xf16, #blocked>) -> (tensor<128xf16, #slice0>, tensor<256xf16, #slice1>, tensor<128xf16, #slice0>) {
+    %red_nc = "tt.reduce"(%t1) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blocked>) -> tensor<128xf16, #slice0>
+
+    %red_c = "tt.reduce"(%t1) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 1 : i32} : (tensor<256x128xf16, #blocked>) -> tensor<256xf16, #slice1>
+
+    %red_nc2 = "tt.reduce"(%t2) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blocked>) -> tensor<128xf16, #slice0>
+
+    tt.return %red_nc, %red_c, %red_nc2 : tensor<128xf16, #slice0>, tensor<256xf16, #slice1>, tensor<128xf16, #slice0>
+  }
+}
+
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#shared1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: @reduce_cluster_barrier
+  // CHECK: "tt.reduce"
+  // CHECK: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttg.local_alloc
+  tt.func @reduce_cluster_barrier() -> tensor<128xf16, #slice0> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %red = "tt.reduce"(%cst) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<128xf16, #slice0>
+    %buf = ttg.local_alloc %red : (tensor<128xf16, #slice0>) -> !ttg.memdesc<128xf16, #shared1d, #smem, mutable>
+    ttg.local_store %red, %buf : tensor<128xf16, #slice0> -> !ttg.memdesc<128xf16, #shared1d, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<128xf16, #shared1d, #smem, mutable> -> tensor<128xf16, #slice0>
+    tt.return %ld : tensor<128xf16, #slice0>
+  }
+}
+
+// -----
+
+#sharedA = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#sharedB = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[0, 1]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 2], order = [0, 1], CGALayout = [[1, 0]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 128, colStride = 1, CTASplitM = 2, twoCTAs = true>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // TODO: Improve the heuristics so that we don't emit a cluster_arrive/wait when num-ctas == 2!
+  // A wait with explicit deps proves the inputs are no longer in use whenever num-ctas == 2 but
+  // we currently emit a cluster barrier
+  // CHECK-LABEL: @mma_v5_two_ctas_wait_barrier_no_cluster
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: ttng.wait_barrier
+  // CHECK: ttng.cluster_arrive
+  // CHECK: ttng.cluster_wait
+  // CHECK: ttg.local_store
+  // CHECK: tt.return
+  tt.func @mma_v5_two_ctas_wait_barrier_no_cluster() -> tensor<256x32xf16, #blocked> {
+    %a = ttg.local_alloc : () -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x32xf16, #blocked>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    ttng.tc_gen5_mma %a, %b, %acc, %true, %true, %barrier[%true] {is_async, two_ctas} :
+       !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>,
+       !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>,
+       !ttg.memdesc<256x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %a, %b :
+      !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>,
+      !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>
+    ttg.local_dealloc %a : !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    ttg.local_dealloc %b : !ttg.memdesc<32x128xf16, #sharedB, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    ttg.local_store %cst, %buf : tensor<256x32xf16, #blocked> -> !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256x32xf16, #sharedA, #smem, mutable> -> tensor<256x32xf16, #blocked>
+    tt.return %ld : tensor<256x32xf16, #blocked>
+  }
+}
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#slice0 = #ttg.slice<{dim = 0, parent = #blockedSplitM}>
+#shared1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // We make sure we generate cluster barriers when we touch distributed shared memory in a loop.
+  // TODO: A better codegen would be:
+  // for {
+  //   reduce
+  //   cluster_arrive
+  //   cluster_wait
+  // }
+  // local_alloc
+  // but not even the membar allocation pass generates this pattern
+  // An even better codegen would be the above + predicate on the last iteration
+  // and come out of the for loop analysis with a read dependency on the last reduce
+
+  // CHECK-LABEL: @scf_for_reduce_cluster_barrier
+  // CHECK: scf.for
+  // CHECK: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: tt.reduce
+  // CHECK: scf.yield
+  // CHECK: ttng.cluster_arrive
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttg.local_alloc
+  tt.func @scf_for_reduce_cluster_barrier() -> tensor<128xf16, #slice0> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %c0 = arith.constant 0 : index
+    %c4 = arith.constant 4 : index
+    %c1 = arith.constant 1 : index
+    %init = arith.constant dense<0.000000e+00> : tensor<128xf16, #slice0>
+    %loop_res = scf.for %i = %c0 to %c4 step %c1 iter_args(%acc = %init) -> (tensor<128xf16, #slice0>) {
+      %red = "tt.reduce"(%cst) ({
+      ^bb0(%lhs: f16, %rhs: f16):
+        %add = arith.addf %lhs, %rhs : f16
+        tt.reduce.return %add : f16
+      }) {axis = 0 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<128xf16, #slice0>
+      scf.yield %red : tensor<128xf16, #slice0>
+    }
+    %buf = ttg.local_alloc %loop_res : (tensor<128xf16, #slice0>) -> !ttg.memdesc<128xf16, #shared1d, #smem, mutable>
+    ttg.local_store %loop_res, %buf : tensor<128xf16, #slice0> -> !ttg.memdesc<128xf16, #shared1d, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<128xf16, #shared1d, #smem, mutable> -> tensor<128xf16, #slice0>
+    tt.return %ld : tensor<128xf16, #slice0>
+  }
+}
+
+// -----
+
+#blockedSrc = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedDst = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0]]}>
+#shared = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [1, 0], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Negative test: no cluster barrier should be inserted for multiCTA when the layouts don't cross CTAs
+  // CHECK-LABEL: @no_cluster_convert_block_trivial
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_convert_block_trivial() -> tensor<256x128xf16, #blockedSrc> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSrc>
+    %cvt = ttg.convert_layout %cst : tensor<256x128xf16, #blockedSrc> -> tensor<256x128xf16, #blockedDst>
+    %buf = ttg.local_alloc %cvt : (tensor<256x128xf16, #blockedDst>) -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    ttg.local_store %cvt, %buf : tensor<256x128xf16, #blockedDst> -> !ttg.memdesc<256x128xf16, #shared, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256x128xf16, #shared, #smem, mutable> -> tensor<256x128xf16, #blockedSrc>
+    tt.return %ld : tensor<256x128xf16, #blockedSrc>
+  }
+}
+
+// -----
+
+#blockedTmaSrc = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#blockedTmaDst = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#nvmmaTma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrierEncTma = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Non-distributed convert_layout followed by multicast TMA should still
+  // insert a cluster barrier before the TMA.
+  // TODO: There is a world where we can do better:
+  // 1. We emit the relaxed = false cluster_arrive/wait pair automatically
+  // 2. We realise that we can avoid emitting it there as there is a cluster barrier after the convert_layout
+  // CHECK-LABEL: @convert_layout_trivial_then_tma_multicast_cluster_barrier
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK-NOT: ttg.barrier local
+  // CHECK: ttg.convert_layout
+  // CHECK: ttng.cluster_arrive {relaxed = false}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  tt.func @convert_layout_trivial_then_tma_multicast_cluster_barrier(%input: tensor<64x128xf16, #blockedTmaSrc>, %desc: !tt.tensordesc<tensor<64x128xf16, #nvmmaTma>>) -> tensor<64x128xf16, #blockedTmaDst> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    %cvt = ttg.convert_layout %input : tensor<64x128xf16, #blockedTmaSrc> -> tensor<64x128xf16, #blockedTmaDst>
+    %dst = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %dst, %barrier, %true {multicast} :
+        !tt.tensordesc<tensor<64x128xf16, #nvmmaTma>>, !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %dst :
+        !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>,
+        !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
+    ttg.local_dealloc %dst : !ttg.memdesc<64x128xf16, #nvmmaTma, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<1xi64, #barrierEncTma, #smem, mutable>
+    tt.return %cvt : tensor<64x128xf16, #blockedTmaDst>
+  }
+}
+
+// -----
+
+#blockedSplitM = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#slice1 = #ttg.slice<{dim = 1, parent = #blockedSplitM}>
+#shared1d = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Negative test: no cluster barrier should be inserted for multiCTA reduce when the axis is not split
+  // CHECK-LABEL: @no_cluster_reduce_unsplit_axis
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_reduce_unsplit_axis() -> tensor<256xf16, #slice1> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x128xf16, #blockedSplitM>
+    %red = "tt.reduce"(%cst) ({
+    ^bb0(%lhs: f16, %rhs: f16):
+      %add = arith.addf %lhs, %rhs : f16
+      tt.reduce.return %add : f16
+    }) {axis = 1 : i32} : (tensor<256x128xf16, #blockedSplitM>) -> tensor<256xf16, #slice1>
+    %buf = ttg.local_alloc %red : (tensor<256xf16, #slice1>) -> !ttg.memdesc<256xf16, #shared1d, #smem, mutable>
+    ttg.local_store %red, %buf : tensor<256xf16, #slice1> -> !ttg.memdesc<256xf16, #shared1d, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<256xf16, #shared1d, #smem, mutable> -> tensor<256xf16, #slice1>
+    tt.return %ld : tensor<256xf16, #slice1>
+  }
+}
+
+// -----
+
+#sharedA = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#sharedB = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = true, elementBitWidth = 16, CGALayout = [[0, 0]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 2], order = [0, 1], CGALayout = [[0, 0]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 64, blockN = 32, colStride = 1, CTASplitN = 2>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Negative test: no cluster barrier should be inserted for multiCTA MMA when the twoCTAs is not set
+  // CHECK-LABEL: @no_cluster_mma_without_two_ctas
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_mma_without_two_ctas() -> tensor<128x16xf16, #blocked> {
+    %true = arith.constant true
+    %c0 = arith.constant 0 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x16xf16, #blocked>
+    %a = ttg.local_alloc : () -> !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>
+    %b = ttg.local_alloc : () -> !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>
+    %acc = ttng.tmem_alloc : () -> !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    ttng.tc_gen5_mma %a, %b, %acc, %true, %true, %barrier[%true] {is_async} :
+       !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>,
+       !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>,
+       !ttg.memdesc<128x128xf32, #tmem, #ttng.tensor_memory, mutable>,
+       !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %a, %b :
+      !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>,
+      !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>
+    ttg.local_dealloc %a : !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>
+    ttg.local_dealloc %b : !ttg.memdesc<16x128xf16, #sharedB, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<2xi64, #barrierEnc, #smem, mutable>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>
+    ttg.local_store %cst, %buf : tensor<128x16xf16, #blocked> -> !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<128x16xf16, #sharedA, #smem, mutable> -> tensor<128x16xf16, #blocked>
+    tt.return %ld : tensor<128x16xf16, #blocked>
+  }
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Negative test: no cluster barrier should be inserted for multiCTA TMA when the multicast is not set
+  // CHECK-LABEL: @no_cluster_tma_without_multicast
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_tma_without_multicast(%desc: !tt.tensordesc<tensor<64x128xf16, #nvmma>>) -> tensor<64x128xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf16, #blocked>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %buf, %barrier, %true :
+      !tt.tensordesc<tensor<64x128xf16, #nvmma>>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %buf :
+      !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_dealloc %buf : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_dealloc %barrier : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    %buf2 = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_store %cst, %buf2 : tensor<64x128xf16, #blocked> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %ld = ttg.local_load %buf2 : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    tt.return %ld : tensor<64x128xf16, #blocked>
+  }
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // Wait included to model the end of the async lifetime. No extra cluster
+  // barriers should appear after the wait when reusing the same alloc.
+  // CHECK-LABEL: @no_cluster_when_same_allocation
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: ttng.wait_barrier
+  // CHECK-NOT: ttng.cluster_arrive
+  // CHECK-NOT: ttng.cluster_wait
+  // CHECK: tt.return
+  tt.func @no_cluster_when_same_allocation(%desc: !tt.tensordesc<tensor<64x128xf16, #nvmma>>) -> tensor<64x128xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf16, #blocked>
+    %buf = ttg.local_alloc : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %buf, %barrier, %true {multicast} :
+      !tt.tensordesc<tensor<64x128xf16, #nvmma>>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %buf :
+      !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttg.local_store %cst, %buf : tensor<64x128xf16, #blocked> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %ld = ttg.local_load %buf : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    tt.return %ld : tensor<64x128xf16, #blocked>
+  }
+}
+
+// -----
+
+#sharedA = #ttg.nvmma_shared<{swizzlingByteWidth = 32, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#sharedB = #ttg.nvmma_shared<{swizzlingByteWidth = 64, transposed = false, elementBitWidth = 16, CGALayout = [[0, 1]]}>
+#barrierTMA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#barrierMMA = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[1]]}>
+#tmem = #ttng.tensor_memory_encoding<blockM = 128, blockN = 64, colStride = 1, CTASplitM = 2, twoCTAs = true>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, "ttng.two-ctas" = true, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // Exact TTGIR shape for:
+  // test_tma_mma_shared_inputs[True-True-ctas_per_cga1-reps0-warps2]
+  // with smem allocations outside the loop.
+  // If we fully manage the shared memory and the allocator does not create any new aliases,
+  // then we shouldn't emit any cluster barriers
+  // CHECK-LABEL: @example_matmul
+  // CHECK: ttg.local_alloc
+  // CHECK: ttg.local_alloc
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.init_barrier
+  // CHECK: ttng.tmem_alloc
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: scf.for
+  // CHECK: ttng.barrier_expect
+  // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
+  // CHECK: ttg.barrier local
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
+  // CHECK: ttng.wait_barrier
+  // CHECK-NOT: ttng.cluster_arrive {relaxed = false}
+  // CHECK: ttng.tc_gen5_mma
+  // CHECK: ttng.wait_barrier
+  tt.func @example_matmul(%a_desc: !tt.tensordesc<tensor<256x16xf16, #sharedA>>, %b_desc: !tt.tensordesc<tensor<16x64xf16, #sharedB>>) {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    %c16 = arith.constant 16 : i32
+    %c0_idx = arith.constant 0 : index
+    %c4_idx = arith.constant 4 : index
+    %c1_idx = arith.constant 1 : index
+    %smem_a = ttg.local_alloc : () -> !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>
+    %smem_b = ttg.local_alloc : () -> !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+    %bTMA = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
+    %bMMA = ttg.local_alloc : () -> !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    ttng.init_barrier %bTMA, 1 : !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
+    ttng.init_barrier %bMMA, 1 : !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    %acc_tmem = ttng.tmem_alloc : () -> !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    %phase_init = arith.constant 0 : i32
+    %phase_tma = scf.for %k = %c0_idx to %c4_idx step %c1_idx iter_args(%phase = %phase_init) -> (i32) {
+      %k_i32 = arith.index_cast %k : index to i32
+      ttng.barrier_expect %bTMA, 5120, %true : !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
+      %offs = arith.muli %k_i32, %c16 : i32
+      ttng.async_tma_copy_global_to_local %a_desc[%c0, %offs] %smem_a, %bTMA, %true {multicast} :
+        !tt.tensordesc<tensor<256x16xf16, #sharedA>>, !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable> -> !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>
+      ttng.async_tma_copy_global_to_local %b_desc[%offs, %c0] %smem_b, %bTMA, %true {multicast} :
+        !tt.tensordesc<tensor<16x64xf16, #sharedB>>, !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable> -> !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+      ttng.wait_barrier %bTMA, %phase, %true deps %smem_a, %smem_b :
+        !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>,
+        !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>,
+        !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+      %next_phase = arith.xori %phase, %c1 : i32
+      %use_acc = arith.cmpi ne, %k_i32, %c0 : i32
+      %mma_tok = ttng.tc_gen5_mma %smem_a, %smem_b, %acc_tmem[], %use_acc, %true, %bMMA[%true] {is_async, two_ctas, multicast} :
+         !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>,
+         !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>,
+         !ttg.memdesc<256x64xf32, #tmem, #ttng.tensor_memory, mutable>,
+         !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+      ttng.wait_barrier %bMMA, %phase, %true deps %smem_a, %smem_b :
+        !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>,
+        !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>,
+        !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+      scf.yield %next_phase : i32
+    }
+    ttg.local_dealloc %bTMA : !ttg.memdesc<1xi64, #barrierTMA, #smem, mutable>
+    ttg.local_dealloc %bMMA : !ttg.memdesc<2xi64, #barrierMMA, #smem, mutable>
+    ttg.local_dealloc %smem_a : !ttg.memdesc<256x16xf16, #sharedA, #smem, mutable>
+    ttg.local_dealloc %smem_b : !ttg.memdesc<16x64xf16, #sharedB, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#nvmma = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16, CGALayout = [[1, 0]]}>
+#barrierEnc = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [0, 1], CGALayout = [[1, 0]]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // The wait just waits on the first CTA, so there should be a barrier in between
+  // CHECK-LABEL: @cluster_barrier_between_lifetimes_same_offset
+  // CHECK: ttng.init_barrier
+  // CHECK-NEXT: ttng.fence_mbarrier_init_release_cluster
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = true}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK: ttg.local_alloc
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  // CHECK: ttng.wait_barrier
+  // CHECK: ttg.local_dealloc
+  // CHECK: ttg.local_alloc
+  // CHECK-NEXT: ttng.cluster_arrive {relaxed = false}
+  // CHECK-NEXT: ttng.cluster_wait
+  // CHECK-NEXT: ttng.async_tma_copy_global_to_local
+  tt.func @cluster_barrier_between_lifetimes_same_offset(%desc: !tt.tensordesc<tensor<64x128xf16, #nvmma>>) -> tensor<64x128xf16, #blocked> {
+    %c0 = arith.constant 0 : i32
+    %true = arith.constant true
+
+    %barrier = ttg.local_alloc : () -> !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.init_barrier %barrier, 1 : !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>
+    ttng.fence_mbarrier_init_release_cluster
+    ttng.cluster_arrive {relaxed = true}
+    ttng.cluster_wait
+    // a lifetime start
+    %a = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %a, %barrier, %true {multicast} :
+      !tt.tensordesc<tensor<64x128xf16, #nvmma>>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %a :
+      !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %t = ttg.local_load %a : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    ttg.local_dealloc %a : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    // a lifetime end
+
+    // b lifetime start
+    %b = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %desc[%c0, %c0] %b, %barrier, %true {multicast} :
+      !tt.tensordesc<tensor<64x128xf16, #nvmma>>, !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable> -> !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    ttng.wait_barrier %barrier, %c0 deps %b :
+      !ttg.memdesc<1xi64, #barrierEnc, #smem, mutable>,
+      !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    %t2 = ttg.local_load %b : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable> -> tensor<64x128xf16, #blocked>
+    ttg.local_dealloc %b : !ttg.memdesc<64x128xf16, #nvmma, #smem, mutable>
+    // b lifetime end
+
+    tt.return %t2 : tensor<64x128xf16, #blocked>
+  }
+}

--- a/test/lib/Analysis/CMakeLists.txt
+++ b/test/lib/Analysis/CMakeLists.txt
@@ -5,5 +5,5 @@ add_library(TritonTestAnalysis
   TestBufferRegion.cpp
   TestMembar.cpp
 )
-target_link_libraries(TritonTestAnalysis PUBLIC MLIRPass TritonAnalysis)
+target_link_libraries(TritonTestAnalysis PUBLIC MLIRPass TritonAnalysis TritonNvidiaGPUTransforms)
 target_compile_options(TritonTestAnalysis PRIVATE ${TRITON_DISABLE_EH_RTTI_FLAGS})

--- a/test/lib/Analysis/TestMembar.cpp
+++ b/test/lib/Analysis/TestMembar.cpp
@@ -1,8 +1,12 @@
 #include "../third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Utility.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Allocation.h"
+#include "third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 
 using namespace mlir;
 
@@ -21,8 +25,18 @@ struct TestMembarPass
   void runOnOperation() override {
     Operation *operation = getOperation();
     ModuleOp moduleOp = cast<ModuleOp>(operation);
-    // Print all ops after membar pass
     ModuleAllocation allocation(moduleOp);
+    if (moduleOp->hasAttr("ttg.target")) {
+      int computeCapability = getNVIDIAComputeCapability(moduleOp);
+      int ptxVersion = computeCapability;
+      triton::NVIDIA::TargetInfo targetInfo(computeCapability, ptxVersion);
+      allocation = ModuleAllocation(
+          moduleOp,
+          triton::nvidia_gpu::getNvidiaAllocationAnalysisScratchSizeFn(
+              targetInfo));
+      triton::nvidia_gpu::runClusterBarrierInsertion(allocation,
+                                                     computeCapability);
+    }
     ModuleMembarAnalysis membarPass(&allocation,
                                     mlir::triton::NVIDIA::canSkipBarSync);
     membarPass.run();

--- a/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
+++ b/third_party/amd/include/TritonAMDGPUToLLVM/MembarUtility.h
@@ -26,7 +26,8 @@ namespace mlir::triton::AMD {
 //      # Requires ttg.barrier but filter will prevent it
 //     %4 = AsyncCopyGlobalToLocal %ptr_2 %tile_a
 //     scf.yield
-bool membarFilter(Operation *op1, Operation *op2, Allocation *allocation);
+bool membarFilter(Operation *op1, Operation *op2, bool op1IsRead,
+                  bool op2IsRead, Allocation *allocation);
 } // namespace mlir::triton::AMD
 
 #endif

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -67,7 +67,7 @@ static BlockInfo buildBlockInfoFromBlock(Block *block, Allocation *allocation) {
             if (bufId == Allocation::InvalidBufferId)
               continue;
             auto interval = allocation->getAllocatedInterval(bufId);
-            auto slice = AllocationSlice(v, interval);
+            auto slice = AllocationSlice(v, interval, bufId);
             if (isa<MemoryEffects::Write>(eff.getEffect()))
               info.syncWriteSlices[slice].insert(op);
             else if (isa<MemoryEffects::Read>(eff.getEffect()))

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -64,7 +64,8 @@ bool filterLDSMemoryBarriersDependencies(Operation *op1, Operation *op2) {
 }
 } // namespace
 
-bool membarFilter(Operation *op1, Operation *op2, Allocation *allocation) {
+bool membarFilter(Operation *op1, Operation *op2, bool /*op1IsRead*/,
+                  bool /*op2IsRead*/, Allocation *allocation) {
   return (filterAsyncLocalLoadsDependencies(op1, op2, allocation) ||
           filterLDSMemoryBarriersDependencies(op1, op2));
 }

--- a/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/include/TritonNVIDIAGPUToLLVM/Utility.h
@@ -10,8 +10,8 @@ namespace NVIDIA {
 
 /// Return true if we can skip a barrier synchronization between two operations
 /// even if they access the same shared memory.
-bool canSkipBarSync(Operation *before, Operation *after,
-                    Allocation *allocation);
+bool canSkipBarSync(Operation *before, Operation *after, bool beforeIsRead,
+                    bool afterIsRead, Allocation *allocation);
 } // namespace NVIDIA
 } // namespace triton
 } // namespace mlir

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -18,6 +18,7 @@
 #include "triton/Dialect/Triton/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
+#include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
 
 #include "Allocation.h"
 #include "PatternTritonGPUOpToLLVM.h"
@@ -96,6 +97,8 @@ struct ConvertTritonGPUToLLVM
     ModuleAllocation allocation(
         mod, mlir::triton::nvidia_gpu::getNvidiaAllocationAnalysisScratchSizeFn(
                  targetInfo));
+    mlir::triton::nvidia_gpu::runClusterBarrierInsertion(allocation,
+                                                         computeCapability);
     ModuleMembarAnalysis membarPass(&allocation, canSkipBarSync);
     membarPass.run();
 
@@ -253,6 +256,7 @@ createConvertTritonGPUToLLVMPass(int32_t computeCapability,
 }
 
 bool NVIDIA::canSkipBarSync(Operation *before, Operation *after,
+                            bool /*beforeIsRead*/, bool /*afterIsRead*/,
                             Allocation *allocation) {
   // These mbarrier ops are single threaded, so are always synchronized wrt.
   // each other.


### PR DESCRIPTION
Stacked PRs:
 * #9327
 * __->__#9318


--- --- ---

### [Membar] Membar pass for clusters


The main invariant here is that:

Membar for CTAs only synchronises CTAs when their buffers did not
alias in the ttgir, but they alias after the Allocation pass

In other words, in Gluon, the user is in charge of manually
synchronising the bufferes they declare.

For now, we always emit a full cluster barrier. We can improve this in
the future by emitting `mbarrier`s that just synchronise subsets of the
CTAs. For that we would need to be a bit more clever, as we would need
to allocate some `mbarrier`s  but the Allocation pass has already run...

We add a number of test cases with comments of which of them are
expected and which can be improved.
