### PR TITLE
[AMD] Widen LDS pad interval to bank-wrap boundary

### DIFF
--- a/test/TritonGPU/amd/amd-pipeline-padded-layout-gfx1250.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-padded-layout-gfx1250.mlir
@@ -6,11 +6,11 @@
 
 // ============================================================
 // f16 GEMM: 64x64 tile, 4 warps, WMMA v3
-//   opIdx=0 (non-transposed): pad = 128/16 = 8,  interval = K = 32
-//   opIdx=1 (transposed):     pad = 2*128/16 = 16, interval = N = 64
+//   opIdx=0 (non-transposed): pad = 128/16 = 8,  interval = max(32, 128) = 128
+//   opIdx=1 (transposed):     pad = 2*128/16 = 16, interval = max(64, 128) = 128
 // ============================================================
-// CHECK: #shared = #ttg.padded_shared<[32:+8] {order = [1, 0], shape = [64, 32]}>
-// CHECK: #shared1 = #ttg.padded_shared<[64:+16] {order = [1, 0], shape = [32, 64]}>
+// CHECK: #shared = #ttg.padded_shared<[128:+8] {order = [1, 0], shape = [64, 32]}>
+// CHECK: #shared1 = #ttg.padded_shared<[128:+16] {order = [1, 0], shape = [32, 64]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 32]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
@@ -43,11 +43,11 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
 
 // ============================================================
 // f8E4M3FN GEMM: 64x64 tile, 4 warps, WMMA v3
-//   opIdx=0 (non-transposed): pad = 128/8 = 16,  interval = K = 64
-//   opIdx=1 (transposed):     pad = 2*64/8 = 16, interval = N = 64
+//   opIdx=0 (non-transposed): pad = 128/8 = 16,  interval = max(64, 256) = 256
+//   opIdx=1 (transposed):     pad = 2*64/8 = 16, interval = max(64, 256) = 256
 //   Both operands have same shape and padding → single shared encoding
 // ============================================================
-// CHECK: #shared = #ttg.padded_shared<[64:+16] {order = [1, 0], shape = [64, 64]}>
+// CHECK: #shared = #ttg.padded_shared<[256:+16] {order = [1, 0], shape = [64, 64]}>
 #blocked = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
 #mma = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = [[0, 1], [1, 0]]}, instrShape = [16, 16, 64]}>
 module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {

--- a/test/TritonGPU/amd/amd-pipeline-tdm.mlir
+++ b/test/TritonGPU/amd/amd-pipeline-tdm.mlir
@@ -51,9 +51,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 //   queryLDSTransLoadParams(16) → instBitWidth=128, padAmount = 2*128/16 = 16
 //   innerDimLength = shape[order[0]] = shape[1] = 64 (N dim)
 //   → padded_shared<[64:+16]>
-// CHECK:     #ttg.padded_shared<[32:+8] {
+// CHECK:     #ttg.padded_shared<[128:+8] {
 // CHECK-NOT: #ttg.padded_shared
-// CHECK:     #ttg.padded_shared<[64:+16] {
+// CHECK:     #ttg.padded_shared<[128:+16] {
 // CHECK-NOT: #ttg.padded_shared
 
 // CHECK-LABEL: tt.func @matmul_kernel_make_tensor_descriptor
@@ -81,9 +81,9 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 //   queryLDSTransLoadParams(8) → instBitWidth=64, padAmount = 2*64/8 = 16
 //   innerDimLength = shape[1] = 64 (N dim)
 //   → padded_shared<[64:+16]>
-// CHECK:     #ttg.padded_shared<[64:+16] {
+// CHECK:     #ttg.padded_shared<[256:+16] {
 // CHECK-NOT: #ttg.padded_shared
-// CHECK:     #ttg.padded_shared<[64:+16] {
+// CHECK:     #ttg.padded_shared<[256:+16] {
 // CHECK-NOT: #ttg.padded_shared
 
 #blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [8, 1], order = [1, 0]}>
@@ -146,7 +146,7 @@ module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 8 : i32, ttg.targ
 //   queryLDSTransLoadParams(32) → nullopt, falls back to padAmount = 128/32 = 4
 //   innerDimLength = shape[1] = 64 (N dim)
 //   → padded_shared<[64:+4]>
-// CHECK:     #ttg.padded_shared<[16:+4] {
+// CHECK:     #ttg.padded_shared<[64:+4] {
 // CHECK-NOT: #ttg.padded_shared
 // CHECK:     #ttg.padded_shared<[64:+4] {
 // CHECK-NOT: #ttg.padded_shared

--- a/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/Utility.cpp
@@ -442,10 +442,19 @@ composePaddedLayoutWMMA(int opIdx, unsigned vecWidth,
       padAmount = std::min(vecWidth, padAmount);
   }
 
-  if (padAmount == 0)
+  if (padAmount == 0 || padAmount >= static_cast<unsigned>(innerDimLength))
     return {};
 
-  unsigned padInterval = innerDimLength;
+  // When innerDimLength doesn't span all LDS banks, widen the padding
+  // interval to the bank-wrap boundary so padding is inserted every N
+  // rows instead of every row, at the point where the bank pattern
+  // would repeat.
+  constexpr unsigned ldsNumBanks = 64;
+  constexpr unsigned ldsBankWidthInBytes = 4;
+  unsigned elemBytes = typeWidthInBit / 8;
+  unsigned bankWrapInterval = ldsNumBanks * ldsBankWidthInBytes / elemBytes;
+  unsigned padInterval =
+      std::max(static_cast<unsigned>(innerDimLength), bankWrapInterval);
   auto *context = srcTy.getContext();
   return triton::gpu::PaddedSharedEncodingAttr::get(
       context, {{padInterval, padAmount}}, order, shape, CGALayout);


### PR DESCRIPTION
Set padInterval to `max(innerDimLength, 64*4/elemBytes)` so that padding is inserted at the LDS bank-wrap boundary rather than every row. This avoids unnecessary padding overhead when the inner dimension is smaller than the full bank span.

Also skip padding entirely when padAmount >= innerDimLength.

This is the last PR for LDS padding heuristic, I've verified that the bank conflict count stay the same before and after this PR.