### PR TITLE
Fix: Remove tensor pointers from autotune keys in 08-grouped-gemm tutorial

### DIFF
--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -225,7 +225,7 @@ tma_configs = [
 
 @triton.autotune(
     tma_configs,
-    key=['group_a_ptrs', 'group_b_ptrs', 'group_c_ptrs', 'group_size'],
+    key=['group_size'],
 )
 @triton.jit
 def grouped_matmul_tma_kernel(


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

**Description**: This PR removes tensor objects (`group_a_ptrs`, `group_b_ptrs`, `group_c_ptrs`) from the `@triton.autotune` keys in the Grouped GEMM tutorial.

Why this matters:
1. **Prevents Misleading Practices**: Tutorials serve as reference templates. Passing tensors to autotune keys is a known anti-pattern. Fixing this prevents developers from propagating this flawed logic into production environments.
2. **Fixes Overhead & Memory Leaks**: Using tensors as keys relies on hashing their Python object IDs. Since these IDs change across dispatches, it triggers continuous re-benchmarking (100% cache miss) and causes VRAM leaks because the autotuner cache retains strong references to the temporary tensors.

Only the scalar `group_size` is retained as a valid cache key.