### PR TITLE
[CI] Fix yapf pre-commit hook missing platformdirs dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
     hooks:
       - id: yapf
         args: ["-p", "-i"]
+        additional_dependencies: [platformdirs]
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v19.1.6


### PR DESCRIPTION
Without this dep I'm unable to run the `pre-commit run --from-ref origin/main --to-ref HEAD` step of the contribution checklist, which is blocking my ability to make an unrelated change.

Marking draft to start as this could be an issue with how `pre-commit` for NixOS is packaged, but it does fix it. I'll investigate further and undraft if there's not a nixpkgs issue.

```
     Traceback (most recent call last):                                                                                                                                                                            
       File "/home/lun/.cache/pre-commit/repo8u6fs4a4/py_env-python3.13/bin/yapf", line 3, in <module>
         from yapf import run_main                                                                                                                                                                                 
       File "/home/lun/.cache/pre-commit/repo8u6fs4a4/py_env-python3.13/lib/python3.13/site-packages/yapf/__init__.py", line 40, in <module>                                                                       
         from yapf.yapflib import yapf_api                                                                                                                                                                         
       File "/home/lun/.cache/pre-commit/repo8u6fs4a4/py_env-python3.13/lib/python3.13/site-packages/yapf/yapflib/yapf_api.py", line 38, in <module>                                                               
         from yapf.pyparser import pyparser
       File "/home/lun/.cache/pre-commit/repo8u6fs4a4/py_env-python3.13/lib/python3.13/site-packages/yapf/pyparser/pyparser.py", line 44, in <module>
         from yapf.yapflib import format_token
       File "/home/lun/.cache/pre-commit/repo8u6fs4a4/py_env-python3.13/lib/python3.13/site-packages/yapf/yapflib/format_token.py", line 23, in <module>
         from yapf.pytree import pytree_utils
       File "/home/lun/.cache/pre-commit/repo8u6fs4a4/py_env-python3.13/lib/python3.13/site-packages/yapf/pytree/pytree_utils.py", line 30, in <module>
         from yapf_third_party._ylib2to3 import pygram
       File "/home/lun/.cache/pre-commit/repo8u6fs4a4/py_env-python3.13/lib/python3.13/site-packages/yapf_third_party/_ylib2to3/pygram.py", line 9, in <module>
         from .pgen2 import driver
       File "/home/lun/.cache/pre-commit/repo8u6fs4a4/py_env-python3.13/lib/python3.13/site-packages/yapf_third_party/_ylib2to3/pgen2/driver.py", line 32, in <module>
         from platformdirs import user_cache_dir
     ModuleNotFoundError: No module named 'platformdirs'
```

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
