### PR TITLE
WSSpecialize to invalidate barriers it has initialized

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization.cpp
@@ -3,6 +3,7 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 #include "nvidia/hopper/include/Transforms/Passes.h"
+#include "nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h"
 #include "nvidia/include/Dialect/NVWS/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonGPU/Transforms/PipeliningUtility.h"
@@ -104,6 +105,7 @@ public:
           << moduleOp << "\n\n\n";
     }
     doTokenLowering(funcOp, numWarpGroups - 1);
+    invalidateWarpSpecializeBarriers(funcOp);
     // Clear num_stages to disable SWP.
     funcOp->walk([&](scf::ForOp forOp) {
       forOp->setAttr(mlir::triton::kNumStagesAttrName,

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/CodePartitionUtility.h
@@ -79,6 +79,9 @@ struct TmemDataChannel : Channel {
 } // namespace nvidia_gpu
 } // namespace triton
 
+constexpr static char kWarpSpecializeGeneratedBarrierAttrName[] =
+    "ttg.ws_generated_barrier";
+
 bool enclosing(scf::IfOp ifOp, Operation *op);
 bool enclosing(scf::ForOp forOp, Operation *op);
 
@@ -128,6 +131,7 @@ Operation *optimizeTMALoads(OpBuilderWithAsyncTaskIds &builder,
                             Value phase, Operation *headProducer,
                             Operation *headConsumer);
 void specializeRegion(triton::FuncOp funcOp, unsigned requestedRegisters);
+void invalidateWarpSpecializeBarriers(triton::FuncOp funcOp);
 
 } // namespace mlir
 

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSCodePartition.cpp
@@ -553,6 +553,8 @@ static Value createBarrierAlloc(triton::FuncOp funcOp, unsigned distance) {
                             sharedMemorySpace, /*mutableMemory=*/true);
   Value barrierAlloc = mlir::triton::gpu::LocalAllocOp::create(
       builder, loc, barrierMemDescType, Value());
+  barrierAlloc.getDefiningOp()->setAttr(kWarpSpecializeGeneratedBarrierAttrName,
+                                        builder.getUnitAttr());
   for (unsigned i = 0; i < distance; i++) {
     Value idx = arith::ConstantIntOp::create(builder, loc, i, 32);
     Value barrierView = ttg::MemDescIndexOp::create(

--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSLowerToken.cpp
@@ -1,4 +1,4 @@
-#include "Utility.h"
+#include "CodePartitionUtility.h"
 #include "mlir/Transforms/Passes.h"
 #include "triton/Dialect/TritonGPU/Transforms/Passes.h"
 
@@ -128,6 +128,10 @@ void lowerTokenOperations(Operation *parentOp, int numCTAs,
         builder, loc, barrierMemDescType, Value());
     Value bufferEmptyArray = mlir::triton::gpu::LocalAllocOp::create(
         builder, loc, barrierMemDescType, Value());
+    bufferFullArray.getDefiningOp()->setAttr(
+        kWarpSpecializeGeneratedBarrierAttrName, builder.getUnitAttr());
+    bufferEmptyArray.getDefiningOp()->setAttr(
+        kWarpSpecializeGeneratedBarrierAttrName, builder.getUnitAttr());
     tokenToFull[createTokenOp.getOperation()] = bufferFullArray;
     tokenToEmpty[createTokenOp.getOperation()] = bufferEmptyArray;
 


### PR DESCRIPTION
WSSpecialize.cpp never invalidates barriers it allocates. This means when the barrier live range ends, allocator can place another barrier in that memory, and WS code will initialize that "same" barrier, which is against ptx spec. This change tags barriers introduced by WS code and invalidates them after the WS Op.