### PR TITLE
[test] Fix indentation in loop-unroll lit test

### DIFF
--- a/test/Triton/loop-unroll.mlir
+++ b/test/Triton/loop-unroll.mlir
@@ -15,7 +15,7 @@ tt.func @add_kernel_unroll(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
   // CHECK-NOT: tt.load
   // CHECK: tt.num_stages = 1 : i32
   %2:2 = scf.for %arg3 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg4 = %1, %arg5 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
-      %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
+    %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
     %4 = arith.addf %arg4, %3 : tensor<256xf32>
     %5 = tt.addptr %arg5, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
     scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>
@@ -37,7 +37,7 @@ tt.func @add_kernel_nounroll(%arg0: tensor<256x!tt.ptr<f32>>, %arg1: i32) {
   // CHECK-NOT: tt.load
   // CHECK-NOT: scf.for
   %2:2 = scf.for %arg3 = %c1_i32 to %arg1 step %c1_i32 iter_args(%arg4 = %1, %arg5 = %arg0) -> (tensor<256xf32>, tensor<256x!tt.ptr<f32>>)  : i32 {
-      %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
+    %3 = tt.load %arg5 : tensor<256x!tt.ptr<f32>>
     %4 = arith.addf %arg4, %3 : tensor<256xf32>
     %5 = tt.addptr %arg5, %0 : tensor<256x!tt.ptr<f32>>, tensor<256xi32>
     scf.yield %4, %5 : tensor<256xf32>, tensor<256x!tt.ptr<f32>>


### PR DESCRIPTION
  ## Summary

Fix two indentation issues in `test/Triton/loop-unroll.mlir` so the loop bodies use consistent formatting.

  ## Why

The two `tt.load` lines in the test file were over-indented compared with the surrounding operations in the same `scf.for` bodies. This change makes the test formatting consistent without changing behavior.

 # New contributor declaration
  - [ ] I am not making a trivial change, such as fixing a typo in a comment.
  - [x] I have written a PR description following these [rules](https://cbea.ms/git-commit/#why-not-how).
  - [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.
  - Select one of the following.
    - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
    - [x] This PR does not need a test because it only fixes indentation in an existing lit test and does not change test behavior or compiler functionality.

  - Select one of the following.
    - [x] I have not added any `lit` tests.
    - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices), including the "tests should be minimal" section. (Usually running Python code and using the instructions it generates is not minimal.)