### PR TITLE
[Release] Revert enabling use_async_copy by default (revert https://github.com/triton-lang/triton/pull/9087)

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -29,7 +29,7 @@ def is_in_thread_transpose_enabled(arch):
 
 
 def is_async_copy_enabled(arch):
-    return (arch in ["gfx950", "gfx1250"]) if knobs.amd.use_async_copy is None else knobs.amd.use_async_copy
+    return knobs.amd.use_async_copy
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Reverts the use of use_async_copy in the hopes of fixing the many rocm failures. Ideally we could land this PR instead: https://github.com/triton-lang/triton/pull/9431, but I think we should test the revert first so we have a fallback in case LLVM upgrades cause other issues.