### PR TITLE
[MultiCTA] Implement broadcast semantics in mbarrier.arrive

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -1379,14 +1379,8 @@ struct AsyncTMACopyGlobalToLocalOpConversion
     // out)
     bool clusterBarrier = barrierMask & ~maskCGABroadcast;
     if (clusterBarrier) {
-      // This part is to support TMA into tcgen05.mma 2CTA mostly, i.e.,
-      // barrierMask == 1
-      // Mask with ones on the bits where the CTA broadcasts.
-      // This is a trick from cutlass to implement a faster `mapa`.
-      uint32_t fullMask = ~(barrierMask << 24);
-      Value barrierInt = b.ptrtoint(i32_ty, barrierPtr);
-      barrierInt = b.and_(barrierInt, b.i32_val(fullMask));
-      barrierPtr = b.inttoptr(barrierPtr.getType(), barrierInt);
+      barrierPtr =
+          LLVM::NVIDIA::getLeaderAddress(loc, rewriter, barrierPtr, barrierTy);
     }
 
     // Don't set cta_group::1 as it doesn't exist pre-Blackwell

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/Utility.h
@@ -2,6 +2,7 @@
 #define TRITON_CONVERSION_TRITONNVIDIAGPU_TO_LLVM_UTILITY_H
 
 #include <cstdint>
+#include <optional>
 
 #include "nvidia/include/TritonNVIDIAGPUToLLVM/PTXAsmFormat.h"
 
@@ -63,6 +64,18 @@ LogicalResult lowerLdStMatrix(
 // group
 Value createTMAMulticastMask(Location loc, ConversionPatternRewriter &rewriter,
                              uint16_t broadcastBits);
+
+// Returns the lead CTA predicate for this barrier layout when lowering through
+// cluster scope. Returns std::nullopt for CTA-local lowering.
+std::optional<Value>
+getLeaderCTAPredicate(Location loc, ConversionPatternRewriter &rewriter,
+                      mlir::triton::gpu::MemDescType barrierTy);
+
+// Returns the lead CTA barrier address for this layout. If there is no
+// cross-cluster lowering, returns barrierPtr unchanged.
+Value getLeaderAddress(Location loc, ConversionPatternRewriter &rewriter,
+                       Value barrierPtr,
+                       mlir::triton::gpu::MemDescType barrierTy);
 } // namespace NVIDIA
 } // namespace LLVM
 


### PR DESCRIPTION
This was missing and it is necessary for multiCTA warp-specialised
kernels.

We also fix `mbarrier.init` to rescale the number of arrivals on the leader CTA to follow this pattern.

In `mbarrier.expect` we emit `mbarrier.expect` from the leader CTA (which actas as an `mbarrier.arrive bar, 1`), 
and we emit `mbarrier.arrive bar, 1` from the non leader CTAs to go with the semantics above.
This has as a nice corollary now `expect` also has release semantics, which is nice. We hope this
should not be a perf issue in real kernels really.

Finally, we implement these semantics in two helper functions and use them across the codebase.