### PR TITLE
[AMD][gfx1250] Fix tensordesc index after kernel launch change

### DIFF
--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -368,7 +368,7 @@ def wrap_handle_tensordesc(launcher, signature, tensordesc_metadata):
 
     def inner(*args):
         base_args = args[:-1]
-        kernel_metadata = base_args[7]
+        kernel_metadata = base_args[8]
         kernel_args = args[-1]
 
         final_kernel_args = []


### PR DESCRIPTION
Commit ff4076270 adds a new global_scratch argument to the kernel launch call which means we need to shift all subsequent arguments by one position.

This fixes host TDM failures.