### PR TITLE
[interpreter] Fix Python bool argument conversion in _implicit_cvt

### DIFF
--- a/python/test/unit/runtime/test_launch.py
+++ b/python/test/unit/runtime/test_launch.py
@@ -3,6 +3,7 @@ import tracemalloc
 import pytest
 import pathlib
 import os
+import numpy as np
 
 import torch
 import triton
@@ -229,3 +230,13 @@ def test_pre_run_hooks(device):
     a = torch.ones(n_elements, device=device, dtype=torch.int32)
     add_kernel.run(a, n_elements, grid=(1, ), warmup=False)
     assert torch.all(a == 2)
+
+
+def test_interpreter_implicit_cvt_bool() -> None:
+    from triton.runtime.interpreter import _implicit_cvt
+
+    value = _implicit_cvt(True)
+
+    assert value.dtype == tl.int1
+    assert value.handle.data.dtype == np.bool_
+    assert bool(value.handle.data[0]) is True

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -1200,6 +1200,9 @@ def _patch_lang(fn):
 
 # TODO: wrap everything in triton tensors
 def _implicit_cvt(arg):
+    if isinstance(arg, bool):
+        handle = TensorHandle(np.array([arg], dtype=np.bool_), tl.int1)
+        return tl.tensor(handle, tl.int1)
     if isinstance(arg, int):
         ty = tl.str_to_ty(triton.runtime.jit.mangle_type(arg), None)
         dtype = np.int32


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
---
In interpreter mode, `_implicit_cvt()` handled Python `bool` values through the generic `int` path because `bool` is a subclass of `int`.

That produced a mismatched interpreter value:
- Triton type: `tl.int1`
- NumPy storage: `np.int32`

`TensorHandle` rejects that mismatch during argument conversion.

I updated `_implicit_cvt()` to handle `bool` before `int` in `_implicit_cvt()` and construct the value with:
  - Triton type: `tl.int1`
  - NumPy storage: `np.bool_`

This matches the interpreter's existing storage convention for `tl.int1`.

### Test
Added a regression test that checks `_implicit_cvt(True)` returns:
- `tl.int1`
- `np.bool_` backing storage
- the correct value