### PR TITLE
[AMD] Remove unused `import hip; hip.hip.hipInit(0)`

### DIFF
--- a/third_party/amd/python/examples/gluon/f16_fa_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_fa_gfx1250.py
@@ -2,12 +2,6 @@
 This file implements a BSHD Flash Attention and tests against torch reference.
 """
 
-# ruff: noqa: E402
-import hip
-
-# Needed for internal dev flow for now; will remove later
-hip.hip.hipInit(0)
-
 import torch
 from triton.experimental import gluon
 import triton.experimental.gluon.language as gl

--- a/third_party/amd/python/examples/gluon/f16_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_gfx1250.py
@@ -1,9 +1,3 @@
-# ruff: noqa: E402
-import hip
-
-# Needed for internal dev flow for now; will remove later
-hip.hip.hipInit(0)
-
 import pytest
 import torch
 

--- a/third_party/amd/python/examples/gluon/f16_gemm_streamk_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_streamk_gfx1250.py
@@ -1,9 +1,3 @@
-# ruff: noqa: E402
-import hip
-
-# Needed for internal dev flow for now; will remove later
-hip.hip.hipInit(0)
-
 import pytest
 import torch
 import math

--- a/third_party/amd/python/examples/gluon/f16_gemm_warp_pipeline_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_warp_pipeline_gfx1250.py
@@ -1,9 +1,3 @@
-# ruff: noqa: E402
-import hip
-
-# Needed for internal dev flow for now; will remove later
-hip.hip.hipInit(0)
-
 import pytest
 import torch
 

--- a/third_party/amd/python/examples/gluon/mxfp_fa_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/mxfp_fa_gfx1250.py
@@ -1,12 +1,6 @@
 """
 Multi-head attention kernel in Gluon
 """
-# ruff: noqa: E402
-import hip
-
-# Needed for internal dev flow for now; will remove later
-hip.hip.hipInit(0)
-
 import os
 import sys
 import inspect


### PR DESCRIPTION
`import hip;hip.hip.hipInit(0)` was a workaround, we have updates that do not require this anymore.