### PR TITLE
Fix `tl.fdiv` to respect `ieee_rounding` flag

### DIFF
--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1023,6 +1023,30 @@ def test_precise_math(expr_prec, expr_ref, num_ctas, device):
     assert torch.all(out == out_ref)  # bitwise exact
 
 
+@pytest.mark.interpreter
+@pytest.mark.parametrize("num_ctas", num_ctas_list)
+def test_fdiv_ieee_rounding(num_ctas, device):
+
+    @triton.jit
+    def kernel(X, Y, OUT_IEEE, OUT_RN, BLOCK: tl.constexpr):
+        offs = tl.arange(0, BLOCK)
+        x = tl.load(X + offs)
+        y = tl.load(Y + offs)
+        ieee = tl.math.fdiv(x, y, ieee_rounding=True)
+        rn = tl.math.div_rn(x, y)
+        tl.store(OUT_IEEE + offs, ieee)
+        tl.store(OUT_RN + offs, rn)
+
+    shape = (128, )
+    x = torch.randn(shape, dtype=torch.float32, device=device)
+    y = torch.randn(shape, dtype=torch.float32, device=device) + 1e-6
+    out_ieee = torch.zeros(shape, dtype=torch.float32, device=device)
+    out_rn = torch.zeros(shape, dtype=torch.float32, device=device)
+
+    kernel[(1, )](x, y, out_ieee, out_rn, BLOCK=shape[0], num_ctas=num_ctas)
+    assert torch.all(out_ieee == out_rn)  # bitwise exact
+
+
 # ----------------
 # test abs
 # ----------------

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1024,7 +1024,7 @@ def test_precise_math(expr_prec, expr_ref, num_ctas, device):
 
 
 @pytest.mark.interpreter
-def test_fdiv_ieee_rounding(num_ctas, device):
+def test_fdiv_ieee_rounding(device):
 
     @triton.jit
     def kernel(X, Y, OUT_IEEE, OUT_RN, BLOCK: tl.constexpr):
@@ -1042,7 +1042,7 @@ def test_fdiv_ieee_rounding(num_ctas, device):
     out_ieee = torch.zeros(shape, dtype=torch.float32, device=device)
     out_rn = torch.zeros(shape, dtype=torch.float32, device=device)
 
-    kernel[(1, )](x, y, out_ieee, out_rn, BLOCK=shape[0], num_ctas=num_ctas)
+    kernel[(1, )](x, y, out_ieee, out_rn, BLOCK=shape[0], num_ctas=1)
     assert torch.all(out_ieee == out_rn)  # bitwise exact
 
 

--- a/python/test/unit/language/test_core.py
+++ b/python/test/unit/language/test_core.py
@@ -1024,7 +1024,6 @@ def test_precise_math(expr_prec, expr_ref, num_ctas, device):
 
 
 @pytest.mark.interpreter
-@pytest.mark.parametrize("num_ctas", num_ctas_list)
 def test_fdiv_ieee_rounding(num_ctas, device):
 
     @triton.jit

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -334,7 +334,10 @@ class TritonSemantic(Generic[TensorTy]):
         if not input_scalar_ty.is_floating() or not other_scalar_ty.is_floating():
             raise TypeError("both operands of fdiv must have floating scalar type")
         input, other = self.binary_op_type_checking_impl(input, other, False, False, False, True)
-        ret = self.builder.create_fdiv(input.handle, other.handle)
+        if ieee_rounding:
+            ret = self.builder.create_precise_divf(input.handle, other.handle)
+        else:
+            ret = self.builder.create_fdiv(input.handle, other.handle)
         return self.tensor(ret, input.type)
 
     def mod(self, input: TensorTy | numbers.Number, other: TensorTy | numbers.Number) -> TensorTy:


### PR DESCRIPTION
Fixes #10073

## Summary

`tl.fdiv(x, y, ieee_rounding=True)` silently ignores the `ieee_rounding` parameter. Both `a / b` and `tl.fdiv(a, b, ieee_rounding=True)` generate `div.full.f32` (non-IEEE), when the latter should generate `div.rn.f32` (IEEE-754 compliant).

This was a regression — the flag was recommended as a workaround by #605.

## Root cause

In semantic.py, `fdiv()` accepted `ieee_rounding` but unconditionally called `self.builder.create_fdiv()`, never branching on the flag.

## Fix

When `ieee_rounding=True`, call `self.builder.create_precise_divf()` (which lowers to `div.rn.f32`) instead of `self.builder.create_fdiv()` (which lowers to `div.full.f32`). This matches the behavior of `tl.div_rn()`.

| Method | Before | After |
|---|---|---|
| `tl.fdiv(a, b, ieee_rounding=False)` | `div.full.f32` | `div.full.f32` (unchanged) |
| `tl.fdiv(a, b, ieee_rounding=True)` | `div.full.f32` (bug) | `div.rn.f32` (fix) |
<!---
The core Triton is a small number of people, and we receive many PRs (thank
you!).  To help us review your code more quickly, **if you are a new
contributor (less than 3 PRs merged) we ask that you complete the following
tasks and include the filled-out checklist in your PR description.**

Complete the following tasks before sending your PR, and replace `[ ]` with
`[x]` to indicate you have done them.
-->

# New contributor declaration
- [x] I am not making a trivial change, such as fixing a typo in a comment.

- [x] I have written a PR description following these
  [rules](https://cbea.ms/git-commit/#why-not-how).

- [x] I have run `pre-commit run --from-ref origin/main --to-ref HEAD`.

- Select one of the following.
  - [x] I have added tests.
    - `/test` for `lit` tests
    - `/unittest` for C++ tests
    - `/python/test` for end-to-end tests
  - [ ] This PR does not need a test because `FILL THIS IN`.

- Select one of the following.
  - [x] I have not added any `lit` tests.
  - [ ] The `lit` tests I have added follow these [best practices](https://mlir.llvm.org/getting_started/TestingGuide/#filecheck-best-practices),
    including the "tests should be minimal" section. (Usually running Python code
    and using the instructions it generates is not minimal.)
