### PR TITLE
[AMD] Skip fp8 data type tests on RDNA3 for test_conversions

### DIFF
--- a/python/test/unit/language/test_conversions.py
+++ b/python/test/unit/language/test_conversions.py
@@ -286,7 +286,7 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
             return
     elif is_hip():
         if src_dtype in FP8_DTYPES and is_hip_rdna3():
-            pytest.skip(f"{src_dtype} is not supported on AMDGPU RDNA3 (Navi3)")
+            pytest.skip(f"{src_dtype} is not supported on AMDGPU RDNA3")
         if  (src_dtype == 'float8e4nv' and not (is_hip_cdna3() or is_hip_cdna4())):
             pytest.skip(f"upcasting {src_dtype} to {dst_dtype} not supported in this architecture")
         if  src_dtype == 'float8e4b15':
@@ -348,7 +348,7 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
 
     if is_hip():
         if dst_dtype in FP8_DTYPES and is_hip_rdna3():
-            pytest.skip(f"{dst_dtype} is not supported on AMDGPU RDNA3 (Navi3)")
+            pytest.skip(f"{dst_dtype} is not supported on AMDGPU RDNA3")
         if dst_dtype in ('float8e4b8', 'float8e5b16') and (is_hip_cdna2() or is_hip_rdna4()):
             pytest.skip(f"{dst_dtype} is not supported on AMDGPU CDNA2 and RDNA4")
 
@@ -380,7 +380,7 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
     if dst_dtype in FP8_DTYPES and is_hip_rdna3():
-        pytest.skip(f"{dst_dtype} is not supported on AMDGPU RDNA3 (Navi3)")
+        pytest.skip(f"{dst_dtype} is not supported on AMDGPU RDNA3")
 
     if mode in ('inf', '-inf') and is_hip_rdna4():
         pytest.skip(f"clamping from `{mode}` is not supported on AMDGPU GFX12")


### PR DESCRIPTION
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

Navi3 does not support fp8 data type. This PR skip all the fp8 tests in test_conversions for RDNA3.

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `if fixes a test`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
