### PR TITLE
[AMD] Fix CGA layout bugs about AMDWmmaEncodingAttr

### DIFF
--- a/lib/Dialect/TritonGPU/IR/Dialect.cpp
+++ b/lib/Dialect/TritonGPU/IR/Dialect.cpp
@@ -2974,18 +2974,18 @@ struct TritonGPUInferLayoutInterface
     }
 
     // For AMDWmmaEncodingAttr verify multi-cta CGA layout compatibility
-    auto wmmaAEncoding = dyn_cast<AMDWmmaEncodingAttr>(aEncoding.getParent());
-    auto wmmaBEncoding = dyn_cast<AMDWmmaEncodingAttr>(bEncoding.getParent());
+    auto wmmaAParentEnc = dyn_cast<AMDWmmaEncodingAttr>(aEncoding.getParent());
+    auto wmmaBParentEnc = dyn_cast<AMDWmmaEncodingAttr>(bEncoding.getParent());
     auto wmmaResEncoding = dyn_cast<AMDWmmaEncodingAttr>(resEnc);
-    if (wmmaAEncoding && wmmaBEncoding && wmmaResEncoding) {
+    if (wmmaAParentEnc && wmmaBParentEnc && wmmaResEncoding) {
       auto resLL = wmmaResEncoding.getCGALayout().getLinearLayout();
 
       if (!resLL.isInvertible())
         return op->emitError("Accumulator CGA layout should not broadcast or "
                              "have repeated rows");
 
-      auto aLL = wmmaAEncoding.getCGALayout().getLinearLayout();
-      auto bLL = wmmaBEncoding.getCGALayout().getLinearLayout();
+      auto aLL = aEncoding.getCGALayout().getLinearLayout();
+      auto bLL = bEncoding.getCGALayout().getLinearLayout();
       // In multi-CTA, the CGA layout of operand 0 broadcasts across dim1 and
       // operand 1 broadcasts across dim0.
       auto ctx = op->getContext();

--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -826,7 +826,7 @@ LinearLayout wmmaDotOperandToLinearLayout(DotOperandEncodingAttr dotWmmaLayout,
       permuteDimNames(standardOutDimNames(ctx, rank), order);
   dotOperanLayout = dotOperanLayout.transposeOuts(repDimNames);
 
-  return combineCtaCgaWithShape(dotOperanLayout, wmmaLayout.getCGALayout(),
+  return combineCtaCgaWithShape(dotOperanLayout, dotWmmaLayout.getCGALayout(),
                                 shape);
 }
 

--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -379,14 +379,17 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
-// NOTE: A/B/C/D's CGA-layout are not necessarilly equal when num-ctas > 1
+// NOTE: A/B/C/D's CGA-layout are not necessarily equal when num-ctas > 1
 //  - D and C's should have the same CGA-layout, in this case [[0, 1], [1, 0]]
 //  - A and B's CGA-layout is derived from D-CGA-layout by clearing the elements,
 //    corresponding to the K dim, in the bases to zero. Hence, one have layout
 //    [[0, 0] [1, ]], the other one has layout [[0, 1], [0, 0]]
+//  - However, A and B's CGAlayout is inferred on the fly. We only see parent's
+//    encoding in the IR.
 //
-// CHECK-DAG: #mma{{[0-9]}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 0\], \[1, 0\]\]}}
-// CHECK-DAG: #mma{{[0-9]}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 1\], \[0, 0\]\]}}
+// CHECK-NOT: #mma{{.*}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 0\], \[1, 0\]\]}}
+// CHECK-NOT: #mma{{.*}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 1\], \[0, 0\]\]}}
+// CHECK: #mma{{.*}} = #ttg.amd_wmma<{version = 3, isTranspose = true, {{.*}} CGALayout = {{\[\[0, 1\], \[1, 0\]\]}}
 // CHECK-LABEL: test_multi_ctas
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [4, 8], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [1, 0]]}>

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1600,8 +1600,6 @@ public:
         warpsPerTileWMMA(dotOp, retShape, numWarps, {mDim, nDim});
 
     auto CGALayout = ttg::getCGALayout(oldRetEncoding);
-    auto CGALayoutA = ttg::getCGALayout(oldAType.getEncoding());
-    auto CGALayoutB = ttg::getCGALayout(oldBType.getEncoding());
 
     // Use transposed wmma layout to enable larger vectorization for global
     // store instructions.
@@ -1613,12 +1611,6 @@ public:
     wmmaEnc =
         ttg::AMDWmmaEncodingAttr::get(ctx, wmmaVersion, ctaLayout, isTransposed,
                                       CGALayout, {mDim, nDim, kDim});
-    wmmaEncA =
-        ttg::AMDWmmaEncodingAttr::get(ctx, wmmaVersion, ctaLayout, isTransposed,
-                                      CGALayoutA, {mDim, nDim, kDim});
-    wmmaEncB =
-        ttg::AMDWmmaEncodingAttr::get(ctx, wmmaVersion, ctaLayout, isTransposed,
-                                      CGALayoutB, {mDim, nDim, kDim});
 
     auto newRetType = RankedTensorType::get(retShape, operandTypes[3], wmmaEnc);
 
@@ -1637,10 +1629,10 @@ public:
     }
     auto newAType = RankedTensorType::get(
         aShape, operandTypes[0],
-        ttg::DotOperandEncodingAttr::get(ctx, 0, wmmaEncA, kWidth));
+        ttg::DotOperandEncodingAttr::get(ctx, 0, wmmaEnc, kWidth));
     auto newBType = RankedTensorType::get(
         bShape, operandTypes[1],
-        ttg::DotOperandEncodingAttr::get(ctx, 1, wmmaEncB, kWidth));
+        ttg::DotOperandEncodingAttr::get(ctx, 1, wmmaEnc, kWidth));
 
     Value castedA = convertAndCastTensor(rewriter, a, newAType.getEncoding(),
                                          operandTypes[0]);


### PR DESCRIPTION
### Problem
* AMDWmmaEncodingAttr is one of parent encoding of DotOperandEncodingAttr. To set dot's A or B operand's CGA Layout, what we need to do is following:
    - create DotOperandEncodingAttr with parent-encoding AMDWmmaEncodingAttr depicting D or C's CGA layout. Note that the AMDWmmaEncodingAttr instance does **NOT** describe A/B' CGA layout.
    - To get A/B's CGA layout, call DotOperandEncodingAttr::getCGALayout() which will infer CGA layout on the fly based on parent encoding and operand-index.

### Misc
* linked to internal PR 581