### PR TITLE
[DEBUG] Fix MLIR_DUMP_PATH when it points to a directory (#6548)

### DIFF
--- a/include/triton/Tools/Sys/Dump.hpp
+++ b/include/triton/Tools/Sys/Dump.hpp
@@ -1,18 +1,41 @@
 #ifndef TRITON_TOOLS_SYS_DUMP_HPP
 #define TRITON_TOOLS_SYS_DUMP_HPP
 
+#include <memory>
+
 #include "triton/Tools/Sys/GetEnv.hpp"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace mlir::triton::tools {
 
-inline llvm::raw_fd_ostream &mlirDumps() {
+inline std::unique_ptr<llvm::raw_fd_ostream> createMlirDumpStream() {
   std::error_code EC;
-  static llvm::raw_fd_ostream S(getStrEnv("MLIR_DUMP_PATH"), EC,
-                                llvm::sys::fs::CD_CreateAlways);
+  std::string dumpPath = getStrEnv("MLIR_DUMP_PATH");
+
+  llvm::sys::fs::file_status status;
+  bool pathIsDir = !llvm::sys::fs::status(dumpPath, status) &&
+                   llvm::sys::fs::is_directory(status);
+  if (pathIsDir) {
+    llvm::SmallString<256> model(dumpPath);
+    llvm::sys::path::append(model, "triton-%%%%%%.mlir");
+    int fd = -1;
+    llvm::SmallString<256> uniquePath;
+    EC = llvm::sys::fs::createUniqueFile(model, fd, uniquePath);
+    assert(!EC && "failed to create a dump file under MLIR_DUMP_PATH");
+    return std::make_unique<llvm::raw_fd_ostream>(fd, /*shouldClose=*/true);
+  }
+
+  auto stream = std::make_unique<llvm::raw_fd_ostream>(
+      dumpPath, EC, llvm::sys::fs::CD_CreateAlways);
   assert(!EC && "failed to open MLIR_DUMP_PATH");
-  return S;
+  return stream;
+}
+
+inline llvm::raw_fd_ostream &mlirDumps() {
+  static std::unique_ptr<llvm::raw_fd_ostream> S = createMlirDumpStream();
+  return *S;
 }
 
 inline llvm::raw_ostream &mlirDumpsOrDbgs() {

--- a/python/test/unit/test_debug_dump.py
+++ b/python/test/unit/test_debug_dump.py
@@ -1,4 +1,6 @@
 import os
+import subprocess
+import sys
 from contextlib import contextmanager
 
 import torch
@@ -47,3 +49,33 @@ def test_fn_dump(capfd, device, fresh_triton_cache):
         _kernel[grid](src, N, BLOCK_SIZE)
     captured = capfd.readouterr()
     assert "IR Dump Before" not in captured.err
+
+
+def test_mlir_dump_path_directory(device, tmp_path, fresh_triton_cache):
+    # Regression test for #6548: MLIR_DUMP_PATH can point to a directory.
+    script = r"""
+import torch
+import triton
+import triton.language as tl
+
+N = 128
+x = torch.zeros(N, device="{device}")
+grid = lambda META: (triton.cdiv(N, META["BLOCK_SIZE"]),)
+
+@triton.jit
+def _kernel(ptr, n, BLOCK_SIZE: tl.constexpr):
+    off = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    v = tl.load(ptr + off, mask=off < n)
+    tl.store(ptr + off, v, mask=off < n)
+
+_kernel[grid](x, N, BLOCK_SIZE=32)
+""".format(device=device)
+
+    env = os.environ.copy()
+    env["MLIR_ENABLE_DUMP"] = "1"
+    env["MLIR_DUMP_PATH"] = str(tmp_path)
+    script_path = tmp_path / "jit_dump_script.py"
+    script_path.write_text(script)
+    proc = subprocess.run([sys.executable, str(script_path)], env=env, capture_output=True, text=True)
+    assert proc.returncode == 0, f"stderr:\n{proc.stderr}\nstdout:\n{proc.stdout}"
+    assert any(p.suffix == ".mlir" for p in tmp_path.iterdir())


### PR DESCRIPTION
# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [ ] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)

## Why
When `MLIR_DUMP_PATH` is set to a directory, Triton currently treats it as a file path and fails to open it, which breaks MLIR dump workflows in debug mode.

## What
- Update `mlirDumps()` in `include/triton/Tools/Sys/Dump.hpp` to detect when `MLIR_DUMP_PATH` is a directory and create a unique `.mlir` file in that directory.
- Keep existing behavior unchanged when `MLIR_DUMP_PATH` is a file path.
- Add regression test `python/test/unit/test_debug_dump.py::test_mlir_dump_path_directory`.
