### PR TITLE
[NVIDIA] Add null checks for lookupOrNull in WSDataPartition

### DIFF
--- a/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
+++ b/third_party/nvidia/hopper/lib/Transforms/WarpSpecialization/WSDataPartition.cpp
@@ -867,7 +867,9 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
   } else if (auto tmemLdOp = dyn_cast<nvidia_gpu::TMEMLoadOp>(op)) {
     for (Value operand : op->getOperands())
       sliceOp(operand, offset, mappings, reverseMappings, partitionScheme);
-    auto srcTy = mappings.lookupOrNull(tmemLdOp.getSrc()).getType();
+    auto mappedSrc = mappings.lookupOrNull(tmemLdOp.getSrc());
+    assert(mappedSrc && "expected mapped source for TMEMLoadOp");
+    auto srcTy = mappedSrc.getType();
     auto type = cast<MemDescType>(srcTy);
     auto tmem = cast<nvidia_gpu::TensorMemoryEncodingAttr>(type.getEncoding());
 
@@ -890,7 +892,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     auto newAccType = RankedTensorType::get(shape, oldRetType.getElementType(),
                                             newDistributedEncoding);
     auto ld = builder.createWithAsyncTaskIds<triton::nvidia_gpu::TMEMLoadOp>(
-        op->getLoc(), newAccType, mappings.lookupOrNull(tmemLdOp.getSrc()));
+        op->getLoc(), newAccType, mappedSrc);
 
     auto newType = RankedTensorType::get(shape, oldRetType.getElementType(),
                                          oldRetType.getEncoding());
@@ -907,8 +909,9 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
     // Check for src.
     if (tmemAllocOp.getSrc()) {
       // src is blocked layout. apply convert layout on src
-      auto srcTy = cast<RankedTensorType>(
-          mappings.lookupOrNull(tmemAllocOp.getSrc()).getType());
+      auto mappedSrc = mappings.lookupOrNull(tmemAllocOp.getSrc());
+      assert(mappedSrc && "expected mapped source for TMEMAllocOp");
+      auto srcTy = cast<RankedTensorType>(mappedSrc.getType());
 
       // convert from srcTy to a compatible blocked layout.
       auto retShapePerCTA = getShapePerCTA(srcTy);
@@ -938,8 +941,7 @@ static Operation *sliceOp(Operation *op, int offset, IRMapping &mappings,
       auto newAccType = RankedTensorType::get(
           srcTy.getShape(), srcTy.getElementType(), newDistributedEncoding);
       auto cvtOp = builder.createWithAsyncTaskIds<ConvertLayoutOp>(
-          op->getLoc(), newAccType,
-          mappings.lookupOrNull(tmemAllocOp.getSrc()));
+          op->getLoc(), newAccType, mappedSrc);
 
       // replace tmemAllocOp with alloc, where the src is cvtOp.
       auto alloc =


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
  - [x] This PR does not need a test because it adds defensive assertions
    that enforce an existing invariant. No runtime behavior changes in
    release builds. Existing LIT tests continue to pass.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section.

## Summary

In `sliceOp()`, the TMEMLoadOp branch (line 870) and TMEMAllocOp branch
(line 911) call `.getType()` directly on the result of
`lookupOrNull()` without checking for null. The same file checks for
null on every other `lookupOrNull` call (lines 1111/1114, 1183/1184,
1206).

This change:
- Extracts `lookupOrNull` into `mappedSrc`, adds `assert(mappedSrc && ...)`
- Reuses `mappedSrc` downstream, eliminating redundant duplicate lookups
  (lines 893 and 942 previously called `lookupOrNull` again with the
  same key)
- Follows the same pattern used in the AMD backend
  (`WarpPipeliner.cpp:78`)