### PR TITLE
[FRONTEND] Preserve complete exception details in CompilationError

### DIFF
--- a/python/triton/compiler/code_generator.py
+++ b/python/triton/compiler/code_generator.py
@@ -1338,7 +1338,7 @@ class CodeGenerator(ast.NodeVisitor):
                 # Wrap the error in the callee with the location of the call.
                 if knobs.compilation.front_end_debugging:
                     raise
-                raise CompilationError(self.jit_fn.src, self.cur_node, None) from e
+                raise CompilationError(self.jit_fn.src, self.cur_node, repr(e)) from e
 
             callee_ret_type = generator.ret_type
             self.function_ret_types[fn_name] = callee_ret_type
@@ -1394,7 +1394,7 @@ class CodeGenerator(ast.NodeVisitor):
                 # itself).  But when calling a function, we raise as `from e` to
                 # preserve the traceback of the original error, which may e.g.
                 # be in core.py.
-                raise CompilationError(self.jit_fn.src, node, str(e)) from e
+                raise CompilationError(self.jit_fn.src, node, repr(e)) from e
 
         if fn in self.builtin_namespace.values() or (hasattr(fn, '__self__') and not _is_triton_value(fn.__self__)):
             args = map(_unwrap_if_constexpr, args)


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->
Frontend errors can lose useful context when they are wrapped into CompilationError.

Some code paths currently drop the original exception message entirely, while others only keep str(e). In practice this can hide the exception type or reduce the message to a short, less useful string, which makes frontend failures harder to understand and debug.

This change keeps a more complete representation of the original exception in CompilationError. That makes the final error message more informative for developers

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [x] This PR does not need a test because `it only makes the frontend error message more informative without changing compilation behavior or control flow, and the change is limited to exception wrapping`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
