### PR TITLE
[AMD][WMMA] Proper constant for fp4 mxfp scale

### DIFF
--- a/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
+++ b/test/TritonGPU/amd/accelerate-amd-matmul-wmma-gfx1250.mlir
@@ -433,3 +433,37 @@ module attributes {"ttg.num-ctas" = 4 : i32, "ttg.num-warps" = 4 : i32, ttg.targ
     tt.return
   }
 }
+
+// -----
+
+#blocked = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked1 = #ttg.blocked<{sizePerThread = [1, 16], threadsPerWarp = [16, 2], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked2 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [8, 4], warpsPerCTA = [4, 1], order = [1, 0]}>
+#blocked3 = #ttg.blocked<{sizePerThread = [1, 1], threadsPerWarp = [1, 32], warpsPerCTA = [4, 1], order = [1, 0]}>
+// CHECK-DAG: #[[$SCALE0_LAYOUT:.+]] = #ttg.linear{{<{register = \[\[0, 1\], \[0, 2\]\], lane = \[\[1, 0\], \[2, 0\], \[4, 0\], \[8, 0\], \[0, 0\]\], warp = \[\[0, 0\], \[16, 0\]\], block = \[\]}>}}
+// CHECK-DAG: #[[$SCALE1_LAYOUT:.+]] = #ttg.linear{{<{register = \[\[0, 1\], \[0, 2\]\], lane = \[\[1, 0\], \[2, 0\], \[4, 0\], \[8, 0\], \[0, 0\]\], warp = \[\[16, 0\], \[0, 0\]\], block = \[\]}>}}
+// CHECK-DAG: #[[$MMA:.+]] = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = {{\[\[0, 1\], \[1, 0\]\]}}}, instrShape = [16, 16, 128]}>
+// CHECK-DAG: #[[$MMA1:.+]] = #ttg.amd_wmma<{version = 3, isTranspose = true, ctaLayout = {warp = {{\[\[0, 1\], \[1, 0\]\]}}}, instrShape = [16, 16, 64]}>
+// CHECK-LABEL: wmma_dot_scaled_mxfp4_mxfp4_missing_scale
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, ttg.target = "hip:gfx1250", "ttg.threads-per-warp" = 32 : i32} {
+  tt.func public @wmma_dot_scaled_mxfp4_mxfp4_missing_scale(
+      %arg0: tensor<32x64xi8, #blocked>,
+      %arg1: tensor<64x32xi8, #blocked1>,
+      %arg2: tensor<32x4xi8, #blocked2>,
+      %arg3: tensor<32x32x!tt.ptr<f32>, #blocked3>
+      ) {
+    // CHECK-NOT: arith.constant dense<127> : tensor<32x4xi8, #[[$SCALE0_LAYOUT]]>
+    // CHECK: %[[SCALE1:.+]] = arith.constant dense<127> : tensor<32x4xi8, #[[$SCALE1_LAYOUT]]>
+    // CHECK-NOT: arith.constant dense<127> : tensor<32x4xi8, #[[$SCALE0_LAYOUT]]>
+    // CHECK-NOT: tt.fp_to_fp
+    // CHECK: %[[C:.+]] = ttg.convert_layout {{.*}} : tensor<32x32xf32, {{.*}}> -> tensor<32x32xf32, #[[$MMA]]>
+    // CHECK: %[[A:.+]] = ttg.convert_layout {{.*}} : tensor<32x64xi8, {{.*}}> -> tensor<32x64xi8, #ttg.dot_op<{opIdx = 0, parent = #[[$MMA1]], kWidth = 16}>>
+    // CHECK: %[[B:.+]] = ttg.convert_layout {{.*}} : tensor<64x32xi8, {{.*}}> -> tensor<64x32xi8, #ttg.dot_op<{opIdx = 1, parent = #[[$MMA1]], kWidth = 16}>>
+    // CHECK: %[[SCALE0:.+]] = ttg.convert_layout {{.*}} : tensor<32x4xi8, {{.*}}> -> tensor<32x4xi8, #[[$SCALE0_LAYOUT]]>
+    // CHECK: tt.dot_scaled %[[A]] scale %[[SCALE0]], %[[B]] scale %[[SCALE1]], %[[C]] lhs = e2m1 rhs = e2m1
+    %cst = arith.constant dense<0.000000e+00> : tensor<32x32xf32, #blocked3>
+    %1 = tt.dot_scaled %arg0 scale %arg2, %arg1, %cst lhs = e2m1 rhs = e2m1 {fastMath = false} : tensor<32x64xi8, #blocked>, tensor<32x4xi8, #blocked2> * tensor<64x32xi8, #blocked1>, tensor<32x4xi8, #blocked2> -> tensor<32x32xf32, #blocked3>
+    tt.store %arg3, %1 : tensor<32x32x!tt.ptr<f32>, #blocked3>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/AccelerateAMDMatmul.cpp
@@ -1222,8 +1222,12 @@ public:
           bElemType == ScaleDotElemType::E2M1) {
         // Fp4 x Fp4 requires to use the same scale dtype for both operands.
         TensorValue otherScale = idx == 0 ? bScale : aScale;
-        Type f8Ty = otherScale.getType().getElementType();
-        return {f8Ty, FloatAttr::get(f8Ty, 1.0)};
+        Type scaleTy = otherScale.getType().getElementType();
+        // int8 in this context is actually represents fp8e8m0 dtype,
+        // 127 constant is how 1.0 is represented in this data type.
+        if (scaleTy.isInteger(8))
+          return {scaleTy, rewriter.getIntegerAttr(scaleTy, 127)};
+        return {scaleTy, rewriter.getOneAttr(scaleTy)};
       }
 
       return {i8_ty, rewriter.getIntegerAttr(i8_ty, 0x7F)};


### PR DESCRIPTION
This PR fixes initialization of a constant for second scale operand in mxfp dot in cases when it is not provided. It is implicitly set to 1.0.
In current Triton implementation scales in f8e8m0 format is passed as a int8 tensors, which requires manual constant initialization.
