### PR TITLE
Fix: emit a deprecation warning for make_block_ptr

### DIFF
--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -2358,7 +2358,7 @@ def make_block_ptr(base: tensor, shape, strides, offsets, block_shape, order, _s
     :param block_shape: The shape of the block
     :param order: The order of the original data format
     """
-    warn("make_block_ptr is being deprecated in favor of make_tensor_descriptor.")
+    warn("tl.make_block_ptr is deprecated. Use TensorDescriptor or tl.make_tensor_descriptor instead.")
     return _semantic.make_block_ptr(base, shape, strides, offsets, block_shape, order)
 
 


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Add a deprecation warning for tl.make_block_ptr because in #6847 we are removing block pointers in favor of tensor descriptors.

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
