### PR TITLE
Exclude __annotate__ from aggregate_value-s hash_attrs

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1673,8 +1673,8 @@ def _aggregate(cls):
 
             # Exclude the members with names from hash:
             #  * __init__ - added above.
-            #  * __annotate__ - isn't user facing.
-            if member.__name__ not in {"__init__", "__annotate__"}:
+            #  * __annotate_func__ - isn't user facing.
+            if name not in {"__init__", "__annotate_func__"}:
                 hash_attrs.append(member)
 
     aggregate_value.hash_attrs = hash_attrs


### PR DESCRIPTION
Using python 3.14 with _aggregate-s doesn't currently work as it attempts to use the `__annotate__` member (new in Python 3.14) when updating the kernel hash. As `__annotate__` isn't user facing it can just be excluded from the hash by avoiding adding it to aggregate_value's hash_attrs.

This fixes the test `test_bound_unused_result` for python 3.14.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `Fixes existing test_bound_unused_result for python 3.14`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
