### PR TITLE
[ConSan] Use `-Ofc mid` for ConSan compilation 

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -493,6 +493,10 @@ class CUDABackend(BaseBackend):
             # Accept more ptxas options if provided
             ptx_extra_options = opt.ptx_options.split(" ") if opt.ptx_options else []
 
+            # Use -Ofc mid to compile ConSan code, if nothing else is specified.
+            if "consan" in knobs.compilation.instrumentation_mode:
+                ptx_extra_options += ["-Ofc", "mid"]
+
             # Add --regAllocOptLevel=2 to work around ptxas 13.x bug
             reg_alloc = ['--regAllocOptLevel=2']
 


### PR DESCRIPTION
I tested a variety of `ptxas` flags and found the following (using `01-attention-forward.py`)

```
         compile (sec)    execution (sec)
-O0         19               81
-O1         49               22
-O3         52               21
-Ofc max    19               82 
-Ofc mid    21               9
-Ofc min    21               9
-Ofc 0      52              21
```

Shockingly, `-Ofc mid|min` yield best total compilation+execution times for consan.