### PR TITLE
[Backend] Skip global scratch offset computation when scratch size is zero

### DIFF
--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -1271,7 +1271,7 @@ Value getGlobalScratchPtr(Location loc, RewriterBase &rewriter,
   ModuleOp mod = funcOp.getOperation()->getParentOfType<ModuleOp>();
   auto allocSizeAttr = mod.getOperation()->getAttrOfType<mlir::IntegerAttr>(
       "ttg.global_scratch_memory_size");
-  if (!allocSizeAttr) {
+  if (!allocSizeAttr || allocSizeAttr.getValue().isZero()) {
     return gmemBase;
   }
 

--- a/test/Conversion/amd/tritongpu_to_llvm.mlir
+++ b/test/Conversion/amd/tritongpu_to_llvm.mlir
@@ -732,3 +732,19 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.thr
         tt.return
     }
 }
+
+// -----
+
+// Make sure there is no rocdl.grid.dim.* generated when global_scratch_memory_size is 0.
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 64 : i32, ttg.global_scratch_memory_size = 0 : i32, ttg.global_scratch_memory_alignment = 1 : i32} {
+  // CHECK-LABEL: @test_call_zero_scratch_no_grid_ops
+  // CHECK-NOT: rocdl.grid.dim
+  // CHECK: llvm.call @callee_zero_scratch
+  tt.func public @test_call_zero_scratch_no_grid_ops() attributes {noinline = false} {
+    tt.call @callee_zero_scratch() : () -> ()
+    tt.return
+  }
+  tt.func private @callee_zero_scratch() attributes {noinline = true} {
+    tt.return
+  }
+}


### PR DESCRIPTION
`getGlobalScratchPtr()` was generating `GetNumProgramsOp` (lowered to `__ockl_get_num_groups` on AMD) even when global scratch size is 0. This breaks `test_link_extern_libs` on AMD after adding `GlobalScratchAllocation` pass to the pipeline.