### PR TITLE
Update requirements.txt to use cmake 4

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 setuptools>=40.8.0
 wheel
-cmake>=3.20,<4.0
+cmake==4.0
 ninja>=1.11.1
 pybind11>=2.13.1
 lit


### PR DESCRIPTION
We want to upgrade cmake to 4 because cmake was originally pinned to <4 as macos changes were being broken in https://github.com/triton-lang/triton/commit/575bed88e90d0b7560eb482cd2fa8c22003e96c6
# New contributor declaration
- [x ] I am not making a trivial change, such as fixing a typo in a comment.

- [ x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x ] This PR does not need a test because `I am upgrading the cmake used to cmake 4.`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
