### PR TITLE
[matmul kernel] add input microblock sizes to matmul kernel signature

### DIFF
--- a/python/triton_kernels/bench/bench_mlp.py
+++ b/python/triton_kernels/bench/bench_mlp.py
@@ -17,7 +17,7 @@ from triton_kernels.distributed import convert_dp_to_ep, convert_ep_to_dp, make_
 # quantization
 from triton_kernels.tensor import convert_layout, wrap_torch_tensor, FP4
 from triton_kernels.numerics import InFlexData
-from triton_kernels.numerics_details.mxfp import downcast_to_mxfp
+from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
 
 
 def was_launched_with_torchrun():
@@ -140,9 +140,21 @@ def bench_mlp(batch_per_expt, dim1, dim2, n_expts_tot, n_expts_act, x_dtype, w_d
     wg_global, wg_flex, wg_scale = quantize_weight(wg_global, torch.bfloat16)
     w1_ep_local, w1_flex, w1_scale = quantize_weight(w1_ep_local, w_dtype, **opt1)
     w2_ep_local, w2_flex, w2_scale = quantize_weight(w2_ep_local, w_dtype, **opt2)
-    pcg = PrecisionConfig(flex_ctx=FlexCtx(rhs_data=wg_flex), b_mx_scale=wg_scale)
-    pc1 = PrecisionConfig(flex_ctx=FlexCtx(rhs_data=w1_flex), b_mx_scale=w1_scale)
-    pc2 = PrecisionConfig(flex_ctx=FlexCtx(rhs_data=w2_flex), b_mx_scale=w2_scale)
+    pcg = PrecisionConfig(
+        flex_ctx=FlexCtx(rhs_data=wg_flex),
+        b_mx_scale=wg_scale,
+        b_microblock_size=MXFP_BLOCK_SIZE.value,
+    )
+    pc1 = PrecisionConfig(
+        flex_ctx=FlexCtx(rhs_data=w1_flex),
+        b_mx_scale=w1_scale,
+        b_microblock_size=MXFP_BLOCK_SIZE.value,
+    )
+    pc2 = PrecisionConfig(
+        flex_ctx=FlexCtx(rhs_data=w2_flex),
+        b_mx_scale=w2_scale,
+        b_microblock_size=MXFP_BLOCK_SIZE.value,
+    )
 
     # -- init activation --
     x_dp_local_fp8 = torch.randn((batch // n_ranks, dim1), device=dev).to(x_dtype)

--- a/python/triton_kernels/bench/bench_utils.py
+++ b/python/triton_kernels/bench/bench_utils.py
@@ -5,7 +5,7 @@ import triton_kernels
 import triton_kernels.swiglu
 from triton_kernels.matmul import PrecisionConfig, FlexCtx, FnSpecs, FusedActivation
 from triton_kernels.numerics import InFlexData
-from triton_kernels.numerics_details.mxfp import downcast_to_mxfp
+from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
 from triton_kernels.tensor import convert_layout, wrap_torch_tensor, FP4, Tensor
 from triton_kernels.target_info import is_cuda, get_cdna_version, cuda_capability_geq, is_hip
 from triton_kernels.tensor_details import layout
@@ -73,9 +73,21 @@ def prepare_mlp_numerics(batch: int, w_dtype: str, wg, w1, w2) -> MlpNumerics:
         wg=wg,
         w1=w1,
         w2=w2,
-        pcg=PrecisionConfig(flex_ctx=FlexCtx(rhs_data=wg_flex), b_mx_scale=wg_scale),
-        pc1=PrecisionConfig(flex_ctx=FlexCtx(rhs_data=w1_flex), b_mx_scale=w1_scale),
-        pc2=PrecisionConfig(flex_ctx=FlexCtx(rhs_data=w2_flex), b_mx_scale=w2_scale),
+        pcg=PrecisionConfig(
+            flex_ctx=FlexCtx(rhs_data=wg_flex),
+            b_mx_scale=wg_scale,
+            b_microblock_size=MXFP_BLOCK_SIZE.value,
+        ),
+        pc1=PrecisionConfig(
+            flex_ctx=FlexCtx(rhs_data=w1_flex),
+            b_mx_scale=w1_scale,
+            b_microblock_size=MXFP_BLOCK_SIZE.value,
+        ),
+        pc2=PrecisionConfig(
+            flex_ctx=FlexCtx(rhs_data=w2_flex),
+            b_mx_scale=w2_scale,
+            b_microblock_size=MXFP_BLOCK_SIZE.value,
+        ),
         activation=activation,
     )
 

--- a/python/triton_kernels/tests/test_matmul.py
+++ b/python/triton_kernels/tests/test_matmul.py
@@ -403,7 +403,9 @@ def _test_op(m, n, k, split_k, do_gather, do_scatter, inner_expt_opt, do_gamma, 
         acc_scale=2.0 if c_dtype.has_global_scale or b_dtype.has_global_scale else 1.0,
         out_dtype=c_dtype.torch_dtype,
         a_mx_scale=a_scales,
+        a_microblock_size=a_dtype.microblock_size,
         b_mx_scale=b_scale_tri,
+        b_microblock_size=b_dtype.microblock_size,
     )
 
     # --- create epilogue ---

--- a/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
+++ b/python/triton_kernels/tests/test_matmul_details/test_opt_flags_nvidia.py
@@ -3,7 +3,7 @@ import torch
 
 from triton_kernels.matmul import matmul, matmul_torch, PrecisionConfig
 from triton_kernels.matmul_details.opt_flags_details import opt_flags_nvidia
-from triton_kernels.numerics_details.mxfp import downcast_to_mxfp
+from triton_kernels.numerics_details.mxfp import MXFP_BLOCK_SIZE, downcast_to_mxfp
 from triton_kernels.tensor import FP4, UINT8, Storage, Tensor, convert_layout, wrap_torch_tensor
 from triton_kernels.tensor_details import layout
 from triton_kernels.tensor_details.layout_details.blackwell_scale import BlackwellMXScaleLayout
@@ -27,7 +27,10 @@ def _make_blackwell_mxfp4_weight(device, k, n):
 
 @pytest.mark.parametrize("n, expected", [(64, 128), (200, 256)])
 def test_compute_block_n_blackwell_scale_aligns_to_128(n, expected):
-    precision_config = PrecisionConfig(b_mx_scale=_make_blackwell_scale_tensor())
+    precision_config = PrecisionConfig(
+        b_mx_scale=_make_blackwell_scale_tensor(),
+        b_microblock_size=MXFP_BLOCK_SIZE.value,
+    )
     block_n, block_n_tma = opt_flags_nvidia.compute_block_n(n, None, precision_config)
     assert block_n == block_n_tma == expected
 
@@ -42,7 +45,11 @@ def test_matmul_blackwell_scale_small_n(device):
     m, n, k = 128, 64, 128
     a = torch.randn((m, k), device=device, dtype=torch.bfloat16)
     b, b_scale = _make_blackwell_mxfp4_weight(device, k, n)
-    precision_config = PrecisionConfig(b_mx_scale=b_scale, out_dtype=a.dtype)
+    precision_config = PrecisionConfig(
+        b_mx_scale=b_scale,
+        b_microblock_size=MXFP_BLOCK_SIZE.value,
+        out_dtype=a.dtype,
+    )
     tri_y = matmul(a, b, None, precision_config=precision_config)
     ref_y = matmul_torch(a, b, None, precision_config=precision_config)
     assert_close(ref_y, tri_y, maxtol=3e-2, rmstol=None)

--- a/python/triton_kernels/triton_kernels/matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul.py
@@ -119,13 +119,14 @@ class PrecisionConfig:
     flexpoint_saturate_inf: bool = False
     report_quantization_err_fn: Callable | None = None
     a_mx_scale: torch.Tensor | Tensor | None = None
+    a_microblock_size: int | None = None
     b_mx_scale: torch.Tensor | Tensor | None = None
+    b_microblock_size: int | None = None
     c_mx_scale: torch.Tensor | Tensor | None = None
     c_microblock_size: int | None = None
     c_value_pack_factor: int = 1
     out_dtype: torch.dtype | None = None
     enforce_bitwise_invariance: bool = False
-
 
 # TODO: merge in opt_flags
 def get_swap_xw(precision_config, opt_flags):
@@ -303,23 +304,29 @@ def matmul(a, b, bias,
     b_scale_dtype = None if b_scale is None else b_scale.storage.data.dtype
     # NOTE: uint8 scale means OCP E8M0 here. Direct NVFP-style scales stay float8_e4m3fn.
     if a_scale_dtype is not None:
-        assert (
-            a_scale_dtype == torch.uint8
-            or a_scale_dtype == torch.float8_e4m3fn
-        ), f"Unsupported microscale dtype {a_scale_dtype}"
-    if b_scale_dtype is not None:
-        assert (
-            b_scale_dtype == torch.uint8
-            or b_scale_dtype == torch.float8_e4m3fn
-        ), f"Unsupported microscale dtype {b_scale_dtype}"
-    a_microblock_size = None if a_scale is None else a.shape[-1] // a_scale.shape[-1]
-    b_microblock_size = None if b_scale is None else b.shape[-2] // b_scale.shape[-2]
+        assert a_scale_dtype == torch.uint8 or a_scale_dtype == torch.float8_e4m3fn, (
+            f"Unsupported microscale dtype {a_scale_dtype}"
+        )
+    a_microblock_size = precision_config.a_microblock_size
     if a_microblock_size is not None:
-        assert a_microblock_size in (int(MXFP_BLOCK_SIZE), int(NVFP_BLOCK_SIZE)), \
+        assert a_microblock_size == int(MXFP_BLOCK_SIZE) or a_microblock_size == int(NVFP_BLOCK_SIZE), (
             f"Unsupported microscale block size {a_microblock_size}"
+        )
+    assert a_scale is None or a_microblock_size is not None, (
+        "precision_config.a_microblock_size is required when precision_config.a_mx_scale is set"
+    )
+    if b_scale_dtype is not None:
+        assert b_scale_dtype == torch.uint8 or b_scale_dtype == torch.float8_e4m3fn, (
+            f"Unsupported microscale dtype {b_scale_dtype}"
+        )
+    b_microblock_size = precision_config.b_microblock_size
     if b_microblock_size is not None:
-        assert b_microblock_size in (int(MXFP_BLOCK_SIZE), int(NVFP_BLOCK_SIZE)), \
+        assert b_microblock_size == int(MXFP_BLOCK_SIZE) or b_microblock_size == int(NVFP_BLOCK_SIZE), (
             f"Unsupported microscale block size {b_microblock_size}"
+        )
+    assert b_scale is None or b_microblock_size is not None, (
+        "precision_config.b_microblock_size is required when precision_config.b_mx_scale is set"
+    )
     if a_microblock_size is not None and b_microblock_size is not None:
         assert a_microblock_size == b_microblock_size, (
             f"Microscaled operands must share a block size. Got {a_microblock_size} and {b_microblock_size}"


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
