### PR TITLE
[triton-ext] Fix garbage string in reported errors

### DIFF
--- a/lib/Tools/PluginUtils.cpp
+++ b/lib/Tools/PluginUtils.cpp
@@ -2,8 +2,8 @@
 
 llvm::Error TritonPlugin::checkLibraryValid(const std::string &error) const {
   if (!library.isValid()) {
-    auto msg = llvm::Twine("Failed to load plugin library: " + error + "\n");
-    return llvm::createStringError(msg);
+    return llvm::createStringError(
+        llvm::Twine("Failed to load plugin library: ") + error);
   }
   return llvm::Error::success();
 }
@@ -14,8 +14,8 @@ TritonPlugin::getAddressOfSymbol(const std::string &symbol) const {
     return isValid;
   intptr_t getDetailsFn = (intptr_t)library.getAddressOfSymbol(symbol.c_str());
   if (!getDetailsFn) {
-    auto msg = llvm::Twine("Failed to get symbol: " + symbol + "\n");
-    return llvm::createStringError(msg);
+    return llvm::createStringError(llvm::Twine("Failed to get symbol: ") +
+                                   symbol);
   }
   return getDetailsFn;
 }
@@ -25,11 +25,9 @@ TritonPlugin::checkAPIResult(TritonPluginResult result,
                              const char *handle) const {
   if (result == TP_SUCCESS)
     return TP_SUCCESS;
-  std::string msg;
-  llvm::raw_string_ostream os(msg);
-  os << "Failed to add/register plugin pass (" << handle
-     << ") to pass manager, error code: " << result;
-  return llvm::createStringError(msg);
+  return llvm::createStringError(
+      llvm::Twine("Failed to add/register a plugin pass (") + handle +
+      "), error code: " + std::to_string(result));
 }
 
 std::runtime_error TritonPlugin::err2exp(llvm::Error Err) {
@@ -108,10 +106,9 @@ llvm::Expected<TritonPluginResult> TritonPlugin::enumeratePyBindHandles(
 
   if (result == TP_SUCCESS)
     return TP_SUCCESS;
-  std::string msg;
-  llvm::raw_string_ostream os(msg);
-  os << "Failed to retrive plugin pass handles, error code: " << result;
-  return llvm::createStringError(msg);
+  return llvm::createStringError(
+      llvm::Twine("Failed to retrieve plugin pass handles, error code: ") +
+      std::to_string(result));
 }
 
 llvm::Expected<TritonPluginResult>


### PR DESCRIPTION
When loading an extension library, it is possible that the library is reported invalid by `llvm::sys::DynamicLibrary::getPermanentLibrary`; e.g., if the loaded library has undefined symbols. When trying to add dialects in [triton-ext], I observed some garbage output when loading extensions:

```console
$ LD_LIBRARY_PATH=llvm-27d654c4-linux-x64/lib
 TRITON_PASS_PLUGIN_PATH=build/lib/libexample.so triton-dacfe7ad-linux-x64/bin/triton-opt
LLVM ERROR: {X��J�iĳ(��h��[ĳh��x����������

Aborted                    (core dumped) LD_LIBRARY_PATH=llvm-27d654c4-linux-x64/lib TRITON_PASS_PLUGIN_PATH=build/lib/libexample.so triton-dacfe7ad-linux-x64/bin/triton-opt
```

I tracked this down to incorrect usage of `llvm::Twine` and `llvm::createStringError`. Suspecting that the string messages were not being moved into the error and thus being corrupted by stack movement, I switched all uses of `llvm::createStringError` to use the pattern I see in LLVM. This fixes the garbage error string problem so now I see the proper error:

```
LLVM ERROR: Failed to load plugin library: triton/build/install/lib64/libtriton.so: undefined symbol: _Py_NoneStruct
```

[triton-ext]: https://github.com/triton-lang/triton-ext
