### PR TITLE
[BACKEND] Don't emit cluster barriers unnecessarily

### DIFF
--- a/lib/Analysis/Utility.cpp
+++ b/lib/Analysis/Utility.cpp
@@ -1328,16 +1328,21 @@ bool isCvtDimSync(const triton::LinearLayout &srcLayout,
   auto *ctx = srcLayout.getInDimNames().begin()->getContext();
   auto kWarp = StringAttr::get(ctx, "warp");
   auto kBlock = StringAttr::get(ctx, "block");
-  assert((dim == kWarp || dim == kBlock) && "expected dim to be warp or block");
   assert(srcLayout.hasInDim(dim) && dstLayout.hasInDim(dim) &&
          "expected dim to be present in both layouts");
-  auto parentTrivial = true;
-  if (dim == kWarp) {
-    parentTrivial = isCvtDimSync(srcLayout, dstLayout, kBlock);
-  }
   auto comp = dstLayout.invertAndCompose(srcLayout);
-  return parentTrivial && comp.isTrivialOver(dim) &&
-         srcLayout.getFreeVariableMasks()[dim] == 0 &&
-         dstLayout.getFreeVariableMasks()[dim] == 0;
+  if (dim == kWarp) {
+    // We check that it's trivial over block and warps and that
+    // there is no broadcasting over warp, as if there is, we'll
+    // deduplicate the writes and the reads will read from data
+    // that other warp has written.
+    auto isBlockSync = isCvtDimSync(srcLayout, dstLayout, kBlock);
+    return isBlockSync && comp.isTrivialOver(dim) &&
+           srcLayout.getFreeVariableMasks()[dim] == 0 &&
+           dstLayout.getFreeVariableMasks()[dim] == 0;
+  } else {
+    assert(dim == kBlock);
+    return comp.isTrivialOver(dim);
+  }
 }
 } // namespace mlir

--- a/test/Conversion/tritongpu_to_llvm.mlir
+++ b/test/Conversion/tritongpu_to_llvm.mlir
@@ -1343,6 +1343,25 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32} {
 
 // -----
 
+#blocked0 = #ttg.blocked<{sizePerThread = [1], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CGALayout = [[0]]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [4], threadsPerWarp = [32], warpsPerCTA = [1], order = [0], CGALayout = [[0]]}>
+module attributes {"ttg.num-ctas" = 2 : i32, "ttg.num-warps" = 1 : i32} {
+  // Broadcast-only CGA bases should not force a cluster barrier.
+  // CHECK-LABEL: convert_blocked_to_blocked_broadcast_cga
+  tt.func @convert_blocked_to_blocked_broadcast_cga(%src: tensor<32xf32, #blocked0>) {
+    // CHECK: llvm.store
+    // CHECK: nvvm.bar.warp.sync
+    // CHECK: llvm.load
+    // CHECK-NOT: nvvm.cluster.arrive
+    // CHECK-NOT: nvvm.cluster.wait
+    // CHECK: llvm.return
+    %cvt = ttg.convert_layout %src : tensor<32xf32, #blocked0> -> tensor<32xf32, #blocked1>
+    tt.return
+  }
+}
+
+// -----
+
 // Regression test for https://github.com/triton-lang/triton/issues/5745
 #linear = #ttg.linear<{register = [[0, 1], [0, 2]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [0, 0]], warp = [[1, 0], [2, 0], [4, 0]], block = []}>
 #linear1 = #ttg.linear<{register = [[0, 2]], lane = [[0, 0], [0, 0], [0, 0], [0, 0], [1, 0]], warp = [[2, 0], [4, 0], [0, 1]], block = []}>


### PR DESCRIPTION
We were emitting cluster barriers when we were broadcasting on the block
dimension, which is a horrible pessimisation.

I also checked and we were not crossing CTAs in local_load/local_stores in this
case so that was not so bad at least.

Closes https://github.com/triton-lang/triton/pull/9737
