### PR TITLE
fix(tutorial): correct return order of min/max ms in grouped_gemm benchmark

### DIFF
--- a/python/tutorials/08-grouped-gemm.py
+++ b/python/tutorials/08-grouped-gemm.py
@@ -487,7 +487,7 @@ def benchmark_square_matrices(N, provider):
         ms, min_ms, max_ms = triton.testing.do_bench(
             lambda: triton_tma_perf_fn(d_a_ptrs, d_b_t_ptrs, d_c_ptrs, d_g_sizes, d_g_lds, group_size, dtype=torch.
                                        float16), quantiles=quantiles)
-    return ms, max_ms, min_ms
+    return ms, min_ms, max_ms
 
 
 @triton.testing.perf_report(
@@ -558,7 +558,7 @@ def benchmark_batches(M, provider):
         ms, min_ms, max_ms = triton.testing.do_bench(
             lambda: triton_tma_perf_fn(d_a_ptrs, d_b_t_ptrs, d_c_ptrs, d_g_sizes, d_g_t_lds, group_size, dtype=torch.
                                        float16), quantiles=quantiles)
-    return ms, max_ms, min_ms
+    return ms, min_ms, max_ms
 
 
 benchmark_square_matrices.run(show_plots=True, print_data=True)


### PR DESCRIPTION

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

# Description

**This PR fixes an issue with inverted error bars in the `grouped_gemm` tutorial's performance plot.**

Currently, the `benchmark_batches` and `benchmark_square_matrices` function returns `ms, max_ms, min_ms`. Since the y-axis metric is absolute `runtime(ms)`, this inadvertently swaps the upper and lower bounds for the error bars in the `triton.testing.perf_report` rendering logic.

*(Note: Other tutorials correctly use the inverted order because their y-axis is throughput, e.g., `gbps(min_ms)` as the upper bound. This issue is isolated to `grouped_gemm`.)*