### PR TITLE
Allow third party backends to extend AxisInfoAnalysis

### DIFF
--- a/include/triton/Analysis/AxisInfo.h
+++ b/include/triton/Analysis/AxisInfo.h
@@ -191,9 +191,35 @@ private:
   std::vector<std::unique_ptr<AxisInfoVisitor>> visitors;
 };
 
-namespace axisinfo {
-using CallbackType = std::function<void(AxisInfoVisitorList &)>;
-} // namespace axisinfo
+class AxisInfoAnalysis : public dataflow::SparseForwardDataFlowAnalysis<
+                             dataflow::Lattice<AxisInfo>> {
+protected:
+  AxisInfoVisitorList visitors;
+
+  void setToEntryState(dataflow::Lattice<AxisInfo> *lattice) override;
+
+  void visitNonControlFlowArguments(
+      Operation *op, const RegionSuccessor & /*successor*/,
+      ValueRange /*nonSuccessorInputs*/,
+      ArrayRef<dataflow::Lattice<AxisInfo> *> argLattices) override;
+
+  void
+  visitForOpInductionVar(scf::ForOp op,
+                         ArrayRef<dataflow::Lattice<AxisInfo> *> argLattices);
+
+public:
+  AxisInfoAnalysis(DataFlowSolver &solver);
+  using dataflow::SparseForwardDataFlowAnalysis<
+      dataflow::Lattice<AxisInfo>>::getLatticeElement;
+
+  LogicalResult
+  visitOperation(Operation *op,
+                 ArrayRef<const dataflow::Lattice<AxisInfo> *> operands,
+                 ArrayRef<dataflow::Lattice<AxisInfo> *> results) override;
+
+  static AxisInfoAnalysis *loadDefaultAnalysis(DataFlowSolver *solver);
+  using LoadCallback = decltype(&AxisInfoAnalysis::loadDefaultAnalysis);
+};
 
 // Module level axis info analysis based on the call graph, assuming that we do
 // not have recursive functions.
@@ -205,8 +231,12 @@ using CallbackType = std::function<void(AxisInfoVisitorList &)>;
 using AxisInfoMapT = DenseMap<Value, AxisInfo>;
 class ModuleAxisInfoAnalysis : public CallGraph<AxisInfoMapT> {
 public:
+  // AxisInfoAnalysis::LoadCallback loads the per-function analysis pass into
+  // the DataFlowSolver. This allows passes derived from AxisInfoAnalysis to
+  // re-use the module level analysis framework.
   explicit ModuleAxisInfoAnalysis(ModuleOp moduleOp,
-                                  axisinfo::CallbackType callback = nullptr)
+                                  AxisInfoAnalysis::LoadCallback loadAnalysis =
+                                      AxisInfoAnalysis::loadDefaultAnalysis)
       : CallGraph<AxisInfoMapT>(moduleOp) {
     SmallVector<FunctionOpInterface> funcs;
     walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
@@ -220,7 +250,7 @@ public:
     SetVector<FunctionOpInterface> sortedFuncs(funcs.begin(), funcs.end());
     SymbolTableCollection symbolTable;
     for (auto funcOp : llvm::reverse(sortedFuncs)) {
-      initialize(funcOp, callback);
+      initialize(funcOp, loadAnalysis);
       funcOp.walk([&](CallOpInterface callOp) {
         auto callee = dyn_cast<FunctionOpInterface>(
             callOp.resolveCallableInTable(&symbolTable));
@@ -262,8 +292,7 @@ public:
   unsigned getMaskAlignment(Value mask);
 
 private:
-  void initialize(FunctionOpInterface funcOp,
-                  axisinfo::CallbackType callback = nullptr);
+  void initialize(FunctionOpInterface funcOp, AxisInfoAnalysis::LoadCallback);
   void update(CallOpInterface callOp, FunctionOpInterface funcOp);
 };
 } // namespace mlir::triton

--- a/lib/Analysis/AxisInfo.cpp
+++ b/lib/Analysis/AxisInfo.cpp
@@ -134,43 +134,6 @@ protected:
   }
 };
 
-class AxisInfoAnalysis : public dataflow::SparseForwardDataFlowAnalysis<
-                             dataflow::Lattice<AxisInfo>> {
-private:
-  AxisInfoVisitorList visitors;
-
-  void setToEntryState(dataflow::Lattice<AxisInfo> *lattice) override {
-    propagateIfChanged(
-        lattice, lattice->join(
-                     AxisInfo::getPessimisticValueState(lattice->getAnchor())));
-  }
-
-  void visitNonControlFlowArguments(
-      Operation *op, const RegionSuccessor & /*successor*/,
-      ValueRange /*nonSuccessorInputs*/,
-      ArrayRef<dataflow::Lattice<AxisInfo> *> argLattices) override {
-    if (auto forOp = dyn_cast<scf::ForOp>(op)) {
-      visitForOpInductionVar(forOp, argLattices);
-    } else {
-      setAllToEntryStates(argLattices);
-    }
-  }
-
-public:
-  AxisInfoAnalysis(DataFlowSolver &solver,
-                   axisinfo::CallbackType callback = nullptr);
-  using dataflow::SparseForwardDataFlowAnalysis<
-      dataflow::Lattice<AxisInfo>>::getLatticeElement;
-
-  LogicalResult
-  visitOperation(Operation *op,
-                 ArrayRef<const dataflow::Lattice<AxisInfo> *> operands,
-                 ArrayRef<dataflow::Lattice<AxisInfo> *> results) override;
-  void
-  visitForOpInductionVar(scf::ForOp op,
-                         ArrayRef<dataflow::Lattice<AxisInfo> *> argLattices);
-};
-
 template <typename OpTy>
 class CastOpAxisInfoVisitor final : public AxisInfoVisitorImpl<OpTy> {
 public:
@@ -1192,12 +1155,13 @@ public:
   }
 };
 
+} // anonymous namespace
+
 //===----------------------------------------------------------------------===//
 // AxisInfoAnalysis
 //===----------------------------------------------------------------------===//
 
-AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver,
-                                   axisinfo::CallbackType callback)
+AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver)
     : dataflow::SparseForwardDataFlowAnalysis<dataflow::Lattice<AxisInfo>>(
           solver) {
   // UnrealizedConversionCast:
@@ -1239,9 +1203,22 @@ AxisInfoAnalysis::AxisInfoAnalysis(DataFlowSolver &solver,
                   MaxMinOpAxisInfoVisitor<arith::MinUIOp>>();
   visitors.append<LoadOpAxisInfoVisitor>();
   visitors.append<TransOpAxisInfoVisitor>();
+}
 
-  if (callback)
-    callback(visitors);
+void AxisInfoAnalysis::setToEntryState(dataflow::Lattice<AxisInfo> *lattice) {
+  propagateIfChanged(lattice, lattice->join(AxisInfo::getPessimisticValueState(
+                                  lattice->getAnchor())));
+}
+
+void AxisInfoAnalysis::visitNonControlFlowArguments(
+    Operation *op, const RegionSuccessor & /*successor*/,
+    ValueRange /*nonSuccessorInputs*/,
+    ArrayRef<dataflow::Lattice<AxisInfo> *> argLattices) {
+  if (auto forOp = dyn_cast<scf::ForOp>(op)) {
+    visitForOpInductionVar(forOp, argLattices);
+  } else {
+    setAllToEntryStates(argLattices);
+  }
 }
 
 LogicalResult AxisInfoAnalysis::visitOperation(
@@ -1294,8 +1271,6 @@ void AxisInfoAnalysis::visitForOpInductionVar(
       AxisInfo(knownContiguity, knownDivisibility, knownConstancy);
   (void)argLattices[0]->join(inductionVar);
 }
-
-} // anonymous namespace
 
 void AxisInfo::initPessimisticStateFromFunc(int argNumber,
                                             FunctionOpInterface funcOp,
@@ -1379,6 +1354,11 @@ void AxisInfo::initDimVectorFromHint(Attribute attr, DimVectorT *vec) {
       lhs.getConstantValue() == rhs.getConstantValue())
     constantValue = lhs.getConstantValue();
   return AxisInfo(contiguity, divisibility, constancy, constantValue);
+}
+
+AxisInfoAnalysis *
+AxisInfoAnalysis::loadDefaultAnalysis(DataFlowSolver *solver) {
+  return solver->load<AxisInfoAnalysis>();
 }
 
 unsigned ModuleAxisInfoAnalysis::getContiguity(Value value) {
@@ -1478,10 +1458,10 @@ unsigned ModuleAxisInfoAnalysis::getMaskAlignment(Value mask) {
   return alignment;
 }
 
-void ModuleAxisInfoAnalysis::initialize(FunctionOpInterface funcOp,
-                                        axisinfo::CallbackType callback) {
+void ModuleAxisInfoAnalysis::initialize(
+    FunctionOpInterface funcOp, AxisInfoAnalysis::LoadCallback loadAnalysis) {
   std::unique_ptr<DataFlowSolver> solver = createDataFlowSolver();
-  AxisInfoAnalysis *analysis = solver->load<AxisInfoAnalysis>(callback);
+  AxisInfoAnalysis *analysis = loadAnalysis(solver.get());
   if (failed(solver->initializeAndRun(funcOp)))
     return;
 

--- a/third_party/amd/include/Analysis/AxisInfoExt.h
+++ b/third_party/amd/include/Analysis/AxisInfoExt.h
@@ -5,15 +5,18 @@
 
 namespace mlir::triton::AMD {
 
-struct AxisInfoExt {
-  static void addVisitors(mlir::triton::AxisInfoVisitorList &visitors);
+class AxisInfoAnalysisExt : public triton::AxisInfoAnalysis {
+public:
+  AxisInfoAnalysisExt(DataFlowSolver &solver);
+
+  static triton::AxisInfoAnalysis *loadAnalysis(DataFlowSolver *solver);
 };
 
 class ModuleAxisInfoAnalysis : public mlir::triton::ModuleAxisInfoAnalysis {
 public:
   explicit ModuleAxisInfoAnalysis(ModuleOp moduleOp)
-      : mlir::triton::ModuleAxisInfoAnalysis(moduleOp,
-                                             AxisInfoExt::addVisitors) {}
+      : mlir::triton::ModuleAxisInfoAnalysis(
+            moduleOp, AxisInfoAnalysisExt::loadAnalysis) {}
 };
 } // namespace mlir::triton::AMD
 

--- a/third_party/amd/lib/Analysis/AxisInfoExt.cpp
+++ b/third_party/amd/lib/Analysis/AxisInfoExt.cpp
@@ -60,8 +60,14 @@ public:
 };
 } // namespace
 
-void AxisInfoExt::addVisitors(mlir::triton::AxisInfoVisitorList &visitors) {
+AxisInfoAnalysisExt::AxisInfoAnalysisExt(DataFlowSolver &solver)
+    : triton::AxisInfoAnalysis(solver) {
   visitors.append<ExtractSliceOpAxisInfoVisitor>();
-  return;
 }
+
+triton::AxisInfoAnalysis *
+AxisInfoAnalysisExt::loadAnalysis(DataFlowSolver *solver) {
+  return solver->load<AxisInfoAnalysisExt>();
+}
+
 } // namespace mlir::triton::AMD


### PR DESCRIPTION
Exposes `AxisInfoAnalysis` in the `AxisInfo.h` header allowing third party backends to extend the base analysis (as discussed in #9706). Provides a callback mechanism in `ModuleAxisInfoAnalysis` allowing third party backends to provide their extended analysis class without having to re-implement the `ModuleAxisInfoAnalysis` pass (or its call sites). The previous callback mechanism has been removed since the derived AxisInfo class can update the visitor list for extending AxisInfoAnalysis for third party ops. 

During testing I tried disabling the `AMD::AxisInfoExt` visitor and running `amd/test-alignment.mlir`, expecting the test to fail. But on my system the test still passed even with the AMD variant of AxisInfoAnalysis disabled on main. It turns out this is because `test-alignment.mlir` has a typo: https://github.com/triton-lang/triton/blob/368771a0aec10ab3aedaf4b5d7bcae4d752ce26a/test/Analysis/amd/test-alignment.mlir#L6 

Fixing the typo on main produces this result:
```
test.mlir:7:8: remark: %0 = amdg.extract_slice %arg0 [128, 32] : tensor<256x64xf16, #ttg.amd_mfma<{version = 3, warpsPerCTA = [4, 1], instrShape = [32, 32, 8], isTransposed = true}>> to tensor<128x32xf16, #ttg.amd_mfma<{version = 3, warpsPerCTA = [4, 1], instrShape = [32, 32, 8], isTransposed = true}>> => contiguity = [256], divisibility = [6], constancy = [1], constant_value = <none>
  %0 = amdg.extract_slice %arg0 [128, 32] : tensor<256x64xf16, #mma> to tensor<128x32xf16, #mma>
       ^
#mma = #ttg.amd_mfma<{version = 3, warpsPerCTA = [4, 1], instrShape = [32, 32, 8], isTransposed = true}>
module {
  tt.func public @kernel(%arg0: tensor<256x64xf16, #mma> {tt.constancy = 1 : i32, tt.contiguity = 256 : i32, tt.divisibility = 6 : i32}) {
    %0 = amdg.extract_slice %arg0 [128, 32] : tensor<256x64xf16, #mma> to tensor<128x32xf16, #mma>
    tt.return
  }
}
```
which does not match the expected value in the test. I opened https://github.com/triton-lang/triton/issues/9735 and manually verified that my changes provide the same output as main for that particular test case. 