### PR TITLE
Make the remaining cache tests device agnostic

### DIFF
--- a/python/test/unit/runtime/test_cache.py
+++ b/python/test/unit/runtime/test_cache.py
@@ -899,7 +899,7 @@ def test_preload_higher_order_kernels(device, fresh_triton_cache) -> None:
     assert output.item() == 31
 
 
-def test_module_load_unload(fresh_knobs):
+def test_module_load_unload(device, fresh_knobs):
 
     @triton.jit
     def kernel(out_ptr, val) -> None:
@@ -917,7 +917,7 @@ def test_module_load_unload(fresh_knobs):
     gc.disable()
     triton.knobs.runtime.module_unload_hook.add(module_unload)
 
-    out = torch.randn(1, dtype=torch.float32, device='cuda')
+    out = torch.randn(1, dtype=torch.float32, device=device)
     pre_compile = kernel.warmup(out, 1, grid=(1, ))
     pre_compile._init_handles()
 


### PR DESCRIPTION
Currently these tests are written in a way that isn't device agnostic.

To fix:
 * update the key into device_caches to be `torch.device.current_device()` like the rest of the file.
 * add the pytest fixture device to `test_module_load_unload`

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it updates existing tests`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

