### PR TITLE
[AMD][BACKEND] Allow small M/N block sizes for scaled wmma

### DIFF
--- a/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
+++ b/lib/Dialect/TritonGPU/IR/LinearLayoutConversions.cpp
@@ -733,17 +733,7 @@ LinearLayout AMDWmmaEncodingAttr::getTileLayout(unsigned rank) const {
 
 LinearLayout
 AMDWmmaEncodingAttr::toLinearLayout(ArrayRef<int64_t> shape) const {
-  auto mnkDim = getInstrShape();
   auto rank = shape.size();
-  bool hasBatchDim = rank == 3;
-  int mIndex = 0 + hasBatchDim;
-  int nIndex = 1 + hasBatchDim;
-  unsigned mDim = mnkDim[0], nDim = mnkDim[1];
-  (void)mDim, (void)nDim;
-
-  assert(((shape[mIndex] == 1 || shape[mIndex] >= mDim) &&
-          (shape[nIndex] == 1 || shape[nIndex] >= nDim)) &&
-         "Unsupported tensor shape for given wmma layout");
 
   auto tileLayout = getTileLayout(rank);
   auto ctaLayout = getCtaLayout();

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -3237,6 +3237,13 @@ def get_test_dot_vdot2_cases():
             (4, 32, 32, 4, False, False, 'None', 'ieee', 'bfloat16', 'float32', 1, None)]
 
 
+def get_test_dot_small_mn_wmma_cases():
+    if not is_hip_gfx1250():
+        return []
+    return [(*shape_nw, False, False, 'none', 'ieee', 'float16', 'float32', 1, None)
+            for shape_nw in [(8, 8, 32, 1), (8, 32, 32, 1), (32, 8, 32, 1)]]
+
+
 def get_test_small_dots_cases():
     if not is_cuda():
         return []
@@ -3257,6 +3264,7 @@ def get_test_small_dots_cases():
     get_test_dot_fp8_output_cases() + \
     get_test_dot_small_k_mfma_cases() + \
     get_test_dot_small_mn_mfma_cases() + \
+    get_test_dot_small_mn_wmma_cases() + \
     get_test_dot_softmax() + \
     get_test_small_dots_cases())
 @pytest.mark.parametrize("num_ctas", num_ctas_list)

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/DotOpToLLVM/WMMA.cpp
@@ -34,6 +34,23 @@
 namespace mlir::triton::AMD {
 namespace {
 
+static std::optional<mlir::triton::LinearLayout>
+wmmaRepLayoutForTensor(const mlir::triton::LinearLayout &wholeTileLL,
+                       const mlir::triton::LinearLayout &tileLL) {
+  llvm::SmallDenseMap<StringAttr, int64_t> shape;
+  for (auto outDim : wholeTileLL.getOutDimNames())
+    shape[outDim] = wholeTileLL.getOutDimSize(outDim);
+
+  // Clamp the tileLL to the tensor's output dims so that divideLeft succeeds
+  // when the tensor is smaller than the WMMA instruction shape.
+  auto clampedTileLL = ensureLayoutNotLargerThan(tileLL, shape);
+
+  auto quot = divideLeft(wholeTileLL, clampedTileLL);
+  if (quot.has_value())
+    return zerosLike(clampedTileLL) * *quot;
+  return {};
+}
+
 #define S(v) StringAttr::get(ctx, (v))
 using ::mlir::triton::gpu::AMDWmmaEncodingAttr;
 using ::mlir::triton::gpu::DotOperandEncodingAttr;
@@ -364,11 +381,10 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
 
   auto tile = wmmaLayout.getTileLayout(rank);
   auto wmmaLL = triton::gpu::toLinearLayout(resShape, wmmaLayout);
-  auto maybeQuot = divideLeft(wmmaLL, tile);
-  if (!maybeQuot.has_value()) {
+  auto repLayout = wmmaRepLayoutForTensor(wmmaLL, tile);
+  if (!repLayout.has_value()) {
     return op.emitError("failed to divide wmma layout by tile layout");
   }
-  auto repLayout = zerosLike(tile) * maybeQuot.value();
   const unsigned numRepK = std::max(static_cast<unsigned>(K / kDim), 1u);
 
   Value loadedA = adaptor.getA();
@@ -405,9 +421,9 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
   llvm::DenseSet<uint64_t> mnProcessed;
   int tiedGroup = 1;
 
-  for (int reg = 0; reg < repLayout.getInDimSize(kRegister);
+  for (int reg = 0; reg < repLayout->getInDimSize(kRegister);
        reg += dElemsToStorePerThread) {
-    auto repIndices = repLayout.apply(
+    auto repIndices = repLayout->apply(
         {{kRegister, reg}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}});
     int b = (rank == 3 ? repIndices[0].second : 0);
     int m = repIndices[rank == 3 ? 1 : 0].second;
@@ -419,7 +435,7 @@ LogicalResult convertDot(DotOp op, DotOpAdaptor adaptor,
       if (mnProcessed.count(packMN((uint32_t)m, (uint32_t)n))) {
         continue;
       }
-      nextM = findNextM(repLayout, nextMReg, dElemsToStorePerThread, m, rank);
+      nextM = findNextM(*repLayout, nextMReg, dElemsToStorePerThread, m, rank);
       if (nextM.has_value()) {
         tiedGroup = 2;
         mnProcessed.insert(packMN((uint32_t)m, (uint32_t)n));
@@ -558,11 +574,10 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
 
   auto tile = wmmaLayout.getTileLayout(rank);
   auto wmmaLL = triton::gpu::toLinearLayout(resShape, wmmaLayout);
-  auto maybeQuot = divideLeft(wmmaLL, tile);
-  if (!maybeQuot.has_value()) {
+  auto repLayout = wmmaRepLayoutForTensor(wmmaLL, tile);
+  if (!repLayout.has_value()) {
     return op.emitError("failed to divide wmma layout by tile layout");
   }
-  auto repLayout = zerosLike(tile) * maybeQuot.value();
 
   Value loadedA = adaptor.getA();
   Value loadedAScale = adaptor.getAScale();
@@ -598,10 +613,10 @@ LogicalResult convertScaledDot(triton::DotScaledOp op,
   auto dElemsToStorePerThread = mnkDim[0] * mnkDim[1] / warpSize;
   auto vecTy = vec_ty(dstElemTy, elemsPerVec);
 
-  for (int reg = 0; reg < repLayout.getInDimSize(kRegister);
+  for (int reg = 0; reg < repLayout->getInDimSize(kRegister);
        reg += elemsPerVec) {
 
-    auto repIndices = repLayout.apply(
+    auto repIndices = repLayout->apply(
         {{kRegister, reg}, {kLane, 0}, {kWarp, 0}, {kBlock, 0}});
     int b = (rank == 3 ? repIndices[0].second : 0);
     int m = repIndices[rank == 3 ? 1 : 0].second;

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1384,13 +1384,8 @@ FailureOr<WmmaIntrinsic> chooseWmmaInstruction(Location loc, int wmmaVersion,
   auto M = resShape[rank - 2];
   auto N = resShape[rank - 1];
 
-  unsigned mDim = 0;
-  unsigned nDim = 0;
-  int minSize = std::min(M, N);
-  if (minSize >= 16) {
-    mDim = 16;
-    nDim = 16;
-  }
+  unsigned mDim = 16;
+  unsigned nDim = 16;
 
   FailureOr<WmmaIntrinsic> maybeWmmaIntrinsic = WmmaIntrinsic::selectFor(
       wmmaVersion, mDim, nDim, inputKSize, aElemType, bElemType, cElemType);
@@ -1405,7 +1400,6 @@ FailureOr<WmmaIntrinsic> chooseWmmaInstruction(Location loc, int wmmaVersion,
 
   kDim = maybeWmmaIntrinsic->kDim;
   assert(kDim != 0);
-  assert(M % mDim == 0 && N % nDim == 0);
   return maybeWmmaIntrinsic;
 }
 


### PR DESCRIPTION
We can allow smaller M/N since the redundant rows will not contribute to the final result. The change to divide left is necessary to make sure the `wholeLL` is divisible by the `wmma tile` since for small cases the tile can be larger than the whole LL.

