### PR TITLE
[AMD] Fix bugs about CGALayout and shapePerCTA in AccelerateAMDMatmul

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -404,3 +404,32 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+// CHECK-DAG: [[LINEAR1:#linear.*]] = #ttg.linear<{{.*}} block = {{\[\[0, 0\], \[64, 0\]\]}}
+// CHECK-DAG: [[LINEAR2:#linear.*]] = #ttg.linear<{{.*}} block = {{\[\[64, 0\], \[0, 0\]\]}}
+// CHECK-DAG: [[MMA:#mma.*]] = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {{.*}}warp = {{\[\[0, 1\], \[1, 0\]\]}}{{.*}} CGALayout = {{\[\[0, 1\], \[1, 0\]\]}}, instrShape = {{\[16, 16, 128\]}}
+// CHECK: tt.func public @mxfp_matmul_multi_cta
+// CHECK: tt.dot_scaled {{.*}} tensor<128x64xf8E5M2, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 16}>>, tensor<128x2xi8, [[LINEAR1]]> * tensor<64x128xf8E5M2, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 16}>>, tensor<128x2xi8, [[LINEAR2]]> -> tensor<128x128xf32, [[MMA]]>
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1], [1, 0]]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 0], [1, 0]]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[1, 0], [0, 0]]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 4], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0], CGALayout = [[0, 1], [1, 0]]}>
+#blocked4 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [2, 2], order = [1, 0], CGALayout = [[0, 0], [1, 0]]}>
+#blocked5 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0], CGALayout = [[0, 1], [0, 0]]}>
+module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @mxfp_matmul_multi_cta(
+    %a: tensor<128x64xf8E5M2, #blocked4>,
+    %b: tensor<64x128xf8E5M2, #blocked5>,
+    %a_scale: tensor<128x2xi8, #blocked1>,
+    %b_scale: tensor<128x2xi8, #blocked2>,
+    %d: tensor<128x128x!tt.ptr<f32>, #blocked3>) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<128x128xf32, #blocked>
+    %res = tt.dot_scaled %a scale %a_scale, %b scale %b_scale, %cst lhs = e5m2 rhs = e5m2 {fastMath = false} : tensor<128x64xf8E5M2, #blocked4>, tensor<128x2xi8, #blocked1> * tensor<64x128xf8E5M2, #blocked5>, tensor<128x2xi8, #blocked2> -> tensor<128x128xf32, #blocked>
+    %cvt = ttg.convert_layout %res : tensor<128x128xf32, #blocked> -> tensor<128x128xf32, #blocked3>
+    tt.store %d, %cvt : tensor<128x128x!tt.ptr<f32>, #blocked3>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -69,9 +69,31 @@ FailureOr<ScaleDotElemType> mlirTypeToScaledElemType(Type type) {
       .Default([](Type) { return failure(); });
 }
 
-SmallVector<unsigned, 3>
-warpsPerTile(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
-             std::pair<int64_t, int64_t> shapePerWarp) {
+// This function is to lay out numWarps warps into 2d dimension for the given
+// dot operation, where
+//  - shape : is the shape of the resulting data a single CTA will produce
+//  - instrShape: is shape of data a single wmma/mfma hardware instruction
+//     will consume
+//
+// This function takes into account three situations
+//  a) 1st dot in a chained dot operations (e.g. in FA)
+//  b) 2nd dot in a chained dot operations
+//  c) single dot operation
+//
+// In case a), it will return {numWarp, 1} for the first dot in an attempt to
+// reduce subsequent reduction overhead.
+//
+// TODO: describe b) using terse and intuitive way.
+//
+// Here is an example for case c). Assume instrShape is 16x16, and the shape is
+// 160x320. So, the CTA worth of data is partitioned into 10x20 grid. This
+// function is to lay out the numWarps into a mxn dimension, such that
+//   - m*n = numWarps, and
+//   - 10/m is close to 20/n
+//
+SmallVector<unsigned, 3> planWarps(Operation *dotOp, ArrayRef<int64_t> shape,
+                                   int numWarps,
+                                   std::pair<int64_t, int64_t> instrShape) {
   auto rank = shape.size();
   // Case 1: Early exit for batched matmul
   if (rank == 3)
@@ -102,7 +124,7 @@ warpsPerTile(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
     SmallVector<unsigned, 3> ret = {1, 1};
     ret[0] = static_cast<unsigned>(std::min(
         static_cast<int64_t>(numWarps),
-        static_cast<int64_t>(llvm::divideCeil(shape[0], shapePerWarp.first))));
+        static_cast<int64_t>(llvm::divideCeil(shape[0], instrShape.first))));
     ret[1] = numWarps / ret[0];
     return ret;
   }
@@ -113,9 +135,9 @@ warpsPerTile(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
   do {
     if (ret[0] * ret[1] >= numWarps)
       break;
-    if (tensorShape[0] / (shapePerWarp.first * 2) / ret[0] >=
-        tensorShape[1] / shapePerWarp.second / ret[1]) {
-      if (ret[0] < tensorShape[0] / shapePerWarp.first) {
+    if (tensorShape[0] / (instrShape.first * 2) / ret[0] >=
+        tensorShape[1] / instrShape.second / ret[1]) {
+      if (ret[0] < tensorShape[0] / instrShape.first) {
         ret[0] *= 2;
       } else {
         ret[1] *= 2;
@@ -125,23 +147,11 @@ warpsPerTile(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
     }
   } while (true);
 
-  if (ret[1] * shapePerWarp.second > tensorShape[1]) {
+  if (ret[1] * instrShape.second > tensorShape[1]) {
     return {ret[1], ret[0]};
   }
 
   return ret;
-}
-
-SmallVector<unsigned, 3>
-warpsPerTileMFMA(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
-                 std::pair<int64_t, int64_t> shapePerWarp) {
-  return warpsPerTile(dotOp, shape, numWarps, shapePerWarp);
-}
-
-SmallVector<unsigned, 3>
-warpsPerTileWMMA(Operation *dotOp, ArrayRef<int64_t> shape, int numWarps,
-                 std::pair<int64_t, int64_t> shapePerWarp) {
-  return warpsPerTile(dotOp, shape, numWarps, shapePerWarp);
 }
 
 // Chooses a proper MFMA instruction that can used to compute the given dot op.
@@ -591,8 +601,7 @@ public:
     auto kDim = mfmaInstr->kDim;
     auto kBase = mfmaInstr->kBase;
 
-    auto warpsPerTile =
-        warpsPerTileMFMA(dotOp, retShape, numWarps, {mDim, nDim});
+    auto warpsPerTile = planWarps(dotOp, retShape, numWarps, {mDim, nDim});
 
     Type mfmaAccType;
     if (oldRetType.getElementType().isIntOrIndex())
@@ -937,8 +946,7 @@ public:
     auto kBase = mfmaInstr->kBase;
     assert(mDim == nDim);
 
-    auto warpsPerTile =
-        warpsPerTileMFMA(dotOp, oldShape, numWarps, {mDim, nDim});
+    auto warpsPerTile = planWarps(dotOp, oldShape, numWarps, {mDim, nDim});
 
     SmallVector<unsigned, 2> tilesPerWarp = deduceTilesPerWarpForScale(
         aScale, bScale, mDim, oldShape[0], oldShape[1], warpsPerTile);
@@ -1138,13 +1146,15 @@ public:
     ttg::CGAEncodingAttr cgaLayout =
         ttg::getCGALayout(oldRetType.getEncoding());
     unsigned numWarps = ttg::lookupNumWarps(dotOp);
+    auto oldShapePerCTA =
+        ttg::getShapePerCTA(cgaLayout.getCTASplitNum(), oldShape);
 
     constexpr unsigned mDim = 16;
     constexpr unsigned nDim = 16;
     constexpr unsigned kDim = 128;
 
     auto warpsPerTile =
-        warpsPerTileWMMA(dotOp, oldShape, numWarps, {mDim, nDim});
+        planWarps(dotOp, oldShapePerCTA, numWarps, {mDim, nDim});
     // TODO: Select tilesPerWarp in Triton
     SmallVector<unsigned> tilesPerWarp(rank, 1u);
 
@@ -1171,8 +1181,16 @@ public:
 
     using basisT = std::vector<std::vector<int32_t>>;
 
-    auto aShape = a.getType().getShape();
-    auto bShape = b.getType().getShape();
+    RankedTensorType aType = a.getType();
+    RankedTensorType bType = b.getType();
+    auto aCgaLayout = ttg::getCGALayout(aType.getEncoding());
+    auto bCgaLayout = ttg::getCGALayout(bType.getEncoding());
+    auto aShape = aType.getShape();
+    auto bShape = bType.getShape();
+    auto aShapePerCTA =
+        ttg::getShapePerCTA(aCgaLayout.getCTASplitNum(), aShape);
+    auto bShapePerCTA =
+        ttg::getShapePerCTA(bCgaLayout.getCTASplitNum(), bShape);
 
     auto aEncLL = LinearLayout::empty();
     auto bEncLL = LinearLayout::empty();
@@ -1184,8 +1202,11 @@ public:
       auto newEnc = DotOperandEncodingAttr::get(ctx, opIdx, parent, 16);
       auto newVType = RankedTensorType::get(vType.getShape(),
                                             vType.getElementType(), newEnc);
-      (opIdx == 0 ? aEncLL : bEncLL) *=
-          newEnc.toLinearLayout(opIdx == 0 ? aShape : bShape);
+      if (opIdx == 0)
+        aEncLL *= newEnc.toLinearLayout(aShapePerCTA);
+      else
+        bEncLL *= newEnc.toLinearLayout(bShapePerCTA);
+
       return ttg::ConvertLayoutOp::create(rewriter, v.getLoc(), newVType, v);
     };
     a = convertInputLayout(a, 0, aElemType == ScaleDotElemType::E2M1);
@@ -1210,7 +1231,8 @@ public:
 
     auto convertScaleLayout = [&](TensorValue scale,
                                   llvm::ArrayRef<int64_t> valShape,
-                                  LinearLayout dotLL, int idx) -> Value {
+                                  LinearLayout dotLL, int idx,
+                                  ttg::CGAEncodingAttr cgaLayout) -> Value {
       SmallVector<int64_t> shape;
       Type scaleType;
       // 0x7F is 1.0 in E8M0
@@ -1228,8 +1250,7 @@ public:
       }
 
       LinearLayout newLL = ttg::chooseScaledWmmaScaleLayout(
-          ctx, idx, shape, mDim, scaleFactor, ctaLayout,
-          triton::gpu::CGAEncodingAttr::get1CTALayout(ctx, /*rank=*/2));
+          ctx, idx, shape, mDim, scaleFactor, ctaLayout, cgaLayout);
       Attribute newScaleEncoding = ttg::LinearEncodingAttr::get(ctx, newLL);
       auto newScaleType =
           RankedTensorType::get(shape, scaleType, newScaleEncoding);
@@ -1243,10 +1264,21 @@ public:
                                             newScaleType, scale);
       }
     };
-    auto newAScale =
-        convertScaleLayout(aScale, aShape, aEncLL, /*dotOperandIdx=*/0);
-    auto newBScale =
-        convertScaleLayout(bScale, bShape, bEncLL, /*dotOperandIdx=*/1);
+
+    // Operands A and A-scale are of shape MxK and Mx(K/grp), respectively.
+    // They both split along M-dimension in the same way, and hence have the
+    // same CGA layout.
+    auto aScaleCgaLayout = aCgaLayout;
+    assert(!aScale || (aScaleCgaLayout ==
+                       ttg::getCGALayout((aScale.getType()).getEncoding())));
+    auto newAScale = convertScaleLayout(aScale, aShape, aEncLL,
+                                        /*dotOperandIdx=*/0, aScaleCgaLayout);
+
+    auto bScaleCgaLayout = inferBScaleCgaLayout(ctx, cgaLayout);
+    assert(!bScale || (ttg::getCGALayout(bScale.getType().getEncoding()) ==
+                       bScaleCgaLayout));
+    auto newBScale = convertScaleLayout(bScale, bShape, bEncLL,
+                                        /*dotOperandIdx=*/1, bScaleCgaLayout);
 
     auto newDot = triton::DotScaledOp::create(
         rewriter, dotOp.getLoc(), newRetType, a, b, newAcc, newAScale,
@@ -1258,6 +1290,31 @@ public:
                                                       newDot);
 
     return success();
+  }
+
+  // If Bscale were present, we could directly grab the CGA layout from it.
+  // Unfortunately, it is optional; on top of that, sometime we need to know
+  // its CGA layout even if it's not present.
+  //
+  // Note that split only take place along M and N dimension. For A and Ascale,
+  // their shapes are MxK and Mx(K/grp), respectively. Hence, A and A-scale can
+  // share the CGA layout. For B and Bscale, their shapes are KxN and Nx(K/grp),
+  // respectively. Since N shows up on different positions, we cannot "reuse"
+  // B's CGA layout for B-scale.
+  //
+  // We can grab N's split number from D's CGA layout, and construct Bscale's
+  // using that info.
+  //
+  static ttg::CGAEncodingAttr
+  inferBScaleCgaLayout(MLIRContext *ctx, ttg::CGAEncodingAttr dCgaLayout) {
+    auto resultSplit = dCgaLayout.getCTASplitNum();
+    unsigned nSplit = resultSplit[1];
+    unsigned numCtas = mlir::product(dCgaLayout.getCTAsPerCGA());
+
+    return ttg::CGAEncodingAttr::fromSplitParams(
+        ctx,
+        /*CTAsPerCGA=*/{nSplit, numCtas / nSplit},
+        /*CTASplitNum=*/{nSplit, 1}, /*CTAOrder*/ {0, 1});
   }
 };
 
@@ -1417,10 +1474,21 @@ public:
 
     ttg::AMDWmmaEncodingAttr wmmaEnc, wmmaEncA, wmmaEncB;
 
-    auto warpsPerTile =
-        warpsPerTileWMMA(dotOp, retShape, numWarps, {mDim, nDim});
-
     auto CGALayout = ttg::getCGALayout(oldRetEncoding);
+
+    // Note: Following few lines of code could be very confusing for some
+    // readers. If this is the case, please read AMDWmmaEncodingAttr defined
+    // in include/triton/Dialect/TritonGPU/IR/TritonGPUAttrDefs.td for the
+    // meaning of `ctaLayout`, which depicit how warps and optionally, "tile"
+    // are arranged. Some occurrences of "tile" refer to the portion of tensor
+    // being processed by all entire CGA as a whole, and some occurrences
+    // means small portion of tensor which feed to a *SINGLE* wmma instruction.
+    //
+    // TODO: clean up and refine terms to be clearer.
+    auto retShapePerCTA =
+        ttg::getShapePerCTA(CGALayout.getCTASplitNum(), retShape);
+    auto warpsPerTile =
+        planWarps(dotOp, retShapePerCTA, numWarps, {mDim, nDim});
 
     // Use transposed wmma layout to enable larger vectorization for global
     // store instructions.


### PR DESCRIPTION
Fix following bugs when transforming dot_scaled op in AccelerateAMDMatmul.
  * mistakenly use D's CGA layout for A/B/A-scale/B-Scale
  * use shape-for-entire-cga for shaperPerCTA.
  * and misc other minor issues.

related to internal PR 582