### PR TITLE
[Tests] Add missing forked mark

### DIFF
--- a/python/test/unit/test_debug.py
+++ b/python/test/unit/test_debug.py
@@ -35,6 +35,7 @@ def test_device_assert(monkeypatch, cond, mask, opt_flag, env_var, jit_flag, dev
     getattr(torch, device).synchronize()
 
 
+@pytest.mark.forked
 def test_device_assert_barrier(monkeypatch, device):
     monkeypatch.setenv("TRITON_DEBUG", "1")
     triton.knobs.refresh_knobs()


### PR DESCRIPTION
While this test doesn't have a failed assert, it still requires the cuda runtime to be initialized, which means no more forking is possible from that pytest worker process.