### PR TITLE
[AMD][BACKEND] Cherry pick pr 9487 to rel 3.7

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -740,7 +740,9 @@ public:
       return failure();
 
     // TODO: v_perm could be useful for fp16 tensors.
-    if (srcTy.getElementType().getIntOrFloatBitWidth() != 8)
+    auto elemTy = srcTy.getElementType();
+    int bitwidth = elemTy.isIntOrFloat() ? elemTy.getIntOrFloatBitWidth() : 64;
+    if (bitwidth != 8)
       return failure();
     // TODO: broadcasting is not supported at the moment.
     if (!conversion.isInvertible())


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how):
   This is a cherry-pick of #9487 to rel/3.7.   
   Original PR: https://github.com/triton-lang/triton/pull/9487
   [AMD][BACKEND] Properly handle PointerTypes in v_perm ConvertLayout lowering


- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `This is a cherry-pick of PR #9487 which already includes tests. The tests are included in this cherry-pick`

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices):
    The original PR added tests (we saw the convert_layout.mlir conflict), and those tests are included in this cherry-pick.