### PR TITLE
[Tutorial] Fix a typo in 08-grouped-gemm.py

### DIFF
--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -225,7 +225,7 @@ tma_configs = [
 
 @triton.autotune(
     tma_configs,
-    key=['group_a_ptrs', 'group_b_ptrs', 'gropup_c_ptrs', 'group_size'],
+    key=['group_a_ptrs', 'group_b_ptrs', 'group_c_ptrs', 'group_size'],
 )
 @triton.jit
 def grouped_matmul_tma_kernel(


### PR DESCRIPTION
Fix a typo in the tutorial 08-grouped-gemm.py