### PR TITLE
[triton-ext] Allow plugin tests with static LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ endfunction()
 # Disable warnings that show up in external code (gtest;pybind11)
 if(NOT MSVC)
   set(TRITON_DISABLE_EH_RTTI_FLAGS "$<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions;-fno-rtti>")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default -fvisibility=hidden")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244 /wd4624 /wd4715 /wd4530")
 endif()
@@ -409,6 +409,12 @@ if(TRITON_BUILD_PYTHON_MODULE)
 
   # Link triton with its dependencies
   target_link_libraries(triton PRIVATE ${TRITON_LIBRARIES})
+
+  # Do not propagate libraries that libtriton depends on. This ensures that
+  # targets that link against libtriton do not accidentally link in their own
+  # copies of core Triton code and LLVM.
+  set_target_properties(triton PROPERTIES INTERFACE_LINK_LIBRARIES "")
+
   if(WIN32)
     target_link_libraries(triton PRIVATE ${CMAKE_DL_LIBS})
     set_target_properties(triton PROPERTIES SUFFIX ".pyd")
@@ -431,10 +437,8 @@ if(TRITON_BUILD_PYTHON_MODULE)
     "${TRITON_WHEEL_DIR}/FileCheck"
     COPYONLY)
 
-endif()
-
-if (UNIX AND NOT APPLE)
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
+  # Only build plugins when building libtriton since they depend on libtriton.
+  add_subdirectory(examples/plugins)
 endif()
 
 if(TRITON_BUILD_PYTHON_MODULE AND NOT WIN32)
@@ -460,7 +464,6 @@ find_package(Threads REQUIRED)
 add_subdirectory(third_party/f2reduce)
 add_subdirectory(bin)
 add_subdirectory(test)
-add_subdirectory(examples)
 
 if(TRITON_BUILD_UT)
   add_subdirectory(unittest)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,0 @@
-add_subdirectory(plugins)

--- a/examples/plugins/CMakeLists.txt
+++ b/examples/plugins/CMakeLists.txt
@@ -24,7 +24,7 @@ foreach( plugin ${TRITON_PLUGIN_PASSES} )
       TritonCanonicalizeIncGen
       TritonPluginsIncGen
     )
-    target_link_libraries(${plugin} PRIVATE MLIRPass)
+    target_link_libraries(${plugin} PRIVATE triton)
 
     # CMAKE_LIBRARY_OUTPUT_DIRECTORY is only set during the Python
     # build. It is empty if building directly from the root

--- a/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/CMakeLists.txt
+++ b/examples/plugins/DialectPlugins/DialectPlugin/lib/DialectPlugin/CMakeLists.txt
@@ -20,10 +20,7 @@ add_mlir_dialect_library(MLIRDialectPlugin
         MLIRDialectPluginPassesIncGen
 
         LINK_LIBS PUBLIC
-        MLIRPass
-        LLVMSupport
-        MLIRSupport
-        TritonNVIDIAGPUToLLVM
+        triton
         "$<$<PLATFORM_ID:Darwin>:-undefined dynamic_lookup>"
         )
 

--- a/python/test/unit/plugins/test_plugin.py
+++ b/python/test/unit/plugins/test_plugin.py
@@ -1,11 +1,11 @@
 import torch
 
 import pytest
-import os
 
 import triton
 import triton.language as tl
 from triton import knobs
+from triton._internal_testing import is_hip
 import custom_stages
 
 
@@ -21,10 +21,8 @@ def kernel2(BLOCK_SIZE: tl.constexpr):
     return
 
 
+@pytest.mark.skipif(is_hip(), reason="plugin not supported/tested on AMD yet")
 def test_op(capfd, device: str):
-    if os.environ.get('LLVM_BUILD_SHARED_LIBS', '0') == '0':
-        return
-
     size = 98432
     x = torch.rand(size, device=device)
     output = torch.empty_like(x)


### PR DESCRIPTION
This PR performs a minimal change to export all Triton and LLVM symbols from `libtriton.so`, and have the plugin resolve symbols directly from it, instead of depending on having both of them link separately against LLVM dynamic libraries. This allows us to run the Triton plugin Python tests without any special build configuration.

This is intended to be a minimal incremental step to get the existing tests working. There are at least two remaining considerations:
1. This PR does not guarantee that libtriton includes all of the symbols in the static libraries that are linked into `libtriton`, since we will only pull in the object files containing symbols that `libtriton` itself uses. This may be good enough in practice, otherwise, we may have to link with `whole-archive`, which will have a binary size cost.
2. This PR does not get `triton-opt` working with the new setup. Since the plugin now takes a direct dependency on `libtriton`, it must be available when the plugin is loaded. We could either:
    1. Make `triton-opt` also get its symbols from `libtriton`. This is potentially invasive, and makes it less convenient to copy around `triton-opt` executables since they will have a dependency on the dynamic library.
    2. Export all the Triton and LLVM symbols from `triton-opt`. Then create a fake empty `libtriton.so`, and make `triton-opt` dlopen it before loading a plugin. This "hack" ensures that the plugin's dependency is satisfied, but the symbols are actually resolved from `triton-opt`.