### PR TITLE
[AMD] Enable floating-point sanitizer (FpSan) support

### DIFF
--- a/test/TritonGPU/amd/amd-fpsan.mlir
+++ b/test/TritonGPU/amd/amd-fpsan.mlir
@@ -1,0 +1,116 @@
+// RUN: triton-opt %s -split-input-file -tritoninstrument-fp-sanitizer | FileCheck %s
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [64, 1], warpsPerCTA = [4, 1], order = [1, 0]}>
+#dot_operand_a = #ttg.dot_op<{opIdx = 0, parent = #blocked}>
+#dot_operand_b = #ttg.dot_op<{opIdx = 1, parent = #blocked}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @dot_emulation
+  tt.func public @dot_emulation() -> tensor<16x16xf32, #blocked> {
+    // CHECK: scf.for
+    // CHECK-NOT: tt.dot
+    // CHECK-NOT: ttg.convert_layout
+    %cst = arith.constant 1.000000e+00 : f16
+    %zero = arith.constant dense<0.000000e+00> : tensor<16x16xf32, #blocked>
+    %a = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_operand_a>
+    %b = tt.splat %cst : f16 -> tensor<16x16xf16, #dot_operand_b>
+    %out = tt.dot %a, %b, %zero : tensor<16x16xf16, #dot_operand_a> * tensor<16x16xf16, #dot_operand_b> -> tensor<16x16xf32, #blocked>
+    tt.return %out : tensor<16x16xf32, #blocked>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @binary_ops
+  tt.func public @binary_ops(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK: tt.bitcast
+    // CHECK: arith.addi
+    // CHECK: arith.subi
+    // CHECK: arith.muli
+    // CHECK-NOT: arith.addf
+    // CHECK-NOT: arith.subf
+    // CHECK-NOT: arith.mulf
+    %add = arith.addf %a, %b : tensor<4xf32>
+    %sub = arith.subf %a, %b : tensor<4xf32>
+    %mul = arith.mulf %a, %b : tensor<4xf32>
+    %sum = arith.addf %add, %sub : tensor<4xf32>
+    %out = arith.mulf %sum, %mul : tensor<4xf32>
+    tt.return %out : tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @div_rem_ops
+  tt.func public @div_rem_ops(%a: tensor<4xf32>, %b: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK: tt.bitcast
+    // CHECK: arith.xori
+    // CHECK: arith.muli
+    // CHECK-NOT: arith.divf
+    // CHECK-NOT: arith.remf
+    %div = arith.divf %a, %b : tensor<4xf32>
+    %rem = arith.remf %a, %b : tensor<4xf32>
+    %out = arith.addf %div, %rem : tensor<4xf32>
+    tt.return %out : tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @fma_op
+  tt.func public @fma_op(%a: tensor<4xf32>, %b: tensor<4xf32>, %c: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK: arith.muli
+    // CHECK: arith.addi
+    // CHECK-NOT: math.fma
+    %fma = math.fma %a, %b, %c : tensor<4xf32>
+    tt.return %fma : tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @unary_ops
+  tt.func public @unary_ops(%a: tensor<4xf32>) -> tensor<4xf32> {
+    // CHECK: tt.bitcast
+    // CHECK: arith.xori
+    // CHECK: arith.xori
+    // CHECK-NOT: math.exp
+    // CHECK-NOT: math.log
+    // CHECK-NOT: math.sqrt
+    %e = math.exp %a : tensor<4xf32>
+    %l = math.log %e : tensor<4xf32>
+    %s = math.sqrt %l : tensor<4xf32>
+    tt.return %s : tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @cast_extf
+  tt.func public @cast_extf(%a: tensor<4xf16>) -> tensor<4xf32> {
+    // CHECK: tt.bitcast
+    // CHECK: arith.extui
+    // CHECK: arith.shli
+    // CHECK-NOT: arith.extf
+    %0 = arith.extf %a : tensor<4xf16> to tensor<4xf32>
+    tt.return %0 : tensor<4xf32>
+  }
+}
+
+// -----
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @cast_truncf
+  tt.func public @cast_truncf(%a: tensor<4xf32>) -> tensor<4xf16> {
+    // CHECK: tt.bitcast
+    // CHECK: arith.shrui
+    // CHECK: arith.trunci
+    // CHECK-NOT: arith.truncf
+    %0 = arith.truncf %a : tensor<4xf32> to tensor<4xf16>
+    tt.return %0 : tensor<4xf16>
+  }
+}

--- a/third_party/amd/backend/compiler.py
+++ b/third_party/amd/backend/compiler.py
@@ -32,6 +32,10 @@ def is_async_copy_enabled(arch):
     return (arch in ["gfx950", "gfx1250"]) if knobs.amd.use_async_copy is None else knobs.amd.use_async_copy
 
 
+def is_fpsan_supported(arch):
+    return arch in ["gfx942", "gfx950", "gfx1250"]
+
+
 @dataclass(frozen=True)
 class HIPOptions:
     num_warps: int = 4
@@ -270,7 +274,7 @@ class HIPBackend(BaseBackend):
         passes.common.add_canonicalizer(pm)
         passes.common.add_cse(pm)
         passes.common.add_symbol_dce(pm)
-        if options.instrumentation_mode == "fpsan":
+        if options.instrumentation_mode == "fpsan" and is_fpsan_supported(options.arch):
             passes.ttgpuir.add_fp_sanitizer(pm)
         pm.run(mod, 'make_ttgir')
         metadata["tensordesc_meta"] = mod.get_tensordesc_metadata()
@@ -291,7 +295,7 @@ class HIPBackend(BaseBackend):
         amd.passes.ttgpuir.add_warp_pipeline(pm)
         passes.ttgpuir.add_allocate_warp_groups(pm)
 
-        if options.instrumentation_mode == "fpsan":
+        if options.instrumentation_mode == "fpsan" and is_fpsan_supported(options.arch):
             passes.ttgpuir.add_fp_sanitizer(pm)
 
         pm.run(mod, 'gluon_to_ttgir')
@@ -311,6 +315,7 @@ class HIPBackend(BaseBackend):
         passes.convert.add_index_to_llvmir(pm)
 
         amd.passes.ttgpuir.add_allocate_shared_memory(pm)
+        passes.ttgpuir.add_allocate_global_scratch_memory(pm)
         # instrumentation point here so we can override IRs above (e.g., ttir and ttgir)
         if HIPBackend.instrumentation:
             HIPBackend.instrumentation.patch("ttgpuir_to_llvmir", pm, mod.context)
@@ -452,6 +457,8 @@ class HIPBackend(BaseBackend):
         # Get some metadata
         metadata["num_warps"] = total_warps_num
         metadata["shared"] = src.get_int_attr("ttg.shared")
+        metadata["global_scratch_size"] = src.get_int_attr("ttg.global_scratch_memory_size")
+        metadata["global_scratch_align"] = src.get_int_attr("ttg.global_scratch_memory_alignment")
         metadata["profile_scratch_size"] = src.get_int_attr("ttg.profile_scratch_memory_size") or 0
         metadata["profile_scratch_align"] = src.get_int_attr("ttg.profile_scratch_memory_alignment") or 1
 

--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -1002,6 +1002,7 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   uint64_t _stream;
   uint64_t _function;
   int launch_cooperative_grid;
+  PyObject *global_scratch_obj = NULL;
   PyObject *profile_scratch_obj = NULL;
   PyObject *launch_enter_hook = NULL;
   PyObject *launch_exit_hook = NULL;
@@ -1011,12 +1012,12 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
   PyObject *arg_annotations = NULL;
   Py_buffer signature;
   PyObject *kernel_args = NULL;
-  if (!PyArg_ParseTuple(args, "piiiKKO(iii)OOOiOy*O", &launch_cooperative_grid,
+  if (!PyArg_ParseTuple(args, "piiiKKOO(iii)OOOiOy*O", &launch_cooperative_grid,
                         &gridX, &gridY, &gridZ, &_stream, &_function,
-                        &profile_scratch_obj, &num_warps, &num_ctas,
-                        &shared_memory, &launch_metadata, &launch_enter_hook,
-                        &launch_exit_hook, &warp_size, &arg_annotations,
-                        &signature, &kernel_args)) {
+                        &global_scratch_obj, &profile_scratch_obj, &num_warps,
+                        &num_ctas, &shared_memory, &launch_metadata,
+                        &launch_enter_hook, &launch_exit_hook, &warp_size,
+                        &arg_annotations, &signature, &kernel_args)) {
     return NULL;
   }
 
@@ -1058,9 +1059,9 @@ static PyObject *launchKernel(PyObject *self, PyObject *args) {
       goto cleanup;
     }
   }
-  // Add global scratch object (nullptr).
+  // Add global scratch object.
   params[params_idx] = alloca(sizeof(void *));
-  if (!extractPointer(params[params_idx++], Py_None)) {
+  if (!extractPointer(params[params_idx++], global_scratch_obj)) {
     goto cleanup;
   }
   // Add profile scratch object.

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -407,6 +407,8 @@ class HIPLauncher(object):
             device_properties = driver.utils.get_device_properties(device)
             assert device_properties['cooperativeLaunch'], \
                 "Cooperative launch requested but not supported by device"
+        self.global_scratch_size = metadata.global_scratch_size
+        self.global_scratch_align = metadata.global_scratch_align
         self.profile_scratch_size = metadata.profile_scratch_size
         self.profile_scratch_align = metadata.profile_scratch_align
 
@@ -421,12 +423,13 @@ class HIPLauncher(object):
                 return alloc_fn(alloc_size, align, stream)
             return None
 
+        global_scratch = allocate_scratch(self.global_scratch_size, self.global_scratch_align, _allocation._allocator)
         profile_scratch = allocate_scratch(self.profile_scratch_size, self.profile_scratch_align,
                                            _allocation._profile_allocator)
 
-        self.launch(self.launch_cooperative_grid, gridX, gridY, gridZ, stream, function, profile_scratch,
-                    kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook, self.warp_size,
-                    self.arg_annotations, self.kernel_signature, args)
+        self.launch(self.launch_cooperative_grid, gridX, gridY, gridZ, stream, function, global_scratch,
+                    profile_scratch, kernel_metadata, launch_metadata, launch_enter_hook, launch_exit_hook,
+                    self.warp_size, self.arg_annotations, self.kernel_signature, args)
 
 
 class HIPDriver(GPUDriver):


### PR DESCRIPTION
Enable fpsan for gfx942/gfx950/gfx1250, add support for global scratch memory allocation in the launcher and driver, and update the Python tests.