### PR TITLE
Add descending flag to topk

### DIFF
--- a/python/test/unit/language/test_standard.py
+++ b/python/test/unit/language/test_standard.py
@@ -43,7 +43,7 @@ def test_sort(M, N, k, descending, dtype_str, device):
         if k is None or x.numel < k:
             z = tl.sort(x, descending=descending)
         else:
-            z = tl.topk(x, k)
+            z = tl.topk(x, k, descending=descending)
         offs_z = offs_m[:, None] * stride_zm + offs_z_n[None, :]
         tl.store(Z + offs_z, z)
 
@@ -54,7 +54,7 @@ def test_sort(M, N, k, descending, dtype_str, device):
     if k is None or x.numel() < k:
         y = torch.sort(x, descending=descending)[0]
     else:
-        y = torch.topk(x, k=k).values
+        y = torch.topk(x, k=k, largest=descending).values
     sort_kernel[(1, )](x, x.stride(0), z, z.stride(0), M, N, k, descending, num_warps=8)
     assert (y == z).all(), (y, z)
 

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -466,9 +466,9 @@ def sort(x, dim: core.constexpr = None, descending: core.constexpr = core.CONSTE
 
 
 @jit
-def topk(x, k: core.constexpr, dim: core.constexpr = None):
+def topk(x, k: core.constexpr, dim: core.constexpr = None, descending: core.constexpr = True):
     """
-    Returns the k largest elements of the input tensor along the specified dimension.
+    Returns the k largest (or smallest) elements of the input tensor along the specified dimension.
 
     The elements are returned in sorted order (largest first).
 
@@ -479,6 +479,8 @@ def topk(x, k: core.constexpr, dim: core.constexpr = None):
     :param dim: The dimension along which to find the top k elements.
                 If None, uses the last dimension. Currently only the last dimension is supported.
     :type dim: int, optional
+    :param descending: If set to True, returns k largest elements. If set to False, returns k smallest elements.
+    :type descending: bool, optional
     :return: A tensor containing the k largest elements along the specified dimension.
     :rtype: Tensor
 
@@ -488,7 +490,7 @@ def topk(x, k: core.constexpr, dim: core.constexpr = None):
         x = tl.arange(0, 16)
         top4 = tl.topk(x, 4)  # Returns [15, 14, 13, 12]
     """
-    return sort_impl(x, k=k, dim=dim, descending=True)
+    return sort_impl(x, k=k, dim=dim, descending=descending)
 
 
 @jit


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

`topk` function in `standard.py` is missing `descending` flag, that is pretty useful in torch.topk. I have added this flag, allowing to return the smallest k values.