### PR TITLE
[TESTS] Run all tests in CI

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -1,22 +1,5 @@
-from collections import defaultdict
-import hashlib
-import tempfile
-
 import pytest
-
-
-def _top_level_test_key(item):
-    nodeid = item.nodeid
-    bracket = nodeid.find("[")
-    return nodeid if bracket == -1 else nodeid[:bracket]
-
-
-def _case_key(item):
-    return item.name
-
-
-def _sha256_hex(s: str) -> str:
-    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+import tempfile
 
 
 def pytest_configure(config):
@@ -27,35 +10,6 @@ def pytest_configure(config):
 
 def pytest_addoption(parser):
     parser.addoption("--device", action="store", default="cuda")
-    parser.addoption(
-        "--max-cases-per-test",
-        action="store",
-        type=int,
-        default=100,
-        help="Maximum number of cases per top-level test",
-    )
-
-
-def pytest_collection_modifyitems(config, items):
-    max_cases = config.getoption("--max-cases-per-test")
-    if max_cases <= 0:
-        return
-
-    groups = defaultdict(list)
-    for item in items:
-        groups[_top_level_test_key(item)].append(item)
-
-    kept = []
-    deselected = []
-    for group in groups.values():
-        ordered = sorted(group, key=lambda item: _sha256_hex(_case_key(item)))
-        kept.extend(ordered[:max_cases])
-        deselected.extend(ordered[max_cases:])
-
-    if deselected:
-        config.hook.pytest_deselected(items=deselected)
-
-    items[:] = kept
 
 
 @pytest.fixture


### PR DESCRIPTION
Revert the cap to the number of tests run in CI from https://github.com/triton-lang/triton/pull/10016
CI times are quite reasonable and we want to catch regressions early.
