### PR TITLE
fix: correct typo 'seperate' to 'separate'

### DIFF
--- a/python/test/unit/plugins/custom_stages.py
+++ b/python/test/unit/plugins/custom_stages.py
@@ -17,7 +17,7 @@ def get_hash():
     return hashlib.sha256(get_key().encode('utf-8')).hexdigest()
 
 
-# Keep custom pipeline stages in a seperate file from kernels as any change to the file
+# Keep custom pipeline stages in a separate file from kernels as any change to the file
 # will trigger a recompile.
 
 


### PR DESCRIPTION
Fix typo in comment: 'seperate' → 'separate'.