### PR TITLE
[AMD][BACKEND] Fix order of LL when applying offsets

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -1741,8 +1741,9 @@ LinearLayout getTDMLinearLayout(ArrayRef<int64_t> blockShape,
 
   auto order = getMatrixOrder(numDims, /*rowMajor=*/false);
 
-  return identityStandardND(S("message"), messageShape, order) *
-         identityStandardND(S("warp"), warpsPerCTA, order) * cgaLayout;
+  return (identityStandardND(S("message"), messageShape, order) *
+          identityStandardND(S("warp"), warpsPerCTA, order) * cgaLayout)
+      .transposeOuts(standardOutDimNames(ctx, numDims));
 }
 
 } // namespace mlir::triton::gpu


### PR DESCRIPTION
The linear layout returned by `getTDMLinearLayout` will have the output dims in memory order, however the only call site of this function expects it to be in logical order (dim0 -> dimN) when computing the offsets.

https://github.com/triton-lang/triton/blob/b032222f5e12dac1ec1a9a3cc39b2bc14a77e88f/third_party/amd/lib/TritonAMDGPUToLLVM/TDMUtility.cpp#L506-L520

We could also move the `transposeOuts` to the call site but doing this in `getTDMLinearLayout` might avoid a similar bug in the future? Any opinion on this @lezcano?