### PR TITLE
[NVIDIA] Fixed mixed-prec scaled-dot lowering for sm120

### DIFF
--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -693,10 +693,12 @@ public:
     auto isFP4 = [&](ScaleDotElemType elemType) -> bool {
       return elemType == ScaleDotElemType::E2M1;
     };
-    // mixed precision is not supported
-    if (isFP8(aElemType) && isFP4(bElemType) ||
-        isFP4(aElemType) && isFP8(bElemType)) {
-      return failure();
+
+    // TODO: Enable mixed-precision mxfp for sm120
+    if (!((isFP8(aElemType) && isFP8(bElemType)) ||
+          (isFP4(aElemType) && isFP4(bElemType)))) {
+      return rewriter.notifyMatchFailure(
+          dotOp, "only FP8xFP8 and FP4xFP4 are supported on sm120");
     }
 
     auto scaleElemType = dotOp.getAScale().getType().getElementType();


### PR DESCRIPTION
Closes https://github.com/triton-lang/triton/issues/9558

As of https://github.com/triton-lang/triton/pull/8494, we are incorrectly trying to lower mixed-prec workload to native mxfp MMAv2, which is currently not supported. Fixed by falling back to the decomposition path instead.