### PR TITLE
[AMD][CI] Disable ASAN tests due to non-deterministic failures

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -180,7 +180,7 @@ jobs:
             python3 -m pytest -s -n 12 tests/
           fi
       - name: Run asan tests on AMD
-        if: ${{ matrix.runner[0] == 'amd-gfx942' }}
+        if: false
         run: |
           cd third_party/amd/python/test/
           ulimit -s 1024


### PR DESCRIPTION
The test has been failing increasingly freqently.
Disable while investigating.