### PR TITLE
Advance version 3.6.0->3.7.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -145,7 +145,7 @@ extensions = [
 autosummary_generate = True
 
 # versioning config
-smv_tag_whitelist = r'^(v3.6.0)$'
+smv_tag_whitelist = r'^(v3.7.0)$'
 smv_branch_whitelist = r'^main$'
 smv_remote_whitelist = None
 smv_released_pattern = r'^tags/.*$'

--- a/python/triton/__init__.py
+++ b/python/triton/__init__.py
@@ -1,5 +1,5 @@
 """isort:skip_file"""
-__version__ = '3.6.0'
+__version__ = '3.7.0'
 
 # ---------------------------------------
 # Note: import order is significant here.

--- a/setup.py
+++ b/setup.py
@@ -554,7 +554,7 @@ def get_triton_version_suffix():
 
 
 # keep it separate for easy substitution
-TRITON_VERSION = "3.6.0" + get_triton_version_suffix()
+TRITON_VERSION = "3.7.0" + get_triton_version_suffix()
 
 # Dynamically define supported Python versions and classifiers
 MIN_PYTHON = (3, 10)


### PR DESCRIPTION
Same as https://github.com/triton-lang/triton/pull/8836

We have release branch: https://github.com/triton-lang/triton/tree/release/3.7.x will be cherry-picking this change to release once merged