### PR TITLE
Reapply "[AMD] Introduce PartitionedSharedEncodingAttr" (#9367)

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -104,6 +104,10 @@ public:
   virtual bool supportLdStMatrixB8() const { return false; }
   virtual bool isCuda() const { return false; }
 
+  // Returns the shared memory partition size in bytes. A value of 0 means
+  // shared memory is not partitioned.
+  virtual size_t getSharedMemoryPartitionSize() const { return 0; }
+
   // Annotate target specific information to local load operations during
   // lowering to LLVM. `llLoadOp` is the generated LLVM load op.
   virtual void localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,

--- a/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
+++ b/include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td
@@ -359,6 +359,72 @@ For identity mappings a short form based on order and shape is used to increase 
   let genVerifyDecl = 1;
 }
 
+
+def PartitionedSharedEncodingAttr
+    : TritonGPU_Attr<"PartitionedSharedEncoding", "partitioned_shared_encoding",
+                     [SharedEncodingTrait, DeclareLayoutEncodingMethods,  LayoutEncodingTrait]> {
+  let mnemonic = "partitioned_shared";
+
+  let description = [{
+    An encoding for tensors whose elements are partitioned across multiple
+    separate shared memory allocations. This reduces shared memory partition
+    conflicts by splitting a tensor along a specific dimension into separate
+    allocations.
+
+    Parameters:
+    - numPartitions: Number of distinct memory partitions (and separate buffers).
+      Buffers in different partitions MUST be placed in different physical
+      shared memory slots.
+    - numGroups: Number of groups. Each group contains numPartitions
+      consecutive pieces of the tensor.
+    - partitionDim: The dimension along which the tensor is partitioned.
+    - partitionLayout: The shared memory layout used within each piece.
+
+    The total number of logical pieces is numPartitions * numGroups.
+    Pieces are organized as:
+      [Group 0: pieces 0..numPartitions-1]
+      [Group 1: pieces numPartitions..2*numPartitions-1]
+      ...
+
+    ## Memory Allocation
+
+    The allocator creates numPartitions buffers (NOT numLogicalPieces buffers).
+    Each buffer contains all pieces from all groups that belong to that partition,
+    concatenated together. Buffer size = pieceSize * numGroups.
+
+    For example, with numPartitions=2, numGroups=4 and
+    partitionDim=0 on a [128, 32] tensor:
+    - Total 8 logical pieces, each of size [16, 32] (pieceSize = 16*32 elements)
+    - Piece layout: [0, 1, 2, 3, 4, 5, 6, 7]
+    - Partitions:    0  1  0  1  0  1  0  1
+    - Groups:       |Grp0||Grp1||Grp2||Grp3|
+
+    Physical allocation (2 buffers, each containing 4 pieces):
+    - Buffer 0 (Partition 0): [Piece0 | Piece2 | Piece4 | Piece6]
+    - Buffer 1 (Partition 1): [Piece1 | Piece3 | Piece5 | Piece7]
+
+    Physical allocation guarantee: Buffers in different partitions MUST reside
+    in distinct physical shared memory partitions.
+  }];
+
+  let parameters = (ins
+      "unsigned":$numPartitions,
+      "unsigned":$numGroups,
+      "unsigned":$partitionDim,
+      "SharedEncodingTrait":$partitionLayout
+  );
+
+  let extraClassDeclaration = [{
+    /// Returns the total number of logical pieces.
+    unsigned getNumLogicalPieces() const {
+      return getNumPartitions() * getNumGroups();
+    }
+  }];
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+}
+
 def SharedLinearEncodingAttr
     : TritonGPU_Attr<"SharedLinearEncoding", "shared_linear_encoding",
                      [SharedEncodingTrait, LayoutEncodingTrait,

--- a/lib/Analysis/Allocation.cpp
+++ b/lib/Analysis/Allocation.cpp
@@ -20,6 +20,13 @@
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 #define LDBG(X) LLVM_DEBUG(DBGS() << X << "\n")
 
+// Returns partition index when partitionSize > 0, otherwise returns 0.
+static size_t getPartitionIndex(size_t offset, size_t partitionSize) {
+  if (partitionSize == 0)
+    return 0;
+  return offset / partitionSize;
+}
+
 namespace ttng = mlir::triton::nvidia_gpu;
 
 namespace mlir {
@@ -116,9 +123,11 @@ public:
   AllocationAnalysis(Operation *operation,
                      Allocation::FuncAllocMapT *funcAllocMap,
                      Allocation *allocation,
-                     AllocationAnalysisScratchSizeFn scratchSizeGetter)
+                     AllocationAnalysisScratchSizeFn scratchSizeGetter,
+                     size_t partitionSize)
       : operation(operation), funcAllocMap(funcAllocMap),
-        allocation(allocation), scratchSizeGetter(scratchSizeGetter) {
+        allocation(allocation), scratchSizeGetter(scratchSizeGetter),
+        partitionSize(partitionSize) {
     run();
   }
 
@@ -143,6 +152,47 @@ private:
     if (!alloc || !alloc.isSharedMemoryAlloc())
       return;
     auto allocType = alloc.getType();
+    auto alignment = alloc.getAlignmentOrDefault();
+
+    // Handle PartitionedSharedEncodingAttr: create one buffer per partition,
+    // where each buffer contains all groups for that partition concatenated.
+    // With numPartitions=2, numGroups=4: creates 2 buffers, each containing
+    // 4 concatenated pieces.
+    if (auto partitionedEnc = dyn_cast<gpu::PartitionedSharedEncodingAttr>(
+            allocType.getEncoding())) {
+      unsigned numPartitions = partitionedEnc.getNumPartitions();
+      unsigned numGroups = partitionedEnc.getNumGroups();
+      unsigned numLogicalPieces = partitionedEnc.getNumLogicalPieces();
+
+      // Calculate size per logical piece
+      auto partitionLayout = partitionedEnc.getPartitionLayout();
+      int64_t totalNumElems = 0;
+
+      if (auto paddedEnc =
+              dyn_cast<gpu::PaddedSharedEncodingAttr>(partitionLayout)) {
+        SmallVector<int64_t> unpaddedShape = gpu::getShapePerCTA(allocType);
+        totalNumElems = paddedEnc.getPaddedSize(unpaddedShape);
+      } else {
+        auto shapePerCTA = gpu::getAllocationShapePerCTA(allocType);
+        totalNumElems = product<int64_t>(shapePerCTA);
+      }
+
+      int64_t totalBytes =
+          totalNumElems *
+          getIntOrFloatOrPtrBitWidth(allocType.getElementType()) / 8;
+      int64_t pieceSize = totalBytes / numLogicalPieces;
+
+      // Each partition buffer contains all groups concatenated
+      int64_t partitionBufferSize = pieceSize * numGroups;
+
+      // Create buffers for each partition. All partition buffers are neighbors
+      // (must be placed in different physical shared memory partitions).
+      allocation->addPartitionBuffers(alloc, numPartitions, partitionBufferSize,
+                                      alignment);
+      return;
+    }
+
+    // Standard (non-partitioned) buffer allocation
     int64_t numElems = 0;
     if (auto paddedEnc =
             dyn_cast<gpu::PaddedSharedEncodingAttr>(allocType.getEncoding())) {
@@ -155,7 +205,6 @@ private:
     int64_t bytes =
         numElems * getIntOrFloatOrPtrBitWidth(allocType.getElementType()) / 8;
 
-    auto alignment = alloc.getAlignmentOrDefault();
     allocation->addBuffer<BufferT::BufferKind::Explicit>(alloc, bytes,
                                                          alignment);
   }
@@ -247,16 +296,23 @@ private:
 
   /// Computes the liveness range of the allocated value.
   /// Each buffer is allocated only once.
+  /// For partitioned tensors, all partition buffers share the same liveness
+  /// range.
   void resolveExplicitBufferLiveness(
       function_ref<Interval<size_t>(Value value)> getLiveness) {
-    for (auto valueBufferIter : allocation->valueBuffer) {
+    for (auto &valueBufferIter : allocation->valueBuffer) {
       auto value = valueBufferIter.first;
-      auto *buffer = valueBufferIter.second;
-      bufferRange[buffer] = getLiveness(value);
-      LLVM_DEBUG({
-        llvm::dbgs() << "-- buffer " << buffer->id << "; value: ";
-        value.dump();
-      });
+      auto &buffers = valueBufferIter.second;
+      auto range = getLiveness(value);
+
+      // Apply the same liveness range to all buffers for this value
+      for (auto *buffer : buffers) {
+        bufferRange[buffer] = range;
+        LLVM_DEBUG({
+          llvm::dbgs() << "-- buffer " << buffer->id << "; value: ";
+          value.dump();
+        });
+      }
     }
   }
 
@@ -491,7 +547,8 @@ private:
   }
 
   /// Builds a graph of all shared memory values. Edges are created between
-  /// shared memory values that are overlapping.
+  /// shared memory values that are overlapping, or between partition neighbors
+  /// that are placed in the same physical partition.
   void buildInterferenceGraph(const SmallVector<BufferT *> &buffers,
                               GraphT &interference) {
     // Reset interference graph
@@ -527,12 +584,27 @@ private:
           interference[x].insert(y);
         }
       }
+
+      // Partition neighbors interfere if they are in the same
+      // physical partition. This ensures that different partitions of the
+      // same partitioned tensor are placed in different physical partitions.
+      // Only check this when partitioning is enabled (partitionSize > 0).
+      if (partitionSize > 0) {
+        for (auto *neighbor : x->neighbors) {
+          if (getPartitionIndex(x->offset, partitionSize) ==
+              getPartitionIndex(neighbor->offset, partitionSize)) {
+            interference[x].insert(neighbor);
+          }
+        }
+      }
     }
 
     LLVM_DEBUG(dumpInterferenceGraph(interference));
   }
 
   /// Finalizes shared memory offsets considering interference.
+  /// For partition neighbors, bumps to the next physical partition boundary
+  /// to ensure they are placed in different physical partitions.
   void allocate(const SmallVector<BufferT *> &buffers,
                 const GraphT &interference) {
     // Reset shared memory size
@@ -570,7 +642,20 @@ private:
     for (auto x : buffers) {
       size_t newOffset = 0;
       for (auto y : interference.lookup(x)) {
-        newOffset = std::max(newOffset, y->offset + y->size);
+        // Check if y is a partition neighbor of x
+        bool isPartitionNeighbor =
+            std::find(x->neighbors.begin(), x->neighbors.end(), y) !=
+            x->neighbors.end();
+        if (isPartitionNeighbor && partitionSize > 0) {
+          // For partition neighbors, bump to the next partition
+          // boundary to ensure they are in different physical partitions
+          size_t nextPartitionStart =
+              (getPartitionIndex(y->offset, partitionSize) + 1) * partitionSize;
+          newOffset = std::max(newOffset, nextPartitionStart);
+        } else {
+          // Regular interference - just move past the interfering buffer
+          newOffset = std::max(newOffset, y->offset + y->size);
+        }
       }
       if (colors.lookup(x) != 0)
         x->setOffsetAligned(newOffset);
@@ -586,15 +671,48 @@ private:
   Allocation *allocation;
   BufferRangeMapT bufferRange;
   AllocationAnalysisScratchSizeFn scratchSizeGetter;
+  size_t partitionSize;
 };
 
 } // namespace triton
 
-void Allocation::run(
-    FuncAllocMapT &funcAllocMap,
-    triton::AllocationAnalysisScratchSizeFn scratchSizeGetter) {
+void Allocation::run(FuncAllocMapT &funcAllocMap,
+                     triton::AllocationAnalysisScratchSizeFn scratchSizeGetter,
+                     size_t sharedMemoryPartitionSize) {
   triton::AllocationAnalysis(getOperation(), &funcAllocMap, this,
-                             scratchSizeGetter);
+                             scratchSizeGetter, sharedMemoryPartitionSize);
+}
+
+void Allocation::addPartitionBuffers(Value key, unsigned numPartitions,
+                                     size_t partitionSize, size_t alignment) {
+  SmallVector<BufferT *> partitionBuffers;
+  partitionBuffers.reserve(numPartitions);
+
+  Operation *ownerOp = key.getDefiningOp();
+
+  // Create all partition buffers first
+  for (unsigned i = 0; i < numPartitions; ++i) {
+    BufferId nextId = bufferIdCounter++;
+    auto [it, inserted] = bufferSet.insert_or_assign(
+        nextId, BufferT(BufferT::BufferKind::Explicit, nextId, ownerOp,
+                        partitionSize, alignment));
+    partitionBuffers.push_back(&it->second);
+  }
+
+  // Link all different partitions as neighbors.
+  // This ensures they are placed in different physical shared memory
+  // partitions.
+  for (unsigned i = 0; i < numPartitions; ++i) {
+    for (unsigned j = 0; j < numPartitions; ++j) {
+      if (i != j) {
+        partitionBuffers[i]->neighbors.push_back(partitionBuffers[j]);
+      }
+    }
+  }
+
+  // Store all partition buffers in valueBuffer
+  // (all partitions share the same liveness range via their owner)
+  valueBuffer[key] = std::move(partitionBuffers);
 }
 
 std::map<Operation *, SmallVector<Allocation::BufferId>>
@@ -608,12 +726,14 @@ Allocation::getLiveBuffers() {
     if (scratchBuffer != InvalidBufferId)
       liveBuffers[op].push_back(scratchBuffer);
     for (auto result : op->getOpResults()) {
-      auto bufferId = getBufferId(result);
-      if (bufferId == Allocation::InvalidBufferId)
+      auto bufferIds = getBufferIds(result);
+      if (bufferIds.empty())
         continue;
       auto liveOperations = liveness.resolveLiveness(result);
-      for (auto depOp : liveOperations)
-        liveBuffers[depOp].push_back(bufferId);
+      for (auto depOp : liveOperations) {
+        for (auto bufferId : bufferIds)
+          liveBuffers[depOp].push_back(bufferId);
+      }
     }
   };
   rootOperation->walk(analyzeOperation);

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -284,7 +284,7 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
       memoryEffectOpInterface.getEffects(effectInstances);
       for (auto effectInstance : effectInstances) {
         if (auto value = effectInstance.getValue()) {
-          for (auto bufferId : allocation->getBufferIds(value)) {
+          for (auto bufferId : allocation->getAllBufferIdsWithAliases(value)) {
             if (bufferId != Allocation::InvalidBufferId) {
               auto interval = allocation->getAllocatedInterval(bufferId);
               auto slice = AllocationSlice(value, interval);

--- a/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.cpp
@@ -1,28 +1,47 @@
 #include "triton/Conversion/TritonGPUToLLVM/AllocateSharedMemoryUtility.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 namespace mlir::triton::gpu {
 
 void attachAllocationSizeAndOffsetAttr(ModuleOp mod,
                                        ModuleAllocation &allocation) {
   MLIRContext *ctx = mod.getContext();
+  auto i32Ty = IntegerType::get(ctx, 32);
 
   mod.walk<mlir::WalkOrder::PreOrder>([&](FunctionOpInterface funcOp) {
     auto *funcAllocation = allocation.getFuncData(funcOp);
     funcOp.walk([&](Operation *op) {
+      // Handle scratch buffers (from operations like convert_layout)
       auto oBufferId = funcAllocation->getBufferId(op);
-      int offset = -1;
-      if (oBufferId != Allocation::InvalidBufferId)
-        offset = funcAllocation->getOffset(oBufferId);
-      else if (op->getNumResults() == 1) {
-        Value value = op->getResult(0);
-        auto vBufferId = funcAllocation->getBufferId(value);
-        if (vBufferId != Allocation::InvalidBufferId)
-          offset = funcAllocation->getOffset(vBufferId);
-      }
-      if (offset == -1)
+      if (oBufferId != Allocation::InvalidBufferId) {
+        int offset = funcAllocation->getOffset(oBufferId);
+        op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
         return;
-      op->setAttr("allocation.offset",
-                  IntegerAttr::get(IntegerType::get(ctx, 32), offset));
+      }
+
+      // Handle explicit buffers (from values like local_alloc results)
+      if (op->getNumResults() != 1)
+        return;
+
+      Value value = op->getResult(0);
+      auto bufferIds = funcAllocation->getBufferIds(value);
+      if (bufferIds.empty())
+        return;
+
+      // For partitioned tensors, set an array of offsets (one per partition)
+      if (bufferIds.size() > 1) {
+        SmallVector<Attribute> offsetAttrs;
+        for (auto bufferId : bufferIds) {
+          int partitionOffset = funcAllocation->getOffset(bufferId);
+          offsetAttrs.push_back(IntegerAttr::get(i32Ty, partitionOffset));
+        }
+        op->setAttr("allocation.offset", ArrayAttr::get(ctx, offsetAttrs));
+        return;
+      }
+
+      // Standard single offset for non-partitioned tensors
+      int offset = funcAllocation->getOffset(bufferIds[0]);
+      op->setAttr("allocation.offset", IntegerAttr::get(i32Ty, offset));
     });
     return WalkResult::skip();
   });

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -207,9 +207,16 @@ struct LocalAllocOpConversion
     if (!op.isSharedMemoryAlloc())
       return failure();
     Location loc = op->getLoc();
+    auto memDescTy = cast<MemDescType>(op.getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     Value smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
-    auto memDescTy = cast<MemDescType>(op.getType());
     auto typeConverter = getTypeConverter();
 
     auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
@@ -263,6 +270,13 @@ public:
     auto memDescVal = op.getSrc();
     auto regVal = op.getResult();
     auto memDescTy = cast<MemDescType>(memDescVal.getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     auto regTy = cast<RankedTensorType>(regVal.getType());
     auto typeConverter = getTypeConverter();
 
@@ -327,6 +341,13 @@ public:
     Value memDescVal = op.getDst();
     auto typeConverter = getTypeConverter();
     auto memDescTy = cast<MemDescType>(memDescVal.getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
     auto smemObj = LLVM::getSharedMemoryObjectFromStruct(loc, adaptor.getDst(),
                                                          llvmElemTy, rewriter);
@@ -374,6 +395,13 @@ public:
     auto loc = op.getLoc();
     auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getSrc().getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     auto regTy = cast<RankedTensorType>(op.getType());
     auto typeConverter = getTypeConverter();
 
@@ -416,6 +444,13 @@ public:
     auto loc = op.getLoc();
     auto *ctx = op.getContext();
     auto memDescTy = cast<MemDescType>(op.getDst().getType());
+    // TODO: PartitionedSharedEncoding lowering will be enabled in subsequent
+    // PRs.
+    if (isa<triton::gpu::PartitionedSharedEncodingAttr>(
+            memDescTy.getEncoding())) {
+      return rewriter.notifyMatchFailure(
+          op, "PartitionedSharedEncoding not yet supported in lowering");
+    }
     auto valuesTy = cast<RankedTensorType>(op.getValues().getType());
     auto typeConverter = getTypeConverter();
 

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -1834,6 +1834,96 @@ SharedLinearEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
 }
 
 //===----------------------------------------------------------------------===//
+// PartitionedShared encoding
+//===----------------------------------------------------------------------===//
+
+void PartitionedSharedEncodingAttr::print(AsmPrinter &printer) const {
+  printer << "<{numPartitions = " << getNumPartitions()
+          << ", numGroups = " << getNumGroups()
+          << ", partitionDim = " << getPartitionDim()
+          << ", partitionLayout = " << getPartitionLayout() << "}>";
+}
+
+Attribute PartitionedSharedEncodingAttr::parse(AsmParser &parser, Type type) {
+  if (parser.parseLess().failed())
+    return {};
+  DictionaryAttr dict;
+  if (parser.parseAttribute(dict).failed())
+    return {};
+  if (parser.parseGreater().failed())
+    return {};
+
+  unsigned numPartitions = 0;
+  unsigned numGroups = 0;
+  unsigned partitionDim = 0;
+  Attribute partitionLayout = nullptr;
+
+  for (const NamedAttribute &attr : dict) {
+    if (attr.getName() == "numPartitions") {
+      if (parseUInt(parser, attr, numPartitions, "numPartitions").failed())
+        return {};
+    } else if (attr.getName() == "numGroups") {
+      if (parseUInt(parser, attr, numGroups, "numGroups").failed())
+        return {};
+    } else if (attr.getName() == "partitionDim") {
+      if (parseUInt(parser, attr, partitionDim, "partitionDim").failed())
+        return {};
+    } else if (attr.getName() == "partitionLayout") {
+      partitionLayout = attr.getValue();
+    } else {
+      parser.emitError(parser.getNameLoc(), "unexpected key: ")
+          << attr.getName().strref();
+      return {};
+    }
+  }
+
+  if (!partitionLayout) {
+    parser.emitError(parser.getNameLoc(), "missing partitionLayout");
+    return {};
+  }
+
+  auto sharedEnc = mlir::dyn_cast<SharedEncodingTrait>(partitionLayout);
+
+  if (!sharedEnc) {
+    parser.emitError(parser.getNameLoc(),
+                     "partitionLayout must be a SharedEncodingTrait");
+    return {};
+  }
+
+  return PartitionedSharedEncodingAttr::get(parser.getContext(), numPartitions,
+                                            numGroups, partitionDim, sharedEnc);
+}
+
+CGAEncodingAttr PartitionedSharedEncodingAttr::getCGALayout() const {
+  auto layoutEncTrait = cast<LayoutEncodingTrait>(getPartitionLayout());
+  return layoutEncTrait.getCGALayout();
+}
+
+LogicalResult PartitionedSharedEncodingAttr::verify(
+    function_ref<InFlightDiagnostic()> emitError, unsigned numPartitions,
+    unsigned numGroups, unsigned partitionDim,
+    SharedEncodingTrait partitionLayout) {
+  // Check numPartitions is a power of 2 and > 0
+  if (numPartitions == 0 || !llvm::isPowerOf2_32(numPartitions))
+    return emitError()
+           << "numPartitions must be a power of 2 and greater than 0";
+
+  // Check numGroups is a power of 2 and > 0
+  if (numGroups == 0 || !llvm::isPowerOf2_32(numGroups))
+    return emitError() << "numGroups must be a power of 2 and greater than 0";
+
+  // Check partitionDim is within bounds of the layout rank
+  auto layoutEncTrait = cast<LayoutEncodingTrait>(partitionLayout);
+  unsigned rank = layoutEncTrait.getRank();
+  if (partitionDim >= rank)
+    return emitError() << "partitionDim (" << partitionDim
+                       << ") must be less than the layout rank (" << rank
+                       << ")";
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // PaddedShared encoding
 //===----------------------------------------------------------------------===//
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -120,7 +120,7 @@ void ProxyFenceAnalysis::update(Operation *op, BlockInfo *blockInfo,
       memoryEffectOpInterface.getEffects(effectInstances);
       for (auto effectInstance : effectInstances) {
         if (auto value = effectInstance.getValue()) {
-          for (auto bufferId : allocation->getBufferIds(value)) {
+          for (auto bufferId : allocation->getAllBufferIdsWithAliases(value)) {
             if (bufferId != Allocation::InvalidBufferId) {
               // TODO: handle proxy read cases. Those are currently handled in
               // FenceInsertionPass where it can generate better placement for

--- a/test/Analysis/test-allocation-partitioned.mlir
+++ b/test/Analysis/test-allocation-partitioned.mlir
@@ -1,0 +1,133 @@
+// RUN: triton-opt %s -allow-unregistered-dialect -test-print-allocation="partition-size=65536" -verify-diagnostics -o /dev/null
+
+// Test allocation with shared memory partitioning enabled (64KB partition size like for AMD GFX1250)
+// With partition-size=65536, partition buffers should be placed in different 64KB physical partitions
+
+#A_SHARED = #ttg.swizzled_shared<{vec = 2, perPhase = 2, maxPhase = 4, order = [1, 0]}>
+#PADDED_SHARED = #ttg.padded_shared<[256:+8] {order = [1, 0], shape = [16, 32]}>
+
+// 2 partitions, 2 groups each
+// Each piece is 1052 bytes, so each partition buffer is 1052 * 2 = 2104 bytes
+#PARTITIONED_2P_2G = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #PADDED_SHARED}>
+
+// 4 partitions, 1 group each
+// Each piece is 1052 bytes, each partition buffer is 1052 * 1 = 1052 bytes
+#PARTITIONED_4P_1G = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 0, partitionLayout = #PADDED_SHARED}>
+
+// 2 partitions, 4 groups each (using swizzled layout)
+// 64x32xf16 = 4096 bytes total, 8 pieces = 512 bytes each, partition buffer = 512 * 4 = 2048 bytes
+#PARTITIONED_2P_4G = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 4, partitionDim = 0, partitionLayout = #A_SHARED}>
+
+// 4 partitions, 2 groups each (using swizzled layout)
+// 64x32xf16 = 4096 bytes total, 8 pieces = 512 bytes each, partition buffer = 512 * 2 = 1024 bytes
+#PARTITIONED_4P_2G = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 2, partitionDim = 0, partitionLayout = #A_SHARED}>
+
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
+
+// Test basic 2 partitions, 2 groups allocation
+// expected-remark @below {{partitioned_2p_2g}}
+// expected-remark @below {{size = 67640}}
+tt.func @partitioned_2p_2g() {
+  // 2 partition buffers: one for partition 0 (contains groups 0,1) and one for partition 1 (contains groups 0,1)
+  // Each partition buffer is 2104 bytes (1052 bytes per piece * 2 groups)
+  // With 64KB partition size, the two partition buffers are placed in different 64KB physical partitions
+  // expected-remark @below {{offset = 0, size = 2104}}
+  // expected-remark @below {{offset = 65536, size = 2104}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Test 4 partitions, 1 group each - each partition is a neighbor to all others
+// expected-remark @below {{partitioned_4p_1g}}
+// expected-remark @below {{size = 197660}}
+tt.func @partitioned_4p_1g() {
+  // 4 partition buffers, each containing 1 group = 1052 bytes each
+  // All 4 partitions are neighbors, so they must be in different 64KB physical partitions
+  // expected-remark @below {{offset = 0, size = 1052}}
+  // expected-remark @below {{offset = 65536, size = 1052}}
+  // expected-remark @below {{offset = 131072, size = 1052}}
+  // expected-remark @below {{offset = 196608, size = 1052}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_4P_1G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Test 2 partitions, 4 groups each with swizzled layout
+// expected-remark @below {{partitioned_2p_4g}}
+// expected-remark @below {{size = 67584}}
+tt.func @partitioned_2p_4g() {
+  // 2 partition buffers, each containing 4 groups concatenated = 2048 bytes each
+  // With 64KB partition size, the two partition buffers are placed in different 64KB physical partitions
+  // expected-remark @below {{offset = 0, size = 2048}}
+  // expected-remark @below {{offset = 65536, size = 2048}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Test 4 partitions, 2 groups each - four partitions need four different physical partitions
+// expected-remark @below {{partitioned_4p_2g}}
+// expected-remark @below {{size = 197632}}
+tt.func @partitioned_4p_2g() {
+  // 4 partition buffers, each containing 2 groups concatenated = 1024 bytes each
+  // All 4 partitions are neighbors, so they must be in different 64KB physical partitions
+  // expected-remark @below {{offset = 0, size = 1024}}
+  // expected-remark @below {{offset = 65536, size = 1024}}
+  // expected-remark @below {{offset = 131072, size = 1024}}
+  // expected-remark @below {{offset = 196608, size = 1024}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_4P_2G, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// Test partitioned allocation alongside non-partitioned allocation
+// expected-remark @below {{partitioned_with_regular}}
+// expected-remark @below {{size = 67640}}
+tt.func @partitioned_with_regular() {
+  // Non-partitioned allocation: 1024 bytes (placed after the partitioned buffer in partition 0)
+  // expected-remark @below {{offset = 4224, size = 1024}}
+  %regular = ttg.local_alloc : () -> !ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>
+  // Partitioned allocation: 2 partition buffers of 2104 bytes each
+  // expected-remark @below {{offset = 0, size = 2104}}
+  // expected-remark @below {{offset = 65536, size = 2104}}
+  %partitioned = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  // Use both allocations so they overlap in liveness
+  "use"(%regular) : (!ttg.memdesc<32x16xf16, #A_SHARED, #ttg.shared_memory, mutable>) -> ()
+  "use"(%partitioned) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>) -> ()
+  tt.return
+}
+
+// Test multiple partitioned allocations (both live at the same time)
+// expected-remark @below {{multiple_partitioned}}
+// expected-remark @below {{size = 69696}}
+tt.func @multiple_partitioned() {
+  // First partitioned allocation: 2 partition buffers of 2104 bytes each
+  // expected-remark @below {{offset = 0, size = 2104}}
+  // expected-remark @below {{offset = 65536, size = 2104}}
+  %alloc1 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  // Second partitioned allocation: 2 partition buffers of 2048 bytes each
+  // Both allocations are live, so they must be at different offsets within each physical partition
+  // expected-remark @below {{offset = 4224, size = 2048}}
+  // expected-remark @below {{offset = 67648, size = 2048}}
+  %alloc2 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>
+  // Use both allocations so they overlap in liveness
+  "use"(%alloc1) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>) -> ()
+  "use"(%alloc2) : (!ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>) -> ()
+  tt.return
+}
+
+// Test liveness/reuse of partitioned buffers
+// expected-remark @below {{partitioned_reuse}}
+// expected-remark @below {{size = 67640}}
+tt.func @partitioned_reuse() {
+  // First allocation: 2 partition buffers of 2104 bytes each
+  // expected-remark @below {{offset = 0, size = 2104}}
+  // expected-remark @below {{offset = 65536, size = 2104}}
+  %alloc1 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  ttg.local_dealloc %alloc1 : !ttg.memdesc<64x32xf16, #PARTITIONED_2P_2G, #ttg.shared_memory, mutable>
+  // Second allocation after dealloc: should reuse the same memory
+  // expected-remark @below {{offset = 0, size = 2048}}
+  // expected-remark @below {{offset = 65536, size = 2048}}
+  %alloc2 = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_2P_4G, #ttg.shared_memory, mutable>
+  tt.return
+}
+}

--- a/test/Analysis/test-allocation.mlir
+++ b/test/Analysis/test-allocation.mlir
@@ -31,6 +31,10 @@
 #PADDED_SHARED_1_16x256 = #ttg.padded_shared<[128:+4, 256:+8] {order = [1, 0], shape = [16, 256]}>
 #PADDED_SHARED_2_16x256 = #ttg.padded_shared<[64:+2, 128:+4, 256:+8] {order = [1, 0], shape = [16, 256]}>
 
+// PartitionedSharedEncoding attributes for testing
+#PARTITIONED_SHARED_SWIZZLE = #ttg.partitioned_shared<{numPartitions = 2, numGroups = 2, partitionDim = 0, partitionLayout = #A_SHARED}>
+#PARTITIONED_SHARED_PADDED = #ttg.partitioned_shared<{numPartitions = 4, numGroups = 1, partitionDim = 1, partitionLayout = #PADDED_SHARED_0_16x32}>
+
 #smem = #ttg.shared_memory
 
 module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32} {
@@ -1051,6 +1055,32 @@ tt.func @padded_shared_layout_multi_tier() {
   // expected-remark @+2 {{offset = 0, size = 4466}}
   // (16 * 256 + 2 * 63 + 4 * 31 + 8 * 15) * 1B = 4466B
   %alloc1 = ttg.local_alloc : () -> !ttg.memdesc<16x256xi8, #PADDED_SHARED_2_16x256, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// PartitionedSharedEncoding with swizzled inner layout: 64x32xf16, 2 partitions, 2 groups each
+// Without partition-size, pieces are placed consecutively
+// expected-remark @below {{partitioned_shared_swizzle_alloc}}
+// expected-remark @below {{size = 4096}}
+tt.func @partitioned_shared_swizzle_alloc() {
+  // 2 partition buffers, each containing 2 groups = 2048 bytes each
+  // expected-remark @below {{offset = 0, size = 2048}}
+  // expected-remark @below {{offset = 2048, size = 2048}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_SHARED_SWIZZLE, #ttg.shared_memory, mutable>
+  tt.return
+}
+
+// PartitionedSharedEncoding with padded inner layout: 64x32xf16, 4 partitions, 1 group each
+// Without partition-size, pieces are placed consecutively
+// expected-remark @below {{partitioned_shared_padded_alloc}}
+// expected-remark @below {{size = 4220}}
+tt.func @partitioned_shared_padded_alloc() {
+  // 4 partition buffers, each containing 1 group = 1052 bytes each
+  // expected-remark @below {{offset = 0, size = 1052}}
+  // expected-remark @below {{offset = 1056, size = 1052}}
+  // expected-remark @below {{offset = 2112, size = 1052}}
+  // expected-remark @below {{offset = 3168, size = 1052}}
+  %alloc = ttg.local_alloc : () -> !ttg.memdesc<64x32xf16, #PARTITIONED_SHARED_PADDED, #ttg.shared_memory, mutable>
   tt.return
 }
 }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -23,6 +23,7 @@
 #include "TargetInfo.h"
 #include "TritonAMDGPUToLLVM/MembarUtility.h"
 #include "TritonAMDGPUToLLVM/Passes.h"
+#include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -62,7 +63,7 @@ static BlockInfo buildBlockInfoFromBlock(Block *block, Allocation *allocation) {
       mei.getEffects(effs);
       for (auto &eff : effs) {
         if (Value v = eff.getValue()) {
-          for (auto bufId : allocation->getBufferIds(v)) {
+          for (auto bufId : allocation->getAllBufferIdsWithAliases(v)) {
             if (bufId == Allocation::InvalidBufferId)
               continue;
             auto interval = allocation->getAllocatedInterval(bufId);
@@ -357,8 +358,12 @@ public:
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
-    ModuleAllocation moduleAllocation(m);
+
     mlir::triton::AMD::TargetInfo targetInfo(arch.getValue());
+    size_t partitionSize = targetInfo.getSharedMemoryPartitionSize();
+    ModuleAllocation moduleAllocation(
+        m, triton::defaultAllocationAnalysisScratchSizeFn, partitionSize);
+
     if (targetInfo.getISAFamily() == mlir::triton::AMD::ISAFamily::Unknown) {
       m.emitError("unsupported target: '") << arch.getValue() << "'";
       return signalPassFailure();

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MembarUtility.cpp
@@ -38,8 +38,8 @@ bool filterAsyncLocalLoadsDependencies(Operation *op1, Operation *op2,
   Value op2Memdesc = getMemdescValue(op2);
   if (!op1Memdesc || !op2Memdesc)
     return false;
-  auto op1BufferIds = allocation->getBufferIds(op1Memdesc);
-  auto op2BufferIds = allocation->getBufferIds(op2Memdesc);
+  auto op1BufferIds = allocation->getAllBufferIdsWithAliases(op1Memdesc);
+  auto op2BufferIds = allocation->getAllBufferIdsWithAliases(op2Memdesc);
 
   // Check if operations access the same buffer
   bool sameBuffer = llvm::any_of(

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -85,7 +85,7 @@ int TargetInfo::getWarpSize() const {
 }
 
 int TargetInfo::getSharedMemorySize() const {
-  // Should return the maximum capacity in kbyte
+  // Should return the maximum capacity in bytes
   switch (getISAFamily()) {
   case ISAFamily::GFX1250:
     return 320 * 1024;
@@ -93,6 +93,16 @@ int TargetInfo::getSharedMemorySize() const {
     return 160 * 1024;
   default:
     return 64 * 1024;
+  }
+}
+
+size_t TargetInfo::getSharedMemoryPartitionSize() const {
+  switch (getISAFamily()) {
+  case ISAFamily::GFX1250:
+    return 64 * 1024;
+  default:
+    // No partitioning on other targets
+    return 0;
   }
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -22,6 +22,8 @@ public:
 
   int getSharedMemorySize() const;
 
+  size_t getSharedMemoryPartitionSize() const override;
+
   bool supportMaximumMinimum() const override;
 
   bool supportDppBroadcast() const;


### PR DESCRIPTION
The initial patch was reverted because ProxyFenceInsertion.cpp still used 
getBufferIds instead of getAllBufferIdsWithAliases.  Previously, getBufferIds returned 
buffer IDs for both a value and its aliases. With partitioned tensor support, 
a single value can now hold multiple buffers, so the API was split: getBufferIds 
returns only the buffer IDs for a value, while getAllBufferIdsWithAliases includes aliased 
buffer IDs as well.
