### PR TITLE
[BACKEND] Revert CLC result's layout

### DIFF
--- a/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/IR/Ops.cpp
@@ -1171,26 +1171,14 @@ static LogicalResult verifyCLCResultMemdesc(Location loc, MemDescType desc) {
   auto int_ty = dyn_cast<IntegerType>(desc.getElementType());
   if (!int_ty || int_ty.getWidth() != 64) {
     return emitError(loc)
-           << "Expected CLC result buffer to have integer element type int64, "
-              "but got "
+           << "Expected CLC result buffer to have type int64, but got"
            << desc.getElementType();
   }
   auto layout = desc.getEncoding();
-  auto kBlock = StringAttr::get(desc.getContext(), "block");
-  // TODO put this into a helper function
-  int numCTAs;
-  if (auto sharedLinearEnc = dyn_cast<SharedLinearEncodingAttr>(layout)) {
-    const auto &ll = sharedLinearEnc.getLinearLayout();
-    numCTAs = ll.getInDimSize(kBlock);
-  } else {
-    numCTAs = getCGALayout(layout).getLinearLayout().getInDimSize(kBlock);
-  }
-
   auto rank = desc.getRank();
-  if (rank != 1 || desc.getDimSize(0) != 2 * numCTAs) {
+  if (rank != 1 || desc.getDimSize(0) != 2) {
     return emitError(loc) << "Expected CLC result buffer to have rank 1 and a "
-                             "single dimension equal to 2x the number of CTAs, "
-                             "but got "
+                             "single dimension equal to 2, but got "
                           << desc.getShape() << ".";
   }
   return success();

--- a/python/examples/gluon/03-matmul-multicta.py
+++ b/python/examples/gluon/03-matmul-multicta.py
@@ -487,8 +487,9 @@ def _matmul_kernel(
         mbarrier.init(clc_barriers.index(i), count=1)
         mbarrier.init(clc_consumed_bars.index(i), count=3)
 
-    clc_result_shape: gl.constexpr = [clc_barriers.shape[0], 2 * clc_barriers.shape[1]]
-    clc_result_buffers = gl.allocate_shared_memory(gl.int64, clc_result_shape, clc_barriers.layout)
+    cga_layout: gl.constexpr = [[0]] * (gl.num_ctas().bit_length() - 1)
+    clc_result_buffers = gl.allocate_shared_memory(gl.int64, [clc_barriers.shape[0], 2],
+                                                   gl.SwizzledSharedLayout(1, 1, 1, [0], cga_layout=cga_layout))
 
     if TWO_CTAS:
         mbarrier.sync_cluster_init()

--- a/python/test/gluon/test_core.py
+++ b/python/test/gluon/test_core.py
@@ -3459,8 +3459,9 @@ def test_clc_basic(num_ctas):
         # Allocate clc_mbar before clc_result to make sure that we are indeed aligning
         # clc_result correctly after a i64 element.
         clc_mbar = mbarrier.allocate_mbarrier()
-        clc_result_shape: ttgl.constexpr = [clc_mbar.shape[0] * 2]
-        clc_result = ttgl.allocate_shared_memory(ttgl.int64, clc_result_shape, clc_mbar.layout)
+        cga_layout: ttgl.constexpr = [[0]] * (ttgl.num_ctas().bit_length() - 1)
+        layout: ttgl.constexpr = ttgl.SwizzledSharedLayout(1, 1, 1, order=[0], cga_layout=cga_layout)
+        clc_result = ttgl.allocate_shared_memory(ttgl.int64, [2], layout)
         mbarrier.init(clc_mbar, count=1)
 
         # Large shared memory allocation to force 1 block per SM

--- a/python/tutorials/gluon/12-cluster-launch-control.py
+++ b/python/tutorials/gluon/12-cluster-launch-control.py
@@ -70,8 +70,7 @@ class ClcTileScheduler:
         starting_tile_id = gl.program_id(0)
 
         barrier = mbarrier.allocate_mbarrier()
-        clc_result_shape: gl.constexpr = [2 * barrier.shape[0]]
-        clc_result_buffer = gl.allocate_shared_memory(gl.int64, clc_result_shape, barrier.layout)
+        clc_result_buffer = gl.allocate_shared_memory(gl.int64, [2], gl.SwizzledSharedLayout(1, 1, 1, [0]))
         mbarrier.init(barrier, count=1)
         phase = gl.to_tensor(0)
         return ClcTileScheduler(has_work, starting_tile_id, clc_result_buffer, barrier, phase)

--- a/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
+++ b/third_party/nvidia/lib/NVGPUToLLVM/NVGPUToLLVMPass.cpp
@@ -558,7 +558,7 @@ void freeTMAlloc(LLVM::LLVMFuncOp func, Value alloc, size_t size, Value pred,
     auto loc = ret.getLoc();
     auto voidTy = void_ty(ctx);
     if (twoCTAs) {
-      NVVM::ClusterArriveRelaxedOp::create(b, loc, UnitAttr::get(ctx));
+      NVVM::ClusterArriveOp::create(b, loc, UnitAttr::get(ctx));
       NVVM::ClusterWaitOp::create(b, loc, UnitAttr::get(ctx));
     } else {
       NVVM::Barrier0Op::create(b, loc);


### PR DESCRIPTION
We revert a few isues introduced in https://github.com/triton-lang/triton/pull/9546
