### PR TITLE
update cupti version for blackwell

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -627,7 +627,7 @@ def download_and_copy_dependencies():
         src_func=lambda system, arch, version: f"cuda_cupti-{system}-{arch}-{version}-archive/lib",
         dst_path="lib/cupti-blackwell",
         variable="TRITON_CUPTI_LIB_BLACKWELL_PATH",
-        version=NVIDIA_TOOLCHAIN_VERSION["cupti"],
+        version=NVIDIA_TOOLCHAIN_VERSION["cupti-blackwell"],
         url_func=lambda system, arch, version:
         f"https://developer.download.nvidia.com/compute/cuda/redist/cuda_cupti/{system}-{arch}/cuda_cupti-{system}-{arch}-{version}-archive.tar.xz",
     )


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/9451 made a change to use cupti 13.1 for blackwell, but setup.py still used NVIDIA_TOOLCHAIN_VERSION["cupti"] for the cupti-blackwell bundle, so this change fixes it to use NVIDIA_TOOLCHAIN_VERSION["cupti-blackwell"] as intended.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this fixes the cupti version for blackwell`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
