### PR TITLE
[Build] Add missing dependencies to TritonPlugin.cpp build

### DIFF
--- a/examples/plugins/CMakeLists.txt
+++ b/examples/plugins/CMakeLists.txt
@@ -21,6 +21,8 @@ foreach( plugin ${TRITON_PLUGIN_PASSES} )
     add_library(${plugin} SHARED ${${plugin}_SOURCES})
     add_dependencies(${plugin}
       TritonTableGen
+      TritonGPUTableGen
+      TritonNvidiaGPUTableGen
       TritonCanonicalizeIncGen
       TritonPluginsIncGen
     )


### PR DESCRIPTION
Currently seeing a build error:
```
    In file included from /__w/triton/triton/examples/plugins/TritonPlugin.cpp:4:
  In file included from /__w/triton/triton/include/triton/Dialect/TritonGPU/IR/Dialect.h:11:
  In file included from /__w/triton/triton/include/triton/Dialect/TritonGPU/IR/Attributes.h:6:/__w/triton/triton/include/triton/Dialect/TritonGPU/IR/TritonGPUInterfaces.h:10:10: fatal error: 'triton/Dialect/TritonGPU/IR/OpInterfaces.h.inc' file not found
  #include "triton/Dialect/TritonGPU/IR/OpInterfaces.h.inc"
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This happens because TritonGPU is included, but not declared as a dependency so the tablegen headers may not exist yet.