### PR TITLE
[AMD] Fix SSA dominance violation in ConvertToBufferOps with i64 offsets

### DIFF
--- a/test/TritonGPU/amd/amd-convert-buffer-ops-i64-offset.mlir
+++ b/test/TritonGPU/amd/amd-convert-buffer-ops-i64-offset.mlir
@@ -145,3 +145,35 @@ module attributes {"ttg.num-warps" = 1 : i32, ttg.target = "hip:gfx942", "ttg.th
     tt.return
   }
 }
+
+// -----
+
+// 2D offset = row * stride + col with i64 stride; extracted block stride is the
+// scalar splat source (i64) and must be truncated to i32 for amdg.buffer_load
+// operand #2 (regression: verifier expected i32, got i64).
+
+#blocked6 = #ttg.blocked<{sizePerThread = [1, 8], threadsPerWarp = [8, 8], warpsPerCTA = [8, 1], order = [1, 0]}>
+
+// CHECK-LABEL: @stride_i64_minimal
+module attributes {"ttg.num-warps" = 8 : i32, ttg.target = "hip:gfx942", "ttg.threads-per-warp" = 64 : i32} {
+  tt.func @stride_i64_minimal(
+    %ptr: !tt.ptr<f16> {tt.divisibility = 16 : i32, tt.pointer_range = 32 : i32},
+    %stride: i64,
+    %row: tensor<256x1xi64, #blocked6>,
+    %col: tensor<1x64xi64, #blocked6>
+  ) -> tensor<256x64xf16, #blocked6> {
+    %s = tt.splat %stride : i64 -> tensor<256x1xi64, #blocked6>
+    %mul = arith.muli %row, %s : tensor<256x1xi64, #blocked6>
+    %bc0 = tt.broadcast %mul : tensor<256x1xi64, #blocked6> -> tensor<256x64xi64, #blocked6>
+    %bc1 = tt.broadcast %col : tensor<1x64xi64, #blocked6> -> tensor<256x64xi64, #blocked6>
+    %off = arith.addi %bc1, %bc0 : tensor<256x64xi64, #blocked6>
+    %base = tt.splat %ptr : !tt.ptr<f16> -> tensor<256x64x!tt.ptr<f16>, #blocked6>
+    %p = tt.addptr %base, %off : tensor<256x64x!tt.ptr<f16>, #blocked6>, tensor<256x64xi64, #blocked6>
+    // CHECK: arith.trunci {{.*}} : tensor<256x64xi64, {{.*}}> to tensor<256x64xi32, {{.*}}>
+    // CHECK: arith.trunci {{.*}} : i64 to i32
+    // CHECK: amdg.buffer_load
+    // CHECK-NOT: tt.load
+    %v = tt.load %p : tensor<256x64x!tt.ptr<f16>, #blocked6>
+    tt.return %v : tensor<256x64xf16, #blocked6>
+  }
+}

--- a/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
+++ b/third_party/amd/lib/TritonAMDGPUTransforms/ConvertToBufferOps.cpp
@@ -4,6 +4,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
@@ -209,6 +210,27 @@ Value getBlockStride(Location loc, Value offset, PatternRewriter &rewriter) {
   return nullptr;
 }
 
+// Buffer ops take Optional<I32> stride. getBlockStride walks the offset chain
+// and returns the splat's scalar source, which may be i64 when the kernel uses
+// i64 indices (e.g. row * stride + col with stride in i64).
+static Value maybeTruncateStrideToI32(Value stride, PatternRewriter &rewriter,
+                                      Location loc, Operation *insertBefore) {
+  if (!stride)
+    return stride;
+  auto intTy = dyn_cast<IntegerType>(stride.getType());
+  if (!intTy)
+    return stride;
+  if (intTy.getWidth() == 32)
+    return stride;
+  if (intTy.getWidth() == 64) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(insertBefore);
+    return arith::TruncIOp::create(rewriter, loc, rewriter.getI32Type(),
+                                   stride);
+  }
+  return stride;
+}
+
 // /*-----------------AtomicCAS-------------------*/
 
 struct ConvertTritonAtomicCASOpToBufferAtomicCAS
@@ -290,7 +312,9 @@ struct ConvertTritonAtomicCASOpToBufferAtomicCAS
       return rewriter.notifyMatchFailure(
           op, "BufferAtomicCAS requires opBitWidth >= 32");
     }
-    Value blockStride = getBlockStride(op->getLoc(), tensorOffset, rewriter);
+    Value blockStride = maybeTruncateStrideToI32(
+        getBlockStride(op->getLoc(), tensorOffset, rewriter), rewriter,
+        op->getLoc(), op);
     rewriter.replaceOpWithNewOp<triton::amdgpu::BufferAtomicCASOp>(
         op, op.getVal().getType(), basePtr, tensorOffset, op.getCmp(),
         op.getVal(), blockStride, sem, scope);
@@ -446,7 +470,9 @@ struct ConvertTritonAtomicRMWOpToBufferAtomicRMW
     Value maybeMask{};
     if (op.getMask() && !isSplatOneConstTensor(op.getMask()))
       maybeMask = op.getMask();
-    Value blockStride = getBlockStride(op->getLoc(), tensorOffset, rewriter);
+    Value blockStride = maybeTruncateStrideToI32(
+        getBlockStride(op->getLoc(), tensorOffset, rewriter), rewriter,
+        op->getLoc(), op);
     rewriter.replaceOpWithNewOp<triton::amdgpu::BufferAtomicRMWOp>(
         op, op.getVal().getType(), atomicRmwOp, basePtr, tensorOffset,
         op.getVal(), blockStride, sem, scope, maybeMask);
@@ -499,7 +525,9 @@ struct ConvertTritonLoadToBufferLoad : public mlir::OpRewritePattern<SourceOp> {
       Value maybeMask{};
       if (op.getMask() && !isSplatOneConstTensor(op.getMask()))
         maybeMask = op.getMask();
-      Value blockStride = getBlockStride(op->getLoc(), tensorOffset, rewriter);
+      Value blockStride = maybeTruncateStrideToI32(
+          getBlockStride(op->getLoc(), tensorOffset, rewriter), rewriter,
+          op->getLoc(), op);
 
       auto bufferLoadOp = [&]() {
         if constexpr (std::is_same_v<SourceOp, triton::LoadOp>) {
@@ -576,7 +604,9 @@ struct ConvertTritonStoreToBufferStore
         contig = std::min<unsigned>(
             contig, axisAnalysisPass.getMaskAlignment(maybeMask));
       }
-      Value blockStride = getBlockStride(op->getLoc(), tensorOffset, rewriter);
+      Value blockStride = maybeTruncateStrideToI32(
+          getBlockStride(op->getLoc(), tensorOffset, rewriter), rewriter,
+          op->getLoc(), op);
 
       rewriter.replaceOpWithNewOp<triton::amdgpu::BufferStoreOp>(
           op, op.getValue(), basePtr, tensorOffset, blockStride, op.getCache(),


### PR DESCRIPTION
When multiple loads shared the same tt.addptr with an i64 offset,
 canUseBufferOps() would insert arith.trunci and mutate the addptr's
 offset operand in place. This had three problems:

1. Wrong insertion point: the trunci was created at the rewriter's
 position (before the load), but the addptr referencing it was
 defined earlier, violating SSA dominance.

2. Mutating a shared op: addPtrOp.getOffsetMutable().assign() changed
 the offset for all users of the addptr, not just the load being
 matched.

3. Side effects in a query: canUseBufferOps() modified IR despite
 being a predicate, making repeated calls produce different results.
   
  
Fixed by:
- Making canUseBufferOps() a pure query with no IR modification.
- Introducing truncateOffsetToI32() that uses InsertionGuard to
 insert the trunci right after the offset definition, making it
  self-contained regardless of the caller's insertion point.
- Extracting the original offset in `getBlockStride()` in case of truncation.
- Each pattern creates its own trunci; the addptr is never mutated.

Fixes https://github.com/triton-lang/triton/issues/9907

