### PR TITLE
refine the module unload test to fix a non-deterinistic failure

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -898,7 +898,7 @@ def test_module_load_unload(fresh_knobs):
 
     @triton.jit
     def kernel(out_ptr, val) -> None:
-        tl.store(out_ptr, val * 123)
+        tl.store(out_ptr, val)
 
     # we should hit the module unload call to decrese the counter from 1 to 0
     counter = 1


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

This PR is related to the PR: https://github.com/triton-lang/triton/pull/9444, in which we observed non-deterministic failure of the test `runtime/test_cache.py::test_module_load_unload`. With some investigation, the problem is as follows: Once the `module_unload` callback function is added, it applies to globally. The callback is executed and the counter value will change, whenever any kernel is deleted by the garbage collector. If the deletion happens between adding the callback and checking counter value, then the counter value checking failed.  

We changed the test by pausing the python garbage collector in this test, so the callback will not be called when running this test.  

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
