### PR TITLE
[Swizzling] More generic bank conflict computation

### DIFF
--- a/include/triton/Tools/GenericSwizzling.h
+++ b/include/triton/Tools/GenericSwizzling.h
@@ -50,7 +50,8 @@ int bankConflictsMemDesc(const LinearLayout &reg, const LinearLayout &smem,
 
 std::pair<int, int> bankConflicts(llvm::ArrayRef<int32_t> tileSrc,
                                   llvm::ArrayRef<int32_t> tileDst,
-                                  const LinearLayout &smem);
+                                  const LinearLayout &smem,
+                                  int32_t bitwidth);
 } // namespace mlir::triton::gpu
 
 #endif // TRITON_GENERIC_SWIZZLING_H

--- a/lib/Tools/GenericSwizzling.cpp
+++ b/lib/Tools/GenericSwizzling.cpp
@@ -216,9 +216,6 @@ SmallVector<int32_t> complementBasis(ArrayRef<int32_t> basis, int32_t dim) {
 
   return comp;
 }
-} // namespace
-
-namespace mlir::triton::gpu {
 
 SmallVector<int32_t> intersectionBasis(ArrayRef<int32_t> b1,
                                        ArrayRef<int32_t> b2, int32_t dim) {
@@ -245,24 +242,55 @@ SmallVector<int32_t> intersectionBasis(ArrayRef<int32_t> b1,
   }
 }
 
+// The bank conflict can be mathematically computed as
+// $|span(tile, inBank) ∩ span(segment)|$ given
+// 1. Shared memory layout has no broadcast.
+// 2. No write conflict aka. multiple threads write to the same memory location
+// in one wavefront.
+int computeBankConflict(ArrayRef<int32_t> tileBases,
+                        ArrayRef<int32_t> smemBases, int32_t bitwidth,
+                        int32_t totalDim) {
+  constexpr int bankWidth = 32;
+  constexpr int bankCount = 32;
+
+  int smemSizeLog2 = smemBases.size();
+  assert(totalDim == smemSizeLog2 && "The bank conflict formula is valid only "
+                                     "if the smem layout is bijective");
+  int smemSize = 1 << smemSizeLog2;
+
+  int inBankBasesSpanSize =
+      std::min(std::max(1, bankWidth / bitwidth), smemSize);
+  int bankBasesSpanSize = std::min(bankCount * bankWidth / bitwidth, smemSize) /
+                          inBankBasesSpanSize;
+  int segmentBasesSpanSize = smemSize / inBankBasesSpanSize / bankBasesSpanSize;
+
+  auto inBankBases = smemBases.take_front(llvm::Log2_32(inBankBasesSpanSize));
+  auto segmentBases = smemBases.take_back(llvm::Log2_32(segmentBasesSpanSize));
+
+  SmallVector<int32_t> tileUnionInBankBases(tileBases);
+  tileUnionInBankBases.append(inBankBases.begin(), inBankBases.end());
+  return (1 << intersectionBasis(segmentBases, tileUnionInBankBases, totalDim)
+                   .size()) -
+         1;
+}
+} // namespace
+
+namespace mlir::triton::gpu {
+
 std::pair<int, int> bankConflicts(ArrayRef<int32_t> tileSrc,
                                   ArrayRef<int32_t> tileDst,
-                                  const LinearLayout &smem) {
+                                  const LinearLayout &smem, int32_t bitwidth) {
   auto *ctx = smem.getOutDimNames().begin()->getContext();
   auto smemFlat = smem.flattenOuts();
   auto inDim = *smem.getInDimNames().begin();
-  // Look at the intersection between the segment bases and the tile bases
-  // We don't need to intersect with the bases that covert the bank (as in
-  // the first 32 / bitwidth bases) because if we hit any of those broadcasting
-  // will avoid the bank conflict
-  auto segment = StringAttr::get(ctx, "segment");
-  auto segmentBases = flatten(smemFlat, segment);
 
+  auto S = [ctx](StringRef str) { return StringAttr::get(ctx, str); };
   int32_t rank = smem.getTotalOutDimSizeLog2();
   // compute conflicts
-  int write = 1 << intersectionBasis(segmentBases, tileSrc, rank).size();
-  int read = 1 << intersectionBasis(segmentBases, tileDst, rank).size();
-  return {read - 1, write - 1};
+  auto smemBases = flatten(smemFlat.flattenIns(), S("vector"));
+  int write = computeBankConflict(tileSrc, smemBases, bitwidth, rank);
+  int read = computeBankConflict(tileDst, smemBases, bitwidth, rank);
+  return {read, write};
 }
 
 std::pair<int, int> bankConflictsLdSt(const LinearLayout &src,
@@ -276,11 +304,11 @@ std::pair<int, int> bankConflictsLdSt(const LinearLayout &src,
   auto kVec = S("vector");
   auto srcLane = flatten(srcFlat, S("lane"));
   auto dstLane = flatten(dstFlat, S("lane"));
-  auto log2Vec =
+  auto log2Wavefronts =
       llvm::Log2_32(std::max(smem.getInDimSize(kVec) * bitwidth / 32, 1));
-  srcLane.resize(srcLane.size() - log2Vec);
-  dstLane.resize(dstLane.size() - log2Vec);
-  return bankConflicts(srcLane, dstLane, smem);
+  srcLane.resize(srcLane.size() - log2Wavefronts);
+  dstLane.resize(dstLane.size() - log2Wavefronts);
+  return bankConflicts(srcLane, dstLane, smem, bitwidth);
 }
 
 int bankConflictsMemDesc(const LinearLayout &reg, const LinearLayout &smem,
@@ -293,23 +321,16 @@ int bankConflictsMemDesc(const LinearLayout &reg, const LinearLayout &smem,
          "register layout must have a register dim");
   auto regNoBroadcast = actionRemoveBroadcastedRegs(reg).apply(reg);
   auto regToShared = regNoBroadcast.invertAndCompose(smem);
-  auto [elemsPerVec, permutation] =
-      largestVectorisation(ctx, regToShared, bitwidth);
-  regNoBroadcast = permutation.apply(regNoBroadcast);
+  auto [elemsPerVec, _] = largestVectorisation(ctx, regToShared, bitwidth);
+  auto log2Wavefronts = llvm::Log2_32(std::max(elemsPerVec * bitwidth / 32, 1));
+  auto regFlat = reg.flattenOuts();
+  auto laneBases = flatten(regFlat, S("lane"));
+  laneBases.resize(laneBases.size() - log2Wavefronts);
 
-  int32_t vecSize = elemsPerVec;
-  int32_t bankSize =
-      std::min(32 * 32 / (vecSize * bitwidth), smem.getTotalInDimSize());
-  int32_t segmentSize = smem.getTotalInDimSize() / (bankSize * vecSize);
-  SmallVector<std::pair<StringAttr, int32_t>> newInDims = {
-      {S("vector"), vecSize},
-      {S("bank"), bankSize},
-      {S("segment"), segmentSize},
-  };
-  auto smemReshaped = smem.reshapeIns(newInDims);
-  return bankConflictsLdSt(regNoBroadcast, regNoBroadcast, smemReshaped,
-                           bitwidth)
-      .first;
+  auto smemFlat = smem.flattenOuts();
+  auto smemBases = flatten(smemFlat.flattenIns(), S("offset"));
+  return computeBankConflict(laneBases, smemBases, bitwidth,
+                             smem.getTotalOutDimSizeLog2());
 }
 
 std::optional<SmallVector<int32_t>> optimalSwizzlingTile(
@@ -713,7 +734,7 @@ optimalSwizzling(const LinearLayout &src, const LinearLayout &dst,
       auto smem = optimalSwizzling(srcFlat, dstFlat, bitwidth, vbasis, tileSrc,
                                    tileDst, blockSrcSet.getArrayRef(),
                                    src.getOutDims(), leaveReps);
-      auto [read, write] = bankConflicts(tileSrc, tileDst, smem);
+      auto [read, write] = bankConflicts(tileSrc, tileDst, smem, bitwidth);
       smems.push_back({read + write, smem, {instrs.first, instrs.second}});
     }
     // Current heuristic: Minimise total bank conflicts

--- a/unittest/Dialect/TritonGPU/SwizzleTest.cpp
+++ b/unittest/Dialect/TritonGPU/SwizzleTest.cpp
@@ -14,6 +14,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <llvm/ADT/SmallSet.h>
+#include <random>
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -30,6 +31,86 @@ static std::string attrStr(Attribute a) {
   a.print(os);
   return s;
 }
+
+template <typename IntTy>
+static IntTy sampleInt(std::mt19937 &rng, IntTy lo, IntTy hi) {
+  std::uniform_int_distribution<IntTy> dist(lo, hi);
+  return dist(rng);
+}
+
+static SmallVector<uint32_t> randomColumns(std::mt19937 &rng, unsigned k,
+                                           unsigned n) {
+  assert(k > 0 && "Expected non-empty output space");
+  assert(n >= k && "Surjective map needs enough input bits");
+
+  SmallVector<uint32_t> cols;
+  cols.reserve(n);
+  for (int i = 0; i < k; i++) {
+    cols.push_back(1u << i);
+  }
+
+  for (int iter = 0; iter < 8 * k; iter++) {
+    unsigned i = sampleInt(rng, 0u, k - 1);
+    unsigned j = sampleInt(rng, 0u, k - 1);
+    if (i == j) {
+      continue;
+    }
+    int op = sampleInt(rng, 0, 1);
+    if (op == 0) {
+      std::swap(cols[i], cols[j]);
+    } else {
+      cols[j] ^= cols[i];
+    }
+  }
+
+  for (int i = k; i < n; i++) {
+    unsigned col = sampleInt(rng, 0u, (1u << k) - 1);
+    cols.push_back(col);
+  }
+  return cols;
+}
+
+static std::vector<int32_t> columnToBasis(uint32_t value,
+                                          ArrayRef<unsigned> outDimSizesLog2) {
+  std::vector<int32_t> basis;
+  basis.reserve(outDimSizesLog2.size());
+  int shift = 0;
+  for (auto bits : outDimSizesLog2) {
+    int32_t out = 0;
+    if (bits > 0) {
+      out = static_cast<int32_t>((value >> shift) & ((1u << bits) - 1u));
+    }
+    basis.push_back(out);
+    shift += bits;
+  }
+  return basis;
+}
+
+static LinearLayout
+buildRandomLayout(std::mt19937 &rng,
+                  ArrayRef<std::pair<StringAttr, unsigned>> inDimsBits,
+                  ArrayRef<unsigned> outDimSizesLog2, int totalOutSizeBits,
+                  const SmallVector<std::pair<StringAttr, int32_t>> &outDims) {
+  int n = 0;
+  for (const auto &[_, bits] : inDimsBits) {
+    n += bits;
+  }
+
+  auto columns = randomColumns(rng, totalOutSizeBits, n);
+  int colIdx = 0;
+  std::vector<std::pair<StringAttr, std::vector<std::vector<int32_t>>>> inBases;
+  inBases.reserve(inDimsBits.size());
+  for (const auto &[dim, bits] : inDimsBits) {
+    std::vector<std::vector<int32_t>> bases;
+    bases.reserve(bits);
+    for (int i = 0; i < bits; i++) {
+      bases.push_back(columnToBasis(columns[colIdx++], outDimSizesLog2));
+    }
+    inBases.push_back({dim, std::move(bases)});
+  }
+  return LinearLayout(inBases, outDims, /*requireSurjective=*/true);
+}
+
 class SwizzleTest : public ::testing::Test {
 public:
   StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
@@ -47,7 +128,7 @@ protected:
 
   MLIRContext ctx;
 
-  using LinearLayout = mlir::triton::LinearLayout;
+  StringAttr S(StringRef str) { return StringAttr::get(&ctx, str); }
 
   mlir::triton::gpu::BlockedEncodingAttr
   blocked(ArrayRef<unsigned> spt, ArrayRef<unsigned> tpw,
@@ -97,22 +178,17 @@ protected:
     return mlir::triton::gpu::toLinearLayout(shape, attr);
   }
 
-  int computeConflicts(ArrayRef<int64_t> shape, Attribute regAttr,
-                       Attribute sharedAttr, int bitwidth) {
-    auto regLL = toLL(shape, regAttr);
-    auto sharedLL = toLL(shape, sharedAttr);
+  int computeConflicts(const LinearLayout &regLL, const LinearLayout &sharedLL,
+                       int bitwidth) {
     return mlir::triton::gpu::bankConflictsMemDesc(regLL, sharedLL, bitwidth);
   }
 
-  int bruteforceBankConflictsPerWavefront(ArrayRef<int64_t> shape,
-                                          Attribute regAttr,
-                                          Attribute sharedAttr, int bitwidth) {
+  int bruteforceBankConflictsPerWavefront(const LinearLayout &regLL,
+                                          const LinearLayout &sharedLL,
+                                          int bitwidth) {
     // Compute the bank conflicts per wavefront
     // In other words, we compute how many extra memory accesses (bank
     // conflicts) are needed for a given wavefront.
-    auto regLL = toLL(shape, regAttr);
-    auto sharedLL = toLL(shape, sharedAttr);
-
     auto *ctx = sharedLL.getInDimNames().begin()->getContext();
     auto S = [ctx](StringRef str) { return StringAttr::get(ctx, str); };
 
@@ -121,7 +197,8 @@ protected:
     auto kLane = S("lane");
     auto kWarp = S("warp");
     auto regToShared = regLL.invertAndCompose(sharedLL);
-    assert(regToShared.isTrivialOver({S("block")}) && "NYI");
+    auto kBlock = S("block");
+    assert(regToShared.isTrivialOver({kBlock}) && "NYI");
     regToShared = regToShared.sublayout({kReg, kLane, kWarp}, {kOffset});
 
     // Remove broadcasting
@@ -169,6 +246,78 @@ protected:
     // Assert homogeneity
     assert(wavefronts % minWavefronts == 0);
     return wavefronts / minWavefronts - 1;
+  }
+
+  LinearLayout
+  makeSharedLL(std::mt19937 &rng, ArrayRef<unsigned> outDimSizesLog2,
+               int totalOutSizeBits,
+               const SmallVector<std::pair<StringAttr, int32_t>> &outDims) {
+    // Do not allow broadcast for shared memory layout
+    int sharedInBits = totalOutSizeBits;
+    return buildRandomLayout(rng,
+                             {{S("offset"), sharedInBits}, {S("block"), 0}},
+                             outDimSizesLog2, totalOutSizeBits, outDims);
+  }
+
+  LinearLayout
+  makeRegLL(std::mt19937 &rng, ArrayRef<unsigned> outDimSizesLog2,
+            int totalOutSizeBits,
+            const SmallVector<std::pair<StringAttr, int32_t>> &outDims) {
+    int laneBits = 5;
+    int minExtraBits = std::max(0, totalOutSizeBits - laneBits);
+    int regBits = sampleInt(rng, 0, minExtraBits);
+    int warpBits = minExtraBits - regBits;
+    // Add broadcast bases
+    int slack = sampleInt(rng, 0, 2);
+    for (int i = 0; i < slack; i++) {
+      if (sampleInt(rng, 0, 1) == 0) {
+        regBits++;
+      } else {
+        warpBits++;
+      }
+    }
+
+    return buildRandomLayout(rng,
+                             {{S("register"), regBits},
+                              {S("lane"), laneBits},
+                              {S("warp"), warpBits},
+                              {S("block"), 0}},
+                             outDimSizesLog2, totalOutSizeBits, outDims);
+  }
+
+  struct FuzzCase {
+    LinearLayout regLL;
+    LinearLayout sharedLL;
+    SmallVector<std::pair<StringAttr, int32_t>> outDims;
+    int bitwidth;
+  };
+
+  FuzzCase generateFuzzCase(std::mt19937 &rng) {
+    constexpr static int kBitwidthOptions[] = {8, 16, 32};
+    int bitwidth = kBitwidthOptions[sampleInt(rng, 0, 2)];
+
+    int rank = sampleInt(rng, 1, 4);
+    SmallVector<unsigned, 8> outDimSizesLog2(rank);
+    for (int i = 0; i < rank; ++i) {
+      outDimSizesLog2[i] = sampleInt(rng, 0, 5);
+    }
+    int mustBeNonZero = sampleInt(rng, 0, rank - 1);
+    outDimSizesLog2[mustBeNonZero] = sampleInt(rng, 1, 5);
+    int totalOutSizeBits =
+        std::accumulate(outDimSizesLog2.begin(), outDimSizesLog2.end(), 0);
+
+    SmallVector<std::pair<StringAttr, int32_t>> outDims;
+    outDims.reserve(outDimSizesLog2.size());
+    for (int i = 0; i < outDimSizesLog2.size(); i++) {
+      outDims.push_back(
+          {S(("dim" + std::to_string(i)).c_str()), 1 << outDimSizesLog2[i]});
+    }
+
+    auto regLL = makeRegLL(rng, outDimSizesLog2, totalOutSizeBits, outDims);
+    auto sharedLL =
+        makeSharedLL(rng, outDimSizesLog2, totalOutSizeBits, outDims);
+    return {std::move(regLL), std::move(sharedLL), std::move(outDims),
+            bitwidth};
   }
 };
 
@@ -352,14 +501,35 @@ TEST_F(BankConflictTest, bankConflicts) {
   };
 
   for (const auto &c : cases) {
-    EXPECT_EQ(computeConflicts(c.shape, c.reg, c.shared, c.bitwidth),
-              bruteforceBankConflictsPerWavefront(c.shape, c.reg, c.shared,
-                                                  c.bitwidth))
-
-        << toLL(c.shape, c.reg).invertAndCompose(toLL(c.shape, c.shared))
-        << "\nbitwidth=" << c.bitwidth << "\n"
+    auto regLL = toLL(c.shape, c.reg);
+    auto sharedLL = toLL(c.shape, c.shared);
+    EXPECT_EQ(computeConflicts(regLL, sharedLL, c.bitwidth),
+              bruteforceBankConflictsPerWavefront(regLL, sharedLL, c.bitwidth))
+        << regLL.invertAndCompose(sharedLL) << "\nbitwidth=" << c.bitwidth
+        << "\n"
         << attrStr(c.reg) << "\n"
         << attrStr(c.shared);
+  }
+}
+
+TEST_F(BankConflictTest, bankConflictsFuzz) {
+  constexpr int numCases = 512;
+  constexpr uint32_t seed = 0x5f3f8f83U;
+  std::mt19937 rng(seed);
+
+  for (int i = 0; i < numCases; i++) {
+    auto c = generateFuzzCase(rng);
+    ASSERT_TRUE(c.regLL.isSurjective());
+    ASSERT_TRUE(c.sharedLL.isSurjective());
+
+    int computed = computeConflicts(c.regLL, c.sharedLL, c.bitwidth);
+    int brute =
+        bruteforceBankConflictsPerWavefront(c.regLL, c.sharedLL, c.bitwidth);
+    EXPECT_EQ(computed, brute) << "case_idx=" << i << "\n"
+                               << c.regLL.invertAndCompose(c.sharedLL)
+                               << "\nbitwidth=" << c.bitwidth << "\n"
+                               << c.regLL << "\n"
+                               << c.sharedLL;
   }
 }
 


### PR DESCRIPTION
This change makes the bank conflict computation applicable to any linear layout. 

The bank conflict could be mathematically computed for any form of distributed and shared linear layout (allow swizzling on any dims) given several conditions we already met.

I think this is useful if we want to improve the swizzling algorithm to cover any LL cases in the future. For now, this change gives a more accurate theoretical result of bank conflict, which should not incur massive behavior changes. 

A fuzz test is added to verify its correctness. The linear layouts are randomly generated from full-rank matrices.

The signature of public `bankConflicts` function is expanded to accept an extra `bitwidth`. I've searched through the codebase and there is no usage of it outside the GenericSwizzling file, so I think this is safe.

I could provide a math proof (AI-assisted) for the new formula if required.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
