### PR TITLE
[GSan] Use AxisInfo to deduplicate sub-word shadow updates

### DIFF
--- a/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/include/triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -108,6 +108,7 @@ void populateInstrumentationToLLVMPatterns(LLVMTypeConverter &typeConverter,
 
 void populateGSanToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                 RewritePatternSet &patterns,
+                                ModuleAxisInfoAnalysis &axisInfoAnalysis,
                                 const TargetInfoBase &targetInfo);
 
 } // namespace triton

--- a/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
+++ b/lib/Conversion/TritonInstrumentToLLVM/GSanToLLVM.cpp
@@ -97,7 +97,7 @@ void emitTensorAccessRuntimeCall(ConversionPatternRewriter &rewriter,
                                  ArrayRef<Value> ptrElems,
                                  ArrayRef<Value> maskElems, uint32_t regMask,
                                  Value threadPred, int32_t bytesPerElem,
-                                 bool isStore) {
+                                 bool isStore, unsigned elemIndexStride = 1) {
   if (ptrElems.empty())
     return;
 
@@ -108,14 +108,15 @@ void emitTensorAccessRuntimeCall(ConversionPatternRewriter &rewriter,
   Type i8Ty = rewriter.getI8Type();
   Type i64Ty = rewriter.getI64Type();
 
-  auto ptrArrayTy = array_ty(i64Ty, ptrElems.size());
-  auto maskArrayTy = array_ty(i8Ty, ptrElems.size());
+  unsigned numElems = ptrElems.size();
+  auto ptrArrayTy = array_ty(i64Ty, numElems);
+  auto maskArrayTy = array_ty(i8Ty, numElems);
   SmallVector<Type> argsFieldTys = {ptrArrayTy, maskArrayTy};
   auto argsTy = LLVM::LLVMStructType::getLiteral(ctx, argsFieldTys);
   auto argsBuffer = LLVM::AllocaOp::create(rewriter, loc, ptr_ty(ctx), argsTy,
                                            one, /*alignment=*/0);
 
-  for (unsigned i = 0; i < ptrElems.size(); ++i) {
+  for (unsigned i = 0; i < numElems; ++i) {
     Value idx = b.i32_val(i);
     Value ptrValue = b.ptrtoint(i64_ty, ptrElems[i]);
     Value ptrSlot =
@@ -123,7 +124,7 @@ void emitTensorAccessRuntimeCall(ConversionPatternRewriter &rewriter,
     b.store(ptrValue, ptrSlot);
 
     Value maskValue = maskElems.empty() ? b.true_val() : maskElems[i];
-    if (!isCanonicalIndex(i, regMask))
+    if (!isCanonicalIndex(i * elemIndexStride, regMask))
       maskValue = b.false_val();
     maskValue = maybeAnd(rewriter, loc, maskValue, threadPred);
     Value maskByte = b.zext(i8Ty, maskValue);
@@ -140,8 +141,9 @@ void emitTensorAccessRuntimeCall(ConversionPatternRewriter &rewriter,
   }
   Value argsPtr = b.bitcast(argsBuffer, ptr_ty(ctx));
   auto sourceLoc = materializeSourceLocation(rewriter, loc);
+
   b.call(runtimeFunc,
-         ValueRange{gsanGlobalStatePtr, argsPtr, b.i32_val(ptrElems.size()),
+         ValueRange{gsanGlobalStatePtr, argsPtr, b.i32_val(numElems),
                     b.i32_val(bytesPerElem), sourceLoc.file, sourceLoc.line});
 }
 
@@ -218,12 +220,31 @@ public:
   using ConvertOpToLLVMPattern<
       tti::ExperimentalGSanTensorAccessOp>::ConvertOpToLLVMPattern;
   const TargetInfoBase *targetInfo;
+  ModuleAxisInfoAnalysis *axisInfoAnalysis;
 
   GSanTensorAccessOpConversion(LLVMTypeConverter &typeConverter,
+                               ModuleAxisInfoAnalysis &axisInfoAnalysis,
                                const TargetInfoBase &targetInfo,
                                PatternBenefit benefit = 1)
-      : ConvertOpToLLVMPattern(typeConverter, benefit),
-        targetInfo(&targetInfo) {}
+      : ConvertOpToLLVMPattern(typeConverter, benefit), targetInfo(&targetInfo),
+        axisInfoAnalysis(&axisInfoAnalysis) {}
+
+  unsigned getVecSize(tti::ExperimentalGSanTensorAccessOp op) const {
+    auto ptrTy = op.getPtr().getType();
+    auto contiguity = axisInfoAnalysis->getContiguity(op.getPtr());
+    if (!op.getMask()) {
+      return contiguity;
+    }
+
+    auto maskAlign = axisInfoAnalysis->getMaskAlignment(op.getMask());
+    auto bytesPerElem = tt::getPointeeBitWidth(ptrTy) / 8;
+    // Round up to at least shadow granularity, and we will or together the
+    // masks
+    if (bytesPerElem < 4) {
+      maskAlign = std::max(maskAlign, 4 / bytesPerElem);
+    }
+    return std::min(contiguity, maskAlign);
+  }
 
   LogicalResult
   matchAndRewrite(tti::ExperimentalGSanTensorAccessOp op, OpAdaptor adaptor,
@@ -249,6 +270,33 @@ public:
              "Expected mask element count to match layout");
     }
 
+    unsigned mergeVec = getVecSize(op);
+    if (mergeVec > 1) {
+      auto maskAlign =
+          op.getMask() ? axisInfoAnalysis->getMaskAlignment(op.getMask()) : 1;
+      SmallVector<Value> mergedPtrElems;
+      SmallVector<Value> mergedMaskElems;
+      mergedPtrElems.reserve(numElems / mergeVec);
+      if (!maskElems.empty())
+        mergedMaskElems.reserve(numElems / mergeVec);
+
+      for (unsigned i = 0; i < numElems; i += mergeVec) {
+        mergedPtrElems.push_back(ptrElems[i]);
+        if (maskElems.empty())
+          continue;
+        Value mergedMask = maskElems[i];
+        for (unsigned j = maskAlign; j < mergeVec; j += maskAlign) {
+          mergedMask =
+              arith::OrIOp::create(rewriter, loc, mergedMask, maskElems[i + j]);
+        }
+        mergedMaskElems.push_back(mergedMask);
+      }
+
+      ptrElems = std::move(mergedPtrElems);
+      maskElems = std::move(mergedMaskElems);
+      bytesPerElem *= mergeVec;
+    }
+
     auto freeVarMasks = getFreeVariableMasks(ptrTy);
     auto *ctx = getContext();
     uint32_t regMask = freeVarMasks.lookup(str_attr("reg"));
@@ -256,7 +304,7 @@ public:
                                                          loc, *targetInfo);
     emitTensorAccessRuntimeCall(rewriter, loc, gsanGlobalStatePtr, ptrElems,
                                 maskElems, regMask, threadPred, bytesPerElem,
-                                op.getIsStore());
+                                op.getIsStore(), mergeVec);
 
     rewriter.eraseOp(op);
     return success();
@@ -344,8 +392,10 @@ public:
 
 void mlir::triton::populateGSanToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
+    ModuleAxisInfoAnalysis &axisInfoAnalysis,
     const TargetInfoBase &targetInfo) {
   patterns.add<GSanInitOpConversion>(typeConverter);
   patterns.add<GSanTensorDescInfoOpConversion>(typeConverter);
-  patterns.add<GSanTensorAccessOpConversion>(typeConverter, targetInfo);
+  patterns.add<GSanTensorAccessOpConversion>(typeConverter, axisInfoAnalysis,
+                                             targetInfo);
 }

--- a/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/GlobalSanitizer.cpp
@@ -39,6 +39,26 @@ struct DescriptorInfo {
   SmallVector<Value> strides;
 };
 
+static void setTMAPtrAxisHints(OpBuilder &builder, Value ptr) {
+  auto ptrTy = cast<RankedTensorType>(ptr.getType());
+  auto elemTy = cast<tt::PointerType>(ptrTy.getElementType()).getPointeeType();
+
+  Operation *def = ptr.getDefiningOp();
+  if (!def)
+    return;
+
+  auto rank = ptrTy.getRank();
+  SmallVector<int32_t> contiguity(rank, 1);
+  contiguity.back() = ptrTy.getShape().back();
+  SmallVector<int32_t> divisibility(rank, 1);
+  divisibility.back() = 16;
+  auto attrTy = RankedTensorType::get({rank}, builder.getI32Type());
+  def->setDiscardableAttr("tt.contiguity",
+                          DenseIntElementsAttr::get(attrTy, contiguity));
+  def->setDiscardableAttr("tt.divisibility",
+                          DenseIntElementsAttr::get(attrTy, divisibility));
+}
+
 static Value castToI64(OpBuilder &builder, Location loc, Value value) {
   if (value.getType().isInteger(64))
     return value;
@@ -63,17 +83,25 @@ getInstrumentationEncoding(OpBuilder &builder, ArrayRef<int64_t> shape,
   auto base = ttg::getDefaultBlockedEncoding(builder.getContext(), shape,
                                              numWarps, threadsPerWarp, numCTAs);
   SmallVector<unsigned> order = llvm::to_vector(base.getOrder());
+  SmallVector<unsigned> warpsPerCTA = llvm::to_vector(base.getWarpsPerCTA());
   SmallVector<unsigned> sizePerThread(shape.size(), 1);
   unsigned elemBits = elemType.getIntOrFloatBitWidth();
   unsigned maxElems = std::max(128u / elemBits, 1u);
   if (!order.empty()) {
     unsigned dim = order.front();
-    sizePerThread[dim] =
-        static_cast<unsigned>(std::min<int64_t>(shape[dim], maxElems));
+    // Distribute last dim to maximize contiguity within a thread
+    if (order.size() > 1 && warpsPerCTA[dim] > 1) {
+      warpsPerCTA[order[1]] *= warpsPerCTA[dim];
+      warpsPerCTA[dim] = 1;
+    }
+
+    auto threadsOnDim = base.getThreadsPerWarp()[dim] * warpsPerCTA[dim];
+    auto numUniqueElems = ceil(static_cast<unsigned>(shape[dim]), threadsOnDim);
+    sizePerThread[dim] = std::min(maxElems, numUniqueElems);
   }
-  return ttg::BlockedEncodingAttr::get(
-      builder.getContext(), sizePerThread, base.getThreadsPerWarp(),
-      base.getWarpsPerCTA(), order, base.getCGALayout());
+  return ttg::BlockedEncodingAttr::get(builder.getContext(), sizePerThread,
+                                       base.getThreadsPerWarp(), warpsPerCTA,
+                                       order, base.getCGALayout());
 }
 
 static Value expandAllSlicedDims(OpBuilder &builder, Location loc,
@@ -229,6 +257,7 @@ createTiledAccess(OpBuilder &builder, Location loc, const DescriptorInfo &desc,
     Value predTensor = tt::SplatOp::create(builder, loc, maskType, *pred);
     mask = arith::AndIOp::create(builder, loc, mask, predTensor);
   }
+  setTMAPtrAxisHints(builder, ptr);
   return std::make_pair(ptr, mask);
 }
 
@@ -251,9 +280,12 @@ static std::pair<Value, Value> createGatherScatterAccess(
   Value yRange =
       createExpandedOffsetRange(builder, loc, fullI64Type, yOffset, /*dim=*/1);
   SmallVector<Value> offsetRanges = {xRange, yRange};
-  return std::make_pair(
-      createPtrFromRanges(builder, loc, desc, offsetRanges, fullI64Type),
-      createMaskFromRanges(builder, loc, desc, offsetRanges, fullI64Type));
+  auto ptrs =
+      createPtrFromRanges(builder, loc, desc, offsetRanges, fullI64Type);
+  auto mask =
+      createMaskFromRanges(builder, loc, desc, offsetRanges, fullI64Type);
+  setTMAPtrAxisHints(builder, ptrs);
+  return std::make_pair(ptrs, mask);
 }
 
 static void instrumentAsyncTMALoad(ttng::AsyncTMACopyGlobalToLocalOp op) {

--- a/test/Conversion/tritongpu_to_llvm_gsan.mlir
+++ b/test/Conversion/tritongpu_to_llvm_gsan.mlir
@@ -18,3 +18,47 @@ module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32
     tt.return
   }
 }
+
+// -----
+
+#shared_f16 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @tma_f16_gsan_merge
+  tt.func @tma_f16_gsan_merge(%desc: !tt.tensordesc<tensor<32x64xf16, #shared_f16>>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<32x64xf16, #shared_f16, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 4096 : i32} : () -> !ttg.memdesc<1xi64, #bar, #smem, mutable>
+    // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<32 x i64>, array<32 x i8>)>
+    // CHECK: %[[COUNT:.*]] = llvm.mlir.constant(32 : i32) : i32
+    // CHECK: %[[BYTES:.*]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK: llvm.call @__triton_gsan_load_tensor(%{{.*}}, %{{.*}}, %[[COUNT]], %[[BYTES]], %{{.*}}, %{{.*}})
+    ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %buf, %barrier, %true : !tt.tensordesc<tensor<32x64xf16, #shared_f16>>, !ttg.memdesc<1xi64, #bar, #smem, mutable> -> !ttg.memdesc<32x64xf16, #shared_f16, #smem, mutable>
+    tt.return
+  }
+}
+
+// -----
+
+#shared_f16 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#bar = #ttg.swizzled_shared<{vec = 1, perPhase = 1, maxPhase = 1, order = [0]}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.instrumentation_mode" = "gsan", "ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK-LABEL: llvm.func @tma_f16_gsan_merge_4warps
+  tt.func @tma_f16_gsan_merge_4warps(%desc: !tt.tensordesc<tensor<128x64xf16, #shared_f16>>) {
+    %true = arith.constant true
+    %c0_i32 = arith.constant 0 : i32
+    %buf = ttg.local_alloc {allocation.offset = 0 : i32} : () -> !ttg.memdesc<128x64xf16, #shared_f16, #smem, mutable>
+    %barrier = ttg.local_alloc {allocation.offset = 16384 : i32} : () -> !ttg.memdesc<1xi64, #bar, #smem, mutable>
+    // CHECK: llvm.alloca %{{.*}} x !llvm.struct<(array<32 x i64>, array<32 x i8>)>
+    // CHECK: %[[COUNT_4W:.*]] = llvm.mlir.constant(32 : i32) : i32
+    // CHECK: %[[BYTES_4W:.*]] = llvm.mlir.constant(4 : i32) : i32
+    // CHECK: llvm.call @__triton_gsan_load_tensor(%{{.*}}, %{{.*}}, %[[COUNT_4W]], %[[BYTES_4W]], %{{.*}}, %{{.*}})
+    ttng.async_tma_copy_global_to_local %desc[%c0_i32, %c0_i32] %buf, %barrier, %true : !tt.tensordesc<tensor<128x64xf16, #shared_f16>>, !ttg.memdesc<1xi64, #bar, #smem, mutable> -> !ttg.memdesc<128x64xf16, #shared_f16, #smem, mutable>
+    tt.return
+  }
+}

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -183,7 +183,7 @@ struct ConvertTritonGPUToLLVM
     mlir::triton::populateInstrumentationToLLVMPatterns(typeConverter, patterns,
                                                         targetInfo);
     mlir::triton::populateGSanToLLVMPatterns(typeConverter, patterns,
-                                             targetInfo);
+                                             axisInfoAnalysis, targetInfo);
 
     TritonLLVMConversionTarget convTarget(*context);
     if (failed(applyPartialConversion(mod, convTarget, std::move(patterns))))


### PR DESCRIPTION
Currently we take each pointer and update the corresponding shadow address, but this can lead to duplicate shadow updates if you have e.g. contiguous float16 elements. Here I fix this by looking at the AxisInfo and using the contiguity property to merge neighbouring pointers.

This also includes a tweak to the TMA instrumentation that helps it to trigger this optimisation. 

With these changes, I see a 2x speedup in gsan-instrumented fp16 tl.load based matmul and 10x speedup in fp16 TMA-based matmul.