### PR TITLE
[Kernels] Re-enable 4-warp persistent kernel

### DIFF
--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -242,8 +242,6 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
                 pytest.skip("float8 x mx not supported with cuda capability < 10")
         if swiglu_opts is not None and do_gamma:
             pytest.skip("NYI: swiglu and gamma not supported together")
-        if weight_dtype_str.startswith("mxfloat4") and b_hbm_swizzling and num_warps == 4:
-            pytest.skip("Disabled due to ptxas bug")
 
     elif is_hip():
         if "float8" in act_dtype_str and "mx" in weight_dtype_str and not is_hip_cdna4():

--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -212,7 +212,8 @@ def _p_matmul(
         tl.program_id(0), num_blocks, NUM_SMS,
         flatten=FLATTEN_LOOPS,
         disallow_acc_multi_buffer=DISALLOW_ACC_MULTI_BUFFER,
-        warp_specialize=True,
+        # Workaround for compile error in hopper warp specialization
+        warp_specialize=FLATTEN_LOOPS,
     ):
 
         pid_z, pid_m, pid_n, pid_k = compute_pids(block_id, useful_grid_m, grid_n, num_blocks, XCD_SWIZZLE, GROUP_M, SPLIT_K)

--- a/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/opt_flags.py
@@ -236,9 +236,6 @@ def make_default_opt_flags_nvidia(
     supports_persistent = can_use_persistent_tma and (arch is None or int(arch[2:-1]) >= 9)
     a_mx_scale_layout = None if not isinstance(precision_config.a_mx_scale, Tensor) else precision_config.a_mx_scale.storage.layout
     b_mx_scale_layout = None if not isinstance(precision_config.b_mx_scale, Tensor) else precision_config.b_mx_scale.storage.layout
-    if isinstance(b_mx_scale_layout, HopperMXScaleLayout) and b_mx_scale_layout.num_warps == 4:
-        # TODO: persistent kernel is broken due with 4 warps due to a ptxas bug
-        supports_persistent = False
 
     def _is_layout_strided(layout: Layout | None) -> bool:
         return layout is None or isinstance(layout, StridedLayout)


### PR DESCRIPTION
Looks like some of the interceding changes have removed the code sequence was causing issues with ptxas. I also had to disable `warp_specialize` as I'm getting an invalid IR error from inside the pass.