### PR TITLE
[AMD] Adjust test_amd_wmma_scaled_batched to new create_mxfp_scale API

### DIFF
--- a/third_party/amd/python/test/test_gluon_gfx1250.py
+++ b/third_party/amd/python/test/test_gluon_gfx1250.py
@@ -950,7 +950,9 @@ def test_amd_wmma_scaled_multi_cta(M, N, K, a_type, b_type, a_scale_type, b_scal
 @pytest.mark.parametrize("B", [4])
 @pytest.mark.parametrize("M, N, K", get_test_mxfp_block_mnk())
 @pytest.mark.parametrize("a_type, b_type", get_test_mxfp_variants())
-def test_amd_wmma_scaled_batched(B, M, N, K, a_type, b_type):
+@pytest.mark.parametrize("a_scale_type, b_scale_type", itertools.product(["e8m0", "e4m3"], repeat=2))
+@pytest.mark.parametrize("scale_factor", [16, 32])
+def test_amd_wmma_scaled_batched(B, M, N, K, a_type, b_type, a_scale_type, b_scale_type, scale_factor):
 
     @gluon.constexpr_function
     def _slice_layout(layout, indices):
@@ -960,15 +962,16 @@ def test_amd_wmma_scaled_batched(B, M, N, K, a_type, b_type):
 
     @gluon.jit
     def _offsets(dim0, dim1, dim2, layout):
-        return ttgl.arange(0, dim0, layout=_slice_layout(layout, [1, 2]))[:, None, None] * (dim1 * dim2) + \
-               ttgl.arange(0, dim1, layout=_slice_layout(layout, [0, 2]))[None, :, None] * dim2 + \
-               ttgl.arange(0, dim2, layout=_slice_layout(layout, [0, 1]))[None, None, :]
+        return ttgl.arange(0, dim0, _slice_layout(layout, [1, 2]))[:, None, None] * (dim1 * dim2) + \
+               ttgl.arange(0, dim1, _slice_layout(layout, [0, 2]))[None, :, None] * dim2 + \
+               ttgl.arange(0, dim2, _slice_layout(layout, [0, 1]))[None, None, :]
 
     @gluon.jit
     def kernel(c_ptr, a_ptr, a_scale_ptr, b_ptr, b_scale_ptr,  #
                a_type: ttgl.constexpr, b_type: ttgl.constexpr,  #
                BLOCK_B: ttgl.constexpr, BLOCK_M: ttgl.constexpr,  #
-               BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr):
+               BLOCK_N: ttgl.constexpr, BLOCK_K: ttgl.constexpr,  #
+               SCALE_FACTOR: ttgl.constexpr):
         DIV_FACTOR_A: ttgl.constexpr = 2 if a_type == "e2m1" else 1
         DIV_FACTOR_B: ttgl.constexpr = 2 if b_type == "e2m1" else 1
 
@@ -982,32 +985,35 @@ def test_amd_wmma_scaled_batched(B, M, N, K, a_type, b_type):
         b_layout: ttgl.constexpr = \
             ttgl.DotOperandLayout(1, wmma_layout_packed if b_type == "e2m1" else wmma_layout, 16)
         a_scale_layout: ttgl.constexpr = \
-            get_wmma_scale_layout(a_layout, [BLOCK_B, BLOCK_M, BLOCK_K // 32])
+            get_wmma_scale_layout(a_layout, [BLOCK_B, BLOCK_M, BLOCK_K // SCALE_FACTOR], SCALE_FACTOR)
         b_scale_layout: ttgl.constexpr = \
-            get_wmma_scale_layout(b_layout, [BLOCK_B, BLOCK_N, BLOCK_K // 32])
+            get_wmma_scale_layout(b_layout, [BLOCK_B, BLOCK_N, BLOCK_K // SCALE_FACTOR], SCALE_FACTOR)
 
         a_offs = _offsets(BLOCK_B, BLOCK_M, BLOCK_K // DIV_FACTOR_A, a_layout)
         a = ttgl.load(a_ptr + a_offs)
         b_offs = _offsets(BLOCK_B, BLOCK_K // DIV_FACTOR_B, BLOCK_N, b_layout)
         b = ttgl.load(b_ptr + b_offs)
 
-        a_scale_offs = _offsets(BLOCK_B, BLOCK_M, BLOCK_K // 32, a_scale_layout)
+        a_scale_offs = _offsets(BLOCK_B, BLOCK_M, BLOCK_K // SCALE_FACTOR, a_scale_layout)
         a_scale = ttgl.load(a_scale_ptr + a_scale_offs)
-        b_scale_offs = _offsets(BLOCK_B, BLOCK_N, BLOCK_K // 32, b_scale_layout)
+        b_scale_offs = _offsets(BLOCK_B, BLOCK_N, BLOCK_K // SCALE_FACTOR, b_scale_layout)
         b_scale = ttgl.load(b_scale_ptr + b_scale_offs)
 
-        zero = ttgl.zeros([BLOCK_B, BLOCK_M, BLOCK_N], dtype=ttgl.float32, layout=wmma_layout)
+        zero = ttgl.zeros([BLOCK_B, BLOCK_M, BLOCK_N], ttgl.float32, wmma_layout)
         c = ttgl.amd.gfx1250.wmma_scaled(a, a_scale, a_type, b, b_scale, b_type, zero)
         c = c.to(c_ptr.dtype.element_ty)
 
         c_offs = _offsets(BLOCK_B, BLOCK_M, BLOCK_N, wmma_layout)
         ttgl.store(c_ptr + c_offs, c)
 
+    if (a_type, b_type, a_scale_type, b_scale_type) not in _valid_dtype_combinations:
+        pytest.skip(f"Invalid type combination: {a_type}, {a_scale_type}, {b_type}, {b_scale_type}")
+
     torch.manual_seed(42)
     a, a_ref = zip(*[create_mxfp_operand(0, M, K, a_type) for _ in range(B)])
     b, b_ref = zip(*[create_mxfp_operand(1, K, N, b_type) for _ in range(B)])
-    a_scale, a_scale_ref = zip(*[create_mxfp_scale(0, M, K) for _ in range(B)])
-    b_scale, b_scale_ref = zip(*[create_mxfp_scale(1, K, N) for _ in range(B)])
+    a_scale, a_scale_ref = zip(*[create_mxfp_scale(0, M, K, a_scale_type, scale_factor) for _ in range(B)])
+    b_scale, b_scale_ref = zip(*[create_mxfp_scale(1, K, N, b_scale_type, scale_factor) for _ in range(B)])
 
     a = torch.stack(a, dim=0)
     b = torch.stack(b, dim=0)
@@ -1023,7 +1029,7 @@ def test_amd_wmma_scaled_batched(B, M, N, K, a_type, b_type):
     b, b_scale = b.cuda(), b_scale.cuda()
 
     c = torch.zeros((B, M, N), dtype=torch.float32).cuda()
-    kernel[(1, )](c, a, a_scale, b, b_scale, a_type, b_type, B, M, N, K, num_warps=4)
+    kernel[(1, )](c, a, a_scale, b, b_scale, a_type, b_type, B, M, N, K, scale_factor, num_warps=4)
 
     c_torch = (a_ref * a_scale_ref) @ (b_ref * b_scale_ref)
     torch.testing.assert_close(c.cpu(), c_torch, atol=1e-5, rtol=2e-5)


### PR DESCRIPTION
Seems like those tests were left behind after the API change to `create_mxfp_scale` so they no longer compile without this change.