### PR TITLE
[AMD] Improve LDS padding heuristic for gfx1250 TDM dot operand loads

### DIFF
--- a/test/TritonGPU/amd/amd-pipeline-tdm.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-tdm.mlir
@@ -42,6 +42,20 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
   }
 }
 
+// Operand A (opIdx=0, order=[1,0]): loadTransposed = (1 != 1) = false → non-transposed
+//   padAmount = min(kWidth=8, 128/16) = min(8, 8) = 8
+//   innerDimLength = shape[order[0]] = shape[1] = 32 (K dim)
+//   → padded_shared<[32:+8]>
+//
+// Operand B (opIdx=1, order=[1,0]): loadTransposed = (1 != 0) = true → transposed
+//   queryLDSTransLoadParams(16) → instBitWidth=128, padAmount = 2*128/16 = 16
+//   innerDimLength = shape[order[0]] = shape[1] = 64 (N dim)
+//   → padded_shared<[64:+16]>
+// CHECK:     #ttg.padded_shared<[32:+8] {
+// CHECK-NOT: #ttg.padded_shared
+// CHECK:     #ttg.padded_shared<[64:+16] {
+// CHECK-NOT: #ttg.padded_shared
+
 // CHECK-LABEL: tt.func @matmul_kernel_make_tensor_descriptor
 // CHECK: async_tdm_copy_global_to_local
 // CHECK: ttg.async_commit_group tokens
@@ -51,4 +65,135 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 // CHECK: amdg.async_tdm_wait
 // CHECK: async_tdm_copy_global_to_local
 // CHECK: ttg.async_commit_group tokens
+// CHECK: }
+
+// -----
+
+// Test TDM padding for fp8 (f8E5M2) matmul on gfx1250.
+//
+// Operand A (opIdx=0, order=[1,0]): loadTransposed = (1 != 1) = false → non-transposed
+//   padAmount = 128/8 = 16 (sub-dword: no min with vecWidth, full 4-dword
+//   stride separation needed for ds_load_2addr_b64 cross-address conflicts)
+//   innerDimLength = shape[1] = 64 (K dim)
+//   → padded_shared<[64:+16]>
+//
+// Operand B (opIdx=1, order=[1,0]): loadTransposed = (1 != 0) = true → transposed
+//   queryLDSTransLoadParams(8) → instBitWidth=64, padAmount = 2*64/8 = 16
+//   innerDimLength = shape[1] = 64 (N dim)
+//   → padded_shared<[64:+16]>
+// CHECK:     #ttg.padded_shared<[64:+16] {
+// CHECK-NOT: #ttg.padded_shared
+// CHECK:     #ttg.padded_shared<[64:+16] {
+// CHECK-NOT: #ttg.padded_shared
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[1, 0], [2, 0], [4, 0]]}, instrShape = [16, 16, 64]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tdm_padding_fp8(%a_ptr: !tt.ptr<f8E5M2> {tt.divisibility = 16 : i32},
+    %b_ptr: !tt.ptr<f8E5M2> {tt.divisibility = 16 : i32}, %c_ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32},
+    %M: i32 {tt.divisibility = 16 : i32}, %N: i32 {tt.divisibility = 16 : i32}, %K: i32 {tt.divisibility = 16 : i32}) {
+    %c256_i32 = arith.constant 256 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c1_i32 = arith.constant 1 : i32
+    %c63_i32 = arith.constant 63 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x64xf32, #mma>
+    %0 = tt.get_program_id x : i32
+    %1 = tt.get_program_id y : i32
+    %2 = arith.muli %0, %c256_i32 : i32
+    %3 = arith.muli %1, %c64_i32 : i32
+    %4 = arith.extsi %K : i32 to i64
+    %5 = tt.make_tensor_descriptor %a_ptr, [%M, %K], [%4, %c1_i64] : <f8E5M2>, <tensor<256x64xf8E5M2>>
+    %6 = arith.extsi %N : i32 to i64
+    %7 = tt.make_tensor_descriptor %b_ptr, [%K, %N], [%6, %c1_i64] : <f8E5M2>, <tensor<64x64xf8E5M2>>
+    %8 = tt.make_tensor_descriptor %c_ptr, [%M, %N], [%6, %c1_i64] : <f16>, <tensor<256x64xf16>>
+    %9 = arith.addi %K, %c63_i32 : i32
+    %10 = arith.divsi %9, %c64_i32 : i32
+    %accumulator:2 = scf.for %iv = %c0_i32 to %10 step %c1_i32 iter_args(%k_off = %c0_i32, %acc = %cst) -> (i32, tensor<256x64xf32, #mma>)  : i32 {
+      %a = tt.descriptor_load %5[%2, %k_off] : !tt.tensordesc<tensor<256x64xf8E5M2>> -> tensor<256x64xf8E5M2, #blocked>
+      %b = tt.descriptor_load %7[%k_off, %3] : !tt.tensordesc<tensor<64x64xf8E5M2>> -> tensor<64x64xf8E5M2, #blocked1>
+      %a_dot = ttg.convert_layout %a : tensor<256x64xf8E5M2, #blocked> -> tensor<256x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+      %b_dot = ttg.convert_layout %b : tensor<64x64xf8E5M2, #blocked1> -> tensor<64x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+      %d = tt.dot %a_dot, %b_dot, %acc : tensor<256x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<64x64xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<256x64xf32, #mma>
+      %next_k = arith.addi %k_off, %c64_i32 : i32
+      scf.yield %next_k, %d : i32, tensor<256x64xf32, #mma>
+    }
+    %out = arith.truncf %accumulator#1 : tensor<256x64xf32, #mma> to tensor<256x64xf16, #mma>
+    %out_blocked = ttg.convert_layout %out : tensor<256x64xf16, #mma> -> tensor<256x64xf16, #blocked1>
+    tt.descriptor_store %8[%2, %3], %out_blocked : !tt.tensordesc<tensor<256x64xf16>>, tensor<256x64xf16, #blocked1>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @tdm_padding_fp8
+// CHECK: async_tdm_copy_global_to_local
+// CHECK: async_tdm_copy_global_to_local
+// CHECK: scf.for
+// CHECK: }
+
+// -----
+
+// Test TDM padding for f32 matmul on gfx1250.
+//
+// Operand A (opIdx=0, order=[1,0]): loadTransposed = (1 != 1) = false → non-transposed
+//   padAmount = min(kWidth=8, 128/32) = min(8, 4) = 4
+//   innerDimLength = shape[1] = 16 (K dim)
+//   → padded_shared<[16:+4]>
+//
+// Operand B (opIdx=1, order=[1,0]): loadTransposed = (1 != 0) = true → transposed
+//   queryLDSTransLoadParams(32) → nullopt, falls back to padAmount = 128/32 = 4
+//   innerDimLength = shape[1] = 64 (N dim)
+//   → padded_shared<[64:+4]>
+// CHECK:     #ttg.padded_shared<[16:+4] {
+// CHECK-NOT: #ttg.padded_shared
+// CHECK:     #ttg.padded_shared<[64:+4] {
+// CHECK-NOT: #ttg.padded_shared
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [4, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+#mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[1, 0], [2, 0], [4, 0]]}, instrShape = [16, 16, 4]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @tdm_padding_f32(%a_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+    %b_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %c_ptr: !tt.ptr<f32> {tt.divisibility = 16 : i32},
+    %M: i32 {tt.divisibility = 16 : i32}, %N: i32 {tt.divisibility = 16 : i32}, %K: i32 {tt.divisibility = 16 : i32}) {
+    %c256_i32 = arith.constant 256 : i32
+    %c64_i32 = arith.constant 64 : i32
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i64 = arith.constant 1 : i64
+    %c16_i32 = arith.constant 16 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c15_i32 = arith.constant 15 : i32
+    %cst = arith.constant dense<0.000000e+00> : tensor<256x64xf32, #mma>
+    %0 = tt.get_program_id x : i32
+    %1 = tt.get_program_id y : i32
+    %2 = arith.muli %0, %c256_i32 : i32
+    %3 = arith.muli %1, %c64_i32 : i32
+    %4 = arith.extsi %K : i32 to i64
+    %5 = tt.make_tensor_descriptor %a_ptr, [%M, %K], [%4, %c1_i64] : <f32>, <tensor<256x16xf32>>
+    %6 = arith.extsi %N : i32 to i64
+    %7 = tt.make_tensor_descriptor %b_ptr, [%K, %N], [%6, %c1_i64] : <f32>, <tensor<16x64xf32>>
+    %8 = tt.make_tensor_descriptor %c_ptr, [%M, %N], [%6, %c1_i64] : <f32>, <tensor<256x64xf32>>
+    %9 = arith.addi %K, %c15_i32 : i32
+    %10 = arith.divsi %9, %c16_i32 : i32
+    %accumulator:2 = scf.for %iv = %c0_i32 to %10 step %c1_i32 iter_args(%k_off = %c0_i32, %acc = %cst) -> (i32, tensor<256x64xf32, #mma>)  : i32 {
+      %a = tt.descriptor_load %5[%2, %k_off] : !tt.tensordesc<tensor<256x16xf32>> -> tensor<256x16xf32, #blocked>
+      %b = tt.descriptor_load %7[%k_off, %3] : !tt.tensordesc<tensor<16x64xf32>> -> tensor<16x64xf32, #blocked1>
+      %a_dot = ttg.convert_layout %a : tensor<256x16xf32, #blocked> -> tensor<256x16xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+      %b_dot = ttg.convert_layout %b : tensor<16x64xf32, #blocked1> -> tensor<16x64xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+      %d = tt.dot %a_dot, %b_dot, %acc, inputPrecision = tf32 : tensor<256x16xf32, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<16x64xf32, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<256x64xf32, #mma>
+      %next_k = arith.addi %k_off, %c16_i32 : i32
+      scf.yield %next_k, %d : i32, tensor<256x64xf32, #mma>
+    }
+    %out_blocked = ttg.convert_layout %accumulator#1 : tensor<256x64xf32, #mma> -> tensor<256x64xf32, #blocked1>
+    tt.descriptor_store %8[%2, %3], %out_blocked : !tt.tensordesc<tensor<256x64xf32>>, tensor<256x64xf32, #blocked1>
+    tt.return
+  }
+}
+
+// CHECK-LABEL: tt.func @tdm_padding_f32
+// CHECK: async_tdm_copy_global_to_local
+// CHECK: async_tdm_copy_global_to_local
+// CHECK: scf.for
 // CHECK: }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -339,7 +339,8 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
 // the same dot operand encoding, return true and get the shared encoding that
 // needs to be used to be compatible with users' layouts.
 static std::optional<ttg::PaddedSharedEncodingAttr>
-getSharedEncIfAllUsersAreDotEncPadded(Value loadedValue) {
+getSharedEncIfAllUsersAreDotEncPadded(
+    Value loadedValue, const triton::AMD::TargetInfo &targetInfo) {
   ttg::PaddedSharedEncodingAttr attr;
   for (Operation *user : loadedValue.getUsers()) {
     LDBG(" getSharedEncIfAllUsersAreDotEnc current user: " << *user);
@@ -353,7 +354,8 @@ getSharedEncIfAllUsersAreDotEncPadded(Value loadedValue) {
       // First time we find a shared encoding in the chain, save it and try to
       // use it if it is compatible with the other users.
       tempAttr = cast<ttg::PaddedSharedEncodingAttr>(memDesc.getEncoding());
-      auto newAttr = getSharedEncIfAllUsersAreDotEncPadded(user->getResult(0));
+      auto newAttr =
+          getSharedEncIfAllUsersAreDotEncPadded(user->getResult(0), targetInfo);
 
       if (!newAttr.has_value())
         return std::nullopt;
@@ -390,7 +392,7 @@ getSharedEncIfAllUsersAreDotEncPadded(Value loadedValue) {
         // For async descriptor loads, enable padding.
         tempAttr = getPaddedEncodingForDotOp(
             loadedValue.getContext(), dotOpEnc.getOpIdx(), srcTy.getShape(),
-            sharedOrder, cgaLayout, bitWidth);
+            sharedOrder, cgaLayout, bitWidth, dotOpEnc.getKWidth(), targetInfo);
       } else if (auto llEnc = dyn_cast<ttg::LinearEncodingAttr>(userResEnc)) {
         // We use linear layout directly for scaled dot fp8 operands. For such
         // cases, we need to look further down the def-use chain to find the dot
@@ -399,9 +401,9 @@ getSharedEncIfAllUsersAreDotEncPadded(Value loadedValue) {
         unsigned vecSize;
         if (auto dotEnc = getDotEncoding<ttg::AMDWmmaEncodingAttr>(
                 userResult, &opIdx, &vecSize)) {
-          tempAttr = getPaddedEncodingForDotOp(loadedValue.getContext(), opIdx,
-                                               srcTy.getShape(), order,
-                                               cgaLayout, bitWidth);
+          tempAttr = getPaddedEncodingForDotOp(
+              loadedValue.getContext(), opIdx, srcTy.getShape(), order,
+              cgaLayout, bitWidth, vecSize, targetInfo);
         }
       }
     }
@@ -973,9 +975,9 @@ void lowerLoop(scf::ForOp forOp,
       auto useTDM = isa<tt::DescriptorLoadOp>(load);
       if (useTDM) {
         hasTDMLoad = true;
-        auto paddedEncoding =
-            getSharedEncIfAllUsersAreDotEncPadded(load->getResult(0))
-                .value_or(nullptr);
+        auto paddedEncoding = getSharedEncIfAllUsersAreDotEncPadded(
+                                  load->getResult(0), targetInfo)
+                                  .value_or(nullptr);
         LoadInfo ldInfo;
         ldInfo.sharedEncoding = paddedEncoding;
         ldInfo.distToUse = distance;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -350,27 +350,98 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
                                             std::move(linearComponent));
 }
 
-// Get a padded encoding instead of going through the classical swizzled one.
-// Please note that padding here is in terms of elements and not bytes or dwords
+// LDS padding strategy for TDM (descriptor) loads.
+//
+// Currently only invoked for gfx1250 TDM loads (via
+// getSharedEncIfAllUsersAreDotEncPadded in LowerLoops.cpp when useTDM is
+// true).
+//
+// Padding is chosen per-dtype and per-access-path to minimize bank conflicts
+// while avoiding unnecessary LDS waste.  The two load paths have different
+// access patterns and therefore different optimal padding values.
+//
+//   Transposed (ds_load_tr*):
+//     Used when K is contiguous in shared memory but the dot instruction
+//     needs the non-K dimension contiguous in registers. The instruction
+//     cooperatively loads a fixed sub-tile across shuffle groups. In each
+//     execution cycle, two shuffle groups (16 lanes total) access a combined
+//     row of 2 × (instBitWidth/elemBits) elements. To avoid bank conflicts,
+//     the padding must equal this combined row width so that each successive
+//     LDS row lands on a completely disjoint set of banks.
+//
+//       16-bit (fp16/bf16): ds_load_tr16_b128 → 2 × 128/16 = 16 elems → pad 16
+//        8-bit (fp8/i8):    ds_load_tr8_b64   → 2 ×  64/8  = 16 elems → pad 16
+//       32-bit (f32):       no transposed instruction; falls back to
+//                           non-transposed ds_load_b* where each thread
+//                           loads sequentially.
+//
+//   Non-transposed (ds_load_b*):
+//     Used when the shared memory layout already matches what the dot
+//     instruction expects. Each thread issues a vector load of consecutive
+//     elements.  Padding ensures the LDS row stride (in dwords) avoids
+//     periodic bank aliasing across the 16 nonK-positions per cycle.
+//
+//     For dword-or-wider elements (f32+): pad = min(vecWidth, 128/elemBits).
+//     The load width in dwords equals vecWidth, so pad = vecWidth gives
+//     gcd(stride_dwords, 64) = vecWidth — optimal bank separation.
+//       32-bit kWidth=4: min(4, 4) = 4 elems (MFMA 16x16x4)
+//       32-bit kWidth=2: min(2, 4) = 2 elems (MFMA 32x32x2)
+//
+//     For sub-dword elements (fp16/fp8): pad = 128/elemBits (= 4 dwords).
+//     Dual-address loads (e.g. ds_load_2addr_b64) need the full 4-dword
+//     stride separation to avoid cross-address bank conflicts.
+//       16-bit (fp16): 128/16 =  8 elems
+//        8-bit (fp8):  128/8  = 16 elems
+//
+// Note on 4-bit types (i4): two i4 elements are packed into one i8 in LDS,
+// so from a bank-conflict perspective 4-bit behaves identically to 8-bit
+// in both transposed and non-transposed paths below.
+
 triton::gpu::PaddedSharedEncodingAttr
 getPaddedEncodingForDotOp(mlir::MLIRContext *context, int opIdx,
                           ArrayRef<int64_t> shape, ArrayRef<unsigned> order,
                           triton::gpu::CGAEncodingAttr CGALayout,
-                          unsigned typeWidthInBit) {
-  // LDS padding strategy to reduce bank conflicts for dot operand loads.
-  //
-  // Both ds_load_tr (transposed) and ds_load (non-transposed) use 128-bit
-  // loads where 16 lanes cooperatively access 16 different rows. The bank
-  // conflict pattern is identical for both instructions since each lane
-  // reads contiguously within its row.
-  //
-  // Always pad by maxVecSize (128 bits / element size) to spread accesses
-  // across different banks.
+                          unsigned typeWidthInBit, unsigned vecWidth,
+                          const triton::AMD::TargetInfo &targetInfo) {
   auto blockShapePerCTA =
       triton::gpu::getShapePerCTA(CGALayout.getCTASplitNum(), shape);
   int innerDimLength = blockShapePerCTA[order[0]];
-  unsigned maxVecSize = 128 / typeWidthInBit;
-  unsigned padAmount = maxVecSize;
+
+  bool loadTransposed = (order[0] != (1 - opIdx));
+
+  // Fallback: assume padding to match widest load width
+  unsigned padAmount = 128 / typeWidthInBit;
+  if (loadTransposed) {
+    // Transposed path: pad by twice the elements-per-lane of the transposed
+    // instruction.  Two shuffle groups execute per cycle, each reading
+    // instBitWidth/elemBits elements from the same row set.  Padding by
+    // 2× ensures the stride (in dwords) is an odd multiple of the combined
+    // row-access width, distributing all 16 lanes' bank accesses across
+    // disjoint banks and eliminating conflicts for tile widths >= 32.
+    if (auto ldsParams = targetInfo.queryLDSTransLoadParams(typeWidthInBit)) {
+      padAmount = 2 * ldsParams->instBitWidth / typeWidthInBit;
+    }
+  } else {
+    // Non-transposed path: each cycle 16 lanes at distinct nonK rows load
+    // vecWidth consecutive K elements.  Padding shifts the row stride so
+    // that gcd(stride_dwords, 64) is small enough for all lanes' bank
+    // sets to be disjoint.
+    //
+    // For dword-or-wider elements (f32+): pad = min(vecWidth, 128/elemBits).
+    // vecWidth elements = vecWidth dwords, giving gcd(stride_dwords, 64) =
+    // vecWidth for power-of-2 BLOCK_K.  This is optimal:
+    //   MFMA 16x16x4 f32 (kWidth=4): pad=4 → conflict-free
+    //   MFMA 32x32x2 f32 (kWidth=2): pad=2 → conflict-free
+    //
+    // For sub-dword elements (fp16/fp8): keep pad = 128/elemBits (4 dwords).
+    // On architectures with dual-address LDS loads (e.g. gfx1250
+    // ds_load_2addr_b64 for fp8), two addresses are served simultaneously,
+    // requiring the full 4-dword stride separation to avoid cross-address
+    // bank conflicts.
+    if (typeWidthInBit >= 32)
+      padAmount = std::min(vecWidth, padAmount);
+  }
+
   unsigned padInterval = innerDimLength;
   return triton::gpu::PaddedSharedEncodingAttr::get(
       context, {{padInterval, padAmount}}, order, shape, CGALayout);

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -30,6 +30,7 @@ triton::gpu::PaddedSharedEncodingAttr
 getPaddedEncodingForDotOp(mlir::MLIRContext *context, int opIdx,
                           ArrayRef<int64_t> shape, ArrayRef<unsigned> order,
                           triton::gpu::CGAEncodingAttr CGALayout,
-                          unsigned typeWidthInBit);
+                          unsigned typeWidthInBit, unsigned vecWidth,
+                          const triton::AMD::TargetInfo &targetInfo);
 
 #endif


### PR DESCRIPTION
Refine the padding strategy in getPaddedEncodingForDotOp to choose padding per-dtype and per-access-path (transposed vs non-transposed), reducing bank conflicts while avoiding unnecessary LDS waste.
 - Transposed path (ds_load_tr*): pad by 2x the elements-per-lane of the transposed instruction so that two shuffle groups' accesses land on disjoint banks.
 - Non-transposed path (ds_load_b*): for dword-or-wider elements, pad by min(vecWidth, 128/elemBits); for sub-dword elements, keep the full 4-dword stride separation needed for dual-address loads.

### Verification

I've run the below sweep that confirms the correctness of the heuristic. Each configuration is a GEMM kernel. In each configurations, BLOCK_M = M; BLOCK_N = N; K = 1024. This is so that this data comes from exactly a single workgroup.

dtype | Warps | Tile (MxNxK) | SQ_INSTS_LDS | BANK_CONFL
-- | -- | -- | -- | --
fp16 | 1 | 16x32x64 | 192 | 0 
fp16 | 1 | 16x64x64 | 320 | 0
fp16 | 2 | 32x32x64 | 384 | 0
fp16 | 4 | 64x64x64 | 1024 | 0
fp16 | 8 | 128x128x64 | 3072 | 0
fp8 | 1 | 16x32x64 | 160 | 0
fp8 | 1 | 16x64x64 | 288 | 0
fp8 | 2 | 32x32x64 | 256 | 0
fp8 | 4 | 64x64x64 | 768 | 0
fp8 | 8 | 128x128x64 | 2048 | 0

Note: This is the first PR in a series of improving the shared padded encoding. Next PRs down the line includes work to refactor the pipeliner to unify the gfx1250 and CDNA4 approach, and make sure a fallback is ready when padding isn't necessary. I'm limiting the scope of the first PR so the feature can upstream incrementally.