### PR TITLE
[AMD] Propagate buffer cache modifiers to LLVM IR for RDNA3 targets

### DIFF
--- a/test/TritonGPU/amd/amd-buffer-cache-modifiers-rdna3.mlir
+++ b/test/TritonGPU/amd/amd-buffer-cache-modifiers-rdna3.mlir
@@ -1,0 +1,87 @@
+// RUN: triton-opt %s -split-input-file --convert-triton-amdgpu-to-llvm=arch=gfx1150 | FileCheck %s
+
+// Verify that RDNA3 (and 3.5) cache modifier qualifiers emit the correct cachepolicy
+// aux values in rocdl.raw.ptr.buffer.load/store operations.
+//
+// DLC (bit 2) = non-temporal hint for MALL. DLC=1 means skip MALL allocation.
+//
+//   Load  .cg -> 1   (GLC only: bypass GL1)
+//   Load  .cs -> 7   (GLC|SLC|DLC: non-temporal everywhere)
+//   Load  .cv -> 7   (GLC|SLC|DLC: non-temporal everywhere)
+//   Store .cs -> 7   (GLC|SLC|DLC: non-temporal everywhere)
+//   Store .wt -> 7   (GLC|SLC|DLC: non-temporal everywhere)
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+// CHECK-LABEL: buffer_load_cg
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @buffer_load_cg(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
+    // .cg load on RDNA3.5: aux = 1 (GLC)
+    // CHECK: %[[aux:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, %[[aux]]
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cg : tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+// CHECK-LABEL: buffer_load_cs
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @buffer_load_cs(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
+    // .cs load on RDNA3.5: aux = 7 (GLC|SLC|DLC)
+    // CHECK: %[[aux:.*]] = llvm.mlir.constant(7 : i32) : i32
+    // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, %[[aux]]
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cs : tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+// CHECK-LABEL: buffer_load_cv
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @buffer_load_cv(%arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
+    // .cv load on RDNA3.5: aux = 7 (GLC|SLC|DLC)
+    // CHECK: %[[aux:.*]] = llvm.mlir.constant(7 : i32) : i32
+    // CHECK: rocdl.raw.ptr.buffer.load {{.*}}, {{.*}}, {{.*}}, %[[aux]]
+    %ret = amdg.buffer_load %arg0[%offset] cacheModifier = cv : tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+// CHECK-LABEL: buffer_store_cs
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @buffer_store_cs(%value: tensor<128xf32, #blocked>, %arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
+    %c256_i32 = arith.constant 256 : i32
+    // .cs store on RDNA3.5: aux = 7 (GLC|SLC|DLC)
+    // CHECK: %[[aux:.*]] = llvm.mlir.constant(7 : i32) : i32
+    // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux]]
+    amdg.buffer_store %value, %arg0[%offset] cacheModifier = cs stride = %c256_i32 : tensor<128xf32, #blocked>
+    tt.return
+  }
+}
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0]}>
+
+// CHECK-LABEL: buffer_store_wt
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  tt.func @buffer_store_wt(%value: tensor<128xf32, #blocked>, %arg0: !tt.ptr<f32> {tt.divisibility = 16 : i32}, %offset: tensor<128xi32, #blocked> {tt.divisibility = 16 : i32}) {
+    %c256_i32 = arith.constant 256 : i32
+    // .wt store on RDNA3.5: aux = 7 (GLC|SLC|DLC)
+    // CHECK: %[[aux:.*]] = llvm.mlir.constant(7 : i32) : i32
+    // CHECK: rocdl.raw.ptr.buffer.store {{.*}}, {{.*}}, {{.*}}, {{.*}}, %[[aux]]
+    amdg.buffer_store %value, %arg0[%offset] cacheModifier = wt stride = %c256_i32 : tensor<128xf32, #blocked>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -421,7 +421,7 @@ void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
 }
 
 // Create the auxiliary/cachepolicy value of ROCDL::RawPtrBufferLoad/StoreOp
-//   gfx942 and gfx950: bit 0 = sc0, bit 1 = nt, bit 3 = swz, bit 4 = sc1
+//   CDNA3 and CDNA4: bit 0 = sc0, bit 1 = nt, bit 3 = swz, bit 4 = sc1
 // Vector Memory instructions (Flat, Global, Scratch, and Buffer) have 3
 // bits to control scope and cacheability:
 // - SC[1:0] System Cache level: 0=wave, 1=group, 2=device, 3=system
@@ -444,8 +444,8 @@ void llStore(RewriterBase &rewriter, Location loc, Value ptr, Value val,
 //        | N/A |  1  |  0  | x  | Setting sc1 performs a system-scope atomic
 // -------+-----+-----+-----+----+--
 static int32_t
-getCtrlBitsForCacheModifierOnGFX_942_950(triton::CacheModifier cm,
-                                         bool isLoad) {
+getCtrlBitsForCacheModifierOn_CDNA3_CDNA4(triton::CacheModifier cm,
+                                          bool isLoad) {
   const int sc0Bit = 0b1, ntBit = 0b10, sc1Bit = 0b10000;
   int32_t aux = 0;
   switch (cm) {
@@ -477,6 +477,81 @@ getCtrlBitsForCacheModifierOnGFX_942_950(triton::CacheModifier cm,
   return aux;
 }
 
+// Create the auxiliary/cachepolicy value for RDNA3 (and 3.5) buffer ops
+//
+// LLVM CPol bit layout (from SIDefines.h):
+//   bit 0 = GLC  (Graphics L1 cache, GL1)
+//   bit 1 = SLC  (Graphics L2 cache, GL2)
+//   bit 2 = DLC  (Memory-Attached Last-Level cache, MALL)
+//
+// Hardware semantics on RDNA3:
+//   GLC=1  forces MISS_EVICT at GL1 (bypass / invalidate L1 line).
+//   SLC=1  sets GL2 to STREAM (evict-first) policy, limiting L2 pollution.
+//   DLC=1  non-temporal hint for MALL: data is not expected to be reused,
+//          so skip MALL allocation. Ignored if MALL is not present.
+//   DLC=0  temporal (default): allow normal MALL caching.
+//
+// Cache modifier definitions (PTX/Triton semantics):
+//   .ca  Cache at All levels (L1+L2+MALL). Default load policy, LRU eviction.
+//   .cg  Cache at Global level only (L2 and below, bypass L1).
+//   .cs  Cache Streaming, likely accessed once. Evict-first to limit pollution.
+//   .cv  Cache Volatile. Invalidates matching L2 line and re-fetches.
+//   .wb  Write-Back at all cache levels (default store policy).
+//   .wt  Write-Through, writes data directly to system memory.
+//
+// -------+-----+-----+-----+-----+-----------
+// Op     | cm  | DLC | SLC | GLC | aux value
+// -------+-----+-----+-----+-----+-----------
+// Load   | .ca |  0  |  0  |  0  |  0
+//        | .cg |  0  |  0  |  1  |  1
+//        | .cs |  1  |  1  |  1  |  7
+//        | .cv |  1  |  1  |  1  |  7
+// -------+-----+-----+-----+-----+-----------
+// Store  | .wb |  0  |  0  |  0  |  0
+//        | .cg |  0  |  0  |  0  |  0
+//        | .cs |  1  |  1  |  1  |  7
+//        | .wt |  1  |  1  |  1  |  7
+// -------+-----+-----+-----+-----+-----------
+//
+// Condensed hardware behavior:
+//   DLC=0, SLC=0, GLC=0  -> temporal at all levels (MALL+GL2+GL1) (.ca/.wb)
+//   DLC=0, SLC=0, GLC=1  -> bypass GL1, cache in GL2              (.cg load)
+//   DLC=0, SLC=0, GLC=0  -> default (no special flags)            (.cg store)
+//   DLC=1, SLC=1, GLC=1  -> non-temporal: bypass GL1, stream GL2,
+//                           skip MALL                             (.cs/.cv/.wt)
+static int32_t getCtrlBitsForCacheModifierOnRDNA3(triton::CacheModifier cm,
+                                                  bool isLoad) {
+  const int glcBit = 0b1, slcBit = 0b10, dlcBit = 0b100;
+  int32_t aux = 0;
+  switch (cm) {
+  case triton::CacheModifier::CA:
+    aux = 0;
+    break;
+  case triton::CacheModifier::CG:
+    if (isLoad)
+      aux |= glcBit;
+    break;
+  case triton::CacheModifier::CS:
+    aux |= glcBit | slcBit | dlcBit;
+    break;
+  case triton::CacheModifier::CV:
+    assert(isLoad);
+    aux |= glcBit | slcBit | dlcBit;
+    break;
+  case triton::CacheModifier::WB:
+    assert(!isLoad);
+    aux = 0;
+    break;
+  case triton::CacheModifier::WT:
+    assert(!isLoad);
+    aux |= glcBit | slcBit | dlcBit;
+    break;
+  default:
+    aux = 0;
+  }
+  return aux;
+}
+
 static int32_t getDefaultCtrlBitsForCacheModifier(triton::CacheModifier cm) {
   return 0;
 }
@@ -491,10 +566,12 @@ static int32_t getDefaultCtrlBitsForCacheModifier(triton::CacheModifier cm) {
 int32_t getCtrlBitsForCacheModifierOnTarget(
     triton::CacheModifier cm, bool isLoad,
     const mlir::triton::AMD::TargetInfo &targetInfo) {
-  switch (targetInfo.getGPUKind()) {
-  case llvm::AMDGPU::GK_GFX942:
-  case llvm::AMDGPU::GK_GFX950:
-    return getCtrlBitsForCacheModifierOnGFX_942_950(cm, isLoad);
+  switch (targetInfo.getISAFamily()) {
+  case triton::AMD::ISAFamily::CDNA3:
+  case triton::AMD::ISAFamily::CDNA4:
+    return getCtrlBitsForCacheModifierOn_CDNA3_CDNA4(cm, isLoad);
+  case triton::AMD::ISAFamily::RDNA3:
+    return getCtrlBitsForCacheModifierOnRDNA3(cm, isLoad);
   default:
     return getDefaultCtrlBitsForCacheModifier(cm);
   }


### PR DESCRIPTION
## Summary

- Add `getCtrlBitsForCacheModifierOnRDNA3()` which maps Triton cache modifiers to the RDNA3 CPol bit layout (GLC/SLC/DLC), fixing silent no-ops for `.cg`, `.cs`, `.cv`, and `.wt` on gfx1150–gfx1153 targets.
- Switch `getCtrlBitsForCacheModifierOnTarget()` dispatch from individual `GK_GFX*` GPU kinds to `ISAFamily`, so new chips in a family (e.g. CDNA3, CDNA4, RDNA3) are covered automatically without enumerating every GPU kind.
- Add MLIR FileCheck tests at both the LLVM-IR level (`amd-buffer-cache-modifiers-rdna3.mlir`) covering gfx1150 as RDNA3 example.

## Motivation

Buffer cache modifiers (`.cg`, `.cs`, `.cv`, `.wt`) let kernel authors control caching behavior — for example, marking streaming data as non-temporal to avoid polluting caches. On CDNA3/CDNA4 these modifiers were already translated to the correct `cachepolicy` bits, but on RDNA3 the modifier was silently dropped (always `aux=0`). This meant Triton kernels running on RDNA3 hardware could not express non-temporal or write-through semantics, leaving performance on the table for bandwidth-bound workloads.

## RDNA3 Cache Modifier Mapping

| Op    | Modifier | DLC | SLC | GLC | aux | Behavior                                    |
|-------|----------|-----|-----|-----|-----|---------------------------------------------|
| Load  | `.ca`    |  0  |  0  |  0  |  0  | Temporal at all levels (default)            |
| Load  | `.cg`    |  0  |  0  |  1  |  1  | Bypass GL1, cache in GL2                    |
| Load  | `.cs`    |  1  |  1  |  1  |  7  | Non-temporal everywhere, skip MALL          |
| Load  | `.cv`    |  1  |  1  |  1  |  7  | Non-temporal everywhere, skip MALL          |
| Store | `.wb`    |  0  |  0  |  0  |  0  | Write-back at all levels (default)          |
| Store | `.cg`    |  0  |  0  |  0  |  0  | Default (no special flags)                  |
| Store | `.cs`    |  1  |  1  |  1  |  7  | Non-temporal everywhere, skip MALL          |
| Store | `.wt`    |  1  |  1  |  1  |  7  | Write-through, non-temporal, skip MALL      |

## Test Plan

- [x] `amd-buffer-cache-modifiers-rdna3.mlir` — verifies `rocdl.raw.ptr.buffer.load/store` ops get the correct `aux` constant in LLVM dialect for gfx1150–gfx1153.


<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests

- Select one of the following.
  - [x] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
