### PR TITLE
[AMD] Fix gluon tests on RDNA

### DIFF
--- a/python/test/gluon/test_lowerings.py
+++ b/python/test/gluon/test_lowerings.py
@@ -7,6 +7,8 @@ from triton.experimental.gluon import language as ttgl
 from triton._internal_testing import is_cuda, is_hip, is_hopper_or_newer, get_hip_lds_size
 from triton.experimental.gluon.language.amd.gfx1250 import PartitionedSharedLayout
 
+THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
+
 
 def _is_layout_applicable(layout) -> bool:
     if isinstance(layout, (ttgl.BlockedLayout, ttgl.SwizzledSharedLayout, ttgl.DistributedLinearLayout)):
@@ -25,7 +27,8 @@ def _is_layout_applicable(layout) -> bool:
     elif is_hip():
         if layout in ["padded_shared_layout_single_interval", "padded_shared_layout_multi_interval"]:
             return True
-        # TODO: Add other amd layouts
+        if THREADS_PER_WARP == 32:
+            return isinstance(layout, ttgl.amd.AMDWMMALayout)
         return isinstance(layout, ttgl.amd.AMDMFMALayout)
     else:
         return True
@@ -33,9 +36,6 @@ def _is_layout_applicable(layout) -> bool:
 
 def _filter_layouts(layouts):
     return [l for l in layouts if _is_layout_applicable(l)]
-
-
-THREADS_PER_WARP = triton.runtime.driver.active.get_current_target().warp_size
 
 
 @gluon.jit
@@ -287,7 +287,7 @@ def _reduce_layouts():
     rets = []
     for (M, N) in shapes:
         for layout in layouts:
-            if isinstance(layout, (ttgl.amd.AMDMFMALayout, ttgl.NVMMADistributedLayout)):
+            if isinstance(layout, (ttgl.amd.AMDMFMALayout, ttgl.amd.AMDWMMALayout, ttgl.NVMMADistributedLayout)):
                 instr_shape = layout.instr_shape
                 if M < instr_shape[0] or N < instr_shape[1]:
                     continue

--- a/python/triton/experimental/gluon/language/_layouts.py
+++ b/python/triton/experimental/gluon/language/_layouts.py
@@ -697,7 +697,7 @@ def bases_per_dim(bases, rank, skip_broadcast=True):
 
 
 def warps_per_cta(layout, shape):
-    if isinstance(layout, DistributedLinearLayout):
+    if hasattr(layout, 'warp_bases'):
         return bases_per_dim(layout.warp_bases, len(shape))
     elif isinstance(layout, (SliceLayout, DotOperandLayout)):
         return warps_per_cta(layout.parent, shape)


### PR DESCRIPTION
AMDMFMALayout tests fail because of wave size mismatch. We need to enable the AMDWMMALayout tests for architectures with wave32 and make sure that warps_per_cta() can be calculated for it.