### PR TITLE
[triton_kernels] Add other= to masked scale loads in _matmul.py to match _p_matmul.py

### DIFF
--- a/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
+++ b/python/triton_kernels/triton_kernels/matmul_details/_matmul.py
@@ -388,7 +388,7 @@ def _matmul(
             w_format: tl.constexpr = get_scaled_dot_format_string(w.dtype)
 
             if is_x_microscaled:
-                x_scales = tl.load(XMxScalePtrs, mask=mask_x_k_scale[None, :])
+                x_scales = tl.load(XMxScalePtrs, mask=mask_x_k_scale[None, :], other=0.0)
             elif x_format == "fp16" or x_format == "bf16":
                 x_scales: tl.constexpr = None
             else:
@@ -409,7 +409,7 @@ def _matmul(
             elif SWIZZLE_MX_SCALE == "GFX1250_SCALE":
                 w_scales = unswizzle_mx_scale_gfx1250(tl.load(WMxScalePtrs), BLOCK_N, MX_SCALE_BLOCK_K)
             else:
-                w_scales = tl.load(WMxScalePtrs, mask=mask_k_scale[None, :])
+                w_scales = tl.load(WMxScalePtrs, mask=mask_k_scale[None, :], other=0.0)
 
             if SWIZZLE_MX_VALUE == "HOPPER_VALUE":
                 # Handshake with the swizzling code


### PR DESCRIPTION
When #7598 was ported over to the persistent kernel in #8765, `other=0.0` was added to masked scale loads in the STRIDED fallback path, but was never backported to non-persistent `_matmul.py`. Without other=, masked-off scale lanes contain undefined values.

This case is already covered by existing unit tests, but only hits on fallback-path devices, so no new tests are added.