### PR TITLE
Fix and unify macOS LLVM build

### DIFF
--- a/.github/workflows/llvm-build.yml
+++ b/.github/workflows/llvm-build.yml
@@ -33,7 +33,7 @@ jobs:
         - {runner: 'Ubuntu 22.04 ARM64', runs_on: 'ubuntu-22.04', target-os: 'ubuntu', arch: 'arm64'}
         - {runner: 'AlmaLinux 8', runs_on: 'ubuntu-22.04', target-os: 'almalinux', arch: 'x64', container: 'almalinux:8.10-20250411'}
         - {runner: 'AlmaLinux 8 ARM64', runs_on: 'ubuntu-22.04-arm', target-os: 'almalinux', arch: 'arm64', container: 'almalinux:8.10-20250411'}
-        - {runner: 'MacOS X64', runs_on: 'macos-15', target-os: 'macos', arch: 'x64'}
+        - {runner: 'MacOS X64', runs_on: 'macos-15-intel', target-os: 'macos', arch: 'x64'}
         - {runner: 'MacOS ARM64', runs_on: 'macos-15', target-os: 'macos', arch: 'arm64'}
         - {runner: 'Windows Latest', runs_on: 'windows-latest', target-os: 'windows', arch: 'x64'}
 
@@ -112,8 +112,8 @@ jobs:
         sudo apt-get clean
         df -h
 
-    - name: Configure, Build, Test, and Install LLVM (Linux and macOS x64)
-      if: (matrix.config.arch == 'x64' && (matrix.config.target-os == 'ubuntu' || matrix.config.target-os == 'macos')) || matrix.config.target-os == 'almalinux'
+    - name: Configure, Build, Test, and Install LLVM (Ubuntu x64, CentOS, and macOS)
+      if: (matrix.config.arch == 'x64' && matrix.config.target-os == 'ubuntu') || matrix.config.target-os == 'almalinux' || matrix.config.target-os == 'macos'
       run: >
         python3 -m pip install -r llvm-project/mlir/python/requirements.txt
 
@@ -222,33 +222,6 @@ jobs:
         -DMLIR_INCLUDE_TESTS=OFF \
         llvm-project/llvm
         ninja -C llvm-project/build install
-        tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
-
-    - name: Configure, Build, and Install LLVM (macOS arm64)
-      if: matrix.config.arch == 'arm64' && matrix.config.target-os == 'macos'
-      run: >
-        python3 -m pip install -r llvm-project/mlir/python/requirements.txt
-
-        cmake -GNinja -Bllvm-project/build
-        -DCMAKE_BUILD_TYPE=Release
-        -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-        -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache
-        -DCMAKE_INSTALL_PREFIX="${{ env.llvm_install_dir }}"
-        -DCMAKE_LINKER=lld
-        -DCMAKE_OSX_ARCHITECTURES=arm64
-        -DLLVM_BUILD_UTILS=ON
-        -DLLVM_BUILD_TOOLS=ON
-        -DLLVM_ENABLE_ASSERTIONS=ON
-        -DMLIR_ENABLE_BINDINGS_PYTHON=OFF
-        -DLLVM_ENABLE_PROJECTS="mlir;llvm;lld;clang"
-        -DLLVM_ENABLE_ZSTD=OFF
-        -DLLVM_INSTALL_UTILS=ON
-        -DLLVM_TARGETS_TO_BUILD="AArch64;NVPTX;AMDGPU"
-        -DLLVM_USE_HOST_TOOLS=ON
-        llvm-project/llvm
-
-        ninja -C llvm-project/build install
-
         tar czf "${{ env.llvm_install_dir }}.tar.gz" "${{ env.llvm_install_dir }}"
 
     - name: Upload Build Artifacts


### PR DESCRIPTION

The current macOS build is using the github macos-15 runner, which is
an arm runner. So the x64 build is actually generating arm binaries.

Fix this by changing it to macos-15-intel, and fold the current arm
build into the same step, since that is already on an arm runner and
doesn't need any special handling.

---
[//]: # (BEGIN SAPLING FOOTER)
* #9910
* __->__ #9909