### PR TITLE
[AMD][BACKEND] Properly handle PointerTypes in v_perm ConvertLayout lowering

### DIFF
--- a/test/Conversion/amd/convert_layout.mlir
+++ b/test/Conversion/amd/convert_layout.mlir
@@ -212,3 +212,16 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// Regression test: convert_layout on tensor of pointers must not crash.
+#blocked4x4 = #ttg.blocked<{sizePerThread = [4, 4], threadsPerWarp = [8, 8], warpsPerCTA = [1, 1], order = [1, 0]}>
+#linear4x4 = #ttg.linear<{register = [[1, 0], [2, 0], [0, 1], [0, 2]], lane = [[0, 4], [0, 8], [0, 16], [4, 0], [8, 0], [16, 0]], warp = [], block = []}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: convert_layout_pointer_element_no_crash
+  tt.func @convert_layout_pointer_element_no_crash(%arg0: tensor<32x32x!tt.ptr<i8>, #blocked4x4>) {
+    %0 = ttg.convert_layout %arg0 : tensor<32x32x!tt.ptr<i8>, #blocked4x4> -> tensor<32x32x!tt.ptr<i8>, #linear4x4>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -739,7 +739,9 @@ public:
       return failure();
 
     // TODO: v_perm could be useful for fp16 tensors.
-    if (srcTy.getElementType().getIntOrFloatBitWidth() != 8)
+    auto elemTy = srcTy.getElementType();
+    int bitwidth = elemTy.isIntOrFloat() ? elemTy.getIntOrFloatBitWidth() : 64;
+    if (bitwidth != 8)
       return failure();
 
     // If destination or source is smaller than one register, skip.


### PR DESCRIPTION
`getElementType().getIntOrFloatBitWidth()` asserts on PointerTypes.  