### PR TITLE
Add default global_scratch allocator fallback for Blackwell SM 12.0

### DIFF
--- a/python/triton/backends/driver.py
+++ b/python/triton/backends/driver.py
@@ -146,6 +146,14 @@ class DriverBase(metaclass=ABCMeta):
         """
         raise NotImplementedError
 
+    def allocate_default_global_scratch(self, size: int, alignment: int, stream):
+        """
+        Allocate global scratch when no explicit allocator was installed via set_allocator().
+        Kernels on Blackwell (SM 12.0+) may require global scratch memory for cooperative
+        operations. This fallback prevents RuntimeError when no allocator is configured.
+        """
+        raise NotImplementedError
+
     def allocate_default_profile_scratch(self, size: int, alignment: int, stream):
         """
         Allocate profile scratch when no explicit profile allocator override was installed.
@@ -173,6 +181,18 @@ class GPUDriver(DriverBase):
     # TODO: remove once TMA is cleaned up
     def assemble_tensormap_to_arg(self, tensormaps_info, args):
         return args
+
+    def allocate_default_global_scratch(self, size: int, alignment: int, stream):
+        import torch
+        device = self.get_active_torch_device()
+        device_interface = self.get_device_interface()
+        if stream is None:
+            return torch.empty(size, dtype=torch.uint8, device=device).data_ptr()
+        launch_stream = device_interface.ExternalStream(stream, device=device)
+        with device_interface.stream(launch_stream):
+            scratch = torch.empty(size, dtype=torch.uint8, device=device)
+        scratch.record_stream(launch_stream)
+        return scratch.data_ptr()
 
     def allocate_default_profile_scratch(self, size: int, alignment: int, stream):
         import torch

--- a/third_party/amd/backend/driver.py
+++ b/third_party/amd/backend/driver.py
@@ -349,6 +349,8 @@ class HIPLauncher(object):
                 grid_size = gridX * gridY * gridZ
                 alloc_size = grid_size * size
                 alloc_fn = allocator.get()
+                if isinstance(alloc_fn, _allocation.NullAllocator):
+                    return active_driver.allocate_default_global_scratch(alloc_size, align, stream)
                 return alloc_fn(alloc_size, align, stream)
             return None
 

--- a/third_party/nvidia/backend/driver.py
+++ b/third_party/nvidia/backend/driver.py
@@ -303,6 +303,8 @@ class CudaLauncher(object):
                 grid_size = gridX * gridY * gridZ
                 alloc_size = grid_size * self.num_ctas * size
                 alloc_fn = allocator.get()
+                if isinstance(alloc_fn, _allocation.NullAllocator):
+                    return active_driver.allocate_default_global_scratch(alloc_size, align, stream)
                 return alloc_fn(alloc_size, align, stream)
             return None
 


### PR DESCRIPTION
## Summary

On Blackwell (SM 12.0+), Triton kernels may require `global_scratch` memory for cooperative operations. When no explicit allocator is configured via `triton.set_allocator()`, the `NullAllocator` raises `RuntimeError`, crashing any kernel that uses `global_scratch`.

This adds `allocate_default_global_scratch()` to `GPUDriver` — mirroring the existing `allocate_default_profile_scratch()` pattern — and uses it as a fallback in both NVIDIA and AMD backend launchers when `NullAllocator` is detected.

## Problem

```
RuntimeError: Kernel requires a runtime memory allocation, but no allocator was set.
Use triton.set_allocator to specify an allocator.
```

This crashes on consumer Blackwell GPUs (RTX PRO 6000, RTX 5090, RTX 5080) when running Triton kernels that use `global_scratch` — e.g., FLA `solve_tril` in vLLM for MoE+Mamba models like Qwen3-Coder-Next.

On pre-Blackwell GPUs, these kernels don't use `global_scratch`, so the issue doesn't surface.

## Fix

- Add `allocate_default_global_scratch()` to `GPUDriver` (mirrors `allocate_default_profile_scratch()`)
- In `allocate_scratch()` in both NVIDIA and AMD launchers, fall back to the new method when `NullAllocator` is the current allocator
- Uses `torch.empty()` for allocation, consistent with the existing profile scratch pattern

## Testing

Verified on RTX PRO 6000 Blackwell (SM 12.0, CUDA 13.1):
- Without fix: `RuntimeError` on any kernel using `global_scratch`
- With fix: FLA `chunk_gated_delta_rule` compiles and runs correctly (27.4s first compile, correct output)

## Related Issues

- vllm-project/vllm#36325 — Triton autotuner OOM on Blackwell in `solve_tril`
- vllm-project/vllm#37700 — FLA Hopper/TMA misclassification on SM12x
- Both are vLLM-side workarounds; this PR fixes the root cause in Triton