### PR TITLE
[Language] Fixed the missing f-string format in the add**_docstr documentation helper decorator.

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2693,7 +2693,7 @@ def _add_reduction_docstr(name: str, return_indices_arg: str = None, tie_break_a
                           dtype_arg: str = None) -> Callable[[T], T]:
 
     def _decorator(func: T) -> T:
-        docstr = """
+        docstr = f"""
     Returns the {name} of all elements in the :code:`input` tensor along the provided :code:`axis`
 
     The reduction operation should be associative and commutative.
@@ -2817,7 +2817,7 @@ def _reduce_with_indices(input, axis, combine_fn, keep_dims=False, _semantic=Non
 def _add_scan_docstr(name: str, dtype_arg: str = None) -> Callable[[T], T]:
 
     def _decorator(func: T) -> T:
-        docstr = """
+        docstr = f"""
     Returns the {name} of all elements in the :code:`input` tensor along the provided :code:`axis`
 
     :param input: the input values


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# [Language] Fixed missing f-string format in documentation helper decorators

## Description

This PR fixes a bug where the documentation helper decorators `_add_reduction_docstr` and `_add_scan_docstr` were missing the f-string format prefix. This caused the docstrings to contain literal placeholder references like `{name}` instead of being properly interpolated with the actual values.

## Changes Made

- Added `f` prefix to docstring literals in `_add_reduction_docstr` decorator (python/triton/language/core.py:2696)
- Added `f` prefix to docstring literals in `_add_scan_docstr` decorator (python/triton/language/core.py:2820)

## Why This Change Is Necessary

The documentation helper decorators are used to generate consistent documentation for reduction and scan operations. Without the f-string format, the generated docstrings would be incomplete and contain placeholder text, which would be confusing for users reading the API documentation.

---

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `this is a documentation fix that only affects docstring generation`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
