### PR TITLE
Add const to getFuncData

### DIFF
--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -298,10 +298,10 @@ public:
   }
 
   /// Retrieves the data associated with a function
-  T *getFuncData(FunctionOpInterface funcOp) {
-    if (funcMap.count(funcOp)) {
-      return &funcMap[funcOp];
-    }
+  const T *getFuncData(FunctionOpInterface funcOp) const {
+    auto it = funcMap.find(funcOp);
+    if (it != funcMap.end())
+      return &it->second;
     return nullptr;
   }
 


### PR DESCRIPTION
Subtle, non-invasive change that allows to propagate consts further down, for example in AxisInfo