### PR TITLE
[Backend] Fix padded shared layout getter shape

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2173,9 +2173,12 @@ PaddedSharedEncodingAttr PaddedSharedEncodingAttr::get(
   auto outDimNames = standardOutDimNames(context, shape.size());
   StringAttr kOffset = StringAttr::get(context, "offset");
 
+  SmallVector<int64_t> shapePerCTA =
+      getShapePerCTA(cgaLayout.getCTASplitNum(), shape);
+
   // Create identity mapping based on shape and order
-  LinearLayout linearComponent =
-      identityStandardND(kOffset, SmallVector<unsigned>(shape), order);
+  LinearLayout linearComponent = identityStandardND(
+      kOffset, llvm::to_vector_of<unsigned>(shapePerCTA), order);
   linearComponent = combineCtaCgaWithShape(linearComponent, cgaLayout, shape);
 
   return get(context, intervalPads, std::move(linearComponent));

--- a/unittest/Dialect/TritonGPU/CMakeLists.txt
+++ b/unittest/Dialect/TritonGPU/CMakeLists.txt
@@ -37,3 +37,17 @@ add_triton_ut(
     TritonGPUTransforms
     TritonNvidiaGPUTransforms
 )
+
+add_triton_ut(
+  NAME TestPaddedSharedLayout
+  SRCS PaddedTest.cpp
+  LIBS
+    TritonAnalysis
+    TritonGPUIR
+    TritonNvidiaGPUIR
+    TritonGPUTransforms
+    TritonNvidiaGPUTransforms
+    TritonTools
+    LLVMSupport
+    MLIRSupport
+)

--- a/unittest/Dialect/TritonGPU/PaddedTest.cpp
+++ b/unittest/Dialect/TritonGPU/PaddedTest.cpp
@@ -1,0 +1,48 @@
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
+#include <gtest/gtest.h>
+
+using namespace mlir;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
+
+class PaddedTest : public ::testing::Test {
+public:
+  PaddedTest() {
+    ctx.loadDialect<mlir::triton::TritonDialect,
+                    mlir::triton::gpu::TritonGPUDialect>();
+  }
+
+  StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
+
+protected:
+  MLIRContext ctx;
+};
+
+TEST_F(PaddedTest, TestMultiCTA) {
+  std::pair<unsigned, unsigned> intervalPads(64, 8);
+  unsigned order[2] = {1, 0};
+  int64_t shape[2] = {16, 128};
+
+  {
+    auto cgaLL = LinearLayout({{S("block"), {{0, 1}}}}, {S("dim0"), S("dim1")});
+    CGAEncodingAttr cgaLayout = CGAEncodingAttr::get(&ctx, cgaLL);
+
+    auto attr = PaddedSharedEncodingAttr::get(&ctx, intervalPads, order, shape,
+                                              cgaLayout);
+    auto ll = attr.getLinearComponent();
+    auto ofstLayout = ll.sublayout(S("offset"), to_vector(ll.getOutDimNames()));
+
+    EXPECT_TRUE(ofstLayout.isInjective());
+  }
+
+  {
+    auto cgaLL = LinearLayout({{S("block"), {{0, 0}}}}, {S("dim0"), S("dim1")});
+    CGAEncodingAttr cgaLayout = CGAEncodingAttr::get(&ctx, cgaLL);
+
+    auto attr = PaddedSharedEncodingAttr::get(&ctx, intervalPads, order, shape,
+                                              cgaLayout);
+    auto ll = attr.getLinearComponent();
+    auto ofstLayout = ll.sublayout(S("offset"), to_vector(ll.getOutDimNames()));
+    EXPECT_TRUE(ofstLayout.isInjective());
+  }
+}


### PR DESCRIPTION
shapePerCTA is expected, however shape (for the entire block) is used

links to internal PR 574.