### PR TITLE
[Backend] isCvtDimSync is too conservative

### DIFF
--- a/include/triton/Analysis/Membar.h
+++ b/include/triton/Analysis/Membar.h
@@ -2,7 +2,7 @@
 #define TRITON_ANALYSIS_MEMBAR_H
 
 #include "Allocation.h"
-
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include "llvm/Support/raw_ostream.h"
 #include <functional>
 #include <set>
@@ -264,8 +264,10 @@ protected:
 class MembarAnalysis : public MembarOrFenceAnalysis {
 public:
   MembarAnalysis() = default;
-  explicit MembarAnalysis(Allocation *allocation, MembarFilterFn filter)
-      : MembarOrFenceAnalysis(allocation, filter) {}
+  explicit MembarAnalysis(Allocation *allocation,
+                          mlir::triton::TargetInfoBase *_targInfo,
+                          MembarFilterFn filter)
+      : MembarOrFenceAnalysis(allocation, filter), targInfo(_targInfo) {}
 
   ~MembarAnalysis() override = default;
 
@@ -276,6 +278,8 @@ private:
                       OpBuilder *builder) override;
 
   void insertBarrier(Operation *operation, OpBuilder *builder);
+
+  mlir::triton::TargetInfoBase *targInfo = nullptr;
 };
 
 /// Postorder traversal on the callgraph to insert membar instructions
@@ -287,9 +291,11 @@ template <typename AnalysisType>
 class ModuleMembarOrFenceAnalysis : public triton::CallGraph<BlockInfo> {
 public:
   ModuleMembarOrFenceAnalysis(ModuleAllocation *moduleAllocation,
+                              mlir::triton::TargetInfoBase *_targInfo,
                               MembarFilterFn filter = nullptr)
       : triton::CallGraph<BlockInfo>(moduleAllocation->getModuleOp()),
-        moduleAllocation(moduleAllocation), filter(filter) {}
+        moduleAllocation(moduleAllocation), targInfo(_targInfo),
+        filter(filter) {}
 
   void run() {
     walk<WalkOrder::PreOrder, WalkOrder::PostOrder>(
@@ -300,7 +306,7 @@ public:
           auto *allocation = moduleAllocation->getFuncData(funcOp);
           auto [it, inserted] = funcMap.try_emplace(funcOp, BlockInfo());
           if (inserted) {
-            AnalysisType analysis(allocation, filter);
+            AnalysisType analysis(allocation, targInfo, filter);
             analysis.run(funcMap);
           }
         });
@@ -308,6 +314,7 @@ public:
 
 private:
   ModuleAllocation *moduleAllocation;
+  mlir::triton::TargetInfoBase *targInfo;
   MembarFilterFn filter;
 };
 

--- a/include/triton/Analysis/Utility.h
+++ b/include/triton/Analysis/Utility.h
@@ -419,8 +419,18 @@ protected:
 // Create a basic DataFlowSolver with constant and dead code analysis included.
 std::unique_ptr<DataFlowSolver> createDataFlowSolver();
 
+bool isCvtTrivialOverDims(const triton::LinearLayout &srcLayout,
+                          const triton::LinearLayout &dstLayout,
+                          StringAttr dim);
+
+// Return true if given dimension level sync (within the dimension, not across
+// the dimension) is sufficient if cvt requires accessing shared memory.
+//
+// If the caller does not have target-info, set hasDistSharedMem=true for
+// conservatively correct result.
 bool isCvtDimSync(const triton::LinearLayout &srcLayout,
-                  const triton::LinearLayout &dstLayout, StringAttr dim);
+                  const triton::LinearLayout &dstLayout, StringAttr dim,
+                  bool hasDistSharedMem);
 
 } // namespace mlir
 

--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -42,6 +42,8 @@ public:
                             std::optional<Value> ctaId, Type elemTy, Value pred,
                             Operation *localLoadOp = nullptr) const = 0;
 
+  virtual bool supportDistSharedMem() const = 0;
+
   void storeShared(RewriterBase &rewriter, Location loc, Value ptr, Value val,
                    Value pred) const {
     storeDShared(rewriter, loc, ptr, /*ctaId=*/std::nullopt, val, pred);

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -339,7 +339,12 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
       auto srcLayout = triton::gpu::toLinearLayout(srcTy);
       auto dstLayout = triton::gpu::toLinearLayout(dstTy);
       auto kWarp = StringAttr::get(op->getContext(), "warp");
-      isWarpSync = mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
+      // If target-info is not available, set hasDistSharedMem to true; it will
+      // let isCvtDimSync return conservatively correct result.
+      bool hasDistSharedMem =
+          targInfo ? targInfo->supportDistSharedMem() : true;
+      isWarpSync =
+          mlir::isCvtDimSync(srcLayout, dstLayout, kWarp, hasDistSharedMem);
     }
 
     if (!curBlockInfo.syncReadSlices.empty() ||

--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1321,8 +1321,9 @@ std::unique_ptr<DataFlowSolver> createDataFlowSolver() {
   return solver;
 }
 
-bool isCvtDimSync(const triton::LinearLayout &srcLayout,
-                  const triton::LinearLayout &dstLayout, StringAttr dim) {
+bool isCvtTrivialOverDims(const triton::LinearLayout &srcLayout,
+                          const triton::LinearLayout &dstLayout,
+                          StringAttr dim) {
   // We can use a dimension-level sync when the conversion is trivial over that
   // dimension and there is no broadcasting over it.
   auto *ctx = srcLayout.getInDimNames().begin()->getContext();
@@ -1333,10 +1334,37 @@ bool isCvtDimSync(const triton::LinearLayout &srcLayout,
          "expected dim to be present in both layouts");
   auto parentTrivial = true;
   if (dim == kWarp) {
-    parentTrivial = isCvtDimSync(srcLayout, dstLayout, kBlock);
+    parentTrivial = isCvtTrivialOverDims(srcLayout, dstLayout, kBlock);
   }
   auto comp = dstLayout.invertAndCompose(srcLayout);
-  return parentTrivial && comp.isTrivialOver(dim) &&
+  return parentTrivial && comp.isTrivialOver(dim);
+}
+
+bool isCvtDimSync(const triton::LinearLayout &srcLayout,
+                  const triton::LinearLayout &dstLayout, StringAttr dim,
+                  bool hasDistSharedMem) {
+  auto *ctx = srcLayout.getInDimNames().begin()->getContext();
+  auto kWarp = StringAttr::get(ctx, "warp");
+  auto kBlock = StringAttr::get(ctx, "block");
+
+  if (dim == kBlock) {
+    if (!isCvtTrivialOverDims(srcLayout, dstLayout, dim))
+      return false;
+
+    // If underlying architecture does not support distributed shared memory,
+    // a CTA cannot access neighboring CTAs' shared memory. A free variable in
+    // CTA dimension implies multi-casting, meaning CTAs in the cluster
+    // duplicate some data to their own shared memory. In this case, even if
+    // the cvt requires shared memory access; it will not cross CTA boundary.
+    if (!hasDistSharedMem)
+      return true;
+    return dstLayout.getFreeVariableMasks()[dim] == 0;
+  }
+
+  assert(dim == kWarp && "expected dim to be warp or block");
+
+  return isCvtDimSync(srcLayout, dstLayout, kBlock, hasDistSharedMem) &&
+         isCvtTrivialOverDims(srcLayout, dstLayout, dim) &&
          srcLayout.getFreeVariableMasks()[dim] == 0 &&
          dstLayout.getFreeVariableMasks()[dim] == 0;
 }

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -205,8 +205,11 @@ struct ConvertLayoutOpConversion
     auto affineOffset = b.i32_val(0);
     auto maskSpanAffineOffset = 0;
 
-    bool isWarpSync = mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
-    bool isBlockSync = mlir::isCvtDimSync(srcLayout, dstLayout, kBlock);
+    bool hasDistSharedMem = targetInfo.supportDistSharedMem();
+    bool isWarpSync =
+        mlir::isCvtDimSync(srcLayout, dstLayout, kWarp, hasDistSharedMem);
+    bool isBlockSync =
+        mlir::isCvtDimSync(srcLayout, dstLayout, kBlock, hasDistSharedMem);
     auto emitBarrier = [&]() {
       if (isWarpSync) {
         targetInfo.warpSync(loc, rewriter);

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -82,7 +82,8 @@ public:
         sync(rewriter, loc, lastCvtCrossesCTAs);
       }
       accs = convertLayoutValues(loc, rewriter, op, regLl, tmpLl, accs);
-      lastCvtCrossesCTAs = !mlir::isCvtDimSync(regLl, tmpLl, kBlock);
+      lastCvtCrossesCTAs = !mlir::isCvtDimSync(
+          regLl, tmpLl, kBlock, targetInfo.supportDistSharedMem());
 
       std::tie(regLl, accs) =
           reduceWithinWarps(op, std::move(tmpLl), std::move(accs), rewriter);

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.cpp
@@ -315,7 +315,9 @@ insertCrossCTAMBarrierInitSyncForFunction(FunctionOpInterface funcOp,
 
 class ClusterBarrierAnalysis : public MembarOrFenceAnalysis {
 public:
-  explicit ClusterBarrierAnalysis(Allocation *allocation, MembarFilterFn filter)
+  explicit ClusterBarrierAnalysis(Allocation *allocation,
+                                  mlir::triton::TargetInfoBase *,
+                                  MembarFilterFn filter)
       : MembarOrFenceAnalysis(allocation, filter) {}
 
 private:
@@ -447,7 +449,7 @@ void runClusterBarrierInsertion(ModuleAllocation &moduleAllocation,
   };
 
   ModuleMembarOrFenceAnalysis<ClusterBarrierAnalysis> analysis(
-      &moduleAllocation, filterFn);
+      &moduleAllocation, nullptr, filterFn);
   analysis.run();
 }
 

--- a/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
+++ b/lib/Dialect/TritonNvidiaGPU/Transforms/ProxyFenceInsertion.cpp
@@ -113,7 +113,9 @@ bool filterFn(Operation *op, Operation *other, bool /*opIsRead*/,
 class ProxyFenceAnalysis : public MembarOrFenceAnalysis {
 
 public:
-  explicit ProxyFenceAnalysis(Allocation *allocation, MembarFilterFn filter)
+  explicit ProxyFenceAnalysis(Allocation *allocation,
+                              mlir::triton::TargetInfoBase *,
+                              MembarFilterFn filter)
       : MembarOrFenceAnalysis(allocation, filter) {}
 
 private:
@@ -220,7 +222,7 @@ public:
     // so we can use the default allocation analysis scratch size function
     ModuleAllocation allocation(mod);
     ModuleMembarOrFenceAnalysis<ProxyFenceAnalysis> analysis(&allocation,
-                                                             filterFn);
+                                                             nullptr, filterFn);
     analysis.run();
   }
 };

--- a/python/src/passes.cc
+++ b/python/src/passes.cc
@@ -24,7 +24,7 @@ void init_triton_analysis(py::module &&m) {
   py::class_<mlir::ModuleAllocation>(m, "allocation", py::module_local())
       .def(py::init<mlir::ModuleOp>());
   py::class_<mlir::ModuleMembarAnalysis>(m, "membar", py::module_local())
-      .def(py::init<mlir::ModuleAllocation *>())
+      .def(py::init<mlir::ModuleAllocation *, mlir::triton::TargetInfoBase *>())
       .def("run", &mlir::ModuleMembarAnalysis::run);
 }
 

--- a/test/lib/Analysis/TestMembar.cpp
+++ b/test/lib/Analysis/TestMembar.cpp
@@ -5,6 +5,7 @@
 #include "third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h"
 #include "triton/Analysis/Allocation.h"
 #include "triton/Analysis/Membar.h"
+#include "triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h"
 #include "triton/Dialect/TritonGPU/Transforms/Utility.h"
 #include "triton/Dialect/TritonNvidiaGPU/IR/Dialect.h"
 #include "triton/Dialect/TritonNvidiaGPU/Transforms/ClusterBarrierInsertion.h"
@@ -31,21 +32,23 @@ struct TestMembarPass
     Operation *operation = getOperation();
     ModuleOp moduleOp = cast<ModuleOp>(operation);
     ModuleAllocation allocation(moduleOp);
+    std::unique_ptr<triton::TargetInfoBase> targInfoPtr;
+
     if (moduleOp->hasAttr("ttg.target")) {
       int computeCapability = getNVIDIAComputeCapability(moduleOp);
       int ptxVersion = computeCapability;
-      triton::NVIDIA::TargetInfo targetInfo(computeCapability, ptxVersion);
+      auto ti = new triton::NVIDIA::TargetInfo(computeCapability, ptxVersion);
+      targInfoPtr.reset(ti);
       allocation = ModuleAllocation(
           moduleOp,
-          triton::nvidia_gpu::getNvidiaAllocationAnalysisScratchSizeFn(
-              targetInfo));
+          triton::nvidia_gpu::getNvidiaAllocationAnalysisScratchSizeFn(*ti));
       triton::nvidia_gpu::runClusterBarrierInsertion(allocation,
                                                      computeCapability);
       if (failed(triton::nvidia_gpu::runCrossCTAMBarrierInitSyncInsertion(
               allocation, computeCapability)))
         return signalPassFailure();
     }
-    ModuleMembarAnalysis membarPass(&allocation,
+    ModuleMembarAnalysis membarPass(&allocation, targInfoPtr.get(),
                                     mlir::triton::NVIDIA::canSkipBarSync);
     membarPass.run();
   }

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -46,6 +46,8 @@ public:
                     std::optional<Value> ctaId, Type elemTy, Value pred,
                     Operation *localLoadOp = nullptr) const override;
 
+  bool supportDistSharedMem() const override { return false; }
+
   // Describes the parameters of ds_read_tr for a particular data type
   struct LDSTransLoadParams {
     // Number of lanes that cooperate in the instruction

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TritonGPUToLLVM.cpp
@@ -110,7 +110,7 @@ struct ConvertTritonAMDGPUToLLVM
     if (targetInfo.requiresAliasInfoForAsyncOps())
       AMD::annotateLocalLoadsSyncedViaAsyncWait(mod);
 
-    ModuleMembarAnalysis membarPass(&allocation,
+    ModuleMembarAnalysis membarPass(&allocation, &targetInfo,
                                     mlir::triton::AMD::membarFilter);
     membarPass.run();
 

--- a/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
+++ b/third_party/amd/test/lib/Analysis/TestAMDGPUMembar.cpp
@@ -25,7 +25,8 @@ struct TestAMDGPUMembarPass
     triton::AMD::annotateLocalLoadsSyncedViaAsyncWait(moduleOp);
     // Print all ops after membar pass
     ModuleAllocation allocation(moduleOp);
-    ModuleMembarAnalysis membarPass(&allocation, triton::AMD::membarFilter);
+    ModuleMembarAnalysis membarPass(&allocation, nullptr,
+                                    triton::AMD::membarFilter);
     membarPass.run();
   }
 };

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -168,8 +168,11 @@ struct ConvertLayoutOpSwizzlingConversion
     SmallVector<Value> outVals;
     auto affineOffset = b.i32_val(0);
     auto maskSpanAffineOffset = 0;
-    bool isWarpSync = mlir::isCvtDimSync(srcLayout, dstLayout, kWarp);
-    bool isBlockSync = mlir::isCvtDimSync(srcLayout, dstLayout, kBlock);
+    bool hasDistSharedMem = targetInfo.supportDistSharedMem();
+    bool isWarpSync =
+        mlir::isCvtDimSync(srcLayout, dstLayout, kWarp, hasDistSharedMem);
+    bool isBlockSync =
+        mlir::isCvtDimSync(srcLayout, dstLayout, kBlock, hasDistSharedMem);
     auto emitBarrier = [&]() {
       if (isWarpSync) {
         targetInfo.warpSync(loc, rewriter);

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TargetInfo.h
@@ -30,6 +30,10 @@ public:
                     std::optional<Value> ctaId, Type elemTy, Value pred,
                     Operation *localLoadOp = nullptr) const override;
 
+  virtual bool supportDistSharedMem() const override {
+    return computeCapability >= 90;
+  }
+
   bool supportLdMatrix() const override { return computeCapability >= 75; }
   bool supportStMatrix() const override { return computeCapability >= 90; }
   bool supportLdStMatrixB8() const override { return computeCapability >= 100; }

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -98,7 +98,7 @@ struct ConvertTritonGPUToLLVM
     if (failed(mlir::triton::nvidia_gpu::runCrossCTAMBarrierInitSyncInsertion(
             allocation, computeCapability)))
       return signalPassFailure();
-    ModuleMembarAnalysis membarPass(&allocation, canSkipBarSync);
+    ModuleMembarAnalysis membarPass(&allocation, &targetInfo, canSkipBarSync);
     membarPass.run();
 
     mlir::LowerToLLVMOptions option(context);

--- a/unittest/Analysis/UtilityTest.cpp
+++ b/unittest/Analysis/UtilityTest.cpp
@@ -1,5 +1,9 @@
 #include "triton/Dialect/Triton/IR/Utility.h"
+#include "triton/Analysis/Utility.h"
+#include "triton/Tools/LayoutUtils.h"
+#include "triton/Tools/LinearLayout.h"
 
+#include "mlir/Support/LLVM.h"
 #include "llvm/Support/Signals.h"
 #include <gtest/gtest.h>
 
@@ -21,6 +25,30 @@ TEST(Analysis, reorder) {
     EXPECT_EQ(reordered[1], 10);
     EXPECT_EQ(reordered[2], 30);
   }
+}
+
+TEST(Analysis, isCvtDimSync) {
+  MLIRContext ctx;
+  auto S = [&](StringRef str) { return StringAttr::get(&ctx, str); };
+
+  auto srcLayout = triton::LinearLayout(
+      {{S("register"), {}},
+       {S("lane"), {{0, 1}, {1, 0}, {2, 0}, {4, 0}, {8, 0}}},
+       {S("warp"), {{16, 0}, {32, 0}}},
+       {S("block"), {{0, 0}, {64, 0}}}},
+      {S("dim0"), S("dim1")});
+
+  auto dstLayout = triton::LinearLayout(
+      {{S("register"), {{0, 1}}},
+       {S("lane"), {{1, 0}, {2, 0}, {4, 0}, {8, 0}, {32, 0}}},
+       {S("warp"), {{0, 0}, {16, 0}}},
+       {S("block"), {{0, 0}, {64, 0}}}},
+      {S("dim0"), S("dim1")});
+
+  EXPECT_TRUE(isCvtDimSync(srcLayout, dstLayout, S("block"),
+                           /*hasDistSharedMem=*/false));
+  EXPECT_FALSE(isCvtDimSync(srcLayout, dstLayout, S("block"), true));
+  EXPECT_TRUE(isCvtTrivialOverDims(srcLayout, dstLayout, S("block")));
 }
 
 } // namespace mlir


### PR DESCRIPTION
### Problem statement

isCvtDimSync is bit conservative as it assumes the cvt in question has to use shared memory. That is reasonable that caller make judiciously decision as to if smem is used or not before calling this function.

However, this function is too conservative in handling CTA multi-casting. Without distributed shared memory, CTA involved in multi-casting just duplicate data. As long as srcLayout and dstLayout share same block bases, there will no data movement across CTA even if there (0,0) basis in block bases.

This PR makes following changes
  * introduce `isCvtTrivialOverDims()`, which is similar to the original `isCvtDimSync()` except that it does not consider the free-variables. It just do what the function name suggests. It will be handy in the situation when isCvtDimSync() is too conservative (as it assume shared memory has to be used for the cvt).

  * introduce `TargetInfo::supportDistSharedMemory()` which tell if the underlying architecture supports distributed shared memory.

  * add a new argument to `isCvtDimSync()`, telling the function if dist-shared-mem is used or not. If distributed shared memory is not used, free-variables will be ignored if block-level-cvt is trivial.

#### Misc
* The initial discussion can be found [here](https://github.com/triton-lang/triton/pull/9317/changes#r2917871289) Thank Mario for the insightful comments.
* I check the call-sites of isCvtDimSync in ConvertLayoutOpToLLVM.cpp, it looks like when this function is called, the caller already decide to use shared memory for cvt. So, I guess nothing can be changed here.
* This change is not small, however, most changes is about passing targetInfo to MemBar