### PR TITLE
chore: remove redundant copy constructor in TestScopeIdAllocationPass

### DIFF
--- a/test/lib/Proton/TestScopeIdAllocation.cpp
+++ b/test/lib/Proton/TestScopeIdAllocation.cpp
@@ -12,9 +12,6 @@ struct TestScopeIdAllocationPass
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestScopeIdAllocationPass);
 
   TestScopeIdAllocationPass() = default;
-  TestScopeIdAllocationPass(const TestScopeIdAllocationPass &other)
-      : PassWrapper<TestScopeIdAllocationPass, OperationPass<ModuleOp>>(other) {
-  }
 
   StringRef getArgument() const final {
     return "test-print-scope-id-allocation";


### PR DESCRIPTION
Remove a redundant copy constructor in TestScopeIdAllocationPass. The default copy constructor generated by the compiler is sufficient since the pass does not define custom state