### PR TITLE
[AMD][gfx1250] Add clamp operand to WMMA int intrinsic

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -169,7 +169,7 @@ Value generateWMMAIntrinsic(ConversionPatternRewriter &rewriter, Location loc,
   } else {
     assert(wmmaVer == 3 && "unexpected wmma version");
     // arguments for v3:
-    // int:          %A_mod, %A, %B_mod, %B, %C, %A_reuse, %B_reuse
+    // int:          %A_mod, %A, %B_mod, %B, %C, %A_reuse, %B_reuse, clamp
     // f32/f16/bf16: %A_mod, %A, %B_mod, %B, %C_mod, %C, %A_reuse, %B_reuse
     // f8/bf8:       %A, %B, %C_mod, %C, %A_reuse, %B_reuse
     if (aElType.isInteger())
@@ -190,6 +190,10 @@ Value generateWMMAIntrinsic(ConversionPatternRewriter &rewriter, Location loc,
 
     operands.push_back(b.i1_val(0));
     operands.push_back(b.i1_val(0));
+    // Add clamp for int types
+    if (aElType.isInteger()) {
+      operands.push_back(b.i1_val(0));
+    }
   }
 
   auto wmmaIntrinsic = LLVM::createLLVMIntrinsicCallOp(


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because as it is a bug fix for wmma on int types

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
