### PR TITLE
[AMD][BACKEND] Fix TDM shape adjustment to factor in the CGA offset

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp
@@ -544,9 +544,10 @@ void fillTDMDescriptor(
   }
   dstPtr = b.gep(sharedPtrTy, elementType, dstPtr, dstOffset);
 
-  // Update tensor shapes based on offset
+  // Update tensor shapes based on offset and cgaOffset
   for (size_t i = 0; i < numDims; ++i) {
-    tensorShape[i] = b.smax(b.i32_val(0), b.sub(tensorShape[i], offset[i]));
+    auto fullOffset = b.add(offset[i], cgaOffsets[i].second);
+    tensorShape[i] = b.smax(b.i32_val(0), b.sub(tensorShape[i], fullOffset));
   }
 
   // Update group0 with addresses


### PR DESCRIPTION
TDM needs to adjust the shape in the tensor descriptor to account for the tile offset when computing OOB. However, we did not take the CGA offset into account.

I adjusted the test to overallocate the buffers so the test can catch out of bounds writes and we do not rely on a random segfault to detect the OOB write.