### PR TITLE
[AMD] ConvertWarpPipeline: recognize AsyncWaitOp and fix bars alignment

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ConvertWarpPipeline.cpp
@@ -178,7 +178,7 @@ private:
         clusterBlocks.push_back(&exeOp->getRegion(0).front());
         bars.push_back(false);
       } else if (isa<ROCDL::BarrierOp, gpu::BarrierOp, triton::gpu::AsyncWaitOp,
-                     triton::amdgpu::AsyncTDMWait,
+                     triton::amdgpu::AsyncWaitOp, triton::amdgpu::AsyncTDMWait,
                      triton::amdgpu::AsyncTDMIntrinsicWait>(op)) {
         int currCluster = clusterBlocks.size();
         // Reject if multiple barriers appear without an intervening cluster.
@@ -190,7 +190,6 @@ private:
         if (existingBarrierMap.find(currCluster) != existingBarrierMap.end())
           return failure();
         existingBarrierMap[currCluster] = &op;
-        bars.push_back(false);
       } else if (auto yieldOp = dyn_cast<scf::YieldOp>(op)) {
         terminatorOp = &op;
       } else { // Fail conversion if any other op found outside of the cluster.

--- a/third_party/amd/python/test/test_warp_pipeline_gfx9.py
+++ b/third_party/amd/python/test/test_warp_pipeline_gfx9.py
@@ -1,0 +1,40 @@
+import triton
+import triton.language as tl
+from triton.backends.compiler import GPUTarget
+from triton.experimental import gluon
+import triton.experimental.gluon.language as gl
+from triton.experimental.gluon.language.amd import warp_pipeline_stage
+
+NUM_WARPS = 4
+BLOCK = 128
+
+
+def _compile_gluon(fn, signature, constexprs, arch="gfx950"):
+    """Compile a Gluon kernel for gfx950 and return the compiled object."""
+    return triton.compile(src=gluon._runtime.GluonASTSource(fn, signature, constexprs),
+                          target=GPUTarget("hip", arch, 64), options={"num_warps": NUM_WARPS})
+
+
+@gluon.jit
+def pipeline_simple(A, B, BLOCK: gl.constexpr):
+    """Minimal 2-stage pipeline — baseline for s_setprio check."""
+    blocked: gl.constexpr = gl.BlockedLayout(size_per_thread=[1, 8], threads_per_warp=[16, 4],
+                                             warps_per_cta=[gl.num_warps(), 1], order=[1, 0])
+    offs_layout: gl.constexpr = gl.SliceLayout(dim=1, parent=blocked)
+    offs = gl.program_id(0) * BLOCK + gl.arange(0, BLOCK, layout=offs_layout)
+
+    for i in tl.range(0, 4):
+        with warp_pipeline_stage("stage1", priority=1):
+            a = gl.load(A + offs)
+
+        with warp_pipeline_stage("stage2", priority=0):
+            gl.store(B + offs, a)
+
+
+def test_simple_pipeline_setprio():
+    """Baseline: a simple 2-stage pipeline emits s_setprio."""
+    signature = {"A": "*fp16", "B": "*fp16", "BLOCK": "constexpr"}
+    constexprs = {"BLOCK": BLOCK}
+    k = _compile_gluon(pipeline_simple, signature, constexprs)
+    amdgcn = k.asm["amdgcn"]
+    assert amdgcn.count("s_setprio") > 0, "Simple pipeline must emit s_setprio."


### PR DESCRIPTION
Add `amdgpu::AsyncWaitOp` to the barrier recognition list so that wait_group (which lowers to `amdg.async_wait`) between pipeline stages does not cause the pass to bail out.

Remove stale `bars.push_back(false)` from the barrier branch — bars should only track pipeline clusters (scf.execute_region), not inter-cluster barriers.

- Lit test (`@async_wait_between_stages`) validates that `amdg.async_wait` between two pipeline stages is accepted and barriers are emitted.
- Python e2e smoke test (`test_simple_pipeline_setprio`) checks that a basic 2-stage pipeline emits `s_setprio`.
- A targeted Python e2e test for `amdg.async_wait` is technically possible (the FA kernel exercises this path) but requires non-trivial manually-crafted `DistributedLinearLayout` and `PaddedSharedLayout` that satisfy direct-to-LDS constraints, since the Gluon pipeline does not run `CoalesceAsyncCopy`. Too brittle for a unit test. I can still try to add one if you think it's worth it.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
