### PR TITLE
[AMD ] Fix a crash in SWP.

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -513,19 +513,23 @@ createStreamOps(const LoadToInfoMap &loadToInfo, scf::ForOp &forOp,
     triton::AMD::TargetInfo targetInfo(arch ? arch->str() : "");
 
     // Replace the old load with multi-buffered loads
-    if (useAsyncCopy && descLoadOp) {
+    if (descLoadOp) {
       loadToStreamOp[descLoadOp] =
           createTDMAsyncCopy(descLoadOp, alloc, extractIdx);
-    } else if (useAsyncCopy && canBeConvertedToAsyncLoad(
-                                   numBuffers, loadOp, info.sharedEncoding,
-                                   axisInfoAnalysis, targetInfo)) {
+      continue;
+    }
+
+    if (useAsyncCopy &&
+        canBeConvertedToAsyncLoad(numBuffers, loadOp, info.sharedEncoding,
+                                  axisInfoAnalysis, targetInfo)) {
       unsigned vec = axisInfoAnalysis.getContiguity(loadOp.getPtr());
       if (auto mask = loadOp.getMask())
         vec = std::min<unsigned>(vec, axisInfoAnalysis.getMaskAlignment(mask));
       loadToStreamOp[loadOp] = createAsyncCopy(loadOp, alloc, extractIdx, vec);
-    } else {
-      loadToStreamOp[loadOp] = createStreamCopy(loadOp, alloc, extractIdx);
+      continue;
     }
+
+    loadToStreamOp[loadOp] = createStreamCopy(loadOp, alloc, extractIdx);
   }
 
   return loadToStreamOp;


### PR DESCRIPTION

### The Problem
The logic excerpted below has a blatant problem. It could trigger segfault when running triton-opt without explicitly feeding `use_async_copy` to SWP, the logic was following:

  ```cpp
  assert (exactly one of ldOp and descLdOp is non-null)
  if use_async_cp & descLdOp)
    ...
  else if use_async_cp && cond
     s1: ... ldOp ...
  else
    s2: ... ldOp ...
  ```

If descLdOp != nullptr && use_async_cp == false, then s1 or s2 will crash. Fix the problem into:

  ```cpp
  assert (exactly one of ldOp and descLdOp is non-null)
  if (descLdOp) {
    ...
    continue;
  }
  if (use_async_cp && cond) {
    s1: ... ldOp ...
    continue;
  }
  s2: ... ldOp ...
  ```
  
  ### Misc
  * related to internal PR 569.