### PR TITLE
[AMD][gfx1250] Pack f32 arith ops into <2 x float> for v_pk_* instructions

### DIFF
--- a/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -2108,23 +2108,8 @@ Value EmitDualBF16ElementwiseOp(Location loc,
   return convertFp32ToBf16(loc, rewriter, result, RoundingMode::RTNE);
 }
 
-// Pack 2 adjacent f32 elements into <2 x float> for v_pk_* instructions.
-// Only used on GFX1250 where packed f32 math is beneficial.
-template <typename LLVMOp>
-SmallVector<Value>
-EmitPackedF32Op(Location loc, ConversionPatternRewriter &rewriter, Type elemTy,
-                MultipleOperandsRange operands) {
-  if (operands.size() < 2 || !elemTy.isF32())
-    return {};
-
-  Value va = packLLVector(loc, {operands[0][0], operands[1][0]}, rewriter);
-  Value vb = packLLVector(loc, {operands[0][1], operands[1][1]}, rewriter);
-  Value vr = LLVMOp::create(rewriter, loc, va.getType(), va, vb);
-  return unpackLLVector(loc, vr, rewriter);
-}
-
-// gfx1250-specific override that packs adjacent f32 elementwise ops into
-// <2 x float>. The default elementwise patterns remain target-agnostic.
+// Override pattern that packs adjacent f32 elementwise ops into <2 x float>.
+// The default elementwise patterns remain target-agnostic.
 template <typename SourceOp, typename LLVMOp>
 struct PackedF32ArithOpConversion
     : ElementwiseOpConversionBase<
@@ -2140,7 +2125,13 @@ struct PackedF32ArithOpConversion
                                    ConversionPatternRewriter &rewriter,
                                    Type elemTy, MultipleOperandsRange operands,
                                    Location loc) const {
-    return EmitPackedF32Op<LLVMOp>(loc, rewriter, elemTy, operands);
+    if (operands.size() < 2 || !elemTy.isF32())
+      return {};
+
+    Value va = packLLVector(loc, {operands[0][0], operands[1][0]}, rewriter);
+    Value vb = packLLVector(loc, {operands[0][1], operands[1][1]}, rewriter);
+    Value vr = LLVMOp::create(rewriter, loc, va.getType(), va, vb);
+    return unpackLLVector(loc, vr, rewriter);
   }
 };
 

--- a/third_party/amd/python/test/test_packed_f32_arith.py
+++ b/third_party/amd/python/test/test_packed_f32_arith.py
@@ -4,10 +4,7 @@ Compile-only test — no gfx1250 hardware required.
 Compiles attn_fwd.ttir for gfx1250 and checks that:
   - LLVM IR contains <2 x float> fmul/fsub/fadd (from packed conversion + VectorCombine)
   - ASM contains v_pk_fma_f32 (from ISel contraction of packed fmul+fsub)
-  - Scalar v_fma_f32 count is reduced compared to baseline without packed conversion
-
-Baseline (before Approach B, VectorCombine only):
-  v_pk_fma_f32: 2, v_pk_mul_f32: 392, v_pk_add_f32: 130, v_fma_f32: 260
+  - Packed FMA lowering clearly dominates scalar FMA lowering in the resulting ASM
 """
 
 import re
@@ -78,37 +75,7 @@ def test_gfx1250_v_pk_fma_f32_in_asm(gfx1250_kernel):
     func_body = get_func_body_asm(amdgcn)
     counts = count_asm_instructions(func_body)
 
-    assert counts["v_pk_fma_f32"] > 0, ("Expected v_pk_fma_f32 in gfx1250 asm output")
-
-    # After Approach B, expect significantly more packed FMAs than baseline (2)
-    # and fewer scalar FMAs than baseline (260)
-    assert counts["v_pk_fma_f32"] > 2, (f"Expected more than 2 v_pk_fma_f32 (got {counts['v_pk_fma_f32']}). "
-                                        f"Approach B should generate packed f32 ops from conversion layer.")
-    assert counts["v_fma_f32"] < 260, (f"Expected fewer than 260 v_fma_f32 (got {counts['v_fma_f32']}). "
-                                       f"Approach B packed conversion should reduce scalar FMA count.")
-
-
-if __name__ == "__main__":
-    print("Compiling attn_fwd.ttir for gfx1250...")
-    kernel = compile_for_target(GFX1250_TARGET)
-
-    print("\n=== LLVM IR check ===")
-    llir = kernel.asm["llir"]
-    func_body = get_func_body_llir(llir)
-    packed_fop = re.compile(r"f(mul|sub|add) <2 x float>")
-    matches = packed_fop.findall(func_body)
-    print(f"Packed f32 ops found: {len(matches)}")
-
-    for line in func_body.split("\n"):
-        if packed_fop.search(line):
-            print(f"  {line.strip()}")
-            break  # just show first match
-
-    print("\n=== ASM check ===")
-    amdgcn = kernel.asm["amdgcn"]
-    func_body_asm = get_func_body_asm(amdgcn)
-    counts = count_asm_instructions(func_body_asm)
-    for name, count in counts.items():
-        print(f"{name}: {count}")
-
-    print(f"\nResult: {'PASS' if counts['v_pk_fma_f32'] > 2 else 'BASELINE (Approach B not yet active)'}")
+    assert counts["v_pk_fma_f32"] > 100, (f"Expected a substantial number of v_pk_fma_f32 instructions, got "
+                                          f"{counts['v_pk_fma_f32']}")
+    assert counts["v_fma_f32"] < 20, (f"Expected scalar v_fma_f32 instructions to stay low, got "
+                                      f"{counts['v_fma_f32']}")


### PR DESCRIPTION
Generate packed <2 x float> fmul/fadd/fsub in the TritonGPU -> LLVM conversion layer for GFX1250 targets. ISel contracts packed fmul+fsub into v_pk_fma_f32, reducing scalar v_fma_f32 from 260 to 12 on the attn_fwd kernel (-95%).

- Add EmitPackedF32Op helper template that packs 2 adjacent elements
- Modify FMulOpConversion, FAddOpConversion, FSubOpConversion for GFX1250
- Add compile-only test verifying packed ops in LLVM IR and ASM
- Gated by ISAFamily::GFX1250, gfx942 unaffected

## comparison
The comparison of instruction counts for the attn_fwd kernel (compile triton/third_party/amd/python/test/attn_fwd.ttir) is shown in the following table:
| inst | 1. Baseline | 2. Pack arith::MulFOp/AddFOp/SubFOp | change (1 -> 2)         |
| -------------------------------- | ----------- | ----------------------------------- | ---------------- |
| `v_pk_fma_f32`                   | 2           | **136**                             | **+134**         |
| `v_pk_mul_f32`                   | 392         | 388                                 | -4               |
| `v_pk_add_f32`                   | 130         | 136                                 | +6               |
| `v_pk_sub_f32`                   | 0           | 0                                   | —                |
| `v_fma_f32`                      | 260         | **12**                              | **-248 (-95%)**  |
| `v_mul_f32`                      | 0           | 0                                   | —                |
| `v_add_f32`                      | 0           | 0                                   | —                |
| `v_sub_f32`                      | 0           | 0                                   | —                |
| `v_dual_mov_b32`                 | 281         | 269                                 | -12              |
| `v_mov_b32_e32`                  | 24          | 32                                  | +8               |
| `s_mov_b32`                      | 12          | 9                                   | -3               |
| **total v/s instructions**       | **3637**    | **3293**                            | **-344 (-9.5%)** |

## NOTE
- This is just a **draft** implementation for publication to verify whether the design is correct. The code still needs to be optimized.
- Currently, it directly judges whether it is the gfx1250 arch in the pass, and this part need some optimization.

<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [ ] I am not making a trivial change, such as fixing a typo in a comment.

- [ ] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [ ] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [ ] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
