### PR TITLE
[AMD] resurrect PR-8779: Make arith.select handling in canonicalize pointers more Robust

### DIFF
--- a/test/TritonGPU/amd/amd-canonicalize-pointers-no-large-tensor.mlir
+++ b/test/TritonGPU/amd/amd-canonicalize-pointers-no-large-tensor.mlir
@@ -18,3 +18,46 @@ module attributes {"ttg.num-warps" = 4 : i32} {
 // CHECK-LABEL:   tt.func @conversion1
 // CHECK: %[[ADDPTR:.*]] = tt.addptr
 // CHECK:                = tt.load %[[ADDPTR]]
+
+// ---
+// Verify that a scalar select no longer crashes
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  // CHECK-LABEL: _scalar_select
+  tt.func public @_scalar_select(%arg0: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg1: !tt.ptr<bf16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg2: !tt.ptr<bf16> {tt.divisibility = 16 : i32}, %arg3: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg4: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg5: !tt.ptr<i32> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32}, %arg6: i32 {tt.divisibility = 16 : i32}, %arg7: i32 {tt.divisibility = 16 : i32}, %arg8: i32 {tt.divisibility = 16 : i32}, %arg9: i32 {tt.divisibility = 16 : i32}) attributes {noinline = false} {
+    %c9_i32 = arith.constant 9 : i32
+    %c1_i32 = arith.constant 1 : i32
+    %0 = tt.get_program_id x : i32
+    %1 = tt.get_program_id y : i32
+    %2 = tt.get_program_id z : i32
+    %3 = tt.addptr %arg3, %0 : !tt.ptr<i32>, i32
+    %4 = tt.load %3 : !tt.ptr<i32>
+    %5 = arith.addi %1, %4 : i32
+    %6 = arith.addi %0, %c1_i32 : i32
+    %7 = tt.addptr %arg3, %6 : !tt.ptr<i32>, i32
+    %8 = tt.load %7 : !tt.ptr<i32>
+    %9 = arith.cmpi sge, %2, %c9_i32 : i32
+    %10 = tt.addptr %arg0, %5 : !tt.ptr<bf16>, i32
+    %11 = arith.muli %5, %arg8 : i32
+    %12 = arith.muli %2, %arg9 : i32
+    %13 = arith.addi %11, %12 : i32
+    %14 = tt.addptr %arg1, %13 : !tt.ptr<bf16>, i32
+    %15 = tt.addptr %arg4, %0 : !tt.ptr<i32>, i32
+    %16 = tt.load %15 : !tt.ptr<i32>
+    %17 = tt.addptr %arg5, %0 : !tt.ptr<i32>, i32
+    %18 = tt.load %17 : !tt.ptr<i32>
+    %19 = arith.addi %16, %18 : i32
+    %20 = arith.subi %8, %5 : i32
+    %21 = arith.subi %19, %20 : i32
+    %22 = arith.subi %2, %c9_i32 : i32
+    %23 = arith.muli %22, %arg7 : i32
+    %24 = arith.muli %21, %arg6 : i32
+    %25 = arith.addi %23, %24 : i32
+    %26 = tt.addptr %arg2, %25 : !tt.ptr<bf16>, i32
+    // CHECK-COUNT-2: tt.addptr
+    // CHECK: arith.select
+    %27 = arith.select %9, %26, %14 : !tt.ptr<bf16>
+    %28 = tt.load %10 : !tt.ptr<bf16>
+    tt.store %27, %28 : !tt.ptr<bf16>
+    tt.return
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/CanonicalizePointers.cpp
@@ -1363,16 +1363,43 @@ public:
   LogicalResult
   matchAndRewrite_(arith::SelectOp selectOp, OneToNOpAdaptor adaptor,
                    ConversionPatternRewriter &rewriter) const override {
-    if (adaptor.getTrueValue().size() != 2 ||
-        adaptor.getFalseValue().size() != 2) {
-      assert(adaptor.getTrueValue().size() == adaptor.getFalseValue().size() &&
-             "expected both true and false operands to be the same size");
-      return success();
-    }
-    // If both have been traversed, then we can rewrite select of pointers as a
-    // select of base and offset
+
     ValueRange fatPtrFalse = adaptor.getFalseValue();
     ValueRange fatPtrTrue = adaptor.getTrueValue();
+
+    assert((fatPtrTrue.size() == 1 || fatPtrTrue.size() == 2) &&
+           "expected 1 or 2 element fatPtrTrue");
+    assert((fatPtrFalse.size() == 1 || fatPtrFalse.size() == 2) &&
+           "expected 1 or 2 element fatPtrFalse");
+    if (fatPtrTrue.size() == 1 && fatPtrFalse.size() == 1)
+      return success();
+    if (fatPtrTrue.size() != 2 || fatPtrFalse.size() != 2) {
+      Value trueOp;
+      Value falseOp;
+      if (fatPtrTrue.size() == 2) {
+        trueOp = tt::AddPtrOp::create(rewriter, selectOp.getLoc(),
+                                      selectOp.getType(), fatPtrTrue[0],
+                                      fatPtrTrue[1]);
+      } else {
+        trueOp = fatPtrTrue[0];
+      }
+      if (fatPtrFalse.size() == 2) {
+        falseOp = tt::AddPtrOp::create(rewriter, selectOp.getLoc(),
+                                       selectOp.getType(), fatPtrFalse[0],
+                                       fatPtrFalse[1]);
+      } else {
+        falseOp = fatPtrFalse[0];
+      }
+      auto newSelectOp = arith::SelectOp::create(
+          rewriter, selectOp.getLoc(), selectOp.getType(),
+          selectOp.getCondition(), trueOp, falseOp);
+      rewriter.replaceOp(selectOp, newSelectOp);
+      return success();
+    }
+
+    // If both have been traversed, then we can rewrite select of pointers as a
+    // select of base and offset
+
     // Rewrite to select(fatBaseT, fatBaseF) and select(fatOffsetT, fatOffsetF)
     auto newBase = arith::SelectOp::create(rewriter, selectOp.getLoc(),
                                            selectOp.getCondition(),


### PR DESCRIPTION
To test/resurrect https://github.com/triton-lang/triton/pull/8779.

Credit belong to Nick.

I just grab the patch and apply to the tip and manually resolve conflict. It looks like we occasionally hit the problem (as we can see from recent https://github.com/triton-lang/triton/pull/8779)

Since Nick is not a member, he is able to not run re-test in the event of false failure, This ticket is to test his change in an attempt to resolve the problem ASAP.

Again, credit belong to @njriasan 
co-authored by me (from AMD) ,help for testing. 