### PR TITLE
[AMD] Support optional symbols in driver.c

### DIFF
--- a/third_party/amd/backend/driver.c
+++ b/third_party/amd/backend/driver.c
@@ -230,32 +230,34 @@ static const char *hipLibSearchPaths[] = {"/*py_libhip_search_path*/"};
 // |FOR_EACH_ERR_FN| is a macro to process APIs that return hipError_t;
 // |FOR_EACH_STR_FN| is a macro to process APIs that return const char *.
 #define HIP_SYMBOL_LIST(FOR_EACH_ERR_FN, FOR_EACH_STR_FN)                      \
-  FOR_EACH_STR_FN(hipGetLastError)                                             \
-  FOR_EACH_STR_FN(hipGetErrorString, hipError_t hipError)                      \
-  FOR_EACH_ERR_FN(hipGetDeviceProperties, hipDeviceProp_t *prop, int deviceId) \
-  FOR_EACH_ERR_FN(hipModuleLoadDataEx, hipModule_t *module, const void *image, \
-                  unsigned int numOptions, hipJitOption *options,              \
-                  void **optionValues)                                         \
-  FOR_EACH_ERR_FN(hipModuleUnload, hipModule_t module)                         \
-  FOR_EACH_ERR_FN(hipModuleGetFunction, hipFunction_t *function,               \
+  FOR_EACH_STR_FN(hipGetLastError, true)                                       \
+  FOR_EACH_STR_FN(hipGetErrorString, true, hipError_t hipError)                \
+  FOR_EACH_ERR_FN(hipGetDeviceProperties, true, hipDeviceProp_t *prop,         \
+                  int deviceId)                                                \
+  FOR_EACH_ERR_FN(hipModuleLoadDataEx, true, hipModule_t *module,              \
+                  const void *image, unsigned int numOptions,                  \
+                  hipJitOption *options, void **optionValues)                  \
+  FOR_EACH_ERR_FN(hipModuleUnload, true, hipModule_t module)                   \
+  FOR_EACH_ERR_FN(hipModuleGetFunction, true, hipFunction_t *function,         \
                   hipModule_t module, const char *kname)                       \
-  FOR_EACH_ERR_FN(hipFuncGetAttribute, int *, hipFunction_attribute attr,      \
-                  hipFunction_t function)                                      \
-  FOR_EACH_ERR_FN(hipDrvLaunchKernelEx, const HIP_LAUNCH_CONFIG *config,       \
-                  hipFunction_t f, void **kernelParams, void **extra)          \
-  FOR_EACH_ERR_FN(hipModuleLaunchKernel, hipFunction_t f,                      \
+  FOR_EACH_ERR_FN(hipFuncGetAttribute, true, int *,                            \
+                  hipFunction_attribute attr, hipFunction_t function)          \
+  FOR_EACH_ERR_FN(hipDrvLaunchKernelEx, false,                                 \
+                  const HIP_LAUNCH_CONFIG *config, hipFunction_t f,            \
+                  void **kernelParams, void **extra)                           \
+  FOR_EACH_ERR_FN(hipModuleLaunchKernel, true, hipFunction_t f,                \
                   unsigned int gridDimX, unsigned int gridDimY,                \
                   unsigned int gridDimZ, unsigned int blockDimX,               \
                   unsigned int blockDimY, unsigned int blockDimZ,              \
                   unsigned int sharedMemBytes, hipStream_t stream,             \
                   void **kernelParams, void **extra)                           \
-  FOR_EACH_ERR_FN(hipModuleLaunchCooperativeKernel, hipFunction_t f,           \
+  FOR_EACH_ERR_FN(hipModuleLaunchCooperativeKernel, true, hipFunction_t f,     \
                   unsigned int gridDimX, unsigned int gridDimY,                \
                   unsigned int gridDimZ, unsigned int blockDimX,               \
                   unsigned int blockDimY, unsigned int blockDimZ,              \
                   unsigned int sharedMemBytes, hipStream_t stream,             \
                   void **kernelParams, void **extra)                           \
-  FOR_EACH_ERR_FN(hipPointerGetAttribute, void *data,                          \
+  FOR_EACH_ERR_FN(hipPointerGetAttribute, true, void *data,                    \
                   hipPointer_attribute attribute, hipDeviceptr_t ptr)
 
 // HIP driver version format: HIP_VERSION_MAJOR * 10000000 + HIP_VERSION_MINOR *
@@ -288,9 +290,9 @@ static const char *hipLibSearchPaths[] = {"/*py_libhip_search_path*/"};
 
 // The HIP symbol table for holding resolved dynamic library symbols.
 struct HIPSymbolTable {
-#define DEFINE_EACH_ERR_FIELD(hipSymbolName, ...)                              \
+#define DEFINE_EACH_ERR_FIELD(hipSymbolName, required, ...)                    \
   hipError_t (*hipSymbolName)(__VA_ARGS__);
-#define DEFINE_EACH_STR_FIELD(hipSymbolName, ...)                              \
+#define DEFINE_EACH_STR_FIELD(hipSymbolName, required, ...)                    \
   const char *(*hipSymbolName)(__VA_ARGS__);
 
   HIP_SYMBOL_LIST(DEFINE_EACH_ERR_FIELD, DEFINE_EACH_STR_FIELD)
@@ -380,11 +382,11 @@ bool initSymbolTable() {
   uint64_t hipFlags = 0;
   hipDriverProcAddressQueryResult symbolStatus;
   hipError_t status = hipSuccess;
-#define QUERY_EACH_FN(hipSymbolName, ...)                                      \
+#define QUERY_EACH_FN(hipSymbolName, required, ...)                            \
   status = hipGetProcAddress(#hipSymbolName,                                   \
                              (void **)&hipSymbolTable.hipSymbolName,           \
                              hipVersion, hipFlags, &symbolStatus);             \
-  if (status != hipSuccess) {                                                  \
+  if (required && status != hipSuccess) {                                      \
     PyErr_SetString(PyExc_RuntimeError,                                        \
                     "cannot get address for '" #hipSymbolName                  \
                     "' from libamdhip64.so");                                  \


### PR DESCRIPTION
https://github.com/triton-lang/triton/pull/8729 enabled optional symbol support in driver.py. However, when refactoring driver with https://github.com/triton-lang/triton/pull/6788, the logic was dropped. This ports over to driver.c.