### PR TITLE
[AxisInfo] Add ReshapeOp

### DIFF
--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -795,12 +795,28 @@ public:
       int64_t constancyEnd = srcStride * srcConstancy;
       if (dstStride <= constancyEnd) {
         // If we land inside a constant axis, the constancy is the minimum
-        // between the shape and how much constancy survives
-        constancy[dstDim] =
+        // between the shape and how much constancy survives.
+        int64_t dstConstancy =
             std::min<int64_t>(dstShape[dstDim], constancyEnd / dstStride);
+
+        // Several constant dimensions can merge into a single constant
+        // dimension
+        int64_t remainingSize = dstShape[dstDim] / dstConstancy;
+        for (int dim = srcDim - 1;
+             srcConstancy == srcShape[srcDim] && dim >= 0 && remainingSize > 1;
+             --dim) {
+          int64_t pieceSize = std::min(srcShape[dim], remainingSize);
+          int64_t pieceConstancy =
+              std::min(srcInfo.getConstancy(dim), pieceSize);
+          dstConstancy *= pieceConstancy;
+          if (pieceConstancy < pieceSize)
+            break;
+          remainingSize /= pieceSize;
+        }
+        constancy[dstDim] = dstConstancy;
       }
       // Divisibility stays the same when the constant block is split
-      // even for constancy == 1
+      // even for constancy == 1.
       divisibility[dstDim] = srcDivisibility;
     }
 

--- a/test/Analysis/test-alignment.mlir
+++ b/test/Analysis/test-alignment.mlir
@@ -325,6 +325,18 @@ tt.func @reshape(%arg0: tensor<8xi32> {tt.contiguity = 1 : i32, tt.divisibility 
 
 // -----
 
+tt.func @reshape_refined_piece_merge(
+    %arg0: tensor<4x4xi32> {tt.contiguity = dense<[1, 1]> : tensor<2xi32>, tt.divisibility = dense<[1, 1]> : tensor<2xi32>, tt.constancy = dense<[2, 4]> : tensor<2xi32>},
+    %arg1: tensor<2x2x2xi32> {tt.contiguity = dense<[1, 1, 2]> : tensor<3xi32>, tt.divisibility = dense<[1, 1, 1]> : tensor<3xi32>, tt.constancy = dense<[2, 2, 1]> : tensor<3xi32>}) {
+  // expected-remark @below {{contiguity = [1], divisibility = [1], constancy = [8], constant_value = <none>}}
+  %0 = tt.reshape %arg0 : tensor<4x4xi32> -> tensor<16xi32>
+  // expected-remark @below {{contiguity = [1, 2], divisibility = [1, 1], constancy = [4, 1], constant_value = <none>}}
+  %1 = tt.reshape %arg1 : tensor<2x2x2xi32> -> tensor<4x2xi32>
+  tt.return
+}
+
+// -----
+
 tt.func @broadcast() {
   // expected-remark @below {{contiguity = [1], divisibility = [64], constancy = [128], constant_value = 64}}
   %0 = arith.constant dense<64> : tensor<128xi32>


### PR DESCRIPTION
The formulas were deduced by gpt5.4 Pro, although the ideas are pretty
straightforward (it's all about seeing where do previous axes and new
axes line up and reason about those).

This now recovers vectorisation of block pointers which was killed in
https://github.com/triton-lang/triton/pull/9668 as it uses reshapes.

Fixes https://github.com/triton-lang/triton/issues/9598

Prompt:
```
Consider the following elementary number theory problem:
We say that a sequence of n integers is k-contiguous (with k|n) if there exists n/k integers b_i such that a_i = b_{\floor(i/k)} + (i mod k).
We say that a k-contiguous sequence of n integers is d-divisible if b_i mod d = 0.
We say that a sequence of n integers is c-constant if every aligned block of c elements is constant, that is, there exists n/c integers d_j such that a_i = d_{\floor(i/c)}.
Note that c-constant and k-contiguous are mutually exclusive except for degeneate cases, so if c > 1 then k == 1 and if k > 1 then c == 1.

Consider now N series (x_0, x_1, ..., x_{N-1}) of (L_0, ..., L_{N-1}) integers each that are (k_0, ..., k_{N- 1}) contiguous and (d_0, ..., d_{N-1}) divisible and (c_0, ..., c_{N-1}) constant where L_i, k_i, d_i and c_i are powers of two.
Compute the best lower bounds for the contiguity and divisibility (w.r.t. the contiguity parameter) of the sequence reshape((x_0, ..., x_{N-1}), (S_0, ..., S_{M-1}))
where prod S_i = prod L_i (i.e., S_i are powers of two) and the reshape is defined as reshape((x_0, ..., x_{N-1}), L_0 * ... * L_{N-1})_i = (x_0..., x_{N-1})_{(0, ..., 0, i)} for i = 0, ..., L_{N-1}-1 and reshape((x_0, ..., x_{N-1}), L_0 * ... * L_{N-1})_{L_{N-1}} = (x_0, ..., x_{N-1})_{(0, ..., 1, 0)} and so on
```
