### PR TITLE
[Backend] Fix WarpGroupDotWaitOp semantics when num_warps > 4

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -223,7 +223,7 @@ def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [
 def TTNG_WarpGroupDotWaitOp : TTNG_Op<"warp_group_dot_wait", [DeclareOpInterfaceMethods<InferTypeOpInterface>,
                                                               AllTypesMatch<["inputs", "outputs"]>]> {
   let summary = "warp group dot wait";
-  let arguments = (ins Variadic<TTG_TensorOrMemDesc>:$inputs, I32Attr:$pendings);
+  let arguments = (ins Variadic<TTG_TensorOrMemDesc>:$inputs, I32Attr:$pendings, UnitAttr:$warpGroupLocal);
   let results = (outs Variadic<TTG_TensorOrMemDesc>:$outputs);
   let description = [{
     Waits until there are $pendings or fewer outstanding async dot operations.
@@ -231,6 +231,10 @@ def TTNG_WarpGroupDotWaitOp : TTNG_Op<"warp_group_dot_wait", [DeclareOpInterface
     $inputs must be the tensors corresponding to the async dot ops that we're
     waiting on.  For example, if there are N pending async dot ops and we call
     `warp_group_dot_wait 1`, then $inputs must be the result of the first dot op.
+
+    The `warpGroupLocal` attribute specifies that we only wait for the local
+    warp group, and if num_warps > 4 then shared memory inputs may still be in
+    use by other warp groups.
   }];
 
   let assemblyFormat = "$inputs attr-dict `:` type($inputs)";

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -211,7 +211,8 @@ static void threadValuesThroughWait(ttng::WarpGroupDotWaitOp wait,
   // We can't use replaceWithNewOp because we're changing the number of return
   // values in the operation.
   auto newWait = ttng::WarpGroupDotWaitOp::create(
-      builder, wait.getLoc(), llvm::to_vector(newOperands), wait.getPendings());
+      builder, wait.getLoc(), llvm::to_vector(newOperands),
+      wait.getPendingsAttr(), wait.getWarpGroupLocalAttr());
 
   auto dominatedByNewWait = [&](OpOperand &operand) {
     auto opInThisBlock =
@@ -641,7 +642,8 @@ static void insertAsyncWarpGroupDotWaitInLoop(
 
       OpBuilder builder((*firstUse)->getOwner());
       auto newWait = ttng::WarpGroupDotWaitOp::create(
-          builder, asyncDot->getLoc(), ArrayRef<Value>{}, 0);
+          builder, asyncDot->getLoc(), ArrayRef<Value>{}, 0,
+          /*warpGroupLocal=*/true);
 
       SmallVector<Value> users;
       for (; firstUse != uses.end(); ++firstUse) {

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1601,7 +1601,8 @@ void replaceUsesAndPropagateType(
       auto operands = llvm::to_vector(wait.getOperands());
       operands[operand->getOperandNumber()] = val;
       auto newWait = ttng::WarpGroupDotWaitOp::create(
-          builder, wait.getLoc(), operands, wait.getPendings());
+          builder, wait.getLoc(), operands, wait.getPendingsAttr(),
+          wait.getWarpGroupLocalAttr());
       wait.replaceAllUsesWith(newWait.getResults());
       wait.erase();
     } else {

--- a/python/tutorials/gluon/11-tcgen05-mma-scaled.py
+++ b/python/tutorials/gluon/11-tcgen05-mma-scaled.py
@@ -1250,11 +1250,13 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
     acc_bufs = allocate_tensor_memory(gl.float32, [num_acc_buffers, BLOCK_M, BLOCK_N], tmem_layout)
     acc_idx = 0
 
-    mma_bars = gl.allocate_shared_memory(gl.int64, [num_acc_buffers, 1], mbarrier.MBarrierLayout())
-    for i in gl.static_range(num_acc_buffers):
+    # We double buffer the mma barriers so we can have 2 in flight simultaneously
+    num_mma_bars: gl.constexpr = 2
+    mma_bars = gl.allocate_shared_memory(gl.int64, [2, 1], mbarrier.MBarrierLayout())
+    for i in gl.static_range(num_mma_bars):
         mbarrier.init(mma_bars.index(i), count=1)
-    mma_producer = t8.Counter.create(0, num_acc_buffers)
-    mma_consumer = t8.Counter.create(0, num_acc_buffers)
+    mma_producer = t8.Counter.create(0, num_mma_bars)
+    mma_consumer = t8.Counter.create(0, num_mma_bars)
 
     scheduler = SchedulerImpl.initialize(c_desc.shape[0], c_desc.shape[1], BLOCK_M, BLOCK_N)
     num_tiles = scheduler.get_num_tiles()
@@ -1320,6 +1322,8 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
         mma_consumer = mma_consumer.next()
         acc = cur_acc_buf.load(acc_reg_layout)
         if num_acc_buffers == 1:
+            # Wait for all threads to finish loading from accumulator
+            gl.barrier()
             load_consumer, mma_producer = issue_mma(load_consumer, load_bars, a_bufs, b_bufs,
                                                     a_scale_bufs, b_scale_bufs, mma_producer, mma_bars,
                                                     acc_bufs.index(acc_idx), use_acc=False, pred=has_next_tile)
@@ -1335,7 +1339,7 @@ def mma_scaled_pipelined_kernel(a_desc, b_desc, c_desc, a_scale_desc, b_scale_de
     tma.store_wait(0)
     for i in gl.static_range(num_buffers):
         mbarrier.invalidate(load_bars.index(i))
-    for i in gl.static_range(num_acc_buffers):
+    for i in gl.static_range(num_mma_bars):
         mbarrier.invalidate(mma_bars.index(i))
 
 

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1210,9 +1210,9 @@ tt.func @loop_memindex_subslice(%arg0: tensor<2x128x128xf16>) {
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
-#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 32]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 32]}>
 
-module attributes {ttg.target = "cuda:90", "ttg.num-warps" = 8 : i32} {
+module attributes {ttg.target = "cuda:90", "ttg.num-warps" = 4 : i32} {
   // CHECK-LABEL: warp_dot_multi_read
   tt.func @warp_dot_multi_read(%arg0: !tt.tensordesc<tensor<1x256x128xf8E5M2, #shared1>>, %arg1: tensor<128x128x!tt.ptr<f8E5M2>>, %arg2: i32, %arg3: i1, %arg4: tensor<128x256xf32, #mma>, %arg5: tensor<128x128xi1>) {
 

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -187,7 +187,7 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK:   ttg.async_copy_global_to_local
     // CHECK:   ttg.async_commit_group
     // CHECK:   scf.if
-    // CHECK:     ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32}
+    // CHECK:     ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32, warpGroupLocal}
     // CHECK:     arith.mulf
     // CHECK:     scf.yield
     // CHECK:   scf.yield
@@ -857,7 +857,7 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK:   ttg.async_copy_global_to_local
     // CHECK:   ttg.async_commit_group
     // CHECK:   scf.if
-    // CHECK-NEXT: ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32}
+    // CHECK-NEXT: ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32, warpGroupLocal}
     // CHECK:   } else {
     // CHECK-NOT: ttng.warp_group_dot_wait
     // CHECK:   scf.yield


### PR DESCRIPTION
This is cherry-picked from #9281 and also includes the fix for `gluon/11-tcgen05-mma-scaled.py` which has been causing timeouts in CI since the PR was reverted.