### PR TITLE
Revert "[Backend] Fix WarpGroupDotWaitOp semantics when num_warps > 4…

### DIFF
--- a/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
+++ b/include/triton/Dialect/TritonNvidiaGPU/IR/TritonNvidiaGPUOps.td
@@ -223,7 +223,7 @@ def TTNG_WarpGroupDotOp : TTNG_Op<"warp_group_dot", [
 def TTNG_WarpGroupDotWaitOp : TTNG_Op<"warp_group_dot_wait", [DeclareOpInterfaceMethods<InferTypeOpInterface>,
                                                               AllTypesMatch<["inputs", "outputs"]>]> {
   let summary = "warp group dot wait";
-  let arguments = (ins Variadic<TTG_TensorOrMemDesc>:$inputs, I32Attr:$pendings, UnitAttr:$warpGroupLocal);
+  let arguments = (ins Variadic<TTG_TensorOrMemDesc>:$inputs, I32Attr:$pendings);
   let results = (outs Variadic<TTG_TensorOrMemDesc>:$outputs);
   let description = [{
     Waits until there are $pendings or fewer outstanding async dot operations.
@@ -231,10 +231,6 @@ def TTNG_WarpGroupDotWaitOp : TTNG_Op<"warp_group_dot_wait", [DeclareOpInterface
     $inputs must be the tensors corresponding to the async dot ops that we're
     waiting on.  For example, if there are N pending async dot ops and we call
     `warp_group_dot_wait 1`, then $inputs must be the result of the first dot op.
-
-    The `warpGroupLocal` attribute specifies that we only wait for the local
-    warp group, and if num_warps > 4 then shared memory inputs may still be in
-    use by other warp groups.
   }];
 
   let assemblyFormat = "$inputs attr-dict `:` type($inputs)";

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -7,9 +7,6 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include <deque>
 
-namespace ttg = ::mlir::triton::gpu;
-namespace ttng = ::mlir::triton::nvidia_gpu;
-
 namespace mlir {
 
 AllocationSlice::AllocationSlice(Value value,
@@ -245,24 +242,21 @@ void MembarAnalysis::insertBarrier(Operation *op, OpBuilder *builder) {
                                  triton::gpu::AddrSpace::Local);
 }
 
-static bool containsLocalBarrier(Operation *op) {
-  if (isa<gpu::BarrierOp>(op))
-    return true;
-  if (isa<triton::nvidia_gpu::ClusterWaitOp>(op))
-    return true;
-  if (isa<triton::gpu::WarpSpecializePartitionsOp>(op))
-    return true;
-  if (auto barrier = dyn_cast<triton::gpu::BarrierOp>(op))
-    return barrier.hasLocal();
-  if (auto wgWait = dyn_cast<ttng::WarpGroupDotWaitOp>(op)) {
-    return !wgWait.getWarpGroupLocal() && ttg::lookupNumWarps(op) > 4;
-  }
-  return false;
-}
-
 void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
                             FuncBlockInfoMapT *funcBlockInfoMap,
                             OpBuilder *builder) {
+  auto containsLocalBarrier = [](Operation *op) {
+    if (isa<gpu::BarrierOp>(op))
+      return true;
+    if (isa<triton::nvidia_gpu::ClusterWaitOp>(op))
+      return true;
+    if (isa<triton::gpu::WarpSpecializePartitionsOp>(op))
+      return true;
+    if (auto barrier = dyn_cast<triton::gpu::BarrierOp>(op))
+      return barrier.hasLocal();
+    return false;
+  };
+
   if (containsLocalBarrier(op)) {
     // If the current op is a local barrier, we sync previous reads and writes
     blockInfo->sync();

--- a/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Pipeliner/WGMMAPipeline.cpp
@@ -211,8 +211,7 @@ static void threadValuesThroughWait(ttng::WarpGroupDotWaitOp wait,
   // We can't use replaceWithNewOp because we're changing the number of return
   // values in the operation.
   auto newWait = ttng::WarpGroupDotWaitOp::create(
-      builder, wait.getLoc(), llvm::to_vector(newOperands),
-      wait.getPendingsAttr(), wait.getWarpGroupLocalAttr());
+      builder, wait.getLoc(), llvm::to_vector(newOperands), wait.getPendings());
 
   auto dominatedByNewWait = [&](OpOperand &operand) {
     auto opInThisBlock =
@@ -642,8 +641,7 @@ static void insertAsyncWarpGroupDotWaitInLoop(
 
       OpBuilder builder((*firstUse)->getOwner());
       auto newWait = ttng::WarpGroupDotWaitOp::create(
-          builder, asyncDot->getLoc(), ArrayRef<Value>{}, 0,
-          /*warpGroupLocal=*/true);
+          builder, asyncDot->getLoc(), ArrayRef<Value>{}, 0);
 
       SmallVector<Value> users;
       for (; firstUse != uses.end(); ++firstUse) {

--- a/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1601,8 +1601,7 @@ void replaceUsesAndPropagateType(
       auto operands = llvm::to_vector(wait.getOperands());
       operands[operand->getOperandNumber()] = val;
       auto newWait = ttng::WarpGroupDotWaitOp::create(
-          builder, wait.getLoc(), operands, wait.getPendingsAttr(),
-          wait.getWarpGroupLocalAttr());
+          builder, wait.getLoc(), operands, wait.getPendings());
       wait.replaceAllUsesWith(newWait.getResults());
       wait.erase();
     } else {

--- a/test/Analysis/test-membar.mlir
+++ b/test/Analysis/test-membar.mlir
@@ -1210,9 +1210,9 @@ tt.func @loop_memindex_subslice(%arg0: tensor<2x128x128xf16>) {
 #shared2 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
 #shared3 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 8}>
 #smem = #ttg.shared_memory
-#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 256, 32]}>
+#mma = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [8, 1], instrShape = [16, 256, 32]}>
 
-module attributes {ttg.target = "cuda:90", "ttg.num-warps" = 4 : i32} {
+module attributes {ttg.target = "cuda:90", "ttg.num-warps" = 8 : i32} {
   // CHECK-LABEL: warp_dot_multi_read
   tt.func @warp_dot_multi_read(%arg0: !tt.tensordesc<tensor<1x256x128xf8E5M2, #shared1>>, %arg1: tensor<128x128x!tt.ptr<f8E5M2>>, %arg2: i32, %arg3: i1, %arg4: tensor<128x256xf32, #mma>, %arg5: tensor<128x128xi1>) {
 

--- a/test/TritonGPU/loop-pipeline-hopper.mlir
+++ b/test/TritonGPU/loop-pipeline-hopper.mlir
@@ -187,7 +187,7 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK:   ttg.async_copy_global_to_local
     // CHECK:   ttg.async_commit_group
     // CHECK:   scf.if
-    // CHECK:     ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32, warpGroupLocal}
+    // CHECK:     ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32}
     // CHECK:     arith.mulf
     // CHECK:     scf.yield
     // CHECK:   scf.yield
@@ -857,7 +857,7 @@ module attributes {"ttg.target" = "cuda:90", "ttg.num-ctas" = 1 : i32, "ttg.num-
     // CHECK:   ttg.async_copy_global_to_local
     // CHECK:   ttg.async_commit_group
     // CHECK:   scf.if
-    // CHECK-NEXT: ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32, warpGroupLocal}
+    // CHECK-NEXT: ttng.warp_group_dot_wait {{.*}} {pendings = 0 : i32}
     // CHECK:   } else {
     // CHECK-NOT: ttng.warp_group_dot_wait
     // CHECK:   scf.yield


### PR DESCRIPTION
… (#9484)"

Partial reverts commit c147f0988de75b002a05945a3c82f2597d1ae23d as it is causing performance regressions

