### PR TITLE
 [FRONTEND] Expand MLIR bindings for out-of-tree walks 

### DIFF
--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -424,6 +424,16 @@ void init_triton_ir(py::module &&m) {
                }
              }
            })
+      .def("get_shape",
+           [](Value &self) -> py::object {
+             auto type = self.getType();
+             if (auto tensorType = dyn_cast<RankedTensorType>(type)) {
+               auto shape = tensorType.getShape();
+               return py::cast(
+                   std::vector<int64_t>(shape.begin(), shape.end()));
+             }
+             return py::none();
+           })
       .def("get_context", &Value::getContext)
       .def("get_loc", &Value::getLoc)
       .def("set_loc", &Value::setLoc)
@@ -629,6 +639,26 @@ void init_triton_ir(py::module &&m) {
              if (!ret)
                return py::none();
              return py::int_(ret.getInt());
+           })
+      .def("get_constant_value",
+           [](Operation &self) -> py::object {
+             auto constOp = dyn_cast<arith::ConstantOp>(self);
+             if (!constOp)
+               return py::none();
+
+             auto attr = constOp.getValue();
+
+             if (auto intAttr = dyn_cast<IntegerAttr>(attr))
+               return py::int_(intAttr.getValue().getSExtValue());
+
+             if (auto denseAttr = dyn_cast<DenseIntElementsAttr>(attr)) {
+               if (denseAttr.isSplat())
+                 return py::int_(
+                     denseAttr.getSplatValue<APInt>().getSExtValue());
+               return py::none();
+             }
+
+             return py::none();
            })
       .def("get_bool_attr",
            [](Operation &self, const std::string &name) -> py::object {

--- a/python/test/unit/runtime/test_bindings.py
+++ b/python/test/unit/runtime/test_bindings.py
@@ -26,7 +26,9 @@ def add_kernel(
     mask = offsets < n_elements
     x = tl.load(in_ptr0 + offsets, mask=mask)
     y = tl.load(in_ptr1 + offsets, mask=mask)
-    output = add_helper(x, y)
+    x2d = x[None, :]
+    x1d = tl.reshape(x2d, [BLOCK_SIZE])
+    output = add_helper(x1d, y)
     tl.store(out_ptr + offsets, output, mask=mask)
 
 
@@ -56,8 +58,16 @@ def test_module_walk(device):
             assert 0 == op.get_int_attr("start")
             assert _BLOCK_SIZE == op.get_int_attr("end")
         if name == "arith.constant":
-            val = op.get_int_attr("value")
-            assert val is None or isinstance(val, int)
+            val = op.get_constant_value()
+            assert isinstance(val, int)
+        if name == "tt.expand_dims":
+            shape = op.get_result(0).get_shape()
+            assert shape == [1, _BLOCK_SIZE]
+        if name == "tt.reshape":
+            in_shape = op.get_operand(0).get_shape()
+            out_shape = op.get_result(0).get_shape()
+            assert in_shape == [1, _BLOCK_SIZE]
+            assert out_shape == [_BLOCK_SIZE]
 
     kernel = add_kernel
     args = [


### PR DESCRIPTION
Introduce `Operation.get_constant_value` and `Value.get_shape`.

`get_constant_value` handles scalar `IntegerAttr` and splat
`DenseIntElementsAttr` cases, returning `None` for non-splat dense
constants. Motivated by `get_int_attr("value")` failing for
`arith.constant` ops with dense tensor results.

`get_shape` exposes the shape of `RankedTensorType` value.
Returns a list of `int`s, or `None` if the value is not a ranked tensor.