### PR TITLE
[AMD] Add shared memory alias/noalias scopes for non-overlapping LDS …

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/TargetInfoBase.h
@@ -52,6 +52,11 @@ public:
                        pred);
   }
 
+  // Called after a shared memory store/load to attach shared memory alias scope
+  // metadata. Default implementation is a no-op; AMD backend overrides this.
+  virtual void annotateSharedMemoryAlias(Operation *llOp,
+                                         Operation *sourceOp) const {};
+
   virtual Value shuffleXor(RewriterBase &rewriter, Location loc, Value val,
                            int i) const = 0;
   virtual Value shuffleUp(RewriterBase &rewriter, Location loc, Value val,

--- a/include/triton/Conversion/TritonGPUToLLVM/Utility.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/Utility.h
@@ -613,15 +613,14 @@ uint32_t applyPadding(uint32_t baseOffset,
 // Lowers to st when valArrays is empty, and to ld when it is not,
 // and returns the output values.
 // `paddingShifts` encodes shared memory padding if any.
-SmallVector<Value>
-lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
-                ArrayRef<Value> valsArray, // Input for store, output for load
-                Type llvmElemTy, ArrayRef<Value> smemBases,
-                ArrayRef<std::pair<unsigned, unsigned>> paddingShifts,
-                Value affineOffset, uint64_t maskSpanAffineOffset,
-                RewriterBase &rewriter, const TargetInfoBase &targetInfo,
-                std::optional<int> maybeMaxVecElems = {},
-                Operation *localLoadOp = nullptr);
+SmallVector<Value> lowerLdStShared(
+    Location loc, MLIRContext *ctx, LinearLayout cvt,
+    ArrayRef<Value> valsArray, // Input for store, output for load
+    Type llvmElemTy, ArrayRef<Value> smemBases,
+    ArrayRef<std::pair<unsigned, unsigned>> paddingShifts, Value affineOffset,
+    uint64_t maskSpanAffineOffset, RewriterBase &rewriter,
+    const TargetInfoBase &targetInfo, std::optional<int> maybeMaxVecElems = {},
+    Operation *localLoadOp = nullptr, Operation *aliasScopeSourceOp = nullptr);
 
 // Lower an ld/st-like operation given a layout and a callback that creates the
 // PTX instruction Lowers to st when valArrays is empty, and to ld when it is
@@ -644,14 +643,13 @@ lowerLdSt(Location loc, MLIRContext *ctx, LinearLayout cvt,
               lowerInst);
 
 // Lower local_load/local_store via ld.shared/st.shared
-SmallVector<Value>
-lowerLocalLdSt(Location loc, MLIRContext *ctx,
-               LinearLayout cvt,          // Map from registers to offset
-               ArrayRef<Value> valsArray, // Input for store, empty for load
-               Type llvmElemTy, triton::gpu::MemDescType srcTy,
-               SharedMemoryObject smemObj, RewriterBase &rewriter,
-               const TargetInfoBase &targetInfo,
-               Operation *localLoadOp = nullptr);
+SmallVector<Value> lowerLocalLdSt(
+    Location loc, MLIRContext *ctx,
+    LinearLayout cvt,          // Map from registers to offset
+    ArrayRef<Value> valsArray, // Input for store, empty for load
+    Type llvmElemTy, triton::gpu::MemDescType srcTy, SharedMemoryObject smemObj,
+    RewriterBase &rewriter, const TargetInfoBase &targetInfo,
+    Operation *localLoadOp = nullptr, Operation *aliasScopeSourceOp = nullptr);
 
 SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
                                     RewriterBase &rewriter);

--- a/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ConvertLayoutOpToLLVM.cpp
@@ -109,7 +109,8 @@ struct ConvertLayoutOpConversion
   SmallVector<Value> transferSwizzlingLocalMemImpl(
       Location loc, ConversionPatternRewriter &rewriter,
       const LinearLayout &srcLayout, const LinearLayout &dstLayout,
-      ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase) const {
+      ArrayRef<Value> inVals, Type llvmElemTy, Value smemBase,
+      Operation *aliasScopeSourceOp = nullptr) const {
     auto *ctx = rewriter.getContext();
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     // We handle transformations recursively as they all need a preprocessing
@@ -121,9 +122,9 @@ struct ConvertLayoutOpConversion
       auto newInVals = llvm::to_vector(llvm::map_range(inVals, [&](Value v) {
         return b.ptrtoint(llvmElemTyPtr, v).getResult();
       }));
-      auto outVals =
-          transferSwizzlingLocalMemImpl(loc, rewriter, srcLayout, dstLayout,
-                                        newInVals, llvmElemTyPtr, smemBase);
+      auto outVals = transferSwizzlingLocalMemImpl(
+          loc, rewriter, srcLayout, dstLayout, newInVals, llvmElemTyPtr,
+          smemBase, aliasScopeSourceOp);
       for (auto &v : outVals) {
         v = b.inttoptr(llvmElemTy, v);
       }
@@ -137,7 +138,8 @@ struct ConvertLayoutOpConversion
       auto newInVals = llvm::to_vector(llvm::map_range(
           inVals, [&](Value v) { return b.zext(i8ElemTy, v).getResult(); }));
       auto outVals = transferSwizzlingLocalMemImpl(
-          loc, rewriter, srcLayout, dstLayout, newInVals, i8ElemTy, smemBase);
+          loc, rewriter, srcLayout, dstLayout, newInVals, i8ElemTy, smemBase,
+          aliasScopeSourceOp);
       for (auto &v : outVals) {
         v = b.trunc(llvmElemTy, v);
       }
@@ -150,7 +152,8 @@ struct ConvertLayoutOpConversion
       auto prmtSrc = removeBroadcastSrc.apply(srcLayout);
       auto newInVals = removeBroadcastSrc.apply(inVals);
       return transferSwizzlingLocalMemImpl(loc, rewriter, prmtSrc, dstLayout,
-                                           newInVals, llvmElemTy, smemBase);
+                                           newInVals, llvmElemTy, smemBase,
+                                           aliasScopeSourceOp);
     }
 
     // Remove broadcasting in dst
@@ -158,7 +161,8 @@ struct ConvertLayoutOpConversion
     if (!removeBroadcastDst.isIdentity()) {
       auto prmtDst = removeBroadcastDst.apply(dstLayout);
       auto outVals = transferSwizzlingLocalMemImpl(
-          loc, rewriter, srcLayout, prmtDst, inVals, llvmElemTy, smemBase);
+          loc, rewriter, srcLayout, prmtDst, inVals, llvmElemTy, smemBase,
+          aliasScopeSourceOp);
       return broadcastAs(outVals, dstLayout);
     }
 
@@ -225,12 +229,14 @@ struct ConvertLayoutOpConversion
       // Store
       lowerLdStShared(loc, ctx, storeCvt, tileInVals, llvmElemTy, smemBase,
                       /*paddingShifts=*/{}, affineOffset, maskSpanAffineOffset,
-                      rewriter, targetInfo);
+                      rewriter, targetInfo, /*maybeMaxVecElems=*/{},
+                      /*localLoadOp=*/nullptr, aliasScopeSourceOp);
       emitBarrier();
       // Load
       auto tileOutVals = lowerLdStShared(
           loc, ctx, loadCvt, {}, llvmElemTy, smemBase, /*paddingShifts=*/{},
-          affineOffset, maskSpanAffineOffset, rewriter, targetInfo);
+          affineOffset, maskSpanAffineOffset, rewriter, targetInfo,
+          /*maybeMaxVecElems=*/{}, /*localLoadOp=*/nullptr, aliasScopeSourceOp);
       llvm::append_range(outVals, tileOutVals);
     }
 
@@ -253,8 +259,9 @@ struct ConvertLayoutOpConversion
     auto smemBase =
         LLVM::getSharedMemoryBase(loc, rewriter, targetInfo, op.getOperation());
     auto inVals = unpackLLElements(loc, src, rewriter);
-    auto outVals = transferSwizzlingLocalMemImpl(
-        loc, rewriter, srcLayout, dstLayout, inVals, llvmElemTy, smemBase);
+    auto outVals = transferSwizzlingLocalMemImpl(loc, rewriter, srcLayout,
+                                                 dstLayout, inVals, llvmElemTy,
+                                                 smemBase, op.getOperation());
 
     Value result =
         packLLElements(loc, getTypeConverter(), outVals, rewriter, dstTy);

--- a/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/MemoryOpToLLVM.cpp
@@ -124,7 +124,8 @@ LogicalResult lowerLocalStore(Location loc, MLIRContext *ctx, Value regVal,
                               ArrayRef<Value> inVals,
                               const LLVMTypeConverter *typeConverter,
                               ConversionPatternRewriter &rewriter,
-                              const TargetInfoBase &targetInfo) {
+                              const TargetInfoBase &targetInfo,
+                              Operation *aliasScopeSourceOp = nullptr) {
   auto regTy = cast<RankedTensorType>(regVal.getType());
   auto llvmElemTy = typeConverter->convertType(memDescTy.getElementType());
 
@@ -140,7 +141,8 @@ LogicalResult lowerLocalStore(Location loc, MLIRContext *ctx, Value regVal,
     return failure();
   }
   lowerLocalLdSt(loc, ctx, cvt, inVals, llvmElemTy, memDescTy, smemObj,
-                 rewriter, targetInfo);
+                 rewriter, targetInfo, /*localLoadOp=*/nullptr,
+                 aliasScopeSourceOp);
 
   return success();
 }
@@ -210,8 +212,8 @@ struct LocalAllocOpConversion
       auto *ctx = op.getContext();
       auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
       if (failed(lowerLocalStore(loc, ctx, op.getSrc(), memDescTy, smemObj,
-                                 inVals, typeConverter, rewriter,
-                                 targetInfo))) {
+                                 inVals, typeConverter, rewriter, targetInfo,
+                                 op.getOperation()))) {
         return failure();
       }
     }
@@ -272,8 +274,9 @@ public:
       return failure();
     }
 
-    auto outVals = lowerLocalLdSt(loc, ctx, cvt, {}, llvmElemTy, memDescTy,
-                                  smemObj, rewriter, targetInfo, op);
+    auto outVals =
+        lowerLocalLdSt(loc, ctx, cvt, {}, llvmElemTy, memDescTy, smemObj,
+                       rewriter, targetInfo, op, op.getOperation());
 
     Value result = packLLElements(loc, typeConverter, outVals, rewriter, regTy);
     rewriter.replaceOp(op, result);
@@ -311,7 +314,8 @@ public:
                                                          llvmElemTy, rewriter);
     auto inVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
     if (failed(lowerLocalStore(loc, ctx, regVal, memDescTy, smemObj, inVals,
-                               typeConverter, rewriter, targetInfo))) {
+                               typeConverter, rewriter, targetInfo,
+                               op.getOperation()))) {
       return failure();
     }
 

--- a/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/ReduceOpToLLVM.cpp
@@ -422,6 +422,11 @@ private:
           triton::gpu::ConvertLayoutOp::create(rewriter, loc, dstTy, srcTensor);
       cvt->setAttr("allocation.offset",
                    IntegerAttr::get(offsetTy, baseOffset + smemBaseOffsets[i]));
+      // Propagate alias scope info from the reduce op to the inner cvt
+      if (auto scopeId = op->getAttr("allocation.scope"))
+        cvt->setAttr("allocation.scope", scopeId);
+      if (auto noalias = op->getAttr("allocation.scope.noalias"))
+        cvt->setAttr("allocation.scope.noalias", noalias);
       Type packedDstTy = getTypeConverter()->convertType(dstTy);
       auto packedDst = UnrealizedConversionCastOp::create(
                            rewriter, loc, packedDstTy, cvt.getResult())

--- a/lib/Conversion/TritonGPUToLLVM/Utility.cpp
+++ b/lib/Conversion/TritonGPUToLLVM/Utility.cpp
@@ -586,7 +586,8 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
                 ArrayRef<std::pair<unsigned, unsigned>> paddingShifts,
                 Value affineOffset, uint64_t maskSpanAffineOffset,
                 RewriterBase &rewriter, const TargetInfoBase &targetInfo,
-                std::optional<int> maybeMaxVecElems, Operation *localLoadOp) {
+                std::optional<int> maybeMaxVecElems, Operation *localLoadOp,
+                Operation *aliasScopeSourceOp) {
 
   bool isStore = !valsArray.empty();
   auto b = TritonLLVMOpBuilder(loc, rewriter);
@@ -601,12 +602,23 @@ lowerLdStShared(Location loc, MLIRContext *ctx, LinearLayout cvt,
           packLLVector(loc, ArrayRef<Value>(vals).slice(idx, length), rewriter);
       targetInfo.storeDShared(rewriter, loc, shmemAddr, ctaId, valsVec,
                               /*pred=*/b.true_val());
+      // Propagate shared memory alias scope attrs to the just-created op so
+      // that downstream lowering (e.g. MaskedOpsToLLVM) can emit LLVM metadata
+      if (aliasScopeSourceOp) {
+        auto *lastOp = &*std::prev(rewriter.getInsertionPoint());
+        targetInfo.annotateSharedMemoryAlias(lastOp, aliasScopeSourceOp);
+      }
       return {};
     } else {
       assert(vals.empty());
       Value valsVec =
           targetInfo.loadDShared(rewriter, loc, shmemAddr, ctaId, vecTy,
                                  /*pred=*/b.true_val(), localLoadOp);
+      // Propagate shared memory alias scope attrs to the just-created op
+      if (aliasScopeSourceOp) {
+        auto *lastOp = &*std::prev(rewriter.getInsertionPoint());
+        targetInfo.annotateSharedMemoryAlias(lastOp, aliasScopeSourceOp);
+      }
       return unpackLLVector(loc, valsVec, rewriter);
     }
   };
@@ -799,7 +811,8 @@ lowerLocalLdSt(Location loc, MLIRContext *ctx,
                ArrayRef<Value> valsArray, // Input for store, empty for load
                Type llvmElemTy, triton::gpu::MemDescType srcTy,
                SharedMemoryObject smemObj, RewriterBase &rewriter,
-               const TargetInfoBase &targetInfo, Operation *localLoadOp) {
+               const TargetInfoBase &targetInfo, Operation *localLoadOp,
+               Operation *aliasScopeSourceOp) {
 
   auto isStore = !valsArray.empty();
   // Remove broadcasting in the registers
@@ -810,8 +823,9 @@ lowerLocalLdSt(Location loc, MLIRContext *ctx,
     if (isStore) {
       inVals = removeBroadcastSrc.apply(inVals);
     }
-    auto outVals = lowerLocalLdSt(loc, ctx, prmtCvt, inVals, llvmElemTy, srcTy,
-                                  smemObj, rewriter, targetInfo, localLoadOp);
+    auto outVals =
+        lowerLocalLdSt(loc, ctx, prmtCvt, inVals, llvmElemTy, srcTy, smemObj,
+                       rewriter, targetInfo, localLoadOp, aliasScopeSourceOp);
     if (!isStore) {
       outVals = broadcastAs(outVals, cvt);
     }
@@ -838,7 +852,8 @@ lowerLocalLdSt(Location loc, MLIRContext *ctx,
                                smemObj.getBases().end());
   return lowerLdStShared(loc, ctx, cvt, valsArray, llvmElemTy, smemBases,
                          paddingShifts, affineOffset, maskSpanAffineOffset,
-                         rewriter, targetInfo, maybeMaxVecElems, localLoadOp);
+                         rewriter, targetInfo, maybeMaxVecElems, localLoadOp,
+                         aliasScopeSourceOp);
 }
 
 SmallVector<Value> unpackLLElements(Location loc, Value llvmStruct,
@@ -1859,6 +1874,9 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
         packLLVector(loc, ArrayRef<Value>(vals).slice(idx, length), rewriter);
     targetInfo.storeDShared(rewriter, loc, shmemAddr, ctaId, valsVec,
                             threadPred);
+    // Annotate the just-created store with shared memory alias scope info
+    auto *lastOp = &*std::prev(rewriter.getInsertionPoint());
+    targetInfo.annotateSharedMemoryAlias(lastOp, op);
     return {};
   };
 
@@ -1867,6 +1885,9 @@ void finalizeTensorAtomicResults(Operation *op, RankedTensorType tensorTy,
                     std::optional<Value> ctaId) -> SmallVector<Value> {
     Value loadedVec = targetInfo.loadDShared(rewriter, loc, shmemAddr, ctaId,
                                              vecTy, b.true_val());
+    // Annotate the just-created load with shared memory alias scope info
+    auto *lastOp = &*std::prev(rewriter.getInsertionPoint());
+    targetInfo.annotateSharedMemoryAlias(lastOp, op);
     return unpackLLVector(loc, loadedVec, rewriter);
   };
 

--- a/test/Conversion/amd/allocate_shared_memory.mlir
+++ b/test/Conversion/amd/allocate_shared_memory.mlir
@@ -69,3 +69,48 @@ tt.func @ws_tensordesc_5d_capture(%desc: !tt.tensordesc<tensor<8x8x8x16x16xf16>>
 }
 
 }
+
+// -----
+
+// Test that allocation.scope and allocation.scope.noalias attrs are set on ops
+// with two non-overlapping LDS buffers.
+
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+#shared3 = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
+#smem3 = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+
+// CHECK-LABEL: @two_lds_buffers_alias_scope
+tt.func @two_lds_buffers_alias_scope(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+  %cst_a = arith.constant dense<0.0> : tensor<64x1xf16, #blocked3>
+  %cst_b = arith.constant dense<0.0> : tensor<64x1xf16, #blocked3>
+
+  // CHECK: ttg.local_alloc
+  // CHECK-SAME: allocation.scope = 0 : i32
+  // CHECK-SAME: allocation.scope.noalias = [1 : i32]
+  %alloc_a = ttg.local_alloc %cst_a : (tensor<64x1xf16, #blocked3>) -> !ttg.memdesc<64x1xf16, #shared3, #smem3>
+
+  // CHECK: ttg.local_alloc
+  // CHECK-SAME: allocation.scope = 1 : i32
+  // CHECK-SAME: allocation.scope.noalias = [0 : i32]
+  %alloc_b = ttg.local_alloc %cst_b : (tensor<64x1xf16, #blocked3>) -> !ttg.memdesc<64x1xf16, #shared3, #smem3>
+
+  // CHECK: ttg.local_load
+  // CHECK-SAME: allocation.scope = 0 : i32
+  // CHECK-SAME: allocation.scope.noalias = [1 : i32]
+  %load_a = ttg.local_load %alloc_a : !ttg.memdesc<64x1xf16, #shared3, #smem3> -> tensor<64x1xf16, #blocked3>
+
+  // CHECK: ttg.local_load
+  // CHECK-SAME: allocation.scope = 1 : i32
+  // CHECK-SAME: allocation.scope.noalias = [0 : i32]
+  %load_b = ttg.local_load %alloc_b : !ttg.memdesc<64x1xf16, #shared3, #smem3> -> tensor<64x1xf16, #blocked3>
+
+  // Stores to keep the local_loads alive
+  %ptr = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked3>
+  tt.store %ptr, %load_a : tensor<64x1x!tt.ptr<f16>, #blocked3>
+  tt.store %ptr, %load_b : tensor<64x1x!tt.ptr<f16>, #blocked3>
+  tt.return
+}
+
+}

--- a/test/Conversion/amd/lds-alias-scopes.mlir
+++ b/test/Conversion/amd/lds-alias-scopes.mlir
@@ -1,0 +1,43 @@
+// RUN: triton-opt %s -split-input-file --allocate-amdgpu-shared-memory --convert-triton-amdgpu-to-llvm=arch=gfx950 | FileCheck %s
+
+// Test that the amdg.lds domain alias scopes are correctly propagated to
+// lowered LLVM ops when two non-overlapping LDS buffers exist.
+
+// CHECK-DAG: [[$LDS_SCOPE_0:#.*]] = #llvm.alias_scope<id = "triton.lds.buffer.0"
+// CHECK-DAG: [[$LDS_SCOPE_1:#.*]] = #llvm.alias_scope<id = "triton.lds.buffer.1"
+#blocked = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [64, 1], warpsPerCTA = [1, 1], order = [0, 1]}>
+#shared = #ttg.swizzled_shared<{vec = 8, perPhase = 8, maxPhase = 2, order = [0, 1]}>
+#smem = #ttg.shared_memory
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx950", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: @two_lds_buffers_alias_scopes
+  tt.func public @two_lds_buffers_alias_scopes(%arg0: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}) {
+    %cst_a = arith.constant dense<0.0> : tensor<64x1xf16, #blocked>
+    %cst_b = arith.constant dense<0.0> : tensor<64x1xf16, #blocked>
+
+    %alloc_a = ttg.local_alloc %cst_a : (tensor<64x1xf16, #blocked>) -> !ttg.memdesc<64x1xf16, #shared, #smem>
+    %alloc_b = ttg.local_alloc %cst_b : (tensor<64x1xf16, #blocked>) -> !ttg.memdesc<64x1xf16, #shared, #smem>
+
+    // Stores to LDS for buffer A get scope 0, noalias scope 1
+    // CHECK: llvm.store {{.*}} {alias_scopes = {{.*}}[[$LDS_SCOPE_0]]{{.*}}, {{.*}}noalias_scopes = {{.*}}[[$LDS_SCOPE_1]]
+    // Stores to LDS for buffer B get scope 1, noalias scope 0
+    // CHECK: llvm.store {{.*}} {alias_scopes = {{.*}}[[$LDS_SCOPE_1]]{{.*}}, {{.*}}noalias_scopes = {{.*}}[[$LDS_SCOPE_0]]
+
+    // Loads from buffer A get scope 0, noalias scope 1
+    // CHECK: llvm.load {{.*}} {alias_scopes = {{.*}}[[$LDS_SCOPE_0]]{{.*}}, noalias_scopes = {{.*}}[[$LDS_SCOPE_1]]
+    %load_a = ttg.local_load %alloc_a : !ttg.memdesc<64x1xf16, #shared, #smem> -> tensor<64x1xf16, #blocked>
+
+    // Loads from buffer B get scope 1, noalias scope 0
+    // CHECK: llvm.load {{.*}} {alias_scopes = {{.*}}[[$LDS_SCOPE_1]]{{.*}}, noalias_scopes = {{.*}}[[$LDS_SCOPE_0]]
+    %load_b = ttg.local_load %alloc_b : !ttg.memdesc<64x1xf16, #shared, #smem> -> tensor<64x1xf16, #blocked>
+
+    // Global stores should NOT have LDS alias scopes
+    // CHECK: llvm.store {{.*}} !llvm.ptr<1>
+    // CHECK-NOT: alias_scopes
+    %ptr = tt.splat %arg0 : !tt.ptr<f16> -> tensor<64x1x!tt.ptr<f16>, #blocked>
+    tt.store %ptr, %load_a : tensor<64x1x!tt.ptr<f16>, #blocked>
+    tt.store %ptr, %load_b : tensor<64x1x!tt.ptr<f16>, #blocked>
+
+    // CHECK: llvm.return
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/AllocateSharedMemory.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/AllocateSharedMemory.cpp
@@ -17,6 +17,86 @@ namespace mlir::triton {
 
 namespace {
 
+// Collect all buffer IDs of an op which will access shared memory.
+static SmallVector<Allocation::BufferId>
+getBufferIds(const Allocation *funcAllocation, Operation *op) {
+  DenseSet<Allocation::BufferId> idSet;
+  auto scratchId = funcAllocation->getBufferId(op);
+  if (scratchId != Allocation::InvalidBufferId)
+    idSet.insert(scratchId);
+  // For ops that read/write shared memory (local_alloc, local_load,
+  // local_store, buffer_load_to_local, etc.), collect buffer IDs from
+  // the associated values.
+  if (auto memEffects = dyn_cast<MemoryEffectOpInterface>(op)) {
+    SmallVector<SideEffects::EffectInstance<MemoryEffects::Effect>> effects;
+    memEffects.getEffects(effects);
+    for (auto &effect : effects) {
+      if (effect.getResource() != triton::gpu::SharedMemory::get())
+        continue;
+      if (auto value = effect.getValue()) {
+        for (auto id : funcAllocation->getAllBufferIdsWithAliases(value))
+          idSet.insert(id);
+      }
+    }
+  }
+  return SmallVector<Allocation::BufferId>(idSet.begin(), idSet.end());
+}
+
+// Annotate LDS-accessing ops with alias scope information derived from
+// AllocationAnalysis buffer allocated address ranges [offset, offset+size).
+// Each buffer gets a unique scope ID, and ops are annotated with the set of
+// non-overlapping buffer IDs (noalias).
+static void attachAliasScopeInfo(ModuleOp mod, ModuleAllocation &allocation) {
+  MLIRContext *ctx = mod.getContext();
+  auto i32Ty = IntegerType::get(ctx, 32);
+
+  mod.walk<mlir::WalkOrder::PreOrder>([&](FunctionOpInterface funcOp) {
+    auto *funcAllocation = allocation.getFuncData(funcOp);
+
+    // Walk ops once to collect op -> bufferId mapping
+    SmallVector<std::pair<Operation *, Allocation::BufferId>> opBufferIds;
+    DenseMap<Allocation::BufferId, Interval<size_t>> bufferIntervals;
+    funcOp.walk([&](Operation *op) {
+      auto ids = getBufferIds(funcAllocation, op);
+      // Skip ops with no buffers or partitioned tensors (multiple IDs)
+      if (ids.size() != 1)
+        return;
+      auto id = ids[0];
+      opBufferIds.push_back({op, id});
+      bufferIntervals.try_emplace(id, funcAllocation->getAllocatedInterval(id));
+    });
+
+    // Need at least 2 buffers to have meaningful noalias info
+    if (bufferIntervals.size() <= 1)
+      return WalkResult::skip();
+
+    // Compute noalias sets: two buffers are non-aliasing iff their allocated
+    // address ranges [offset, offset+size) are disjoint
+    DenseMap<Allocation::BufferId, SmallVector<Attribute>> noaliasMap;
+    for (auto &[id1, interval1] : bufferIntervals) {
+      SmallVector<Attribute> noaliasAttrs;
+      for (auto &[id2, interval2] : bufferIntervals) {
+        if (id1 != id2 && !interval1.intersects(interval2))
+          noaliasAttrs.push_back(
+              IntegerAttr::get(i32Ty, static_cast<int64_t>(id2)));
+      }
+      noaliasMap[id1] = std::move(noaliasAttrs);
+    }
+
+    // Annotate ops with scopeId and noalias
+    for (auto &[op, id] : opBufferIds) {
+      op->setAttr("allocation.scope",
+                  IntegerAttr::get(i32Ty, static_cast<int64_t>(id)));
+      auto &noaliasAttrs = noaliasMap[id];
+      if (!noaliasAttrs.empty())
+        op->setAttr("allocation.scope.noalias",
+                    ArrayAttr::get(ctx, noaliasAttrs));
+    }
+
+    return WalkResult::skip();
+  });
+}
+
 struct AllocateAMDGPUSharedMemory
     : public mlir::triton::impl::AllocateAMDGPUSharedMemoryBase<
           AllocateAMDGPUSharedMemory> {
@@ -34,6 +114,7 @@ struct AllocateAMDGPUSharedMemory
                                 partitionSize);
 
     mlir::triton::gpu::attachAllocationSizeAndOffsetAttr(mod, allocation);
+    attachAliasScopeInfo(mod, allocation);
   }
 };
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -827,6 +827,8 @@ struct BufferLoadToLocalOpConversion
           hasOther ? b.true_val() : maybeSwizzledMaskElem, op.getCache());
       if (targetInfo.requiresAliasInfoForAsyncOps())
         AMD::addAsyncCopyAliasScope(bufferLoadToLds);
+      // Merge shared memory alias scope from allocation analysis
+      targetInfo.annotateSharedMemoryAlias(bufferLoadToLds, op);
 
       if (hasOther) {
         emitOtherStore(rewriter, loc, this->getTypeConverter(), vecTy, maskElem,
@@ -963,9 +965,9 @@ struct AsyncCopyGlobalToLocalOpConversion
         Value outOfRangeAddress =
             b.inttoptr(shmemAddr.getType(), b.i32_val(0x7FFFFFFF));
         Value predicatedAddress = b.select(cond, shmemAddr, outOfRangeAddress);
-
         emitAsyncLoad(rewriter, loc, targetInfo, vecBits, srcElem,
-                      predicatedAddress, op.getCache(), multicastMask);
+                      predicatedAddress, op.getCache(), multicastMask,
+                      op.getOperation());
       } else {
         // For architectures not supporting per lane LDS addresses we need to
         // emit a branch
@@ -1004,7 +1006,8 @@ struct AsyncCopyGlobalToLocalOpConversion
   void emitAsyncLoad(RewriterBase &rewriter, Location loc,
                      AMD::TargetInfo targetInfo, int vecBits, Value srcPtr,
                      Value shmemAddr, triton::CacheModifier cacheMod,
-                     Value multicastMask) const {
+                     Value multicastMask,
+                     Operation *aliasScopeSourceOp = nullptr) const {
     auto b = TritonLLVMOpBuilder(loc, rewriter);
     int32_t cacheModifiers =
         mlir::LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
@@ -1017,6 +1020,10 @@ struct AsyncCopyGlobalToLocalOpConversion
           /*offset=*/0, cacheModifiers, nullptr, nullptr, nullptr);
       if (targetInfo.requiresAliasInfoForAsyncOps())
         AMD::addAsyncCopyAliasScope(globalLoadLdsOp);
+      // Merge shared memory alias scope from allocation analysis
+      if (aliasScopeSourceOp)
+        targetInfo.annotateSharedMemoryAlias(globalLoadLdsOp,
+                                             aliasScopeSourceOp);
     } else if (targetInfo.getISAFamily() == ISAFamily::GFX1250) {
       if (cacheMod != triton::CacheModifier::NONE) {
         emitRemark(loc) << "cache modifiers not yet implemented on gfx1250";

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
@@ -75,6 +75,8 @@ public:
       if (loadOp.getForceNoAlias()) {
         AMD::addLocalLoadNoAliasScope(load);
       }
+      // Propagate shared memory alias scope metadata from the MaskedLoadOp
+      targetInfo.annotateSharedMemoryAlias(load, loadOp);
       return load;
     };
 
@@ -116,7 +118,8 @@ private:
 class ConvertMaskedStoreOp
     : public OpRewritePattern<triton::amdgpu::MaskedStoreOp> {
 public:
-  using OpRewritePattern::OpRewritePattern;
+  ConvertMaskedStoreOp(MLIRContext *context, const AMD::TargetInfo &targetInfo)
+      : OpRewritePattern(context), targetInfo(targetInfo) {}
 
   LogicalResult matchAndRewrite(triton::amdgpu::MaskedStoreOp storeOp,
                                 PatternRewriter &rewriter) const override {
@@ -145,6 +148,8 @@ public:
       if (storeOp.getForceNoAlias()) {
         AMD::addLocalLoadNoAliasScope(store);
       }
+      // Propagate shared memory alias scope metadata from the MaskedStoreOp
+      targetInfo.annotateSharedMemoryAlias(store, storeOp);
       return store;
     };
 
@@ -173,6 +178,9 @@ public:
     rewriter.eraseOp(storeOp);
     return success();
   }
+
+private:
+  const AMD::TargetInfo &targetInfo;
 };
 
 } // namespace
@@ -182,7 +190,7 @@ namespace mlir::triton::AMD {
 void populateMaskedOpsToLLVMPatterns(RewritePatternSet &patterns,
                                      const TargetInfo &targetInfo) {
   patterns.add<ConvertMaskedLoadOp>(patterns.getContext(), targetInfo);
-  patterns.add<ConvertMaskedStoreOp>(patterns.getContext());
+  patterns.add<ConvertMaskedStoreOp>(patterns.getContext(), targetInfo);
 }
 } // namespace mlir::triton::AMD
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MemoryOpToLLVM.cpp
@@ -263,11 +263,12 @@ private:
       default:
         return {};
       }
-      // GFX1250 is currently using LLVM intrinsics so it cannot cast it to
-      // AliasAnalysisOpInterface
-      if (targetInfo.getISAFamily() != AMD::ISAFamily::GFX1250)
+      if (targetInfo.getISAFamily() != AMD::ISAFamily::GFX1250) {
         AMD::addLocalLoadNoAliasScope(
             op, cast<LLVM::AliasAnalysisOpInterface>(dsReadTr.getDefiningOp()));
+        // Propagate shared memory alias scope metadata
+        targetInfo.annotateSharedMemoryAlias(dsReadTr.getDefiningOp(), op);
+      }
       Value vecVal = b.bitcast(dsReadTr, vTy);
       SmallVector<Value> loadedVals;
       for (int v = 0; v < vTy.getNumElements(); v++) {
@@ -425,6 +426,8 @@ private:
       auto vTyI32 = VectorType::get(numElemsI32, i32_ty);
       Value dsReadTr =
           ROCDL::ds_read_tr4_b64::create(rewriter, loc, vTyI32, vecAddr);
+      // Propagate shared memory alias scope metadata
+      targetInfo.annotateSharedMemoryAlias(dsReadTr.getDefiningOp(), op);
       Value vecVal = b.bitcast(dsReadTr, vTy);
       SmallVector<Value> loadedVals;
       for (int v = 0; v < vTy.getNumElements(); v++) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -802,6 +802,85 @@ void TargetInfo::localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
                                        Operation *llLoadOp) const {
   if (requiresAliasInfoForAsyncOps())
     AMD::addLocalLoadNoAliasScope(localLoadOp, cast<LLVM::LoadOp>(llLoadOp));
+  // Merge shared memory alias scope from allocation analysis
+  annotateSharedMemoryAlias(llLoadOp, localLoadOp);
+}
+
+namespace {
+LLVM::AliasScopeDomainAttr getLdsScopeDomain(MLIRContext *ctx) {
+  Builder b(ctx);
+  return b.getAttr<LLVM::AliasScopeDomainAttr>(
+      b.getStringAttr("triton.lds"),
+      b.getStringAttr("Domain for LDS(shared memory) alias scopes"));
+}
+
+LLVM::AliasScopeAttr getSharedMemoryScopeAttr(MLIRContext *ctx,
+                                              int64_t bufferId) {
+  Builder b(ctx);
+  auto name = b.getStringAttr("triton.lds.buffer." + std::to_string(bufferId));
+  auto desc =
+      b.getStringAttr("Scope for LDS buffer " + std::to_string(bufferId));
+  return b.getAttr<LLVM::AliasScopeAttr>(name, getLdsScopeDomain(ctx), desc);
+}
+
+void addSharedMemoryAliasScope(Operation *sourceOp,
+                               LLVM::AliasAnalysisOpInterface llOp) {
+  if (!sourceOp)
+    return;
+  auto scopeIdAttr = sourceOp->getAttrOfType<IntegerAttr>("allocation.scope");
+  if (!scopeIdAttr)
+    return;
+
+  auto ctx = llOp->getContext();
+  int64_t scopeId = scopeIdAttr.getValue().getSExtValue();
+
+  // Build alias scope: this op belongs to buffer <scopeId>
+  auto bufferScope = getSharedMemoryScopeAttr(ctx, scopeId);
+
+  // Merge with any existing alias scopes on llOp
+  SmallVector<Attribute> aliasScopes;
+  if (auto existing = llOp.getAliasScopesOrNull()) {
+    for (auto attr : existing)
+      aliasScopes.push_back(attr);
+  }
+  aliasScopes.push_back(bufferScope);
+  llOp.setAliasScopes(ArrayAttr::get(ctx, aliasScopes));
+
+  // Build noalias: this op does not alias with non-overlapping buffers
+  auto noaliasArrayAttr =
+      sourceOp->getAttrOfType<ArrayAttr>("allocation.scope.noalias");
+  if (!noaliasArrayAttr)
+    return;
+
+  SmallVector<Attribute> noAliasScopes;
+  if (auto existing = llOp.getNoAliasScopesOrNull()) {
+    for (auto attr : existing)
+      noAliasScopes.push_back(attr);
+  }
+  for (auto attr : noaliasArrayAttr) {
+    int64_t noaliasId = cast<IntegerAttr>(attr).getValue().getSExtValue();
+    noAliasScopes.push_back(getSharedMemoryScopeAttr(ctx, noaliasId));
+  }
+  llOp.setNoAliasScopes(ArrayAttr::get(ctx, noAliasScopes));
+}
+} // namespace
+
+void TargetInfo::annotateSharedMemoryAlias(Operation *llOp,
+                                           Operation *sourceOp) const {
+  if (!sourceOp || !llOp)
+    return;
+  // If the target op implements LLVM's AliasAnalysisOpInterface, attach
+  // alias scope metadata directly.
+  if (auto aaOp = dyn_cast<LLVM::AliasAnalysisOpInterface>(llOp)) {
+    addSharedMemoryAliasScope(sourceOp, aaOp);
+    return;
+  }
+  // Otherwise (e.g. MaskedStoreOp/MaskedLoadOp), propagate the allocation
+  // attrs so that downstream lowering can emit the metadata.
+  if (auto scopeId = sourceOp->getAttr("allocation.scope"))
+    llOp->setAttr("allocation.scope", scopeId);
+  if (auto noalias = sourceOp->getAttr("allocation.scope.noalias"))
+    llOp->setAttr("allocation.scope.noalias", noalias);
 }
 
 bool TargetInfo::supportDppBroadcast() const {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.h
@@ -145,6 +145,9 @@ public:
   void localLoadOpAnnotation(triton::gpu::LocalLoadOp localLoadOp,
                              Operation *llLoadOp) const override;
 
+  void annotateSharedMemoryAlias(Operation *llOp,
+                                 Operation *sourceOp) const override;
+
 private:
   void printfImpl(Value formatStrStart, int formatStrByteCount, ValueRange args,
                   ArrayRef<bool> isSigned, RewriterBase &rewriter,


### PR DESCRIPTION
  Summary

  - Annotate all LDS-accessing ops with LLVM alias scope metadata so the backend can prove that non-overlapping LDS buffers do not alias, enabling better memory ordering
  optimizations (e.g. relaxing s_waitcnt barriers between independent shared memory accesses).
  - The AllocateSharedMemory pass computes buffer intervals from AllocationAnalysis and attaches allocation.scope / allocation.scope.noalias attributes to Triton IR ops based on
   whether their address ranges are disjoint.
  - During LLVM lowering, annotateSharedMemoryAlias() (virtual method on TargetInfoBase, overridden in the AMD backend) translates these attributes into #llvm.alias_scope /
  noalias_scopes metadata on llvm.load / llvm.store ops.

  Design

  Analysis phase (AllocateSharedMemory.cpp):
  - For each function, collect all ops that access exactly one LDS buffer (via getBufferIds).
  - Build a map of buffer ID → allocated interval [offset, offset+size).
  - Two buffers are marked noalias iff their intervals are disjoint.
  - Attach allocation.scope = <bufferID> and allocation.scope.noalias = [<other IDs>] as integer attrs on Triton IR ops.

  Lowering phase (TargetInfo.cpp + all LDS lowering paths):
  - annotateSharedMemoryAlias(llOp, sourceOp) reads the allocation.scope / allocation.scope.noalias attrs from the source Triton op and sets alias_scopes / noalias_scopes on the
   lowered LLVM op via LLVM::AliasAnalysisOpInterface.
  - For intermediate ops that don't yet implement AliasAnalysisOpInterface (e.g. MaskedStoreOp), the attrs are propagated forward so downstream patterns can emit the metadata.
  - All LDS lowering paths are covered: local_load, local_store, local_alloc, buffer_load_to_local, async_copy, ds_read_tr, convert_layout, reduce, and masked load/store.

  Test plan

  - test/Conversion/amd/allocate_shared_memory.mlir — verifies allocation.scope and allocation.scope.noalias attrs are correctly attached to Triton IR ops with two
  non-overlapping LDS buffers.
  - test/Conversion/amd/lds-alias-scopes.mlir — end-to-end test verifying #llvm.alias_scope metadata appears on lowered llvm.load/llvm.store ops and does NOT appear on global
  memory stores.


