### PR TITLE
[AMD] Unify padded layout heuristic for gfx1250 async copy and TDM paths

### DIFF
--- a/test/TritonGPU/amd/amd-pipeline-padded-layout-gfx1250.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-padded-layout-gfx1250.mlir
@@ -1,0 +1,78 @@
+// RUN: triton-opt %s -split-input-file -tritonamdgpu-schedule-loops="num_stages=2" -tritonamdgpu-pipeline -canonicalize | FileCheck %s
+
+// Verify that the gfx1250 pipeline pass produces padded shared encodings
+// for dot-operand loads, with correct padding values per dtype and access
+// pattern (transposed vs non-transposed).
+
+// ============================================================
+// f16 GEMM: 64x64 tile, 4 warps, WMMA v3
+//   opIdx=0 (non-transposed): pad = 128/16 = 8,  interval = K = 32
+//   opIdx=1 (transposed):     pad = 2*128/16 = 16, interval = N = 64
+// ============================================================
+// CHECK: #shared = #ttg.padded_shared<[32:+8] {order = [1, 0], shape = [64, 32]}>
+// CHECK: #shared1 = #ttg.padded_shared<[64:+16] {order = [1, 0], shape = [32, 64]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 32]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: padded_layout_f16
+  tt.func @padded_layout_f16(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f16> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_range {end = 32 : i32, start = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<32xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x32xi32, #blocked>
+    %2 = tt.broadcast %1 : tensor<1x32xi32, #blocked> -> tensor<64x32xi32, #blocked>
+    %3 = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x32x!tt.ptr<f16>, #blocked>
+    %4 = tt.splat %arg1 : !tt.ptr<f16> -> tensor<32x64x!tt.ptr<f16>, #blocked>
+    %5 = tt.addptr %3, %2 : tensor<64x32x!tt.ptr<f16>, #blocked>, tensor<64x32xi32, #blocked>
+
+    %7 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<64x64xf32, #mma>)  : i32 {
+      %9 = tt.load %5 : tensor<64x32x!tt.ptr<f16>, #blocked>
+      %11 = ttg.convert_layout %9 : tensor<64x32xf16, #blocked> -> tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>>
+      %10 = tt.load %4 : tensor<32x64x!tt.ptr<f16>, #blocked>
+      %12 = ttg.convert_layout %10 : tensor<32x64xf16, #blocked> -> tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>>
+      %13 = tt.dot %11, %12, %arg4 : tensor<64x32xf16, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 4}>> * tensor<32x64xf16, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 4}>> -> tensor<64x64xf32, #mma>
+      scf.yield %13 : tensor<64x64xf32, #mma>
+    }
+    tt.return
+  }
+}
+
+// -----
+
+// ============================================================
+// f8E4M3FN GEMM: 64x64 tile, 4 warps, WMMA v3
+//   opIdx=0 (non-transposed): pad = 128/8 = 16,  interval = K = 64
+//   opIdx=1 (transposed):     pad = 2*64/8 = 16, interval = N = 64
+//   Both operands have same shape and padding → single shared encoding
+// ============================================================
+// CHECK: #shared = #ttg.padded_shared<[64:+16] {order = [1, 0], shape = [64, 64]}>
+#blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 64]}>
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: padded_layout_f8
+  tt.func @padded_layout_f8(%arg0: !tt.ptr<f8E4M3FN> {tt.divisibility = 16 : i32}, %arg1: !tt.ptr<f8E4M3FN> {tt.divisibility = 16 : i32}) {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x64xf32, #mma>
+    %c0_i32 = arith.constant 0 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %c4_i32 = arith.constant 4 : i32
+    %0 = tt.make_range {end = 64 : i32, start = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>>
+    %1 = tt.expand_dims %0 {axis = 0 : i32} : tensor<64xi32, #ttg.slice<{dim = 0, parent = #blocked}>> -> tensor<1x64xi32, #blocked>
+    %2 = tt.broadcast %1 : tensor<1x64xi32, #blocked> -> tensor<64x64xi32, #blocked>
+    %3 = tt.splat %arg0 : !tt.ptr<f8E4M3FN> -> tensor<64x64x!tt.ptr<f8E4M3FN>, #blocked>
+    %4 = tt.splat %arg1 : !tt.ptr<f8E4M3FN> -> tensor<64x64x!tt.ptr<f8E4M3FN>, #blocked>
+    %5 = tt.addptr %3, %2 : tensor<64x64x!tt.ptr<f8E4M3FN>, #blocked>, tensor<64x64xi32, #blocked>
+    %6 = tt.addptr %4, %2 : tensor<64x64x!tt.ptr<f8E4M3FN>, #blocked>, tensor<64x64xi32, #blocked>
+
+    %7 = scf.for %arg3 = %c0_i32 to %c4_i32 step %c1_i32 iter_args(%arg4 = %cst) -> (tensor<64x64xf32, #mma>)  : i32 {
+      %9 = tt.load %5 : tensor<64x64x!tt.ptr<f8E4M3FN>, #blocked>
+      %11 = ttg.convert_layout %9 : tensor<64x64xf8E4M3FN, #blocked> -> tensor<64x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>>
+      %10 = tt.load %6 : tensor<64x64x!tt.ptr<f8E4M3FN>, #blocked>
+      %12 = ttg.convert_layout %10 : tensor<64x64xf8E4M3FN, #blocked> -> tensor<64x64xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>>
+      %13 = tt.dot %11, %12, %arg4 : tensor<64x64xf8E4M3FN, #ttg.dot_op<{opIdx = 0, parent = #mma, kWidth = 8}>> * tensor<64x64xf8E4M3FN, #ttg.dot_op<{opIdx = 1, parent = #mma, kWidth = 8}>> -> tensor<64x64xf32, #mma>
+      scf.yield %13 : tensor<64x64xf32, #mma>
+    }
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/LowerLoops.cpp
@@ -257,8 +257,9 @@ std::optional<ttg::SharedEncodingTrait> getSharedEncIfAllUsersAreDotEnc(
           canUseAsyncCopy = canBeConvertedToAsyncLoad(
               2, cast<tt::LoadOp>(loadOp), {}, axisInfoAnalysis, targetInfo);
         }
-        tempAttr = composePaddedLayout(targetInfo, dotOpEnc, srcTy, sharedOrder,
-                                       canUseAsyncCopy);
+        tempAttr = composePaddedLayout(targetInfo, dotOpEnc.getOpIdx(),
+                                       dotOpEnc.getKWidth(), srcTy, sharedOrder,
+                                       dotOpEnc, canUseAsyncCopy);
         if (!tempAttr) {
           tempAttr = ttg::SwizzledSharedEncodingAttr::get(
               loadedValue.getContext(), dotOpEnc, srcTy.getShape(), sharedOrder,
@@ -369,9 +370,7 @@ getSharedEncIfAllUsersAreDotEncPadded(
         return std::nullopt;
 
       auto srcTy = cast<ttg::TensorOrMemDesc>(loadedValue.getType());
-      auto cgaLayout = ttg::getCGALayout(srcTy.getEncoding());
       auto order = getOrderForMemory(srcTy);
-      unsigned bitWidth = srcTy.getElementType().getIntOrFloatBitWidth();
       SmallVector<unsigned> sharedOrder;
       int rank = order.size();
       // TODO rework this when shared -> dotOperand conversions support
@@ -389,10 +388,9 @@ getSharedEncIfAllUsersAreDotEncPadded(
 
       auto userResEnc = cast<ttg::TensorOrMemDesc>(userResType).getEncoding();
       if (auto dotOpEnc = dyn_cast<ttg::DotOperandEncodingAttr>(userResEnc)) {
-        // For async descriptor loads, enable padding.
-        tempAttr = getPaddedEncodingForDotOp(
-            loadedValue.getContext(), dotOpEnc.getOpIdx(), srcTy.getShape(),
-            sharedOrder, cgaLayout, bitWidth, dotOpEnc.getKWidth(), targetInfo);
+        tempAttr =
+            composePaddedLayout(targetInfo, dotOpEnc.getOpIdx(),
+                                dotOpEnc.getKWidth(), srcTy, sharedOrder);
       } else if (auto llEnc = dyn_cast<ttg::LinearEncodingAttr>(userResEnc)) {
         // We use linear layout directly for scaled dot fp8 operands. For such
         // cases, we need to look further down the def-use chain to find the dot
@@ -401,9 +399,8 @@ getSharedEncIfAllUsersAreDotEncPadded(
         unsigned vecSize;
         if (auto dotEnc = getDotEncoding<ttg::AMDWmmaEncodingAttr>(
                 userResult, &opIdx, &vecSize)) {
-          tempAttr = getPaddedEncodingForDotOp(
-              loadedValue.getContext(), opIdx, srcTy.getShape(), order,
-              cgaLayout, bitWidth, vecSize, targetInfo);
+          tempAttr =
+              composePaddedLayout(targetInfo, opIdx, vecSize, srcTy, order);
         }
       }
     }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -144,7 +144,7 @@ int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
 // pad,  r1, r5,  r9, r13, r17, r21, r25
 // r29, pad, r2,  r6, r10, r14, r18, r22
 // r26, r30, pad, r3 ....
-ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
+static ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
     ttg::DotOperandEncodingAttr dotOpEnc, ttg::TensorOrMemDesc srcTy,
     ArrayRef<unsigned> sharedOrder, bool useAsyncCopy, unsigned warpSize) {
   auto *ctx = srcTy.getContext();
@@ -397,19 +397,19 @@ ttg::PaddedSharedEncodingAttr composePaddedLayoutForAsyncCopyCDNA4(
 // so from a bank-conflict perspective 4-bit behaves identically to 8-bit
 // in both transposed and non-transposed paths below.
 
-triton::gpu::PaddedSharedEncodingAttr
-getPaddedEncodingForDotOp(mlir::MLIRContext *context, int opIdx,
-                          ArrayRef<int64_t> shape, ArrayRef<unsigned> order,
-                          triton::gpu::CGAEncodingAttr CGALayout,
-                          unsigned typeWidthInBit, unsigned vecWidth,
-                          const triton::AMD::TargetInfo &targetInfo) {
+static triton::gpu::PaddedSharedEncodingAttr
+composePaddedLayoutWMMA(int opIdx, unsigned vecWidth,
+                        ttg::TensorOrMemDesc srcTy, ArrayRef<unsigned> order,
+                        const triton::AMD::TargetInfo &targetInfo) {
+  auto shape = srcTy.getShape();
+  auto CGALayout = ttg::getCGALayout(srcTy.getEncoding());
   auto blockShapePerCTA =
       triton::gpu::getShapePerCTA(CGALayout.getCTASplitNum(), shape);
   int innerDimLength = blockShapePerCTA[order[0]];
-
   bool loadTransposed = (order[0] != (1 - opIdx));
 
   // Fallback: assume padding to match widest load width
+  unsigned typeWidthInBit = srcTy.getElementType().getIntOrFloatBitWidth();
   unsigned padAmount = 128 / typeWidthInBit;
   if (loadTransposed) {
     // Transposed path: pad by twice the elements-per-lane of the transposed
@@ -442,21 +442,33 @@ getPaddedEncodingForDotOp(mlir::MLIRContext *context, int opIdx,
       padAmount = std::min(vecWidth, padAmount);
   }
 
+  if (padAmount == 0)
+    return {};
+
   unsigned padInterval = innerDimLength;
+  auto *context = srcTy.getContext();
   return triton::gpu::PaddedSharedEncodingAttr::get(
       context, {{padInterval, padAmount}}, order, shape, CGALayout);
 }
 
 ttg::PaddedSharedEncodingAttr
-composePaddedLayout(const tt::AMD::TargetInfo &targetInfo,
-                    ttg::DotOperandEncodingAttr dotOpEnc,
-                    ttg::TensorOrMemDesc srcTy, ArrayRef<unsigned> sharedOrder,
-                    bool useAsyncCopy) {
-  if (useAsyncCopy &&
-      targetInfo.getISAFamily() == triton::AMD::ISAFamily::CDNA4) {
-    unsigned warpSize = targetInfo.getWarpSize();
-    return composePaddedLayoutForAsyncCopyCDNA4(dotOpEnc, srcTy, sharedOrder,
-                                                useAsyncCopy, warpSize);
+composePaddedLayout(const tt::AMD::TargetInfo &targetInfo, int opIdx,
+                    unsigned vecWidth, ttg::TensorOrMemDesc srcTy,
+                    ArrayRef<unsigned> sharedOrder,
+                    ttg::DotOperandEncodingAttr dotOpEnc, bool useAsyncCopy) {
+  if (targetInfo.getISAFamily() == triton::AMD::ISAFamily::CDNA4) {
+    if (!dotOpEnc)
+      return {};
+    return composePaddedLayoutForAsyncCopyCDNA4(
+        dotOpEnc, srcTy, sharedOrder, useAsyncCopy, targetInfo.getWarpSize());
   }
+
+  if (targetInfo.getISAFamily() == triton::AMD::ISAFamily::GFX1250) {
+    if (!srcTy.getElementType().isIntOrFloat())
+      return {};
+    return composePaddedLayoutWMMA(opIdx, vecWidth, srcTy, sharedOrder,
+                                   targetInfo);
+  }
+
   return {};
 }

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.h
@@ -18,19 +18,14 @@ using namespace mlir;
 int deduceMinCountOnDefChain(Value defValue, Operation *consumerOp,
                              llvm::function_ref<int(Operation *)> countFunc);
 
-// Returns a padded shared encoding minimizing bank conflicts for the given
-// tensor and dot encoding.
+// Returns a padded shared encoding minimizing bank conflicts for a dot
+// operand. Note the CDNA4 path requires both dotOpEnc (parent MFMA encoding's
+// instruction shape) and useAsyncCopy.
 triton::gpu::PaddedSharedEncodingAttr
-composePaddedLayout(const triton::AMD::TargetInfo &targetInfo,
-                    triton::gpu::DotOperandEncodingAttr dotOpEnc,
-                    triton::gpu::TensorOrMemDesc srcTy,
-                    ArrayRef<unsigned> sharedOrder, bool useAsyncCopy);
-
-triton::gpu::PaddedSharedEncodingAttr
-getPaddedEncodingForDotOp(mlir::MLIRContext *context, int opIdx,
-                          ArrayRef<int64_t> shape, ArrayRef<unsigned> order,
-                          triton::gpu::CGAEncodingAttr CGALayout,
-                          unsigned typeWidthInBit, unsigned vecWidth,
-                          const triton::AMD::TargetInfo &targetInfo);
+composePaddedLayout(const triton::AMD::TargetInfo &targetInfo, int opIdx,
+                    unsigned vecWidth, triton::gpu::TensorOrMemDesc srcTy,
+                    ArrayRef<unsigned> sharedOrder,
+                    triton::gpu::DotOperandEncodingAttr dotOpEnc = {},
+                    bool useAsyncCopy = false);
 
 #endif


### PR DESCRIPTION
This is the second step of improving the padding heuristic in the series. The link to previous PR is at: https://github.com/triton-lang/triton/pull/9741

In this PR, I merge composePaddedLayout and getPaddedEncodingForDotOp into a single composePaddedLayout that dispatches by ISA family (CDNA4 vs GFX1250), enabling the gfx1250 padding heuristic for pointer-based async copy loads in addition to TDM descriptor loads.