### PR TITLE
Fix operand A and B's doc for tcgen05_mma

### DIFF
--- a/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
+++ b/python/triton/experimental/gluon/language/nvidia/blackwell/__init__.py
@@ -435,8 +435,8 @@ def tcgen05_mma(a, b, acc, *, use_acc=True, pred=True, multicast=False, mbarrier
     acc = a * b + (acc if use_acc else 0)
 
     Args:
-        a (shared_memory_descriptor): Left hand side operand in shared memory.
-        b (shared_memory_descriptor or tensor_memory_descriptor): Right hand side operand in shared or tensor memory.
+        a (shared_memory_descriptor or tensor_memory_descriptor): Left hand side operand in shared or tensor memory.
+        b (shared_memory_descriptor): Right hand side operand in shared memory.
         acc (tensor_memory_descriptor): Accumulator value in tensor memory (mutated).
         use_acc (bool): Whether to use the initial value of the accumulator. Defaults to True.
         pred (bool): Scalar predicate. Operation is skipped if predicate is False. Defaults to True.


### PR DESCRIPTION
A can be in either SMEM or TMEM. B has to be in SMEM. This is confirmed by checking PTX instruction as well as gluon tutorial:

https://github.com/triton-lang/triton/blob/7f9ba28c1acd9f2d94b316d8a0546759f62a02fb/python/tutorials/gluon/06-tcgen05.py#L200-L218