### PR TITLE
[Hopper] Fix missing negation in WSDataPartition backward slice

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -321,8 +321,8 @@ static bool getBackwardSliceToPartition(Value v,
       partitionScheme.opPartitionDims[ifOp.elseYield()] = currentDim;
       auto thenYieldArg = ifOp.thenYield().getOperand(resultIndex);
       auto elseYieldArg = ifOp.elseYield().getOperand(resultIndex);
-      if (getBackwardSliceToPartition(thenYieldArg, partitionScheme,
-                                      currentDim))
+      if (!getBackwardSliceToPartition(thenYieldArg, partitionScheme,
+                                       currentDim))
         return false;
       if (!getBackwardSliceToPartition(elseYieldArg, partitionScheme,
                                        currentDim))


### PR DESCRIPTION
## Summary
- Fixes a missing `!` negation operator in `getBackwardSliceToPartition` in `WSDataPartition.cpp`
- The condition for `thenYieldArg` of `scf::IfOp` was returning `false` on success instead of failure, making it inconsistent with the `elseYieldArg` check and all other call sites in the file

## Details
In `getBackwardSliceToPartition`, when handling `scf::IfOp`, the recursive call for `thenYieldArg` (line 324) was missing the `!` operator:

```cpp
// Before (bug):
if (getBackwardSliceToPartition(thenYieldArg, partitionScheme, currentDim))
    return false;

// After (fix):
if (!getBackwardSliceToPartition(thenYieldArg, partitionScheme, currentDim))
    return false;