### PR TITLE
2CTA Block Scale MMA with tcgen05.cp

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOpInterfaces.td
@@ -62,6 +62,9 @@ def MMAv5OpInterface : OpInterface<"MMAv5OpInterface"> {
                     "void",
                     "setIsAsync",
                     (ins "bool":$isAsync)>,
+    InterfaceMethod<"Return true if this MMA op uses two CTAs.",
+                    "bool",
+                    "getTwoCtas">,
     InterfaceMethod<"Return true if this MMA op executes asynchronously.",
                     "bool",
                     "isAsync">

--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -619,7 +619,9 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [
 
   let description = [{
     $d += matrix_multiply(scale($lhs, $lhs_scale), scale(rlhs, $rhs_scale))
-    if is_async is false, the op executes synchronously. The barrier operands must not be present in that case.
+    If $two_ctas is set the op will execute a matmul across two contiguous CTAs, it will read the data distributed across the two CTAs
+    and synchronize both CTAs if the op is synchronous.
+    If is_async is false, the op executes synchronously. The barrier operands must not be present in that case.
     Otherwise, if a barrier is given, the op will trigger a commit/arrive on it.
     The result will be safe to read after a barrier wait.
 
@@ -641,6 +643,7 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [
     I1:$pred,
     Variadic<TTG_MemDescType>:$barriers,
     Variadic<I1>:$barrier_preds,
+    UnitAttr:$two_ctas,
     UnitAttr:$is_async
   );
   let results = (outs Optional<TTG_AsyncToken>:$token);
@@ -662,6 +665,7 @@ def TTNG_TCGen5MMAScaledOp : TTNG_Op<"tc_gen5_mma_scaled", [
       "::mlir::Value":$useD, "::mlir::Value":$pred,
       CArg<"::mlir::ValueRange", "{}">:$barriers,
       CArg<"::mlir::ValueRange", "{}">:$barrier_preds,
+      CArg<"bool", "false">:$two_ctas,
       CArg<"bool", "false">:$is_async)>
   ];
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/CheckMatmulTwoCTAs.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/CheckMatmulTwoCTAs.cpp
@@ -28,7 +28,8 @@ public:
     Operation *firstMatmul = nullptr;
     bool firstTwoCTA = false;
 
-    WalkResult result = mod.walk([&](ttng::TCGen5MMAOp op) {
+    // Walk all MMAv5 ops using the interface
+    WalkResult result = mod.walk([&](ttng::MMAv5OpInterface op) -> WalkResult {
       bool currentTwoCTA = op.getTwoCtas();
       if (!firstMatmul) {
         firstMatmul = op;

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -40,10 +40,7 @@ static bool isDistributedMultiCTAOp(Operation *op, bool isRead) {
   if (auto mma = dyn_cast<ttng::TCGen5MMAOp>(op)) {
     return mma.getTwoCtas();
   } else if (auto mmaScaled = dyn_cast<ttng::TCGen5MMAScaledOp>(op)) {
-    // TODO: Change when we support scaled MMA with 2CTAs
-    assert(!ttng::getModuleTwoCTAs(op->getParentOfType<ModuleOp>()) &&
-           "Scaled MMA with 2CTAs not supported");
-    return false;
+    return mmaScaled.getTwoCtas();
   } else if (auto tma = dyn_cast<ttng::AsyncTMACopyGlobalToLocalOp>(op)) {
     return tma.getMulticast();
   }

--- a/python/src/gluon_ir.cc
+++ b/python/src/gluon_ir.cc
@@ -898,13 +898,13 @@ void init_gluon_ir(py::module &&m) {
            [](GluonOpBuilder &self, Value a, Value b, Value acc, Value aScale,
               Value bScale, tt::ScaleDotElemType aType,
               tt::ScaleDotElemType bType, Value useAcc, Value pred,
-              std::vector<Value> &mbarriers,
-              std::vector<Value> &mbarrier_preds) {
+              std::vector<Value> &mbarriers, std::vector<Value> &mbarrier_preds,
+              bool two_ctas) {
              Value accDep;
              auto tokType = self.getBuilder().getType<ttg::AsyncTokenType>();
              self.create<ttng::TCGen5MMAScaledOp>(
                  tokType, a, b, acc, accDep, aScale, bScale, aType, bType,
-                 useAcc, pred, mbarriers, mbarrier_preds);
+                 useAcc, pred, mbarriers, mbarrier_preds, two_ctas);
            })
       .def("create_tcgen05_commit",
            [](GluonOpBuilder &self, Value &barrier, Value &pred,

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -43,6 +43,7 @@ from triton.experimental.gluon.language.nvidia.blackwell import (
     clc,
 )
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
+from triton._C.libtriton.gluon_ir import make_cga_layout
 
 THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
 
@@ -235,7 +236,6 @@ def tma_multicast_copy_kernel(in_desc, out_desc):
 @pytest.mark.skipif(not is_hopper_or_newer(), reason="Requires Hopper")
 @pytest.mark.parametrize("ctas_per_cga", [[2, 1], [1, 4], [4, 4]])
 def test_tma_multicast_copy(ctas_per_cga):
-    from triton._C.libtriton.gluon_ir import make_cga_layout
     cga_split_num = [min(ctas_per_cga[0], 2), min(ctas_per_cga[1], 2)]
     cga_layout = make_cga_layout(ctas_per_cga, cga_split_num, [1, 0])
 
@@ -309,6 +309,22 @@ def tcgen05_mma_multicast_commit_kernel(a_desc, b_desc, out_ptrs, BLOCK_M: ttgl.
     ttgl.store(out_ptrs, out)
 
 
+def make_2cta_cga_layout(ctas_per_cga, cta_split, cta_order, two_cta_dim):
+    ctas_per_cga = list(ctas_per_cga)
+    cta_split = list(cta_split)
+    assert cta_split[two_cta_dim] > 1
+    cta_split[two_cta_dim] //= 2
+    ctas_per_cga[two_cta_dim] //= 2
+    aux_cga_layout = make_cga_layout(ctas_per_cga, cta_split, cta_order)
+    assert two_cta_dim in (0, 1)
+    basis = [0, 0]
+    basis[two_cta_dim] = 1
+    for b in aux_cga_layout:
+        b[two_cta_dim] *= 2
+    cga_layout = [basis] + aux_cga_layout
+    return cga_layout
+
+
 @pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
 @pytest.mark.parametrize("ctas_per_cga", [[2, 1], [2, 4], [4, 4]])
 @pytest.mark.parametrize("two_ctas", [True, False] if is_blackwell() else [False])
@@ -327,24 +343,7 @@ def test_tcgen05_mma_multicast_commit(ctas_per_cga, two_ctas):
     cta_split_b = [1, ctas_per_cga_b[1]]
     cta_order = [1, 0]
 
-    from triton._C.libtriton.gluon_ir import make_cga_layout
     if two_ctas:
-
-        def make_2cta_cga_layout(ctas_per_cga, cta_split, cta_order, two_cta_dim):
-            ctas_per_cga = list(ctas_per_cga)
-            cta_split = list(cta_split)
-            assert cta_split[two_cta_dim] > 1
-            cta_split[two_cta_dim] //= 2
-            ctas_per_cga[two_cta_dim] //= 2
-            aux_cga_layout = make_cga_layout(ctas_per_cga, cta_split, cta_order)
-            assert two_cta_dim in (0, 1)
-            basis = [0, 0]
-            basis[two_cta_dim] = 1
-            for b in aux_cga_layout:
-                b[two_cta_dim] *= 2
-            cga_layout = [basis] + aux_cga_layout
-            return cga_layout
-
         cga_layout_a = make_2cta_cga_layout(ctas_per_cga, cta_split_a, cta_order, 0)
         cga_layout_b = make_2cta_cga_layout(ctas_per_cga_b, cta_split_b, cta_order, 1)
         cga_layout_c = make_2cta_cga_layout(ctas_per_cga, ctas_per_cga, cta_order, 0)
@@ -703,24 +702,7 @@ def test_tma_mma_shared_inputs(warps, reps, ctas_per_cga, two_ctas, multicast):
     BLOCK_K = instr_shape[2] * reps[2]
     K = (256 // bitwidth) * NUM_K_TILES
 
-    from triton._C.libtriton.gluon_ir import make_cga_layout
     if two_ctas:
-
-        def make_2cta_cga_layout(ctas_per_cga, cta_split, cta_order, two_cta_dim):
-            ctas_per_cga = list(ctas_per_cga)
-            cta_split = list(cta_split)
-            assert cta_split[two_cta_dim] > 1
-            cta_split[two_cta_dim] //= 2
-            ctas_per_cga[two_cta_dim] //= 2
-            aux_cga_layout = make_cga_layout(ctas_per_cga, cta_split, cta_order)
-            assert two_cta_dim in (0, 1)
-            basis = [0, 0]
-            basis[two_cta_dim] = 1
-            for b in aux_cga_layout:
-                b[two_cta_dim] *= 2
-            cga_layout = [basis] + aux_cga_layout
-            return cga_layout
-
         cga_layout_a = make_2cta_cga_layout(ctas_per_cga, cta_split_a, cta_order, 0)
         cga_layout_b = make_2cta_cga_layout(ctas_per_cga_b, cta_split_b, cta_order, 1)
         cga_layout_c = make_2cta_cga_layout(ctas_per_cga, ctas_per_cga, cta_order, 0)
@@ -938,26 +920,7 @@ def test_mma_shared_inputs(bitwidth, transpose_a, transpose_b, acc_dtype, warps,
     out_dtype = torch.float32
     cta_order = [1, 0]
 
-    # TODO Remove this function altogether
-
-    from triton._C.libtriton.gluon_ir import make_cga_layout
     if two_ctas:
-
-        def make_2cta_cga_layout(ctas_per_cga, cta_split, cta_order, two_cta_dim):
-            ctas_per_cga = list(ctas_per_cga)
-            cta_split = list(cta_split)
-            assert cta_split[two_cta_dim] > 1
-            cta_split[two_cta_dim] //= 2
-            ctas_per_cga[two_cta_dim] //= 2
-            aux_cga_layout = make_cga_layout(ctas_per_cga, cta_split, cta_order)
-            assert two_cta_dim in (0, 1)
-            basis = [0, 0]
-            basis[two_cta_dim] = 1
-            for b in aux_cga_layout:
-                b[two_cta_dim] *= 2
-            cga_layout = [basis] + aux_cga_layout
-            return cga_layout
-
         cga_layout_a = make_2cta_cga_layout(ctas_per_cga, cta_split_a, cta_order, 0)
         cga_layout_b = make_2cta_cga_layout(ctas_per_cga_b, cta_split_b, cta_order, 1)
         # The TMEM layout for instr_m == 128 splits along M, the one for instr_m == 64 splits along N
@@ -3528,3 +3491,236 @@ def test_clc_basic(num_ctas):
     for pid in range(grid):
         if is_cancelled[pid]:
             assert not was_launched[program_ids[pid]]
+
+
+def align_to(a, b):
+    return triton.cdiv(a, b) * b
+
+
+def make_operand_descriptor(value, BLOCK_MN, BLOCK_K, MIXED_PREC, cga_layout=None):
+    IS_FP4 = value.dtype == torch.uint8
+    ELEM_PER_BYTE = 2 if IS_FP4 else 1
+    IS_MIXED_PREC_FP4 = MIXED_PREC and IS_FP4
+    layout = ttgl.NVMMASharedLayout.get_default_for(
+        [BLOCK_MN, BLOCK_K // ELEM_PER_BYTE],
+        ttgl.uint8 if IS_FP4 else ttgl.float8e4nv,
+        fp4_padded=IS_MIXED_PREC_FP4,
+        cga_layout=cga_layout,
+    )
+    return TensorDescriptor.from_tensor(value, [BLOCK_MN, BLOCK_K // ELEM_PER_BYTE], layout)
+
+
+def make_output_descriptor(M, N, dtype, BLOCK_M, BLOCK_N, cga_layout=None):
+    C = torch.empty(M, N, device="cuda", dtype=dtype)
+    C_dtype = getattr(ttgl, str(dtype).split('.')[1])
+    C_desc_layout = ttgl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_N], C_dtype, cga_layout=cga_layout)
+    return TensorDescriptor.from_tensor(C, [BLOCK_M, BLOCK_N], C_desc_layout)
+
+
+def random_quantized_tensor(MN, K, format):
+    assert format in ["mxfp4", "mxfp8", "nvfp4"]
+    VEC_SIZE = 16 if format == "nvfp4" else 32
+    base = MXFP4Tensor(size=(MN, K), device="cuda").random()
+    scale = MXScaleTensor(size=(MN, K // VEC_SIZE), device="cuda").random(low=1 / 128, high=2.0)
+    ref = base.to(torch.float32)
+    scale_ref = scale.to(torch.float32)
+    value = ref * scale_ref.repeat_interleave(VEC_SIZE, dim=1)
+    if format == "mxfp8":
+        return ref.to(torch.float8_e4m3fn), scale.data, value
+    elif format == "mxfp4":
+        return base.to_packed_tensor(dim=1), scale.data, value
+    else:
+        return base.to_packed_tensor(dim=1), scale_ref.to(torch.float8_e4m3fn), value
+
+
+def swizzle_scales_packed_block(scales, VEC_SIZE):
+    PAD_MN = align_to(scales.shape[0], 128) - scales.shape[0]
+    PAD_K = align_to(scales.shape[1], 4) - scales.shape[1]
+    scales = torch.nn.functional.pad(scales, (0, PAD_K, 0, PAD_MN))
+    MN, SCALE_K = scales.shape[0], scales.shape[1]
+    REP_MN = MN // 128
+    REP_K = SCALE_K // 4
+    scales = scales.reshape(REP_MN, 4, 32, REP_K, 4)
+    scales = scales.permute(0, 3, 2, 1, 4)
+    return scales.contiguous()
+
+
+def make_scales_descriptor(scales, BLOCK_MN, BLOCK_K, VEC_SIZE, cga_layout=None):
+    REP_MN = BLOCK_MN // 128
+    REP_K = BLOCK_K // (VEC_SIZE * 4)
+    block_shape = [1, REP_MN, REP_K, 2, 256]
+    scales = scales.reshape(1, scales.shape[0], scales.shape[1], 2, 256)
+    IS_NVFP4 = scales.dtype == torch.float8_e4m3fn
+    layout = ttgl.NVMMASharedLayout.get_default_for(block_shape, ttgl.float8e4nv if IS_NVFP4 else ttgl.uint8,
+                                                    cga_layout=cga_layout)
+    return TensorDescriptor.from_tensor(scales, block_shape, layout)
+
+
+@gluon.jit
+def unswizzle_scales_shared_memory(smem, BLOCK_MN: ttgl.constexpr, BLOCK_K: ttgl.constexpr, VEC_SIZE: ttgl.constexpr):
+    smem = smem.reshape((smem.shape[1], smem.shape[2], 32, 4, 4))
+    smem = smem.permute((0, 3, 2, 1, 4))
+    return smem.reshape((BLOCK_MN, BLOCK_K // VEC_SIZE))
+
+
+@gluon.jit
+def mma_scaled_tcgen05_copy_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_desc, VEC_SIZE: ttgl.constexpr,
+                                   block_layout_c: ttgl.constexpr, multicast: ttgl.constexpr):
+    A_IS_FP4: ttgl.constexpr = a_desc.dtype == ttgl.uint8
+    B_IS_FP4: ttgl.constexpr = b_desc.dtype == ttgl.uint8
+    A_ELEM_PER_BYTE: ttgl.constexpr = 2 if A_IS_FP4 else 1
+    B_ELEM_PER_BYTE: ttgl.constexpr = 2 if B_IS_FP4 else 1
+    BLOCK_M: ttgl.constexpr = c_desc.block_type.shape[0]
+    BLOCK_N: ttgl.constexpr = c_desc.block_type.shape[1]
+    BLOCK_K: ttgl.constexpr = a_desc.block_type.shape[1] * A_ELEM_PER_BYTE
+    K = a_desc.shape[1] * A_ELEM_PER_BYTE
+
+    a_smem = ttgl.allocate_shared_memory(a_desc.dtype, a_desc.block_type.shape, a_desc.layout)
+    b_smem = ttgl.allocate_shared_memory(b_desc.dtype, b_desc.block_type.shape, b_desc.layout)
+
+    scale_layout: ttgl.constexpr = TensorMemoryScalesLayout()
+    a_scale_tmem = allocate_tensor_memory(a_scale_desc.dtype, [BLOCK_M, BLOCK_K // VEC_SIZE], scale_layout)
+    b_scale_tmem = allocate_tensor_memory(b_scale_desc.dtype, [BLOCK_N, BLOCK_K // VEC_SIZE], scale_layout)
+    num_ctas: ttgl.constexpr = ttgl.num_ctas()
+    two_ctas: ttgl.constexpr = num_ctas > 1
+    tmem_layout: ttgl.constexpr = TensorMemoryLayout([BLOCK_M // num_ctas, BLOCK_N], col_stride=1,
+                                                     cta_split_num=(num_ctas, 1), two_ctas=two_ctas)
+    acc_tmem = allocate_tensor_memory(ttgl.float32, [BLOCK_M, BLOCK_N], tmem_layout)
+
+    tma_bar = mbarrier.allocate_mbarrier(two_ctas=two_ctas)
+    mma_bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(tma_bar, count=1)
+    mbarrier.init(mma_bar, count=1)
+    if two_ctas:
+        mbarrier.sync_cluster_init()
+
+    phase_tma = 0
+    phase_mma = 0
+    pid_m = ttgl.program_id(0)
+    pid_n = ttgl.program_id(1)
+    off_m = pid_m * BLOCK_M
+    off_n = pid_n * BLOCK_N
+
+    a_scale_smem = ttgl.allocate_shared_memory(a_scale_desc.dtype, a_scale_desc.block_type.shape, a_scale_desc.layout)
+    b_scale_smem = ttgl.allocate_shared_memory(b_scale_desc.dtype, b_scale_desc.block_type.shape, b_scale_desc.layout)
+    REP_M: ttgl.constexpr = a_scale_desc.block_type.shape[1]
+    REP_N: ttgl.constexpr = b_scale_desc.block_type.shape[1]
+    A_REP_K: ttgl.constexpr = a_scale_desc.block_type.shape[2]
+    B_REP_K: ttgl.constexpr = b_scale_desc.block_type.shape[2]
+    off_m_a_scale = pid_m * REP_M
+    off_n_b_scale = pid_n * REP_N
+
+    for k in range(0, K, BLOCK_K):
+        off_k_a = k // A_ELEM_PER_BYTE
+        off_k_b = k // B_ELEM_PER_BYTE
+        off_k_a_scale = (k // BLOCK_K) * A_REP_K
+        off_k_b_scale = (k // BLOCK_K) * B_REP_K
+
+        EXPECTED_BYTES: ttgl.constexpr = (a_desc.nbytes_per_cta + b_desc.nbytes_per_cta + a_scale_desc.nbytes_per_cta +
+                                          b_scale_desc.nbytes_per_cta)
+        mbarrier.expect(tma_bar, EXPECTED_BYTES)
+        tma.async_copy_global_to_shared(a_desc, [off_m, off_k_a], tma_bar, a_smem)
+        tma.async_copy_global_to_shared(b_desc, [off_n, off_k_b], tma_bar, b_smem)
+        tma.async_copy_global_to_shared(a_scale_desc, [0, off_m_a_scale, off_k_a_scale, 0, 0], tma_bar, a_scale_smem)
+        tma.async_copy_global_to_shared(b_scale_desc, [0, off_n_b_scale, off_k_b_scale, 0, 0], tma_bar, b_scale_smem,
+                                        multicast=multicast)
+        mbarrier.wait(tma_bar, phase_tma, deps=[a_smem, b_smem, a_scale_smem, b_scale_smem])
+        phase_tma ^= 1
+
+        a_scale = unswizzle_scales_shared_memory(a_scale_smem, BLOCK_M, BLOCK_K, VEC_SIZE)
+        b_scale = unswizzle_scales_shared_memory(b_scale_smem, BLOCK_N, BLOCK_K, VEC_SIZE)
+        fence_async_shared()
+        tcgen05_copy(a_scale, a_scale_tmem)
+        tcgen05_copy(b_scale, b_scale_tmem)
+
+        a_format: ttgl.constexpr = "e2m1" if A_IS_FP4 else "e4m3"
+        b_format: ttgl.constexpr = "e2m1" if B_IS_FP4 else "e4m3"
+        tcgen05_mma_scaled(a_smem, b_smem.permute((1, 0)), acc_tmem, a_scale_tmem, b_scale_tmem, a_format, b_format,
+                           use_acc=(k != 0))
+        tcgen05_commit(mma_bar)
+        mbarrier.wait(mma_bar, phase_mma)
+        phase_mma ^= 1
+
+    mbarrier.invalidate(tma_bar)
+    mbarrier.invalidate(mma_bar)
+    cga_layout: ttgl.constexpr = block_layout_c.cga_layout if block_layout_c is not None else None
+    acc_reg_layout: ttgl.constexpr = get_tmem_reg_layout(ttgl.float32, (BLOCK_M, BLOCK_N), tmem_layout,
+                                                         ttgl.num_warps(), cga_layout=cga_layout)
+    acc = acc_tmem.load(acc_reg_layout)
+    if two_ctas:
+        acc = ttgl.convert_layout(acc, block_layout_c)
+    acc = acc.to(c_desc.dtype)
+    acc_smem = ttgl.allocate_shared_memory(c_desc.dtype, c_desc.block_type.shape, c_desc.layout)
+    acc_smem.store(acc)
+    fence_async_shared()
+    tma.async_copy_shared_to_global(c_desc, [off_m, off_n], acc_smem)
+    tma.store_wait(0)
+
+
+def mma_scaled_tcgen05_copy(A, B, A_scale, B_scale, VEC_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, num_ctas, multicast,
+                            out_dtype=torch.float16):
+    from dataclasses import replace
+    M, N = A.shape[0], B.shape[0]
+    MIXED_PREC = A.dtype != B.dtype
+    two_ctas = num_ctas > 1
+    warps = [4, 1]
+    num_warps = warps[0] * warps[1]
+
+    ctas_per_cga = (2, 1) if two_ctas else None
+    cta_order = (1, 0) if two_ctas else None
+    cta_split = (2, 1) if two_ctas else None
+    cga_layout_a = make_2cta_cga_layout(ctas_per_cga, cta_split, cta_order, 0) if two_ctas else None
+    cga_layout_b = make_2cta_cga_layout(ctas_per_cga, cta_split, cta_order, 0) if two_ctas else None
+    cga_layout_c = make_2cta_cga_layout(ctas_per_cga, ctas_per_cga, cta_order, 0) if two_ctas else None
+
+    # Scale tensors have shape [1, REP_MN, REP_K, 2, 256] (5 dimensions)
+    # CGA layout basis vectors describe how indices change between CTAs
+    # A_scale: [0, 1, 0, 0, 0] split A scales along REP_M axis across CTAs
+    # B_scale: [0, 0, 0, 0, 0] duplicate (no split) B scales to all CTAs
+    cga_layout_a_scale = [[0, 1, 0, 0, 0]] if two_ctas else None
+    cga_layout_b_scale = [[0, 0, 0, 0, 0]] if two_ctas else None
+
+    A_desc = make_operand_descriptor(A, BLOCK_M, BLOCK_K, MIXED_PREC, cga_layout=cga_layout_a)
+    B_desc = make_operand_descriptor(B, BLOCK_N, BLOCK_K, MIXED_PREC, cga_layout=cga_layout_b)
+    C_desc = make_output_descriptor(M, N, out_dtype, BLOCK_M, BLOCK_N, cga_layout=cga_layout_c)
+    A_scale_desc = make_scales_descriptor(A_scale, BLOCK_M, BLOCK_K, VEC_SIZE, cga_layout=cga_layout_a_scale)
+    B_scale_desc = make_scales_descriptor(B_scale, BLOCK_N, BLOCK_K, VEC_SIZE, cga_layout=cga_layout_b_scale)
+
+    a_scale_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=0, element_bitwidth=8, rank=5,
+                                            cga_layout=cga_layout_a_scale)
+    b_scale_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=0, element_bitwidth=8, rank=5,
+                                            cga_layout=cga_layout_b_scale)
+    A_scale_desc = replace(A_scale_desc, layout=a_scale_layout)
+    B_scale_desc = replace(B_scale_desc, layout=b_scale_layout)
+
+    block_layout_c = ttgl.BlockedLayout([1, 8], [1, 32], warps_per_cta=warps, order=[1, 0],
+                                        cga_layout=cga_layout_c) if two_ctas else None
+
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    mma_scaled_tcgen05_copy_kernel[grid](A_desc, B_desc, C_desc, A_scale_desc, B_scale_desc, VEC_SIZE, block_layout_c,
+                                         num_warps=num_warps, num_ctas=num_ctas, multicast=multicast)
+    return C_desc.base
+
+
+@pytest.mark.parametrize("M, N, K", [(2048, 2048, 4096)])
+@pytest.mark.parametrize("BLOCK_N", [128, 256])
+@pytest.mark.parametrize("BLOCK_K", [128, 256])
+@pytest.mark.parametrize("a_format, b_format", [
+    ("mxfp8", "mxfp8"),
+    ("nvfp4", "nvfp4"),
+    ("mxfp8", "mxfp4"),
+])
+@pytest.mark.parametrize("num_ctas", [1, 2])
+@pytest.mark.parametrize("multicast", [True, False])
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_mma_scaled_tcgen05_copy(M, N, K, BLOCK_N, BLOCK_K, a_format, b_format, num_ctas, multicast):
+    BLOCK_M = 256 if num_ctas == 2 else 128
+    torch.manual_seed(0)
+    A, A_scale, A_ref = random_quantized_tensor(M, K, a_format)
+    B, B_scale, B_ref = random_quantized_tensor(N, K, b_format)
+    VEC_SIZE = 16 if a_format == "nvfp4" else 32
+    A_scale = swizzle_scales_packed_block(A_scale, VEC_SIZE)
+    B_scale = swizzle_scales_packed_block(B_scale, VEC_SIZE)
+    C_ref = A_ref @ B_ref.T
+    C = mma_scaled_tcgen05_copy(A, B, A_scale, B_scale, VEC_SIZE, BLOCK_M, BLOCK_N, BLOCK_K, num_ctas, multicast)
+    torch.testing.assert_close(C_ref, C.to(torch.float32), atol=1e-3, rtol=1e-3)

--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -511,7 +511,8 @@ def tcgen05_mma_scaled(a, b, acc, a_scale, b_scale, a_type, b_type, *, use_acc=T
     a_type = _semantic._str_to_fp_type(a_type.value)
     b_type = _semantic._str_to_fp_type(b_type.value)
     _semantic.builder.create_tcgen05_mma_scaled(a.handle, b.handle, acc.handle, a_scale.handle, b_scale.handle, a_type,
-                                                b_type, use_acc.handle, pred.handle, mbarriers, mbarrier_preds)
+                                                b_type, use_acc.handle, pred.handle, mbarriers, mbarrier_preds,
+                                                acc.layout.two_ctas)
 
 
 @constexpr_function

--- a/test/Conversion/tritongpu_to_llvm_blackwell.mlir
+++ b/test/Conversion/tritongpu_to_llvm_blackwell.mlir
@@ -307,8 +307,12 @@ module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 1 : i32, "ttg.thr
 tt.func public @tmem_copy_2d(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>,
                              %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
 		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
+  // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32)
+  // CHECK: [[IS_WARP_0:%.*]] = llvm.icmp "eq" {{.*}}, [[ZERO]] : i32
+  // CHECK: [[ELECT:%.*]] = nvvm.elect.sync
+  // CHECK: [[WARP_PRED:%.*]] = llvm.and [[IS_WARP_0]], [[ELECT]]
   // CHECK-COUNT-8: tcgen05.cp.cta_group::1.warpx4.32x128b
-  // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64
+  // CHECK: tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [ $0 + 0 ];", "r,b" {{.*}}, [[WARP_PRED]]
   ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
   tt.return
 }
@@ -338,6 +342,36 @@ tt.func public @tmem_copy_2d_slice(%src: !ttg.memdesc<128x32xi8, #shared2, #ttg.
   tt.return
 }
 
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread=[1, 4], threadsPerWarp=[32, 1], warpsPerCTA=[4, 1], order=[0, 1], CGALayout = [[1, 0]]}>
+#shared = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16]], block = [[0, 0]]}, alignment = 16>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0], CGALayout = [[0]]}>
+#shared2 = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [0, 4], [0, 8], [0, 16], [128, 0], [256, 0]], block = [[0, 0]]}, alignment = 16>
+#shared3 = #ttg.shared_linear<{offset = [[0, 1], [0, 2], [32, 0], [64, 0], [1, 0], [2, 0], [4, 0], [8, 0], [16, 0], [128, 0]], block = [[0, 0]]}, alignment = 128>
+#tmem_scales = #ttng.tensor_memory_scales_encoding<>
+
+module attributes {"ttg.num-warps" = 4 : i32, "ttg.num-ctas" = 2 : i32, "ttg.threads-per-warp" = 32 : i32, "ttng.two-ctas" = true} {
+
+// CHECK-LABEL: @tmem_copy_2d_2cta
+tt.func public @tmem_copy_2d_2cta(%src: !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>,
+                             %dst: !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>,
+		                         %barrier: !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>) {
+  // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32)
+  // CHECK: [[IS_WARP_0:%.*]] = llvm.icmp "eq" {{.*}}, [[ZERO]] : i32
+  // CHECK: [[ELECT:%.*]] = nvvm.elect.sync
+  // CHECK: [[WARP_PRED:%.*]] = llvm.and [[IS_WARP_0]], [[ELECT]]
+  // CHECK: nvg.cluster_id
+  // CHECK: llvm.and {{.*}}, {{.*}} : i32
+  // CHECK: [[IS_CLUSTER_0:%.*]] = llvm.icmp "eq" {{.*}}, [[ZERO]]
+  // CHECK: [[LEAD_PRED:%.*]] = llvm.and [[WARP_PRED]], [[IS_CLUSTER_0]]
+  // CHECK-COUNT-8: tcgen05.cp.cta_group::2.warpx4.32x128b
+  // CHECK: tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [ $0 + 0 ];", "r,b" {{.*}}, [[LEAD_PRED]]
+  ttng.tmem_copy %src, %dst, %barrier : !ttg.memdesc<128x32xi8, #shared, #ttg.shared_memory>, !ttg.memdesc<128x32xi8, #tmem_scales, #ttng.tensor_memory, mutable>, !ttg.memdesc<1xi64, #shared1, #ttg.shared_memory>
+  tt.return
+}
 }
 
 // -----

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.cpp
@@ -188,6 +188,14 @@ Value getLeaderAddress(Location loc, ConversionPatternRewriter &rewriter,
   return b.inttoptr(barrierPtr.getType(), barrierInt);
 }
 
+Value createLeadCTAPredicate(Location loc, RewriterBase &rewriter) {
+  auto b = TritonLLVMOpBuilder(loc, rewriter);
+  Value leftClusterId = nvgpu::ClusterCTAIdOp::create(rewriter, loc);
+  leftClusterId = b.and_(leftClusterId, b.i32_val(1));
+  Value cluster0 = b.icmp_eq(leftClusterId, b.i32_val(0));
+  return cluster0;
+}
+
 LogicalResult lowerLdStMatrix(
     Location loc, LinearLayout cvt, bool transpose,
     SmallVector<Value> &vals, // Input for stmatrix, output for ldmatrix

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -76,6 +76,9 @@ getLeaderCTAPredicate(Location loc, ConversionPatternRewriter &rewriter,
 Value getLeaderAddress(Location loc, ConversionPatternRewriter &rewriter,
                        Value barrierPtr,
                        mlir::triton::gpu::MemDescType barrierTy);
+
+/// Create a predicate where only the lead CTA is active for two CTA mode.
+Value createLeadCTAPredicate(Location loc, RewriterBase &rewriter);
 } // namespace NVIDIA
 } // namespace LLVM
 


### PR DESCRIPTION
# 2CTA Block Scale MMA with tcgen05.cp

* **New Features**
  * Functional 2-CTA Block Scale MMA with tcgen05.cp: full path (TMA → cp → MMA → commit) for two CTAs

* **Bug Fixes**
  * TMA barrier (2CTA hang): arrive on lead CTA barrier and use .dst shared::cluster
  * TCGen05.cp (2CTA hang): use Lead CTA predicate for tcgen05.cp instruction
  * Scaled MMA 2CTA: per-CTA M/N; double M in the scale descriptor
  * TCGen05.cp: only copy per-CTA scales (block=0)

* **Tests**
  * test_mma_scaled_tcgen05_copy: 48 cases, parameters: num_ctas, multicast, block size, dtype
  * tritongpu_to_llvm_blackwell.mlir: tmem_copy cta_group::2, lead-CTA predicate

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
