### PR TITLE
Include `<optional>`

### DIFF
--- a/include/triton/Tools/Sys/GetEnv.hpp
+++ b/include/triton/Tools/Sys/GetEnv.hpp
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <cstdlib>
 #include <mutex>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Ran into a build error moving things around: we should be including the `optional` header file here if we plan to use it in this interface.