### PR TITLE
Removed debug output form ll::checkInvariants

### DIFF
--- a/lib/Tools/LinearLayout.cpp
+++ b/lib/Tools/LinearLayout.cpp
@@ -163,7 +163,6 @@ LinearLayout::LinearLayout(BasesT bases,
 
 std::optional<std::string>
 LinearLayout::checkInvariants(bool requireSurjective) {
-  LDBG("checkInvariants: " << toString());
   // Check that basis values are non-negative.
   for (const auto &[inDim, inDimBases] : bases) {
     for (const auto &basis : inDimBases) {


### PR DESCRIPTION
This PR removes `LDBG` from `checkInvariants` in `LinearLayout.cpp`. The removed line clutters standard output making it difficult/inconvenient to read the debug info from other Triton/MLIR passes while `triton-opt` is used with `-debug` option. Every time one needs to use `-debug-only` pass to avoid the avalanche `checkInvariants`. If the info `checkInvariants` is needed for some reason we can surround the `LDBG` with an env. variable - .e.g, `TRITON_DEBUG_LINEAR_LAYOUT_OUTPUT`.

cc @antiagainst @ThomasRaoux  