### PR TITLE
[AMD] Fix f16 gemm single warp schedule variant regression due to L2 prefetch enablement

### DIFF
--- a/third_party/amd/python/examples/gluon/f16_gemm_common_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_common_gfx1250.py
@@ -139,7 +139,7 @@ def issue_l2_prefetches(distance, producer, a_desc, b_desc, off_am, off_bn, BLOC
     """
     Creates L2 prefetch for iteration `producer + distance`.
     """
-    if distance == 0:
+    if distance <= 0:
         return
 
     prefetch_iteration = producer + distance


### PR DESCRIPTION
Fixes performance regression due to erroneous enablement of L2 prefetch.