### PR TITLE
[CONSAN] Fix TMA access modelling

### DIFF
--- a/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
+++ b/include/triton/Dialect/TritonInstrument/IR/FunctionBuilder.h
@@ -158,6 +158,12 @@ public:
   void createTrackVisibleReadsCall(ImplicitLocOpBuilder &b, Value mbar,
                                    int thread, Value pred, MemType memType,
                                    Operation *insertPoint);
+  // trackBarrierWriteForBuffer: mark a specific buffer as tracked by a
+  // barrier in the write-tracking table.
+  void createTrackBarrierWriteForBufferCall(ImplicitLocOpBuilder &b, Value mbar,
+                                            Value buf, uint32_t length,
+                                            Value pred, MemType memType,
+                                            Operation *insertPoint);
   // clearBarrierWriteTracking: clear all write tracking associated with the
   // given barrier row.
   void createClearBarrierWriteTrackingCall(ImplicitLocOpBuilder &b, Value mbar,

--- a/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
+++ b/include/triton/Dialect/TritonInstrument/Transforms/ConSanTargetHooks.h
@@ -12,6 +12,14 @@
 namespace mlir::triton::instrument {
 
 struct MemEffectsOpInfo {
+  // Frontier: snapshot thread-visible frontier into barrier tracking.
+  // EffectWrites: track only buffers written by op effects.
+  // None: perform no visibility tracking for the barrier.
+  enum class BarrierTrackingMode {
+    Frontier,
+    EffectWrites,
+    None,
+  };
   struct Effects {
     enum RW { Read, Write } rw;
     Value buf;
@@ -26,6 +34,7 @@ struct MemEffectsOpInfo {
     Value barrier;
     Value pred;
     int count;
+    BarrierTrackingMode trackingMode = BarrierTrackingMode::Frontier;
   };
   enum class TrackingKind {
     None,

--- a/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
+++ b/lib/Dialect/TritonInstrument/IR/FunctionBuilder.cpp
@@ -1430,6 +1430,79 @@ void FunctionBuilder::createTrackVisibleReadsCall(ImplicitLocOpBuilder &b,
       });
 }
 
+void FunctionBuilder::createTrackBarrierWriteForBufferCall(
+    ImplicitLocOpBuilder &b, Value mbar, Value buf, uint32_t length, Value pred,
+    MemType memType, Operation *insertPoint) {
+  if (auxData.barriers.empty() || auxData.buffers[(int)memType].empty() ||
+      auxData.writeTracking[(int)memType].empty()) {
+    return;
+  }
+  if (!pred)
+    pred = arith::ConstantIntOp::create(b, 1, 1);
+  Value barriersVal = auxData.barriers.at(insertPoint).value;
+  auto barriersType =
+      cast<RankedTensorType>(auxData.barriers.at(insertPoint).type);
+  Value buffersVal = auxData.buffers[(int)memType].at(insertPoint).value;
+  auto buffersType = cast<RankedTensorType>(
+      auxData.buffers[(int)memType].at(insertPoint).type);
+  Value writeTrackingVal =
+      auxData.writeTracking[(int)memType].at(insertPoint).value;
+  auto writeTrackingType = cast<RankedTensorType>(
+      auxData.writeTracking[(int)memType].at(insertPoint).type);
+  uint32_t mbarLength = getMemDescLength(mbar);
+  Value mbarOffset = tti::ExperimentalMemDescToI32Op::create(b, mbar);
+  Value mbarLengthVal = arith::ConstantIntOp::create(b, mbarLength, 32);
+  Value bufOffset = tti::ExperimentalMemDescToI32Op::create(b, buf);
+  Value bufLengthVal = arith::ConstantIntOp::create(b, length, 32);
+  SmallVector<Value> args = {mbarOffset, mbarLengthVal,   pred,
+                             bufOffset,  bufLengthVal,    barriersVal,
+                             buffersVal, writeTrackingVal};
+  createCallToCachedFunction(
+      b, "track_barrier_write_for_buffer", args,
+      /*assertInfo=*/std::nullopt,
+      {barriersType, buffersType, writeTrackingType, (uint64_t)memType},
+      [barriersType, buffersType, writeTrackingType](ImplicitLocOpBuilder &fb,
+                                                     Block *entryBlock) {
+        Value mbarOffset = entryBlock->getArgument(0);
+        Value mbarLengthVal = entryBlock->getArgument(1);
+        Value pred = entryBlock->getArgument(2);
+        Value bufOffset = entryBlock->getArgument(3);
+        Value bufLengthVal = entryBlock->getArgument(4);
+        Value barriers = entryBlock->getArgument(5);
+        Value buffers = entryBlock->getArgument(6);
+        Value writeTrackingPtr = entryBlock->getArgument(7);
+
+        auto [prevBlock, ifBlock, thenBlock] = createIfBlock(fb, pred);
+        fb.setInsertionPointToStart(ifBlock);
+
+        Value writeTracking = tti::createLoadScratchMemory(
+            fb, fb.getLoc(), writeTrackingPtr, writeTrackingType);
+        Value barrierDescriptor =
+            createBufferDescriptor(fb, mbarOffset, mbarLengthVal);
+        Value barriersEqBar =
+            createCmpIntTensorScalar(fb, barriers, barrierDescriptor);
+        barriersEqBar = convertAndBroadcast(fb, barriersEqBar, /*dim=*/0,
+                                            writeTrackingType);
+        Value bufferDescriptor =
+            createBufferDescriptor(fb, bufOffset, bufLengthVal);
+        Value buffersEqBuf =
+            createCmpIntTensorScalar(fb, buffers, bufferDescriptor);
+        buffersEqBuf =
+            convertAndBroadcast(fb, buffersEqBuf, /*dim=*/1, writeTrackingType);
+        Value trackMask =
+            arith::AndIOp::create(fb, barriersEqBar, buffersEqBuf);
+        Value writeTrackingOne =
+            tti::createConstIntTensor(fb, fb.getLoc(), 1, writeTrackingType);
+        Value newTracking = arith::SelectOp::create(
+            fb, trackMask, writeTrackingOne, writeTracking);
+        tti::createStoreScratchMemory(fb, fb.getLoc(), writeTrackingPtr,
+                                      newTracking, writeTrackingType);
+
+        fb.setInsertionPointToEnd(thenBlock);
+        triton::ReturnOp::create(fb);
+      });
+}
+
 void FunctionBuilder::createClearBarrierWriteTrackingCall(
     ImplicitLocOpBuilder &b, Value mbar, Value pred, MemType memType,
     Operation *insertPoint) {

--- a/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/ConcurrencySanitizer.cpp
@@ -360,13 +360,28 @@ private:
       Value combinedPred = combinePredicates(barrierInfo.pred);
       funcBuilder.createVerifyBarrierInitializedCall(b, barrier, combinedPred,
                                                      op);
-      // If the op has barriers, we treat it as a commit emitted for each
-      // barrier.
-      for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
-        funcBuilder.createTrackVisibleWritesCall(b, barrier, thread,
-                                                 combinedPred, memType, op);
-        funcBuilder.createTrackVisibleReadsCall(b, barrier, thread,
-                                                combinedPred, memType, op);
+      if (barrierInfo.trackingMode ==
+          MemEffectsOpInfo::BarrierTrackingMode::Frontier) {
+        // If the op has barriers, we treat it as a commit emitted for each
+        // barrier.
+        for (MemType memType : {MemType::SHARED_MEM, MemType::TENSOR_MEM}) {
+          funcBuilder.createTrackVisibleWritesCall(b, barrier, thread,
+                                                   combinedPred, memType, op);
+          funcBuilder.createTrackVisibleReadsCall(b, barrier, thread,
+                                                  combinedPred, memType, op);
+        }
+      } else if (barrierInfo.trackingMode ==
+                 MemEffectsOpInfo::BarrierTrackingMode::EffectWrites) {
+        for (const auto &effect : opInfo->operandEffects) {
+          if (effect.rw != MemEffectsOpInfo::Effects::Write)
+            continue;
+          auto bufType = cast<ttg::MemDescType>(effect.buf.getType());
+          MemType memType = MemType::TENSOR_MEM;
+          if (isa<ttg::SharedEncodingTrait>(bufType.getEncoding()))
+            memType = MemType::SHARED_MEM;
+          funcBuilder.createTrackBarrierWriteForBufferCall(
+              b, barrier, effect.buf, effect.length, combinedPred, memType, op);
+        }
       }
       if (barrierInfo.count > 0) {
         funcBuilder.createVerifyBarrierArriveCall(b, barrier, barrierInfo.count,

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ConSanNVIDIA.cpp
@@ -67,7 +67,8 @@ public:
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = expectOp.getPred();
-      info->barriers.push_back({expectOp.getAlloc(), nullptr, /*count=*/1});
+      info->barriers.push_back({expectOp.getAlloc(), nullptr, /*count=*/1,
+                                MemEffectsOpInfo::BarrierTrackingMode::None});
     }
     if (auto loadOp = dyn_cast<ttng::TMEMLoadOp>(op)) {
       info.emplace();
@@ -134,7 +135,9 @@ public:
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = copyOp.getPred();
-      info->barriers.push_back({copyOp.getBarrier(), nullptr, /*count=*/0});
+      info->barriers.push_back(
+          {copyOp.getBarrier(), nullptr, /*count=*/0,
+           MemEffectsOpInfo::BarrierTrackingMode::EffectWrites});
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         copyOp.getResult());
     }
@@ -150,7 +153,9 @@ public:
       info.emplace();
       info->trackingKind = MemEffectsOpInfo::TrackingKind::Barrier;
       info->pred = gatherOp.getPred();
-      info->barriers.push_back({gatherOp.getBarrier(), nullptr, /*count=*/0});
+      info->barriers.push_back(
+          {gatherOp.getBarrier(), nullptr, /*count=*/0,
+           MemEffectsOpInfo::BarrierTrackingMode::EffectWrites});
       info->operandEffects.emplace_back(MemEffectsOpInfo::Effects::Write,
                                         gatherOp.getResult());
     }

--- a/python/test/gluon/test_consan.py
+++ b/python/test/gluon/test_consan.py
@@ -270,6 +270,61 @@ def test_tma_interleave_kernel(FAILURE, device, run_wrapper, monkeypatch):
     kernel[(1, )](input_desc, output, FAILURE=FAILURE, num_warps=4)
 
 
+@pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires hopper or newer")
+@pytest.mark.parametrize("FAILURE", [True, False])
+def test_tma_wait_tracks_only_waited_barrier(FAILURE, device, run_wrapper, monkeypatch):
+    if run_wrapper:
+        result = run_in_process(test_tma_wait_tracks_only_waited_barrier, (FAILURE, device, False, monkeypatch))
+        if FAILURE:
+            assert "device-side assert" in str(result.exc)
+            assert "Buffer being accessed has outstanding writes" in result.driver_stderr_output
+        else:
+            assert result.exc is None
+            assert result.driver_stderr_output == ""
+        return
+
+    monkeypatch.setenv("TRITON_INSTRUMENTATION_MODE", "consan")
+    monkeypatch.setenv("CUDA_LAUNCH_BLOCKING", "1")
+    knobs.refresh_knobs()
+
+    @gluon.jit
+    def kernel(input_desc, out, FAILURE: ttgl.constexpr):
+        smem = ttgl.allocate_shared_memory(ttgl.float16, [2, XBLOCK, XBLOCK], input_desc.layout)
+        bar = ttgl.allocate_shared_memory(ttgl.int64, [2, 1], mbarrier.MBarrierLayout())
+        mbarrier.init(bar.index(0), count=1)
+        mbarrier.init(bar.index(1), count=1)
+
+        mbarrier.expect(bar.index(0), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(0), smem.index(0))
+        mbarrier.expect(bar.index(1), XBLOCK * XBLOCK * ttgl.float16.primitive_bitwidth // 8)
+        tma.async_copy_global_to_shared(input_desc, [0, 0], bar.index(1), smem.index(1))
+
+        mbarrier.wait(bar.index(1), 0)
+
+        blocked_layout: ttgl.constexpr = ttgl.BlockedLayout(size_per_thread=[1, 1], threads_per_warp=[32, 1],
+                                                            warps_per_cta=[4, 1], order=[0, 1])
+        if FAILURE:
+            val = smem.index(0).load(blocked_layout)
+        else:
+            val = smem.index(1).load(blocked_layout)
+        out_m = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(1, blocked_layout))[:, None]
+        out_n = ttgl.arange(0, XBLOCK, ttgl.SliceLayout(0, blocked_layout))[None, :]
+        out_ptr = out + out_m * XBLOCK + out_n
+        ttgl.store(out_ptr, val)
+
+        if not FAILURE:
+            mbarrier.wait(bar.index(0), 0)
+
+        mbarrier.invalidate(bar.index(0))
+        mbarrier.invalidate(bar.index(1))
+
+    input = torch.randn((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    output = torch.empty((XBLOCK, XBLOCK), device=device, dtype=torch.float16)
+    shared_layout = ttgl.NVMMASharedLayout(swizzle_byte_width=128, element_bitwidth=16, rank=2)
+    input_desc = gluon.nvidia.hopper.TensorDescriptor.from_tensor(input, [XBLOCK.value, XBLOCK.value], shared_layout)
+    kernel[(1, )](input_desc, output, FAILURE=FAILURE, num_warps=4)
+
+
 @pytest.mark.skipif(not is_cuda() or torch.cuda.get_device_capability()[0] < 9, reason="Requires ampere or newer")
 @pytest.mark.parametrize("FAILURE", [True, False])
 def test_async_copy(FAILURE, device, run_wrapper, monkeypatch):

--- a/test/TritonGPU/consan.mlir
+++ b/test/TritonGPU/consan.mlir
@@ -213,7 +213,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_write_tracking
     // CHECK: tt.call @__triton_consan_clear_read_visibility
     // CHECK: tt.call @__triton_consan_clear_read_tracking
-    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK-NOT: tt.call @__triton_consan_track_visible_writes
+    // CHECK-NOT: tt.call @__triton_consan_track_visible_reads
+    // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
     ttng.async_tma_copy_global_to_local %arg0[%c0_i32, %c0_i32] %0, %bar, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
     tt.return
   }
@@ -246,23 +248,57 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_verify_barrier_arrive
     // CHECK: tt.call @__triton_consan_update_barrier_state
     // CHECK: ttng.barrier_expect
-
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_verify_write_visibility
-    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
-    // CHECK: ttng.async_tma_copy_global_to_local
+    // CHECK-COUNT-2: tt.call @__triton_consan_track_barrier_write_for_buffer
     ttng.async_tma_copy_global_to_local %a[%c0_i32, %c0_i32] %a_smem, %bar, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
-
-    // CHECK: tt.call @__triton_consan_verify_barrier_initialized
-    // CHECK: tt.call @__triton_consan_verify_write_visibility
-    // CHECK-NOT: tt.call @__triton_consan_verify_barrier_arrive
-    // CHECK-NOT: tt.call @__triton_consan_update_barrier_state
     ttng.async_tma_copy_global_to_local %b[%c0_i32, %c0_i32] %b_smem, %bar, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
 
     ttng.wait_barrier %bar, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
 
     // Consume results to prevent DCE / to keep realistic ordering.
+    %va = ttg.local_load %a_smem : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    %vb = ttg.local_load %b_smem : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
+    %_ = arith.addf %va, %vb : tensor<32x32xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#shared = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 32}>
+#shared1 = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+#blocked = #ttg.blocked<{sizePerThread = [1, 32], threadsPerWarp = [32, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.shared = 65552 : i32, ttg.target = "cuda:90", ttg.tensor_memory_size = 0 : i32, "ttg.threads-per-warp" = 32 : i32, "ttg.total-num-warps" = 1 : i32} {
+  // CHECK-LABEL: @async_tma_copy_global_to_local_two_bufs_two_barriers
+  // CHECK-NOT: tt.call @__triton_consan_track_visible_writes
+  // CHECK-NOT: tt.call @__triton_consan_track_visible_reads
+  // CHECK: %[[A_SMEM:.*]] = ttg.local_alloc {allocation.offset = 0 : i32}
+  // CHECK: %[[B_SMEM:.*]] = ttg.local_alloc {allocation.offset = 4096 : i32}
+  // CHECK: %[[BAR0:.*]] = ttg.local_alloc {allocation.offset = 65536 : i32}
+  // CHECK: %[[BAR1:.*]] = ttg.local_alloc {allocation.offset = 65544 : i32}
+  // CHECK: ttng.barrier_expect %[[BAR0]], 4096, %true
+  // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer{{.*}}({{[^,]+}}, {{[^,]+}}, %true, %[[A_TRACK:.*]], {{[^,]+}},
+  // CHECK: ttng.async_tma_copy_global_to_local %arg0
+  // CHECK: ttng.barrier_expect %[[BAR1]], 4096, %true
+  // CHECK-NOT: tt.call @__triton_consan_track_barrier_write_for_buffer{{.*}}({{[^,]+}}, {{[^,]+}}, %true, %[[A_TRACK]], {{[^,]+}},
+  // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer{{.*}}({{[^,]+}}, {{[^,]+}}, %true, %[[B_TRACK:.*]], {{[^,]+}},
+  // CHECK: ttng.async_tma_copy_global_to_local %arg1
+  tt.func public @async_tma_copy_global_to_local_two_bufs_two_barriers(
+      %a: !tt.tensordesc<tensor<32x32xf32, #shared>>,
+      %b: !tt.tensordesc<tensor<32x32xf32, #shared>>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %a_smem = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %b_smem = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    %bar0 = ttg.local_alloc {allocation.offset = 65536 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    %bar1 = ttg.local_alloc {allocation.offset = 65544 : i32} : () -> !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar0, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.init_barrier %bar1, 1 : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.barrier_expect %bar0, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %a[%c0_i32, %c0_i32] %a_smem, %bar0, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    ttng.barrier_expect %bar1, 4096, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
+    ttng.async_tma_copy_global_to_local %b[%c0_i32, %c0_i32] %b_smem, %bar1, %true : !tt.tensordesc<tensor<32x32xf32, #shared>>, !ttg.memdesc<1xi64, #shared1, #smem, mutable> -> !ttg.memdesc<32x32xf32, #shared, #smem, mutable>
+    ttng.wait_barrier %bar1, %c0_i32, %true : !ttg.memdesc<1xi64, #shared1, #smem, mutable>
     %va = ttg.local_load %a_smem : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
     %vb = ttg.local_load %b_smem : !ttg.memdesc<32x32xf32, #shared, #smem, mutable> -> tensor<32x32xf32, #blocked>
     %_ = arith.addf %va, %vb : tensor<32x32xf32, #blocked>
@@ -347,7 +383,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.shar
     // CHECK: tt.call @__triton_consan_clear_write_tracking
     // CHECK: tt.call @__triton_consan_clear_read_visibility
     // CHECK: tt.call @__triton_consan_clear_read_tracking
-    // CHECK: tt.call @__triton_consan_track_visible_writes
+    // CHECK: tt.call @__triton_consan_track_barrier_write_for_buffer
     ttng.async_tma_gather %arg0[%x_offsets, %c0_i32] %0, %bar, %true : !tt.tensordesc<tensor<1x32xf32, #shared>>, tensor<32xi32>, i32, !ttg.memdesc<1xi64, #shared1, #smem, mutable>, !ttg.memdesc<32x32xf32, #shared, #smem, mutable>, i1
     tt.return
   }


### PR DESCRIPTION
Previously TMA accesses were modeled as finishing in-order with respect to the issue order in the originating partition. This is not always true however, and in general:
```
tma_cp buf0, bar0
tma_cp buf1, bar1
wait bar1
load buf1
```
is not a correct code.
Instead of modeling tma_cp as issuing a commit/arrive that tracks all the previous accesses in the partition, in this PR we track only the individual buffers being accessed by tma_cp with the associated barrier. This selective tracking allows us to support modeling out-of-order arrival without the need to introduce independent TMA threads.