### PR TITLE
[AMD] Load libhipblaslt from via. rocm_sdk lib if TheRock wheels are used

### DIFF
--- a/third_party/amd/python/triton_amd.cc
+++ b/third_party/amd/python/triton_amd.cc
@@ -550,6 +550,12 @@ void init_triton_amd(py::module &&m) {
   });
 
   auto hipBlas = m.def_submodule("hipblas");
+  // For ROCm installed via TheRock wheels: Preload hipblaslt library via
+  // rocm_sdk if available. When using TheRock wheel installs, libhipblaslt
+  // resides within the Python wheel package rather than in the standard
+  // /opt/rocm/lib location. This preload ensures the library is properly
+  // loaded before HipblasLtInstance tries to dlopen it, allowing the dynamic
+  // linker to find it from the ROCm wheel's bundled libraries.
   try {
     py::module_::import("rocm_sdk").attr("preload_libraries")("hipblaslt");
   } catch (...) {


### PR DESCRIPTION
When TheRock wheels are used, libhipblaslt is inside the python venv that contains the installed wheels. Since it's not in /opt/rocm anymore, the user would have to set LD_LIBRARY_PATH to `$(rocm-sdk path root)/lib`. This patch avoids this by calling `rocm_sdk`'s `preload_libraries` directly. If TheRock wheels aren't use, it'll fallback to the original search method.

This will make the tests in `python/test/unit/runtime/test_blaslt.py` pass when TheRock based wheels are used.