### PR TITLE
Skip unnecessary boundary-check masks in RewriteTensorDescriptorToPointerPass

### DIFF
--- a/include/triton/Dialect/Triton/IR/TritonOps.td
+++ b/include/triton/Dialect/Triton/IR/TritonOps.td
@@ -1233,7 +1233,8 @@ def TT_DescriptorLoadOp : TT_Op<"descriptor_load", [TT_DescriptorOpInterface]> {
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>]>:$desc,
     Variadic<I32>:$indices,
     DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
-    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict
+    DefaultValuedAttr<TT_EvictionPolicyAttr, "::mlir::triton::EvictionPolicy::NORMAL">:$evict,
+    UnitAttr:$skip_boundary_check
   );
 
   let results = (outs TT_Tensor:$result);
@@ -1260,7 +1261,8 @@ def TT_DescriptorStoreOp : TT_Op<"descriptor_store", [TT_DescriptorStoreLikeOpIn
   let arguments = (ins
     Arg<TT_TensorDescType, "", [MemRead<GlobalMemory>, MemWrite<GlobalMemory>]>:$desc,
     TT_Tensor:$src,
-    Variadic<I32>:$indices
+    Variadic<I32>:$indices,
+    UnitAttr:$skip_boundary_check
   );
 
   let assemblyFormat = [{

--- a/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
+++ b/lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp
@@ -25,6 +25,8 @@
 #include <mlir/Pass/Pass.h>
 #include <mlir/Transforms/DialectConversion.h>
 
+#include "mlir/IR/Matchers.h"
+
 #include <iterator>
 
 namespace mlir::triton {
@@ -296,6 +298,27 @@ SmallVector<mlir::Value> castToI64(OpBuilder &builder,
   });
 }
 
+// When all offsets and shapes are compile-time constants and each
+// offset[i] + blockShape[i] <= shape[i], the access is fully in-bounds
+// and we can skip mask generation.
+bool isStaticallyInBounds(ArrayRef<std::int64_t> blockShape,
+                          ValueRange offsets, ValueRange shape) {
+  assert(blockShape.size() == offsets.size() &&
+         blockShape.size() == shape.size());
+  for (size_t i = 0; i < blockShape.size(); ++i) {
+    APInt offsetVal, shapeVal;
+    if (!matchPattern(offsets[i], m_ConstantInt(&offsetVal)) ||
+        !matchPattern(shape[i], m_ConstantInt(&shapeVal))) {
+      return false;
+    }
+    if (offsetVal.getSExtValue() < 0 ||
+        offsetVal.getSExtValue() + blockShape[i] > shapeVal.getSExtValue()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 struct RewriteMakeTensorDesc : OpConversionPattern<triton::MakeTensorDescOp> {
   using OpConversionPattern<triton::MakeTensorDescOp>::OpConversionPattern;
 
@@ -332,10 +355,18 @@ struct RewriteLoadPattern : OpConversionPattern<triton::DescriptorLoadOp> {
     auto descTy = op.getDesc().getType();
     auto desc = unpackDescriptor(descTy, adaptor.getDesc());
     auto offsets = castToI64(rewriter, op.getIndices());
-    auto other = generateOther(rewriter, loc, descTy, desc.paddingOption);
+
+    Value mask;
+    Value other;
+    if (!op.getSkipBoundaryCheck() &&
+        !isStaticallyInBounds(blockShape, offsets, desc.shape)) {
+      mask = generateMask(rewriter, loc, blockShape, desc, offsets);
+      other = generateOther(rewriter, loc, descTy, desc.paddingOption);
+    }
+
     auto newLoad = triton::LoadOp::create(
         rewriter, loc, generatePtr(rewriter, loc, blockShape, desc, offsets),
-        generateMask(rewriter, loc, blockShape, desc, offsets), other,
+        mask, other,
         triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL, false);
     newLoad->setAttrs(filterSegmentSizes(op->getAttrs()));
 
@@ -371,9 +402,15 @@ struct RewriteStorePattern : OpConversionPattern<triton::DescriptorStoreOp> {
     auto desc = unpackDescriptor(descTy, adaptor.getDesc());
     auto offsets = castToI64(rewriter, op.getIndices());
 
+    Value mask;
+    if (!op.getSkipBoundaryCheck() &&
+        !isStaticallyInBounds(blockShape, offsets, desc.shape)) {
+      mask = generateMask(rewriter, loc, blockShape, desc, offsets);
+    }
+
     auto newStore = rewriter.replaceOpWithNewOp<triton::StoreOp>(
         op, generatePtr(rewriter, loc, blockShape, desc, offsets), op.getSrc(),
-        generateMask(rewriter, loc, blockShape, desc, offsets),
+        mask,
         triton::CacheModifier::NONE, triton::EvictionPolicy::NORMAL);
     newStore->setAttrs(filterSegmentSizes(op->getAttrs()));
 

--- a/python/src/ir.cc
+++ b/python/src/ir.cc
@@ -1541,12 +1541,13 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_descriptor_load",
            [](TritonOpBuilder &self, Value desc, std::vector<Value> &indices,
-              CacheModifier cacheModifier,
-              EvictionPolicy evictionPolicy) -> Value {
+              CacheModifier cacheModifier, EvictionPolicy evictionPolicy,
+              bool skipBoundaryCheck) -> Value {
              auto descTy = cast<triton::TensorDescType>(desc.getType());
              auto resTy = descTy.getSignlessBlockType();
              return self.create<DescriptorLoadOp>(
-                 resTy, desc, indices, cacheModifier, evictionPolicy);
+                 resTy, desc, indices, cacheModifier, evictionPolicy,
+                 skipBoundaryCheck);
            })
       .def("create_descriptor_gather",
            [](TritonOpBuilder &self, Value desc, Value x_indices, Value y_index,
@@ -1556,8 +1557,10 @@ void init_triton_ir(py::module &&m) {
            })
       .def("create_descriptor_store",
            [](TritonOpBuilder &self, Value desc, Value value,
-              std::vector<Value> &indices) -> void {
-             self.create<DescriptorStoreOp>(desc, value, indices);
+              std::vector<Value> &indices,
+              bool skipBoundaryCheck) -> void {
+             self.create<DescriptorStoreOp>(desc, value, indices,
+                                            skipBoundaryCheck);
            })
       .def("create_descriptor_reduce",
            [](TritonOpBuilder &self, DescriptorReduceKind kind, Value desc,

--- a/python/triton/language/core.py
+++ b/python/triton/language/core.py
@@ -1422,24 +1422,30 @@ class tensor_descriptor_base(base_value):
         return str(self.type)
 
     @builtin
-    def load(self, offsets: Sequence[constexpr | tensor], _semantic=None) -> tensor:
+    def load(self, offsets: Sequence[constexpr | tensor], skip_boundary_check: bool = False, _semantic=None) -> tensor:
         """Load a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be filled with zeros.
 
+        :param skip_boundary_check: When True, skip generating boundary check masks
+            in backends that lower tensor descriptors to pointer arithmetic.
+            Set this when the caller guarantees the access is in-bounds.
         :note: Offset must be a multiple of 16-bytes
         """
-        return _semantic.descriptor_load(self, offsets, "", "")
+        return _semantic.descriptor_load(self, offsets, "", "", skip_boundary_check=skip_boundary_check)
 
     @builtin
-    def store(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:
+    def store(self, offsets: Sequence[constexpr | tensor], value: tensor, skip_boundary_check: bool = False, _semantic=None) -> tensor:
         """Store a block from the descriptor starting at the given element offsets.
 
         Values outside of the tensor bounds will be ignored.
 
+        :param skip_boundary_check: When True, skip generating boundary check masks
+            in backends that lower tensor descriptors to pointer arithmetic.
+            Set this when the caller guarantees the access is in-bounds.
         :note: Offset must be a multiple of 16-bytes
         """
-        return _semantic.descriptor_store(self, value, offsets)
+        return _semantic.descriptor_store(self, value, offsets, skip_boundary_check=skip_boundary_check)
 
     @builtin
     def atomic_add(self, offsets: Sequence[constexpr | tensor], value: tensor, _semantic=None) -> tensor:

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -1054,14 +1054,14 @@ class TritonSemantic(Generic[TensorTy]):
         return ret
 
     def descriptor_load(self, desc: tl.tensor_descriptor_base, offsets, cache_modifier: str,
-                        eviction_policy: str) -> TensorTy:
+                        eviction_policy: str, skip_boundary_check: bool = False) -> TensorTy:
         assert isinstance(desc, tl.tensor_descriptor_base)
         ndim = len(desc.block_shape)
         assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
 
         offsets = self._convert_to_ir_values(offsets, require_i64=False)
         x = self.builder.create_descriptor_load(desc.handle, offsets, self._str_to_load_cache_modifier(cache_modifier),
-                                                self._str_to_eviction_policy(eviction_policy))
+                                                self._str_to_eviction_policy(eviction_policy), skip_boundary_check)
         return self.tensor(x, desc.block_type)
 
     def validate_store_like(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> None:
@@ -1070,12 +1070,13 @@ class TritonSemantic(Generic[TensorTy]):
         assert len(offsets) == ndim, f"expected {ndim} offsets, but got {len(offsets)}"
         assert value.shape == desc.block_shape
 
-    def descriptor_store(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
+    def descriptor_store(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets,
+                         skip_boundary_check: bool = False) -> TensorTy:
         self.validate_store_like(desc, value, offsets)
         # implicitly cast to the descriptor's type
         value = self.cast(value, desc.dtype)
         offsets = self._convert_to_ir_values(offsets, require_i64=False)
-        return self.tensor(self.builder.create_descriptor_store(desc.handle, value.handle, offsets), tl.void)
+        return self.tensor(self.builder.create_descriptor_store(desc.handle, value.handle, offsets, skip_boundary_check), tl.void)
 
     def descriptor_atomic_add(self, desc: tl.tensor_descriptor_base, value: TensorTy, offsets) -> TensorTy:
         self.validate_store_like(desc, value, offsets)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -725,7 +725,7 @@ class InterpreterBuilder:
         return desc
 
     def create_descriptor_load(self, desc: TensorDescHandle, indices: List[TensorHandle], cache_modifier,
-                               eviction_policy):
+                               eviction_policy, skip_boundary_check=False):
         assert isinstance(desc, TensorDescHandle)
         ptrs, mask = desc.materialize_pointers(indices)
         dtype_tt = ptrs.get_element_ty()
@@ -740,7 +740,8 @@ class InterpreterBuilder:
         return self.create_masked_load(ptrs, mask, other, cache_modifier=cache_modifier,
                                        eviction_policy=eviction_policy, is_volatile=False)
 
-    def create_descriptor_store(self, desc: TensorDescHandle, value: TensorHandle, indices: List[TensorHandle]):
+    def create_descriptor_store(self, desc: TensorDescHandle, value: TensorHandle, indices: List[TensorHandle],
+                                skip_boundary_check=False):
         ptrs, mask = desc.materialize_pointers(indices)
         return self.create_masked_store(ptrs, value, mask, None, None)
 

--- a/test/Triton/tensor-descriptors-in-bounds.mlir
+++ b/test/Triton/tensor-descriptors-in-bounds.mlir
@@ -1,0 +1,212 @@
+// RUN: %triton-opt %s --triton-rewrite-tensor-descriptor-to-pointer -split-input-file | %FileCheck %s
+
+// Tests for in-bounds optimization in RewriteTensorDescriptorToPointerPass.
+// When tensor descriptor accesses are statically provable to be in-bounds
+// (offset[i] + blockShape[i] <= shape[i] for all dims), the pass skips mask
+// generation to avoid unnecessary masked memory operations.
+
+// Test 1: In-bounds 2D load with zero offset
+// Tensor shape is 256x256 and block shape is 256x256, offset is (0,0).
+// Since 0+256 <= 256 for both dims, the access is fully in-bounds.
+// The pass should emit an unmasked tt.load (no arith.cmpi bounds checks).
+
+// CHECK-LABEL: in_bounds_load_static_zero_offset
+// CHECK-NOT:   arith.cmpi
+// CHECK:       tt.load {{%.+}} : tensor<256x256x!tt.ptr<f32>>
+// CHECK-NOT:   arith.cmpi
+tt.func public @in_bounds_load_static_zero_offset(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) {
+  %c256_i32 = arith.constant 256 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c256_i64, %c1_i64] : <f32>, <tensor<256x256xf32>>
+  %result = tt.descriptor_load %desc[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<256x256xf32>> -> tensor<256x256xf32>
+  tt.return
+}
+
+// -----
+
+// Test 2: In-bounds 2D store with zero offset
+// Same as Test 1 but for stores. The pass should emit an unmasked tt.store.
+
+// CHECK-LABEL: in_bounds_store_static_zero_offset
+// CHECK-NOT:   arith.cmpi
+// CHECK:       tt.store {{%.+}}, {{%.+}} : tensor<256x256x!tt.ptr<f32>>
+// CHECK-NOT:   arith.cmpi
+tt.func public @in_bounds_store_static_zero_offset(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32},
+    %data: tensor<256x256xf32>) {
+  %c256_i32 = arith.constant 256 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c256_i64, %c1_i64] : <f32>, <tensor<256x256xf32>>
+  tt.descriptor_store %desc[%c0_i32, %c0_i32], %data : !tt.tensordesc<tensor<256x256xf32>>, tensor<256x256xf32>
+  tt.return
+}
+
+// -----
+
+// Test 3: In-bounds 2D load with nonzero offset
+// Block shape is 128x128, tensor shape is 256x256, offset is (64, 0).
+// 64+128=192 <= 256 and 0+128=128 <= 256, so the access is in-bounds.
+// The pass should emit an unmasked tt.load.
+
+// CHECK-LABEL: in_bounds_load_nonzero_offset
+// CHECK-NOT:   arith.cmpi
+// CHECK:       tt.load {{%.+}} : tensor<128x128x!tt.ptr<f32>>
+// CHECK-NOT:   arith.cmpi
+tt.func public @in_bounds_load_nonzero_offset(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) {
+  %c256_i32 = arith.constant 256 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c64_i32 = arith.constant 64 : i32
+  %c0_i32 = arith.constant 0 : i32
+  %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c256_i64, %c1_i64] : <f32>, <tensor<128x128xf32>>
+  %result = tt.descriptor_load %desc[%c64_i32, %c0_i32] : !tt.tensordesc<tensor<128x128xf32>> -> tensor<128x128xf32>
+  tt.return
+}
+
+// -----
+
+// Test 4: Out-of-bounds load with dynamic shape
+// Shape is a dynamic function argument (%arg1), so we cannot prove in-bounds
+// at compile time. The pass must conservatively generate a mask.
+
+// CHECK-LABEL: out_of_bounds_load_dynamic_shape
+// CHECK:       arith.cmpi
+// CHECK:       tt.load {{%.+}}, {{%.+}}, {{%.+}} : tensor<32x32x!tt.ptr<f32>>
+tt.func public @out_of_bounds_load_dynamic_shape(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32},
+    %arg1: i32) {
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %stride = arith.extsi %arg1 : i32 to i64
+  %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg1], [%stride, %c1_i64] : <f32>, <tensor<32x32xf32>>
+  %result = tt.descriptor_load %desc[%c0_i32, %c0_i32] : !tt.tensordesc<tensor<32x32xf32>> -> tensor<32x32xf32>
+  tt.return
+}
+
+// -----
+
+// Test 5: Out-of-bounds load with dynamic offset
+// Offset is a dynamic function argument (%arg1), so we cannot prove in-bounds.
+// The pass must conservatively generate a mask.
+
+// CHECK-LABEL: out_of_bounds_load_dynamic_offset
+// CHECK:       arith.cmpi
+// CHECK:       tt.load {{%.+}}, {{%.+}}, {{%.+}} : tensor<128x128x!tt.ptr<f32>>
+tt.func public @out_of_bounds_load_dynamic_offset(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32},
+    %arg1: i32) {
+  %c256_i32 = arith.constant 256 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c256_i64, %c1_i64] : <f32>, <tensor<128x128xf32>>
+  %result = tt.descriptor_load %desc[%arg1, %arg1] : !tt.tensordesc<tensor<128x128xf32>> -> tensor<128x128xf32>
+  tt.return
+}
+
+// -----
+
+// Test 6: Out-of-bounds load where offset+block exceeds shape
+// Block shape is 256x256, offset is (64, 64), shape is 256x256.
+// 64+256=320 > 256, so the access is out-of-bounds. Must generate mask.
+
+// CHECK-LABEL: out_of_bounds_load_block_exceeds_shape
+// CHECK:       arith.cmpi
+// CHECK:       tt.load {{%.+}}, {{%.+}}, {{%.+}} : tensor<256x256x!tt.ptr<f32>>
+tt.func public @out_of_bounds_load_block_exceeds_shape(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) {
+  %c256_i32 = arith.constant 256 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %c1_i64 = arith.constant 1 : i64
+  %c64_i32 = arith.constant 64 : i32
+  %desc = tt.make_tensor_descriptor %arg0, [%c256_i32, %c256_i32], [%c256_i64, %c1_i64] : <f32>, <tensor<256x256xf32>>
+  %result = tt.descriptor_load %desc[%c64_i32, %c64_i32] : !tt.tensordesc<tensor<256x256xf32>> -> tensor<256x256xf32>
+  tt.return
+}
+
+// -----
+
+// Test 7: In-bounds 1D load
+// Block shape is 64, offset is 0, shape is 64. 0+64 <= 64 -> in-bounds.
+// The pass should emit an unmasked tt.load.
+
+// CHECK-LABEL: in_bounds_1d_load
+// CHECK-NOT:   arith.cmpi
+// CHECK:       tt.load {{%.+}} : tensor<64x!tt.ptr<f32>>
+// CHECK-NOT:   arith.cmpi
+tt.func public @in_bounds_1d_load(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32}) {
+  %c64_i32 = arith.constant 64 : i32
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %desc = tt.make_tensor_descriptor %arg0, [%c64_i32], [%c1_i64] : <f32>, <tensor<64xf32>>
+  %result = tt.descriptor_load %desc[%c0_i32] : !tt.tensordesc<tensor<64xf32>> -> tensor<64xf32>
+  tt.return
+}
+
+// -----
+
+// Test 8: Out-of-bounds store with dynamic shape
+// Shape is dynamic, so the pass must conservatively generate a mask.
+
+// CHECK-LABEL: out_of_bounds_store_dynamic_shape
+// CHECK:       arith.cmpi
+// CHECK:       tt.store {{%.+}}, {{%.+}}, {{%.+}} : tensor<32x32x!tt.ptr<f32>>
+tt.func public @out_of_bounds_store_dynamic_shape(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32},
+    %arg1: i32,
+    %data: tensor<32x32xf32>) {
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %stride = arith.extsi %arg1 : i32 to i64
+  %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg1], [%stride, %c1_i64] : <f32>, <tensor<32x32xf32>>
+  tt.descriptor_store %desc[%c0_i32, %c0_i32], %data : !tt.tensordesc<tensor<32x32xf32>>, tensor<32x32xf32>
+  tt.return
+}
+
+// -----
+
+// Test 9: skip_boundary_check attribute on load with dynamic shape
+// Even though shapes are dynamic, skip_boundary_check=true tells the pass
+// to skip mask generation (the caller guarantees the access is in-bounds).
+
+// CHECK-LABEL: skip_boundary_check_load_dynamic
+// CHECK-NOT:   arith.cmpi
+// CHECK:       tt.load {{%.+}} : tensor<32x32x!tt.ptr<f32>>
+// CHECK-NOT:   arith.cmpi
+tt.func public @skip_boundary_check_load_dynamic(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32},
+    %arg1: i32) {
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %stride = arith.extsi %arg1 : i32 to i64
+  %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg1], [%stride, %c1_i64] : <f32>, <tensor<32x32xf32>>
+  %result = tt.descriptor_load %desc[%c0_i32, %c0_i32] {skip_boundary_check} : !tt.tensordesc<tensor<32x32xf32>> -> tensor<32x32xf32>
+  tt.return
+}
+
+// -----
+
+// Test 10: skip_boundary_check attribute on store with dynamic shape
+// Same as Test 9 but for stores.
+
+// CHECK-LABEL: skip_boundary_check_store_dynamic
+// CHECK-NOT:   arith.cmpi
+// CHECK:       tt.store {{%.+}}, {{%.+}} {skip_boundary_check} : tensor<32x32x!tt.ptr<f32>>
+// CHECK-NOT:   arith.cmpi
+tt.func public @skip_boundary_check_store_dynamic(
+    %arg0: !tt.ptr<f32> {tt.divisibility = 32 : i32},
+    %arg1: i32,
+    %data: tensor<32x32xf32>) {
+  %c1_i64 = arith.constant 1 : i64
+  %c0_i32 = arith.constant 0 : i32
+  %stride = arith.extsi %arg1 : i32 to i64
+  %desc = tt.make_tensor_descriptor %arg0, [%arg1, %arg1], [%stride, %c1_i64] : <f32>, <tensor<32x32xf32>>
+  tt.descriptor_store %desc[%c0_i32, %c0_i32], %data {skip_boundary_check} : !tt.tensordesc<tensor<32x32xf32>>, tensor<32x32xf32>
+  tt.return
+}


### PR DESCRIPTION
## Summary

`RewriteTensorDescriptorToPointerPass` unconditionally generates masked loads/stores for all tensor descriptor accesses. In contrast, the block pointer path (`RewriteTensorPointerPass`) respects `boundary_check=[]` and produces unmasked loads/stores when no boundary checking is needed.

This causes backends that lower tensor descriptors to pointer arithmetic (i.e., backends without TMA hardware) to always pay the cost of masked memory operations, even for provably in-bounds accesses (~20% perf regression in our benchmarks).

This PR adds two complementary mechanisms to skip unnecessary mask generation:

1. **Static in-bounds analysis** (`isStaticallyInBounds`): compile-time check that verifies `offset[i] + blockShape[i] <= shape[i]` for all dimensions. When provably in-bounds, the pass emits unmasked `tt.load`/`tt.store`.

2. **`skip_boundary_check` attribute**: a new `UnitAttr` on `tt.descriptor_load` and `tt.descriptor_store` that frontends (e.g., Inductor) can set when they guarantee the access is in-bounds. On backends with TMA hardware, this attribute is simply ignored.

Fixes #10033

## Files Changed

- `include/triton/Dialect/Triton/IR/TritonOps.td` — add `UnitAttr:$skip_boundary_check` to `DescriptorLoadOp` and `DescriptorStoreOp`
- `lib/Dialect/Triton/Transforms/RewriteTensorDescriptorToPointer.cpp` — add `isStaticallyInBounds()` and conditionally skip mask/other generation
- `python/src/ir.cc` — thread `skipBoundaryCheck` through `create_descriptor_load`/`create_descriptor_store`
- `python/triton/language/core.py` — add `skip_boundary_check` parameter to `tensor_descriptor_base.load()` and `.store()`
- `python/triton/language/semantic.py` — thread parameter through `descriptor_load`/`descriptor_store`
- `python/triton/runtime/interpreter.py` — accept (and ignore) the new parameter
- `test/Triton/tensor-descriptors-in-bounds.mlir` — 10 LIT test cases covering in-bounds, out-of-bounds, and skip_boundary_check scenarios

## Test Plan

- New MLIR LIT test (`tensor-descriptors-in-bounds.mlir`) with 10 cases:
  - In-bounds 2D load/store with zero offset
  - In-bounds 2D load with nonzero offset
  - Out-of-bounds load with dynamic shape/offset
  - Out-of-bounds load where offset+block exceeds shape
  - In-bounds 1D load
  - Out-of-bounds store with dynamic shape
  - `skip_boundary_check` attribute on load/store with dynamic shapes
- Backward compatible: existing code without `skip_boundary_check` behaves identically
- TMA backends unaffected (attribute is ignored)