### PR TITLE
[tritongpu] Don't crash in unsupported scaled block decomposition

### DIFF
--- a/include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
+++ b/include/triton/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.h
@@ -12,6 +12,7 @@ public:
                                 PatternRewriter &rewriter) const override;
 
 protected:
+  virtual LogicalResult verifyScaleTypeSupport(DotScaledOp scaledDotOp) const;
   FloatType getComputeType(ScaleDotElemType aType, ScaleDotElemType bType,
                            PatternRewriter &rewriter) const;
   TypedValue<RankedTensorType> scaleTo16(PatternRewriter &rewriter,

--- a/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/AccelerateMatmul.cpp
@@ -1015,6 +1015,7 @@ public:
 
     if (applyPatternsGreedily(m, std::move(patterns)).failed()) {
       signalPassFailure();
+      return;
     }
     // Now that we have picked the mma type, decompose dot that are not natively
     // supported.

--- a/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
+++ b/lib/Dialect/TritonGPU/Transforms/DecomposeScaledBlocked.cpp
@@ -24,6 +24,22 @@ SmallVector<int, 2> DecomposeScaledBlocked::getTransposeOrder(int rank) {
 }
 
 LogicalResult
+DecomposeScaledBlocked::verifyScaleTypeSupport(DotScaledOp scaledDotOp) const {
+  auto hasNVFP4Scale = [](TypedValue<RankedTensorType> scale) {
+    return scale && isa<Float8E4M3FNType>(scale.getType().getElementType());
+  };
+  if (!hasNVFP4Scale(scaledDotOp.getAScale()) &&
+      !hasNVFP4Scale(scaledDotOp.getBScale()))
+    return success();
+  auto diag = scaledDotOp.emitOpError(
+      "decomposed scaled block MMA does not support nvfp4");
+  diag.attachNote()
+      << "on NVIDIA, the fallback path only supports integer-encoded "
+         "microscaling factors, try increasing blockM to 128";
+  return failure();
+}
+
+LogicalResult
 DecomposeScaledBlocked::matchAndRewrite(DotScaledOp scaledDotOp,
                                         PatternRewriter &rewriter) const {
   if (isa_and_nonnull<MmaEncodingTrait>(
@@ -32,6 +48,8 @@ DecomposeScaledBlocked::matchAndRewrite(DotScaledOp scaledDotOp,
 
   // TODO: add support for m/n packed formats.
   if (!scaledDotOp.getLhsKPack() || !scaledDotOp.getRhsKPack())
+    return failure();
+  if (failed(verifyScaleTypeSupport(scaledDotOp)))
     return failure();
   // Types
   auto computeType = getComputeType(scaledDotOp.getAElemType(),

--- a/test/TritonGPU/accelerate-matmul.mlir
+++ b/test/TritonGPU/accelerate-matmul.mlir
@@ -734,6 +734,24 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // -----
 
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [1, 4], order = [1, 0]}>
+#blocked3_1 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3_2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [2, 16], warpsPerCTA = [4, 1], order = [1, 0]}>
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "cuda:100", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: sm100_dot_scaled_nvfp4_blocked_error
+  // CHECK: tt.dot_scaled
+  tt.func public @sm100_dot_scaled_nvfp4_blocked_error(%a: tensor<64x128xi8, #blocked3_2>, %scale_a: tensor<64x16xf8E4M3FN, #blocked3_1>, %b: tensor<128x128xi8, #blocked3>, %scale_b: tensor<128x16xf8E4M3FN, #blocked3_1>) -> tensor<64x128xf32, #blocked3> {
+    %cst = arith.constant dense<0.000000e+00> : tensor<64x128xf32, #blocked3>
+    // expected-error @+2 {{'tt.dot_scaled' op decomposed scaled block MMA does not support nvfp4}}
+    // expected-note @+1 {{on NVIDIA, the fallback path only supports integer-encoded microscaling factors, try increasing blockM to 128}}
+    %d = tt.dot_scaled %a scale %scale_a, %b scale %scale_b, %cst lhs = e2m1 rhs = e2m1 {fastMath = false, lhs_k_pack = true, rhs_k_pack = true} : tensor<64x128xi8, #blocked3_2>, tensor<64x16xf8E4M3FN, #blocked3_1> * tensor<128x128xi8, #blocked3>, tensor<128x16xf8E4M3FN, #blocked3_1> -> tensor<64x128xf32, #blocked3>
+    tt.return %d : tensor<64x128xf32, #blocked3>
+  }
+}
+
+// -----
+
 // We previously asserted that a tmem allocation must fit in the available tmem.
 // This would cause an assertion failure if the result matrix was too large.
 // Check that we allow the large result in AccelerateMatmul, and leave it to

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -787,6 +787,10 @@ public:
     return ttg::DecomposeScaledBlocked::matchAndRewrite(dotOp, rewriter);
   }
 
+  LogicalResult verifyScaleTypeSupport(tt::DotScaledOp) const override {
+    return success();
+  }
+
   RankedTensorType getScaleType(RankedTensorType vType, int32_t kDim,
                                 bool isFp4) const {
     if (!isFp4)


### PR DESCRIPTION
Scaled decomposition for nvfp4 fails because the code assumes mxfp scales. Raise an error instead