### PR TITLE
[GSan] Robustly detect the right C++ stdlib for clang++

### DIFF
--- a/third_party/nvidia/CMakeLists.txt
+++ b/third_party/nvidia/CMakeLists.txt
@@ -31,6 +31,7 @@ if(TRITON_BUILD_PYTHON_MODULE)
   set(GSAN_HOST_GNU_CXX "${CMAKE_CXX_COMPILER}")
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Force g++ to be used for querying -print-file-name on libstdc++.so
+    # clang++ does not print an absolute path in this case.
     find_program(GSAN_HOST_GNU_CXX NAMES g++ c++)
   endif()
   if(GSAN_HOST_GNU_CXX)


### PR DESCRIPTION
Without this, getting an error like

```
fatal error: 'climits' file not found
     41 | #include <climits>
        |          ^~~~~~~~~
  1 error generated when compiling for sm_80.
```

Apparently, the GCC version auto-detected by clang++ did not match the `libstdc++` version installed on my system. 