### PR TITLE
allow users to choose whether to use blackwell cupti or not

### DIFF
--- a/python/triton/knobs.py
+++ b/python/triton/knobs.py
@@ -536,6 +536,7 @@ class proton_knobs(base_knobs):
     cupti_lib_blackwell_dir: env_str = env_str(
         "TRITON_CUPTI_LIB_BLACKWELL_PATH",
         str(pathlib.Path(__file__).parent.absolute() / "backends" / "nvidia" / "lib" / "cupti-blackwell"))
+    cupti_variant: env_str = env_str("TRITON_CUPTI_VARIANT", "auto")
     profile_buffer_size: env_int = env_int("TRITON_PROFILE_BUFFER_SIZE", 64 * 1024 * 1024)
     enable_nvtx: env_bool = env_bool("TRITON_ENABLE_NVTX", True)
     # This knob is effective only on Blackwell+ GPUs.

--- a/third_party/proton/proton/profile.py
+++ b/third_party/proton/proton/profile.py
@@ -29,6 +29,24 @@ def _get_mode_str(backend: str, mode: Optional[Union[str, BaseMode]]) -> str:
     return str(mode) if mode else ""
 
 
+def _get_cupti_lib_dir(backend: str) -> Optional[str]:
+    if backend != "cupti":
+        return None
+
+    variant = triton.knobs.proton.cupti_variant
+    if variant == "generic":
+        return triton.knobs.proton.cupti_lib_dir
+    if variant == "blackwell":
+        return triton.knobs.proton.cupti_lib_blackwell_dir
+    if variant != "auto":
+        raise ValueError("TRITON_CUPTI_VARIANT must be one of: auto, generic, blackwell")
+
+    if triton.runtime.driver.active.get_current_target().arch >= 100:
+        return triton.knobs.proton.cupti_lib_blackwell_dir
+
+    return triton.knobs.proton.cupti_lib_dir
+
+
 def _check_env(backend: str) -> None:
     if backend == "roctracer":
         hip_device_envs = ["HIP_VISIBLE_DEVICES", "CUDA_VISIBLE_DEVICES"]
@@ -37,16 +55,14 @@ def _check_env(backend: str) -> None:
                 raise ValueError(
                     f"Proton does not work when the environment variable {env} is set on AMD GPUs. Please unset it and use `ROCR_VISIBLE_DEVICES` instead"
                 )
-
-    use_blackwell_cupti = backend == "cupti" and triton.runtime.driver.active.get_current_target().arch >= 100
+    selected_cupti_lib_dir = _get_cupti_lib_dir(backend)
 
     # Ensure default envs are set for Proton knobs if not already set by the user.
     for attr, desc in triton.knobs.proton.knob_descriptors.items():
         key = desc.key
         if getenv(key, None) is None:
-            if key == "TRITON_CUPTI_LIB_PATH" and use_blackwell_cupti:
-                # For Blackwell+ GPUs, use the cupti library built for Blackwell.
-                triton.knobs.setenv(key, triton.knobs.proton.cupti_lib_blackwell_dir)
+            if key == "TRITON_CUPTI_LIB_PATH" and selected_cupti_lib_dir is not None:
+                triton.knobs.setenv(key, selected_cupti_lib_dir)
                 continue
             val = getattr(triton.knobs.proton, attr)
             if val is not None:

--- a/third_party/proton/test/test_api.py
+++ b/third_party/proton/test/test_api.py
@@ -8,9 +8,11 @@ import pytest
 import json
 import triton.profiler as proton
 import pathlib
+from triton.backends.compiler import GPUTarget
 from triton.profiler.hooks.hook import HookManager
 from triton.profiler.hooks.launch import LaunchHook
 from triton.profiler.hooks.instrumentation import InstrumentationHook
+from triton.profiler import profile as proton_profile
 from triton._internal_testing import is_hip
 
 
@@ -105,6 +107,33 @@ def test_profile_mode(tmp_path: pathlib.Path):
             assert "Cannot add a session with the same profiler but a different mode than existing sessions" in str(e)
         finally:
             proton.finalize()
+
+
+def test_get_cupti_lib_dir_variants(monkeypatch: pytest.MonkeyPatch):
+    class FakeDriver:
+
+        def __init__(self, arch: int):
+            self._target = GPUTarget("cuda", arch, 32)
+
+        def get_current_target(self):
+            return self._target
+
+    monkeypatch.setattr(proton_profile.triton.runtime.driver, "active", FakeDriver(100))
+    monkeypatch.setattr(proton_profile.triton.knobs.proton, "cupti_lib_dir", "/tmp/cupti")
+    monkeypatch.setattr(proton_profile.triton.knobs.proton, "cupti_lib_blackwell_dir", "/tmp/cupti-blackwell")
+
+    monkeypatch.setattr(proton_profile.triton.knobs.proton, "cupti_variant", "auto")
+    assert proton_profile._get_cupti_lib_dir("cupti") == "/tmp/cupti-blackwell"
+
+    monkeypatch.setattr(proton_profile.triton.knobs.proton, "cupti_variant", "generic")
+    assert proton_profile._get_cupti_lib_dir("cupti") == "/tmp/cupti"
+
+    monkeypatch.setattr(proton_profile.triton.knobs.proton, "cupti_variant", "blackwell")
+    assert proton_profile._get_cupti_lib_dir("cupti") == "/tmp/cupti-blackwell"
+
+    monkeypatch.setattr(proton_profile.triton.knobs.proton, "cupti_variant", "invalid")
+    with pytest.raises(ValueError, match="TRITON_CUPTI_VARIANT"):
+        proton_profile._get_cupti_lib_dir("cupti")
 
 
 def test_profile_decorator(tmp_path: pathlib.Path):


### PR DESCRIPTION
Latest cupti has issues in long running profiling mode so added an option to control which version of cupti to use.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
