### PR TITLE
[tools] Fix SASS dumps being truncated

### DIFF
--- a/python/test/unit/tools/test_disasm.py
+++ b/python/test/unit/tools/test_disasm.py
@@ -3,6 +3,7 @@ import torch
 import triton
 import pytest
 import triton.language as tl
+import triton.tools.disasm as disasm
 
 
 def test_disam_cubin():
@@ -19,3 +20,27 @@ def test_disam_cubin():
     sass = h.asm["sass"]
     # check that the sass has a store instruction.
     assert "STG.E" in sass
+
+
+def test_extract_handles_large_instruction_offsets(monkeypatch):
+    # cuobjdump widens instruction offsets to 5+ hex digits past 64 KiB.
+    # Make sure the parser keeps consuming instructions instead of stopping at
+    # /*10000*/.
+    def fake_check_output(cmd):
+        assert cmd == ["/fake/cuobjdump", "-sass", "fake.cubin"]
+        return b"""Function : test_kernel
+.headerflags    @"EF_CUDA_SM103 EF_CUDA_PTX_SM(EF_CUDA_SM103)"
+        /*fff0*/                   NOP;                                   /* 0x0000000000007918 */
+                                                                              /* 0x0000000000000000 */
+        /*10000*/                  EXIT;                                  /* 0x000000000000794d */
+                                                                              /* 0x0000000000000000 */
+"""
+
+    monkeypatch.setattr(disasm, "path_to_cuobjdump", lambda: "/fake/cuobjdump")
+    monkeypatch.setattr(disasm.subprocess, "check_output", fake_check_output)
+
+    sass = disasm.extract("fake.cubin", None)
+
+    assert sass.startswith("Function:test_kernel\n")
+    assert "\tNOP;\n" in sass
+    assert "\tEXIT;\n" in sass

--- a/python/triton/tools/disasm.py
+++ b/python/triton/tools/disasm.py
@@ -26,7 +26,7 @@ import re
 import subprocess
 import tempfile
 
-FLINE_RE = re.compile(r'\s*/\*\w{4}\*/\s*([^;]*;)\s*/\* 0x(\w{16}) \*/\s*')
+FLINE_RE = re.compile(r'\s*/\*\w{4,}\*/\s*([^;]*;)\s*/\* 0x(\w{16}) \*/\s*')
 SLINE_RE = re.compile(r'\s*/\* 0x(\w{16}) \*/\s*')
 FNAME_RE = re.compile(r'\s*Function : (\w+)\s*')
 BRA_RE = re.compile(r'(.*BRA(?:\.U)? )(0x\w+);')
@@ -123,6 +123,8 @@ def extract(file_path, fun):
             line_idx += 1
             asm_buffer.append(processSassLines(fline, sline, labels))
             # peek the next line
+            if line_idx >= len(sass_lines):
+                break
             line = sass_lines[line_idx].decode()
         # Print sass
         # label naming convention: LBB#i


### PR DESCRIPTION
The FLINE_RE regex hard codes 4 hex digits, but for large enough files the number of digits increases and this leads to the sass dump being truncated.