### PR TITLE
Fix LinearLayout::unsqueezeOut.

### DIFF
--- a/include/triton/Tools/LinearLayout.h
+++ b/include/triton/Tools/LinearLayout.h
@@ -433,8 +433,8 @@ public:
   }
 
   // Remove a dimension of size 1 from the layout.
-  [[nodiscard]] LinearLayout unsqueezeIn(StringAttr dim) const;
-  [[nodiscard]] LinearLayout unsqueezeOut(StringAttr dim) const;
+  [[nodiscard]] LinearLayout squeezeIns(StringAttr dim) const;
+  [[nodiscard]] LinearLayout squeezeOuts(StringAttr dim) const;
 
   const BasesT &getBases() const { return bases; }
 
@@ -593,9 +593,6 @@ public:
   // `sublayout`, which slices a layout from a larger one.
   [[nodiscard]] LinearLayout concatIns(const LinearLayout &other) const;
   [[nodiscard]] LinearLayout concatOuts(const LinearLayout &other) const;
-
-  // Remove all the bases that equal to 0 for the given input dimension.
-  [[nodiscard]] LinearLayout unsqueezeIns(StringAttr dim) const;
 
   // Computes the direct sum of two layouts.
   // https://en.wikipedia.org/wiki/Direct_sum#Direct_sum_of_matrices

--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -3380,7 +3380,7 @@ struct TritonGPUInferLayoutInterface
       newOrder.erase(std::remove(newOrder.begin(), newOrder.end(), splitDim),
                      newOrder.end());
       // Remove last dimension from ctall.
-      ctall = ctall.unsqueezeOut(to_vector(ctall.getOutDimNames()).back());
+      ctall = ctall.squeezeOuts(to_vector(ctall.getOutDimNames()).back());
       dstEnc = BlockedEncodingAttr::get(
           enc.getContext(), //
           ArrayRef(enc.getSizePerThread()).drop_back(1),

--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -1117,7 +1117,7 @@ LinearLayout LinearLayout::pseudoinvert() const {
   return identity.invertAndCompose(*this);
 }
 
-LinearLayout LinearLayout::unsqueezeIn(StringAttr dim) const {
+LinearLayout LinearLayout::squeezeIns(StringAttr dim) const {
   assert(getInDimSize(dim) == 1);
   SmallVector<std::pair<StringAttr, int32_t>> newInDims;
   for (auto inDim : getInDimNames()) {
@@ -1128,7 +1128,7 @@ LinearLayout LinearLayout::unsqueezeIn(StringAttr dim) const {
   return reshapeIns(newInDims);
 }
 
-LinearLayout LinearLayout::unsqueezeOut(StringAttr dim) const {
+LinearLayout LinearLayout::squeezeOuts(StringAttr dim) const {
   assert(getOutDimSize(dim) == 1);
   SmallVector<std::pair<StringAttr, int32_t>> newOutDims;
   for (auto [outDim, outDimSize] : getOutDims()) {
@@ -1136,7 +1136,7 @@ LinearLayout LinearLayout::unsqueezeOut(StringAttr dim) const {
       newOutDims.push_back({outDim, outDimSize});
     }
   }
-  return LinearLayout(bases, newOutDims, isSurjective());
+  return reshapeOuts(newOutDims);
 }
 
 llvm::MapVector<StringAttr, int32_t>

--- a/test/Conversion/triton_to_tritongpu.mlir
+++ b/test/Conversion/triton_to_tritongpu.mlir
@@ -1,4 +1,5 @@
 // RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=cuda:80 num-warps=2' | FileCheck %s
+// RUN: triton-opt %s -split-input-file -convert-triton-to-tritongpu='target=cuda:80 num-warps=2 num-ctas=2' | FileCheck %s --check-prefixes=CHECK-TWO-CTAS
 
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 2 : i32} {
 tt.func @ops() {
@@ -166,5 +167,18 @@ tt.func @cf_br(%ptr: !tt.ptr<i32>) {
 ^bb1(%arg0: tensor<128xi32>):
   %ptrs = tt.splat %ptr : !tt.ptr<i32> -> tensor<128x!tt.ptr<i32>>
   tt.store %ptrs, %arg0 : tensor<128x!tt.ptr<i32>>
+  tt.return
+}
+
+// -----
+
+tt.func @split_op(%arg0: !tt.ptr<f32>, %arg1: !tt.ptr<f32>) {
+  // CHECK-TWO-CTAS-LABEL: split_op
+  // CHECK-TWO-CTAS: tt.split
+  %0 = tt.splat %arg0 : !tt.ptr<f32> -> tensor<64x2x!tt.ptr<f32>>
+  %1 = tt.load %0 : tensor<64x2x!tt.ptr<f32>>
+  %res1, %res2 = tt.split %1 : tensor<64x2xf32> -> tensor<64xf32>
+  %2 = tt.splat %arg1 : !tt.ptr<f32> -> tensor<64x!tt.ptr<f32>>
+  tt.store %2, %res1 : tensor<64x!tt.ptr<f32>>
   tt.return
 }


### PR DESCRIPTION
LinearLayout::unsqueezeOut reduces number of output dimensions but doesn't adjust bases. This causes bases size not matching the number of output dimensions. Fixed by using `reshapeOuts`.

There is just a single usage of this function in the code base for the `SplitOp` result's CGA layout inference. The problem causes assert failures in test_simple_matmul tests which use multiple CTAs (and therefore non-empty bases in CGA layout) and epilogue sub-tile (which generates `SplitOp`).

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because it fixes existing test_simple_matmul test.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
