### PR TITLE
[gfx1250/gluon] TDM: Fix OOB handling for Scatter/Gather

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1344,6 +1344,11 @@ struct AsyncTDMScatterOpConversion
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
 
+    // Multi-CTA not supported for scatter
+    if (lookupNumCTAs(op) > 1) {
+      return op.emitError("TDM scatter does not support multi-CTA");
+    }
+
     auto tensorDescTy = op.getDesc().getType();
     auto smemTy = op.getSrc().getType();
     Type elementType = getTypeConverter()->convertType(smemTy.getElementType());
@@ -1422,6 +1427,11 @@ struct AsyncTDMGatherOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     auto loc = op.getLoc();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
+
+    // Multi-CTA not supported for gather
+    if (lookupNumCTAs(op) > 1) {
+      return op.emitError("TDM gather does not support multi-CTA");
+    }
 
     auto tensorDescTy = op.getDesc().getType();
     auto smemTy = op.getDst().getType();


### PR DESCRIPTION
Fixes the incorrect offset handling when the tile size `N` is not a multiple of `BLOCK_N` causing the last block of a TDM Scatter/Gather to be a partial block.

This happened because unlike in `fillTDMDescriptor` for standard TDM, the tensor shapes weren't updated based on offsets within `fillTDMDescriptorForGatherScatter` for gather/scatter.