### PR TITLE
[triton-ext] Insert return Value into args for TritonOpBuilder

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1836,7 +1836,9 @@ void init_triton_ir(py::module &&m) {
     for (const auto &op : plugin.listOps()) {
       TritonOpBuilderBinding.def(
           op.name, [op](TritonOpBuilder &self, std::vector<Value> args) {
+            args.insert(args.begin(), Value());
             op.addOp(self, args);
+            return args[0];
           });
     }
   }


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/9748 introduced some changes to the custom ops API and dropped the return value. But the plugin convention expects operands[0] to be a writable result slot. This adds that return value for the added op back.