### PR TITLE
[CUDA] Fix ptxas -Ofc mid compilation error for fpsan/consan on CUDA 12.8

### DIFF
--- a/third_party/nvidia/backend/compiler.py
+++ b/third_party/nvidia/backend/compiler.py
@@ -502,13 +502,7 @@ class CUDABackend(BaseBackend):
             if any(mode in knobs.compilation.instrumentation_mode for mode in ["consan", "fpsan"]):
                 ptxas_version_str = get_ptxas(self.target.arch).version
                 ptxas_version = tuple(map(int, ptxas_version_str.split('.')[:2]))
-                if ptxas_version < (12, 8):
-                    # Flag does not exist before 12.8; passing it will cause an 'Unknown option' error
-                    pass
-                elif ptxas_version == (12, 8):
-                    # ptxas in 12.8 introduced -Ofc but strictly requires 'max' or '0'
-                    ptx_extra_options += ["-Ofc", "0"]
-                else:
+                if ptxas_version >= (12, 9):
                     # 12.9+ / 13.x fully supports the 'mid' optimization profile
                     ptx_extra_options += ["-Ofc", "mid"]
 


### PR DESCRIPTION
[PR #9415](https://github.com/triton-lang/triton/pull/9415) introduced the `-Ofc mid` (`--Ofast-compile`) flag to speed up PTX compilation times when instrumentation modes like `consan` or `fpsan` are enabled. 

While `-Ofc mid` works as intended on [CUDA 12.9+](https://docs.nvidia.com/cuda/cuda-features-archive/index.html#cuda-12-9-features), it breaks the build on CUDA 12.8 environments. On `ptxas` version 12.8, the compiler recognizes the `-Ofc` flag but strictly limits its arguments to `'max'` or `'0'`. Passing `'mid'` results in a hard crash during test execution:

```text
triton.runtime.errors.PTXASError: PTXAS error: Internal Triton PTX codegen error
`ptxas` stderr:
ptxas fatal   : Invalid value for --Ofast-compile/-Ofc (mid), is not 'max' or '0'
```

To resolve this, this PR dynamically sets the flag based on the ptxas version:
- CUDA 12.9+: Uses -Ofc mid (retaining the optimization).
- CUDA <= 12.8: Omits the option entirely to prevent "Unknown option" errors on older toolchains.