### PR TITLE
[FRONTEND] Add get_shape binding for out-of-tree walk

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -424,6 +424,16 @@ void init_triton_ir(py::module &&m) {
                }
              }
            })
+      .def("get_shape",
+           [](Value &self) -> py::object {
+             auto type = self.getType();
+             if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+               auto shape = tensorType.getShape();
+               return py::cast(
+                   std::vector<int64_t>(shape.begin(), shape.end()));
+             }
+             return py::none();
+           })
       .def("get_context", &Value::getContext)
       .def("get_loc", &Value::getLoc)
       .def("set_loc", &Value::setLoc)

--- a/python/test/unit/runtime/test_bindings.py
+++ b/python/test/unit/runtime/test_bindings.py
@@ -26,7 +26,9 @@ def add_kernel(
     mask = offsets < n_elements
     x = tl.load(in_ptr0 + offsets, mask=mask)
     y = tl.load(in_ptr1 + offsets, mask=mask)
-    output = add_helper(x, y)
+    x2d = x[None, :]
+    x1d = tl.reshape(x2d, [BLOCK_SIZE])
+    output = add_helper(x1d, y)
     tl.store(out_ptr + offsets, output, mask=mask)
 
 
@@ -58,6 +60,14 @@ def test_module_walk(device):
         if name == "arith.constant":
             val = op.get_int_attr("value")
             assert val is None or isinstance(val, int)
+        if name == "tt.expand_dims":
+            shape = op.get_result(0).get_shape()
+            assert shape == [1, _BLOCK_SIZE]
+        if name == "tt.reshape":
+            in_shape = op.get_operand(0).get_shape()
+            out_shape = op.get_result(0).get_shape()
+            assert in_shape == [1, _BLOCK_SIZE]
+            assert out_shape == [_BLOCK_SIZE]
 
     kernel = add_kernel
     args = [


### PR DESCRIPTION
Exposes the shape of RankedTensorType value as part of the MLIR bindings. 
Returns a list of ints, or None if the value is not a ranked tensor.
