### PR TITLE
Revert "[AMD] Don't use s_waitcnt to lower global barrier for now"

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -480,9 +480,7 @@ public:
     IntegerAttr zero = rewriter.getI32IntegerAttr(0);
     bool localBarrier = op.hasLocal();
     bool globalBarrier = op.hasGlobalRead() || op.hasGlobalWrite();
-    if (globalBarrier)
-      return failure();
-    if (localBarrier) {
+    if (localBarrier || globalBarrier) {
       amdgpu::MemoryCounterWaitOp::create(
           rewriter, op->getLoc(),
           /* load= */ op.hasGlobalRead() ? zero : nullptr,


### PR DESCRIPTION
This reverts commit 5c3eed43e8dd0efd56c0231311870faa332a9383 given we have landed the proper fix in LLVM:
https://github.com/llvm/llvm-project/commit/2dcd75eb4420.

Fixes https://github.com/ROCm/triton-internal/issues/1568