### PR TITLE
Fix assert in `_p_matmul`

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_p_matmul.py
@@ -120,7 +120,7 @@ def _p_matmul(
     is_w_microscaled: tl.constexpr = WMxScale is not None
     is_x_microscaled: tl.constexpr = XMxScale is not None
     is_w_mxfp4: tl.constexpr = w_type == tl.uint8 and is_w_microscaled
-    tl.static_assert(not is_w_microscaled or W_TRANSPOSE, "NYI. Non-transposed mxfp4 weights")
+    tl.static_assert(not is_w_mxfp4 or W_TRANSPOSE, "NYI. Non-transposed mxfp4 weights")
     MX_PACK_DIVISOR: tl.constexpr = MXFP_BLOCK_SIZE
     if is_w_microscaled:
         tl.static_assert(w_type == tl.uint8 or (w_type == tl.float8e4nv or w_type == tl.float8e5),


### PR DESCRIPTION
The current check prevents calling the persistent matmul on MXFP8, thought per the comment it is intended to block MXFP4 weights only.