### PR TITLE
[AMD][BACKEND] Fix OOM bug in pipelining with padded layout async copy on GFX950

### DIFF
--- a/test/TritonGPU/amd/amd-pipeline-padded-layout-small-tile-gfx950.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-padded-layout-small-tile-gfx950.mlir
@@ -4,6 +4,7 @@
 #mma = #ttg.amd_mfma<{version = 4, warpsPerCTA = [1, 1], instrShape = [32, 32, 16], isTransposed = true}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
   // CHECK-LABEL: pipeline_padded_layout_gfx950
+  // CHECK-NOT: ttg.padded_shared
   tt.func @pipeline_padded_layout_gfx950(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
     // CHECK: ttg.async_wait %{{.*}}
     %cst = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #mma>

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -215,12 +215,12 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
   constexpr unsigned vecSize = 8; // in favor of dwordX4
   unsigned contigLanes = contigDim / vecSize;
   unsigned wrap = std::min(contigDim, 128u) / padding;
-  unsigned requiredDim = warpSize / contigLanes * wrap;
-  if (nonContigDim < requiredDim) {
-    return {};
-  }
   // wrap == 0 means padding > contigDim, which is not a valid configuration
   if (wrap == 0) {
+    return {};
+  }
+  unsigned requiredDim = warpSize / contigLanes * wrap;
+  if (nonContigDim < requiredDim) {
     return {};
   }
 


### PR DESCRIPTION
# Description
During the execution of TritonAMDGPUPipeline pass on CDNA4, we might end up calling `composePaddedLayoutForAsyncCopyCDNA4` if there is a padded layout and async copy enabled. In the corner case shown in `amd-pipeline-padded-layout-small-tile-gfx950.mlir`, this function will incur in a out-of-memory crash.

The issue is found when computing `llvm::Log2_32(wrap)`, in the case that `wrap` is 0, for which `llvm::Log2_32` will return UINT_MAX. Then, when creating the LinearLayout with UINT_MAX number of bases, it will run out of memory (my system has more than 1TB of memory). It looks like this bug was introduced here: https://github.com/triton-lang/triton/pull/9074

The fix is to simply skip the padded layout composition for such case (like we already do for other invalid cases, such as the `nonContigDim < requiredDim` case). 

To trigger the wrap=0 case, the scenario that I found (there might be more cases) is shown in the LIT test. Basically, we need:
- A small tile ([16, 16] in this case)
- `tt.divisibility = 16 : i32`
- `instrShape` > tile size (in this case, 32 > 16)

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
