### PR TITLE
[docs] Add topk operation to language documentation

### DIFF
--- a/docs/python-api/triton.language.rst
+++ b/docs/python-api/triton.language.rst
@@ -150,6 +150,7 @@ Scan/Sort Ops
     cumsum
     histogram
     sort
+    topk
     gather
 
 Atomic Ops

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -467,6 +467,27 @@ def sort(x, dim: core.constexpr = None, descending: core.constexpr = core.CONSTE
 
 @jit
 def topk(x, k: core.constexpr, dim: core.constexpr = None):
+    """
+    Returns the k largest elements of the input tensor along the specified dimension.
+
+    The elements are returned in sorted order (largest first).
+
+    :param x: The input tensor.
+    :type x: Tensor
+    :param k: The number of top elements to return. Must be a power of two.
+    :type k: int
+    :param dim: The dimension along which to find the top k elements.
+                If None, uses the last dimension. Currently only the last dimension is supported.
+    :type dim: int, optional
+    :return: A tensor containing the k largest elements along the specified dimension.
+    :rtype: Tensor
+
+    Example::
+
+        # Get top 4 elements from a 1D tensor
+        x = tl.arange(0, 16)
+        top4 = tl.topk(x, 4)  # Returns [15, 14, 13, 12]
+    """
     return sort_impl(x, k=k, dim=dim, descending=True)
 
 


### PR DESCRIPTION
## Summary
- Add `topk` to Scan/Sort Ops section in `triton.language.rst`
- Add docstring to `topk` function describing parameters, return value, and usage example

## Motivation
Fixes #9278 

The `topk` operation is implemented and exported in `triton.language` but was not mentioned in the API documentation at https://triton-lang.org/main/python-api/triton.language.html

## Changes
1. **docs/python-api/triton.language.rst**: Added `topk` entry under Scan/Sort Ops section
2. **python/triton/language/standard.py**: Added comprehensive docstring to `topk` function including:
   - Description of functionality
   - Parameter documentation
   - Return type
   - Usage example

## Testing
Documentation builds correctly with the new entry.