### PR TITLE
[AMD] Support TDM AsyncWait in UpdateAsyncWaitCount

### DIFF
--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -861,6 +861,7 @@ def AsyncTDMScatterOp : TT_AMDGPU_Op<"async_tdm_scatter"> {
     Arg<TTG_MemDescType, "", [MemRead<SharedMemory>]>:$src,
     Optional<TTG_MemDescType>:$barrier
   );
+  let results = (outs TTG_AsyncToken:$retToken);
 
   let assemblyFormat = [{
     $desc `[` $dst_row_indices `,` $dst_col_offset `]` `from` $src (`,` `barrier` `=` $barrier^)?
@@ -900,6 +901,7 @@ def AsyncTDMGatherOp : TT_AMDGPU_Op<"async_tdm_gather"> {
     Arg<TTG_MemDescType, "", [MemWrite<SharedMemory>]>:$dst,
     Optional<TTG_MemDescType>:$barrier
   );
+  let results = (outs TTG_AsyncToken:$token);
 
   let assemblyFormat = [{
     $desc `[` $src_row_indices `,` $src_col_offset `]` `to` $dst (`,` `barrier` `=` $barrier^)?
@@ -918,11 +920,33 @@ def AsyncTDMWait : TT_AMDGPU_Op<"async_tdm_wait", [MemWaitOpTrait]> {
   let arguments = (ins Variadic<TTG_AsyncToken>:$asyncToken, I32Attr:$num);
   let description = [{
     This operation waits until there are less than or equal to the given number
-    of outstanding TDM operations, including both loads and stores. This is
-    necessary to ensure that data is available in the LDS before it is used.
+    of outstanding async TDM operations.
+    This is necessary to ensure that data is available in the LDS (load, gather)
+    or HBM (store, scatter) before it is used.
+
+    This operation counts the number of TDM IR operations (AsyncTDMCopyGlobalToLocalOp,
+    AsyncTDMCopyLocalToGlobalOp, AsyncTDMScatterOp, AsyncTDMGatherOp).
   }];
   let results = (outs TTG_AsyncToken:$retToken);
   let assemblyFormat = "$asyncToken attr-dict";
+}
+
+def AsyncTDMIntrinsicWait : TT_AMDGPU_Op<"async_tdm_intrinsic_wait", [MemWaitOpTrait]> {
+  let summary = "Wait until there are less than or equal to the given number of outstanding TDM intrinsics";
+  let arguments = (ins Variadic<TTG_AsyncToken>:$asyncToken, I32Attr:$count);
+  let description = [{
+    This operation waits until there are less than or equal to the given number
+    of outstanding TDM intrinsics (assembly instructions). This is necessary to
+    ensure that data is available in LDS (load, gather) or HBM (store, scatter)
+    before it is used.
+
+    Unlike AsyncTDMWait which counts IR operations, this operation counts the
+    actual number of TDM assembly instructions (e.g., tensor_load_to_lds,
+    tensor_store_from_lds) that are emitted. Which is required for the lowering
+    to LLVM.
+  }];
+  let results = (outs TTG_AsyncToken:$retToken);
+  let assemblyFormat = "($asyncToken^)? attr-dict";
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -177,7 +177,8 @@ private:
         clusterBlocks.push_back(&exeOp->getRegion(0).front());
         bars.push_back(false);
       } else if (isa<ROCDL::BarrierOp, gpu::BarrierOp, triton::gpu::AsyncWaitOp,
-                     triton::amdgpu::AsyncTDMWait>(op)) {
+                     triton::amdgpu::AsyncTDMWait,
+                     triton::amdgpu::AsyncTDMIntrinsicWait>(op)) {
         int currCluster = clusterBlocks.size();
         // Reject if multiple barriers appear without an intervening cluster.
         // This is functionally valid but may cause unpredictable timing. Users

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -2284,17 +2284,18 @@ private:
   const AMD::TargetInfo &targetInfo;
 };
 
-struct AsyncTDMWaitConversion
-    : public ConvertOpToLLVMPattern<triton::amdgpu::AsyncTDMWait> {
-  AsyncTDMWaitConversion(LLVMTypeConverter &converter, PatternBenefit benefit)
+struct AsyncTDMIntrinsicWaitConversion
+    : public ConvertOpToLLVMPattern<triton::amdgpu::AsyncTDMIntrinsicWait> {
+  AsyncTDMIntrinsicWaitConversion(LLVMTypeConverter &converter,
+                                  PatternBenefit benefit)
       : ConvertOpToLLVMPattern(converter, benefit) {}
 
   LogicalResult
-  matchAndRewrite(triton::amdgpu::AsyncTDMWait op, OpAdaptor adaptor,
+  matchAndRewrite(triton::amdgpu::AsyncTDMIntrinsicWait op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
-    ROCDL::WaitTensorcntOp::create(rewriter, loc, op.getNum());
+    ROCDL::WaitTensorcntOp::create(rewriter, loc, op.getCount());
     rewriter.eraseOp(op);
     return success();
   }
@@ -2410,7 +2411,7 @@ void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
       typeConverter, targetInfo, axisInfoAnalysis, benefit);
   patterns.add<AsyncWaitOpConversion>(typeConverter, targetInfo, benefit);
   patterns.add<TDMPrefetchConversion>(typeConverter, targetInfo, benefit);
-  patterns.add<AsyncTDMWaitConversion>(typeConverter, benefit);
+  patterns.add<AsyncTDMIntrinsicWaitConversion>(typeConverter, benefit);
   patterns.add<AsyncCommitGroupOpConversion>(typeConverter, benefit);
   patterns.add<AsyncCopyMbarrierArriveOpConversion>(typeConverter, benefit);
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.h
@@ -78,6 +78,14 @@ void emitTDMLoadStore(RewriterBase &rewriter, Location loc,
                       bool isLoad, const triton::LinearLayout &cgaLayout,
                       Value ctaId);
 
+// Calculate the number of TDM gather/scatter instructions needed.
+// - numIndices: number of row indices
+// - use32BitIndices: true for 32-bit indices (max 8 rows/instr), false for
+//   16-bit (max 16 rows/instr)
+// Returns: the number of TDM instructions that will be emitted
+size_t getTDMGatherScatterInstrinsicCount(size_t numIndices,
+                                          bool use32BitIndices);
+
 // Emit a TDM gather or scatter operation for non-contiguous row access.
 // Gather: reads from non-contiguous global rows into LDS
 // Scatter: writes from LDS to non-contiguous global rows


### PR DESCRIPTION
Since TDM scatter and gather might produce more than 1 intrinsic/assembly instruction we need to compute the correct waitcnt based on the #intrinsics instead of the number of TGGIR ops. This piggy-backs on the analysis pass we already use for `ttg.async_copy_global_to_local`.
This allows us to use the number of TTGIR TDM ops in Gluon and also works with the token based approach from the pipeliner.
