### PR TITLE
[AMD]Fix a bug about CGA-layout in AccelerateAMDMatmul. 

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -376,3 +376,28 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// NOTE: A/B/C/D's CGA-layout are not necessarilly equal when num-ctas > 1
+//  - D and C's should have the same CGA-layout, in this case [[0, 1], [1, 0]]
+//  - A and B's CGA-layout is derived from D-CGA-layout by clearing the elements,
+//    corresponding to the K dim, in the bases to zero. Hence, one have layout
+//    [[0, 0] [1, ]], the other one has layout [[0, 1], [0, 0]]
+//
+// CHECK-DAG: #mma{{[0-9]}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 0\], \[1, 0\]\]}}
+// CHECK-DAG: #mma{{[0-9]}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 1\], \[0, 0\]\]}}
+// CHECK-LABEL: test_multi_ctas
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [1, 0]]}>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @test_multi_ctas(
+    %0: tensor<32x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>>,
+    %1: tensor<64x32xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>>,
+    %2: tensor<32x32x!tt.ptr<i32>, #blocked>) {
+    %3 = arith.constant dense<0> : tensor<32x32xi32, #blocked>
+    %4 = tt.dot %0, %1, %3 : tensor<32x64xi8, #ttg.dot_op<{opIdx = 0, parent = #blocked}>> * tensor<64x32xi8, #ttg.dot_op<{opIdx = 1, parent = #blocked}>> -> tensor<32x32xi32, #blocked>
+    tt.store %2, %4 : tensor<32x32x!tt.ptr<i32>, #blocked>
+    tt.return
+  }
+}


### PR DESCRIPTION
Fix a bug about CGA-layout in AccelerateAMDMatmul. The bug arises only when num-ctas > 1.

### The Problem
Let A/B/C/D be the CGA-layout of dotOpt's A/B/C/D operands, respectively. When num-ctas > 1:
  * D == C
  * A/B/C may not equal

By calling `ttg::getCGALayout()`, A and B is derived from D on-the-fly. Under the hood, `DotOperandEncodingAttr::getCGALayout()` does the job; see its definition in lib/Dialect/TritonGPU/IR/Dialect.cpp:2594 or [online](https://github.com/triton-lang/triton/blob/main/lib/Dialect/TritonGPU/IR/Dialect.cpp#L2594).

Basically, the difference between A and D (or B and D) is that the elements, corresponding to K dim, in the bases are set to 0. e.g., if D's bases are [[a1, b1], ..., [an, bn]]

A/B will be:
  `[[0, b1], ..., [0, bn]]` // if the 1st element corresponds to K
or
  `[[a1, 0], ..., [an, 0]]` // if the 2nd element corresponds to K

### Testing
Pass the this test along with other m.c related local change. test is slightly modified to not skip num-catas > 1 in `python/test/unit/language/test_matmul.py::test_simple_matmul[False-False-8-4-512-64-32-2-float32-float16]`

### Misc
* Corresponds to internal PR-547.