### PR TITLE
[language] Skip f16 to f32 promotion in max/min reductions

### DIFF
--- a/python/test/unit/language/test_compile_only.py
+++ b/python/test/unit/language/test_compile_only.py
@@ -220,3 +220,26 @@ def test_fp8_compiles_for_multiple_architectures_cuda():
     src = ASTSource(fn=fp8_convert, signature={"src": "*fp32", "dst": "*fp8e5"}, constexprs={})
     triton.compile(src, target=GPUTarget("cuda", 90, 32))
     triton.compile(src, target=GPUTarget("cuda", 80, 32))
+
+
+def test_f16_min_max_no_promotion():
+    """f16 should not get promoted to f32 in min/max reductions."""
+
+    @triton.jit
+    def reduce_min(src, dst):
+        idx = tl.arange(0, 64)
+        x = tl.load(src + idx)
+        tl.store(dst, tl.min(x, axis=0))
+
+    @triton.jit
+    def reduce_max(src, dst):
+        idx = tl.arange(0, 64)
+        x = tl.load(src + idx)
+        tl.store(dst, tl.max(x, axis=0))
+
+    targets = [GPUTarget("cuda", 90, 32), GPUTarget("hip", "gfx942", 64)]
+    for target in targets:
+        for kernel in [reduce_min, reduce_max]:
+            f16 = triton.compile(ASTSource(fn=kernel, signature={"src": "*fp16", "dst": "*fp16"}, constexprs={}),
+                                 target=target)
+            assert "arith.extf" not in f16.asm["ttir"], "f16 should not get promoted to f32 in min/max reductions"

--- a/python/triton/language/standard.py
+++ b/python/triton/language/standard.py
@@ -184,7 +184,9 @@ def max(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
     else:
         if core.constexpr(input.dtype.primitive_bitwidth) < core.constexpr(32):
             if core.constexpr(input.dtype.is_floating()):
-                input = input.to(core.float32)
+                # Do not promote f16 to f32 as it has native hardware support
+                if not core.constexpr(input.dtype == core.float16):
+                    input = input.to(core.float32)
             else:
                 assert input.dtype.is_int(), "Expecting input to be integer type"
                 input = input.to(core.int32)
@@ -241,9 +243,11 @@ def min(input, axis=None, return_indices=False, return_indices_tie_break_left=Tr
         else:
             return core._reduce_with_indices(input, axis, _argmin_combine_tie_break_fast, keep_dims=keep_dims)
     else:
-        if core.constexpr(input.dtype.primitive_bitwidth) < 32:
+        if core.constexpr(input.dtype.primitive_bitwidth) < core.constexpr(32):
             if core.constexpr(input.dtype.is_floating()):
-                input = input.to(core.float32)
+                # Do not promote f16 to f32 as it has native hardware support
+                if not core.constexpr(input.dtype == core.float16):
+                    input = input.to(core.float32)
             else:
                 assert input.dtype.is_int(), "Expecting input to be integer type"
                 input = input.to(core.int32)


### PR DESCRIPTION
No need to promote f16 to f32 in min/max reductions as targets have native f16 min/max support.