### PR TITLE
[Gluon] Add TMEM double buffering API for Blackwell

### DIFF
--- a/python/test/gluon/test_tmem_double_buffer.py
+++ b/python/test/gluon/test_tmem_double_buffer.py
@@ -1,0 +1,52 @@
+"""Tests for TMEM double buffering API."""
+import pytest
+import torch
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.language.nvidia.blackwell import (
+    TensorMemoryLayout,
+    tmem_double_buffer,
+    get_tmem_reg_layout,
+)
+
+
+def is_blackwell():
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability()[0] >= 10
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_allocate_double_buffer():
+    """Test single allocation with slice-based phase selection."""
+
+    @gluon.jit
+    def kernel(BLOCK_M: gl.constexpr, BLOCK_N: gl.constexpr, num_warps: gl.constexpr):
+        layout: gl.constexpr = TensorMemoryLayout([BLOCK_M, BLOCK_N], col_stride=1)
+        db = tmem_double_buffer.allocate_double_buffer(gl.float32, BLOCK_M, BLOCK_N, layout)
+        buf0 = db.get_buffer(0)
+        buf1 = db.get_buffer(1)
+        reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), layout, num_warps)
+        _ = buf0.load(reg_layout)
+        _ = buf1.load(reg_layout)
+
+    kernel[(1, )](128, 128, num_warps=4)
+    torch.cuda.synchronize()
+
+
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell GPU")
+def test_allocate_double_buffer_pair():
+    """Test two-allocation approach with index-based selection."""
+
+    @gluon.jit
+    def kernel(BLOCK_M: gl.constexpr, BLOCK_N: gl.constexpr, num_warps: gl.constexpr):
+        layout: gl.constexpr = TensorMemoryLayout([BLOCK_M, BLOCK_N], col_stride=1)
+        pair = tmem_double_buffer.allocate_double_buffer_pair(gl.float32, BLOCK_M, BLOCK_N, layout)
+        buf0 = pair.index(0)
+        buf1 = pair.index(1)
+        reg_layout: gl.constexpr = get_tmem_reg_layout(gl.float32, (BLOCK_M, BLOCK_N), layout, num_warps)
+        _ = buf0.load(reg_layout)
+        _ = buf1.load(reg_layout)
+
+    kernel[(1, )](128, 128, num_warps=4)
+    torch.cuda.synchronize()

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -9,6 +9,7 @@ from triton.experimental.gluon.language._semantic import _check, _compute_tmem_r
 
 from . import tma
 from . import clc
+from . import tmem_double_buffer
 from ..hopper import fence_async_shared, mbarrier
 from ..ampere import async_copy, mma_v2
 
@@ -28,6 +29,7 @@ __all__ = [
     "mma_v2",
     "tensor_memory_descriptor",
     "TensorMemoryLayout",
+    "tmem_double_buffer",
     "TensorMemoryScalesLayout",
     "tma",
     "_TensorMemoryLinearLayout",

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/tmem_double_buffer.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/tmem_double_buffer.py
@@ -1,0 +1,141 @@
+"""
+TMEM Double Buffering for Blackwell (SM100+).
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING, List, Tuple
+from triton.experimental.gluon.language._core import builtin, constexpr, base_type, base_value
+
+if TYPE_CHECKING:
+    from . import tensor_memory_descriptor, TensorMemoryLayout
+
+__all__ = ["TMEMDoubleBuffer", "TMEMBufferPair", "allocate_double_buffer", "allocate_double_buffer_pair"]
+
+
+class tmem_double_buffer_type(base_type):
+
+    def __init__(self, inner_type, block_m, block_n):
+        self.inner_type, self.block_m, self.block_n = inner_type, block_m, block_n
+
+    def to_ir(self, builder):
+        return self.inner_type.to_ir(builder)
+
+    def _unflatten_ir(self, handles, cursor):
+        inner, cursor = self.inner_type._unflatten_ir(handles, cursor)
+        return TMEMDoubleBuffer(inner, self.block_m, self.block_n), cursor
+
+    def _flatten_ir_types(self, builder, out):
+        self.inner_type._flatten_ir_types(builder, out)
+
+    def __str__(self):
+        return f"tmem_double_buffer<{self.block_m}x{self.block_n}>"
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.block_m == other.block_m and self.block_n == other.block_n
+
+    def mangle(self):
+        return f"TMDB{self.block_m}x{self.block_n}"
+
+
+class TMEMDoubleBuffer(base_value):
+
+    def __init__(self, desc, block_m, block_n):
+        self._desc, self._block_m, self._block_n = desc, block_m, block_n
+        self.type = tmem_double_buffer_type(desc.type, block_m, block_n)
+        self.handle = desc.handle
+
+    def _flatten_ir(self, handles):
+        self._desc._flatten_ir(handles)
+
+    @property
+    def block_m(self):
+        return self._block_m
+
+    @property
+    def block_n(self):
+        return self._block_n
+
+    @builtin
+    def get_buffer(self, phase, _semantic=None):
+        if isinstance(phase, constexpr):
+            phase_val = phase.value
+        elif isinstance(phase, int):
+            phase_val = phase
+        else:
+            raise NotImplementedError("Use allocate_double_buffer_pair() for runtime phase.")
+        return self._desc.slice(phase_val * self._block_n, self._block_n, _semantic=_semantic)
+
+
+@builtin
+def allocate_double_buffer(element_ty, block_m, block_n, layout, _semantic=None):
+    from triton.experimental.gluon.language._core import _unwrap_if_constexpr
+    from . import allocate_tensor_memory, TensorMemoryLayout
+    element_ty, block_m, block_n, layout = [_unwrap_if_constexpr(x) for x in [element_ty, block_m, block_n, layout]]
+    double_layout = TensorMemoryLayout(block=(layout.block[0], layout.block[1] * 2), col_stride=layout.col_stride,
+                                       cta_split_num=layout.cta_split_num, two_ctas=layout.two_ctas)
+    desc = allocate_tensor_memory(element_ty, [block_m, block_n * 2], double_layout, value=None, _semantic=_semantic)
+    return TMEMDoubleBuffer(desc, block_m, block_n)
+
+
+class tmem_buffer_pair_type(base_type):
+
+    def __init__(self, inner_type, block_m, block_n):
+        self.inner_type, self.block_m, self.block_n = inner_type, block_m, block_n
+
+    def to_ir(self, builder):
+        return self.inner_type.to_ir(builder)
+
+    def _unflatten_ir(self, handles, cursor):
+        buf0, cursor = self.inner_type._unflatten_ir(handles, cursor)
+        buf1, cursor = self.inner_type._unflatten_ir(handles, cursor)
+        return TMEMBufferPair(buf0, buf1, self.block_m, self.block_n), cursor
+
+    def _flatten_ir_types(self, builder, out):
+        self.inner_type._flatten_ir_types(builder, out)
+        self.inner_type._flatten_ir_types(builder, out)
+
+    def __str__(self):
+        return f"tmem_buffer_pair<{self.block_m}x{self.block_n}>"
+
+    def __eq__(self, other):
+        return type(self) is type(other) and self.block_m == other.block_m and self.block_n == other.block_n
+
+    def mangle(self):
+        return f"TMBP{self.block_m}x{self.block_n}"
+
+
+class TMEMBufferPair(base_value):
+
+    def __init__(self, buf0, buf1, block_m, block_n):
+        self._buf0, self._buf1, self._block_m, self._block_n = buf0, buf1, block_m, block_n
+        self.type = tmem_buffer_pair_type(buf0.type, block_m, block_n)
+        self.handle = buf0.handle
+
+    def _flatten_ir(self, handles):
+        self._buf0._flatten_ir(handles)
+        self._buf1._flatten_ir(handles)
+
+    @property
+    def block_m(self):
+        return self._block_m
+
+    @property
+    def block_n(self):
+        return self._block_n
+
+    @builtin
+    def index(self, phase, _semantic=None):
+        if isinstance(phase, constexpr):
+            return self._buf0 if phase.value == 0 else self._buf1
+        if isinstance(phase, int):
+            return self._buf0 if phase == 0 else self._buf1
+        raise NotImplementedError("Runtime tensor phase not yet supported.")
+
+
+@builtin
+def allocate_double_buffer_pair(element_ty, block_m, block_n, layout, _semantic=None):
+    from triton.experimental.gluon.language._core import _unwrap_if_constexpr
+    from . import allocate_tensor_memory
+    element_ty, block_m, block_n, layout = [_unwrap_if_constexpr(x) for x in [element_ty, block_m, block_n, layout]]
+    buf0 = allocate_tensor_memory(element_ty, [block_m, block_n], layout, value=None, _semantic=_semantic)
+    buf1 = allocate_tensor_memory(element_ty, [block_m, block_n], layout, value=None, _semantic=_semantic)
+    return TMEMBufferPair(buf0, buf1, block_m, block_n)


### PR DESCRIPTION
In persistent matmul kernels, the epilogue (writing results to global memory) can become a bottleneck because it must wait for MMA to complete before reading the accumulator. Double buffering allows overlapping MMA computation on one accumulator while the epilogue reads from the other.

This pattern is commonly used in CUTLASS (ping-pong buffering) to hide epilogue latency and improve throughput.

So this PR adds tmem_double_buffer module with two allocation strategies:
- allocate_double_buffer(): Memory-efficient single allocation
- allocate_double_buffer_pair(): Two separate allocations for flexibility

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
