### PR TITLE
[AMD] Disable True16 for assembler on gfx11

### DIFF
--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -495,6 +495,8 @@ class HIPBackend(BaseBackend):
         target_features = ''
         if knobs.compilation.enable_asan:
             target_features = '+xnack'
+        if 'gfx11' in options.arch:
+            target_features += ',-real-true16'
         hsaco = amd.assemble_amdgcn(src, options.arch, target_features)
         with tempfile.NamedTemporaryFile() as tmp_out:
             with tempfile.NamedTemporaryFile() as tmp_in:


### PR DESCRIPTION
We already disable True16 on gfx11 in make_amdgcn, but since a recent LLVM bump the assembler rejects Fake16 instructions by default, requiring us to disable True16 here as well.
