### PR TITLE
[FPSAN] Fix an issue where tmem writes in WS may get dropped

### DIFF
--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -95,6 +95,11 @@ struct ScratchInfo {
   RankedTensorType tensorType;
 };
 
+struct ScratchState {
+  std::optional<ScratchInfo> canonical;
+  DenseMap<Region *, ScratchInfo> byScope;
+};
+
 class TmemScratchManager {
 public:
   ttg::BlockedEncodingAttr getScratchEncoding(PatternRewriter &rewriter,
@@ -143,26 +148,19 @@ public:
     }
 
     if (auto alloc = memdesc.getDefiningOp<ttng::TMEMAllocOp>()) {
-      auto it = scratchMap.find(memdesc);
-      if (it != scratchMap.end()) {
-        auto itRegion = it->second.find(scope);
-        if (itRegion != it->second.end()) {
-          if (itRegion->second.ptr && itRegion->second.ptr.getType())
-            return itRegion->second;
-          it->second.erase(itRegion);
-        }
-        auto itCanonical = it->second.find(nullptr);
-        if (itCanonical != it->second.end()) {
-          if (itCanonical->second.ptr && itCanonical->second.ptr.getType()) {
-            Value ptr =
-                remapToScope(itCanonical->second.ptr, rewriter, scope,
-                             alloc.getLoc());
-            ScratchInfo info{ptr, itCanonical->second.tensorType};
-            scratchMap[memdesc][scope] = info;
-            return info;
-          }
-          it->second.erase(itCanonical);
-        }
+      ScratchState &state = scratchMap[memdesc];
+      auto itRegion = state.byScope.find(scope);
+      if (itRegion != state.byScope.end()) {
+        if (itRegion->second.ptr && itRegion->second.ptr.getType())
+          return itRegion->second;
+        state.byScope.erase(itRegion);
+      }
+      if (state.canonical) {
+        Value ptr =
+            remapToScope(state.canonical->ptr, rewriter, scope, alloc.getLoc());
+        ScratchInfo info{ptr, state.canonical->tensorType};
+        state.byScope[scope] = info;
+        return info;
       }
 
       OpBuilder::InsertionGuard guard(rewriter);
@@ -188,12 +186,11 @@ public:
           return std::nullopt;
       }
 
-      ScratchInfo canonicalInfo{ptr, tensorTy};
-      scratchMap[memdesc][nullptr] = canonicalInfo;
+      state.canonical = ScratchInfo{ptr, tensorTy};
 
       ptr = remapToScope(ptr, rewriter, scope, loc);
       ScratchInfo info{ptr, tensorTy};
-      scratchMap[memdesc][scope] = info;
+      state.byScope[scope] = info;
       return info;
     }
 
@@ -317,7 +314,7 @@ private:
     return scope->getArgument(captureIdx);
   }
 
-  DenseMap<Value, DenseMap<Region *, ScratchInfo>> scratchMap;
+  DenseMap<Value, ScratchState> scratchMap;
 };
 
 Value createScratchAndStore(PatternRewriter &rewriter, Location loc, Value val,

--- a/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
+++ b/lib/Dialect/TritonInstrument/Transforms/FpSanitizer.cpp
@@ -151,6 +151,18 @@ public:
             return itRegion->second;
           it->second.erase(itRegion);
         }
+        auto itCanonical = it->second.find(nullptr);
+        if (itCanonical != it->second.end()) {
+          if (itCanonical->second.ptr && itCanonical->second.ptr.getType()) {
+            Value ptr =
+                remapToScope(itCanonical->second.ptr, rewriter, scope,
+                             alloc.getLoc());
+            ScratchInfo info{ptr, itCanonical->second.tensorType};
+            scratchMap[memdesc][scope] = info;
+            return info;
+          }
+          it->second.erase(itCanonical);
+        }
       }
 
       OpBuilder::InsertionGuard guard(rewriter);
@@ -176,8 +188,10 @@ public:
           return std::nullopt;
       }
 
-      ptr = remapToScope(ptr, rewriter, scope, loc);
+      ScratchInfo canonicalInfo{ptr, tensorTy};
+      scratchMap[memdesc][nullptr] = canonicalInfo;
 
+      ptr = remapToScope(ptr, rewriter, scope, loc);
       ScratchInfo info{ptr, tensorTy};
       scratchMap[memdesc][scope] = info;
       return info;

--- a/python/test/gluon/test_fpsan.py
+++ b/python/test/gluon/test_fpsan.py
@@ -1609,6 +1609,53 @@ def test_tmem_index_subslice(device, fresh_knobs):
     _assert_payload_equal(out, exp_bits)
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_tmem_store_in_warp_specialize_partition_visible_to_parent(device, fresh_knobs):
+    _require_cuda_backend(device)
+
+    B = 64
+    BLOCK = gl.constexpr(B)
+
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+
+    @gluon.jit
+    def store_one_partition(tmem):
+        reg_layout: gl.constexpr = tmem.get_reg_layout()
+        one = gl.full((BLOCK, BLOCK), 1.0, gl.float32, reg_layout)
+        tmem.store(one)
+
+    @gluon.jit
+    def default_partition():
+        pass
+
+    @gluon.jit
+    def kernel(out_ptr):
+        layout: gl.constexpr = gl.BlockedLayout([1, 1], [32, 1], [gl.num_warps(), 1], [1, 0])
+        offs_m = gl.arange(0, BLOCK, layout=gl.SliceLayout(1, layout))[:, None]
+        offs_n = gl.arange(0, BLOCK, layout=gl.SliceLayout(0, layout))[None, :]
+        offs = offs_m * BLOCK + offs_n
+
+        tmem_layout: gl.constexpr = TensorMemoryLayout((BLOCK, BLOCK), col_stride=1)
+        tmem = allocate_tensor_memory(gl.float32, [BLOCK, BLOCK], layout=tmem_layout)
+        reg_layout: gl.constexpr = tmem.get_reg_layout()
+        zero = gl.full((BLOCK, BLOCK), 0.0, gl.float32, reg_layout)
+        tmem.store(zero)
+
+        gl.warp_specialize([
+            (default_partition, ()),
+            (store_one_partition, (tmem, )),
+        ], [4], [32])
+
+        out = tmem.load()
+        out = gl.convert_layout(out, layout)
+        gl.store(out_ptr + offs, out)
+
+    out = torch.empty((B, B), device=device, dtype=torch.float32)
+    kernel[(1, )](out, num_warps=4)
+
+    torch.testing.assert_close(out, torch.ones_like(out), rtol=0, atol=0)
+
+
 def test_reduction(device, fresh_knobs):
     _require_cuda_backend(device)
 

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -457,35 +457,6 @@ def test_warp_specialize_tma_matmul_persistent_consan(M, N, K, a_use_tma, b_use_
                                                a_use_tma=a_use_tma, b_use_tma=b_use_tma)
 
 
-@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
-def test_warp_specialize_tma_matmul_persistent_fpsan_shares_accumulator_scratch(fresh_knobs):
-    fresh_knobs.compilation.instrumentation_mode = "fpsan"
-    M, N, K = 512, 512, 128
-    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
-    GROUP_SIZE_M = 8
-    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
-
-    A = torch.empty((M, K), dtype=torch.float16, device="cuda")
-    B = torch.empty((N, K), dtype=torch.float16, device="cuda")
-    C = torch.empty((M, N), dtype=torch.float16, device="cuda")
-
-    def grid(META):
-        return (min(
-            NUM_SMS,
-            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
-        ), )
-
-    kernel = matmul_tma_persistent_ws_kernel.warmup(A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, 3,
-                                                    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M, NUM_SMS,
-                                                    num_warps=8, USE_FP8=False, FLATTEN=True, A_USE_TMA=True,
-                                                    B_USE_TMA=True, grid=grid)
-
-    ttgir = kernel.asm["ttgir"]
-    assert "tt.warp_specialize" in kernel.asm["ttir"]
-    assert "ttg.warp_specialize" in ttgir
-    assert ttgir.count("nbytes = 131072 : i32") == 1
-
-
 @triton.jit
 def attention_inner_loop_kernel(  #
         desc_q, desc_k, desc_v,  #

--- a/python/test/unit/language/test_warp_specialization.py
+++ b/python/test/unit/language/test_warp_specialization.py
@@ -457,6 +457,35 @@ def test_warp_specialize_tma_matmul_persistent_consan(M, N, K, a_use_tma, b_use_
                                                a_use_tma=a_use_tma, b_use_tma=b_use_tma)
 
 
+@pytest.mark.skipif(not is_blackwell(), reason="Requires Blackwell")
+def test_warp_specialize_tma_matmul_persistent_fpsan_shares_accumulator_scratch(fresh_knobs):
+    fresh_knobs.compilation.instrumentation_mode = "fpsan"
+    M, N, K = 512, 512, 128
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 128, 64
+    GROUP_SIZE_M = 8
+    NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count
+
+    A = torch.empty((M, K), dtype=torch.float16, device="cuda")
+    B = torch.empty((N, K), dtype=torch.float16, device="cuda")
+    C = torch.empty((M, N), dtype=torch.float16, device="cuda")
+
+    def grid(META):
+        return (min(
+            NUM_SMS,
+            triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        ), )
+
+    kernel = matmul_tma_persistent_ws_kernel.warmup(A, B, C, *A.stride(), *B.stride(), *C.stride(), M, N, K, 3,
+                                                    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K, GROUP_SIZE_M, NUM_SMS,
+                                                    num_warps=8, USE_FP8=False, FLATTEN=True, A_USE_TMA=True,
+                                                    B_USE_TMA=True, grid=grid)
+
+    ttgir = kernel.asm["ttgir"]
+    assert "tt.warp_specialize" in kernel.asm["ttir"]
+    assert "ttg.warp_specialize" in ttgir
+    assert ttgir.count("nbytes = 131072 : i32") == 1
+
+
 @triton.jit
 def attention_inner_loop_kernel(  #
         desc_q, desc_k, desc_v,  #


### PR DESCRIPTION
Fpsan emulates tmem with global scratch. Each tmem buffer is being mapped to a scratch allocation. There was an issue in how the mapping was created for WS partitions, with the same tmem buffer being mapped to distinct scratch allocations. We track the "canonical" tmem allocation now, to make sure that tmem aliases in different regions, even though they are represented by different SSA values, are getting mapped to the original allocation correctly.