### PR TITLE
[AMD][gfx1250] Add fused SwiGLU mode to gluon f16 GEMM examples

### DIFF
--- a/third_party/amd/python/examples/gluon/f16_gemm_common_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_common_gfx1250.py
@@ -247,6 +247,26 @@ def issue_wmma_compute(a, b, accumulator):
     return accumulator
 
 
+@gluon.jit
+def swiglu_epilogue(acc):
+    """Apply SwiGLU: reshape (M, 2N) -> split into gate/up -> swish(gate) * up."""
+    BLOCK_M: ttgl.constexpr = acc.shape[0]
+    BLOCK_N: ttgl.constexpr = acc.shape[1] // 2
+    acc_3d = ttgl.reshape(acc, (BLOCK_M, BLOCK_N, 2))
+    gate, up = ttgl.split(acc_3d)
+    # swish(x) = x * sigmoid(x); sigmoid(x) = 1 / (1 + exp(-x))
+    return gate * (1.0 / (1.0 + ttgl.exp(-gate))) * up
+
+
+@gluon.jit
+def apply_activation_epilogue(acc, ACTIVATION: ttgl.constexpr, ACC_LAYOUT: ttgl.constexpr):
+    if ACTIVATION == "swiglu":
+        result = ttgl.convert_layout(swiglu_epilogue(acc), ACC_LAYOUT)
+    else:
+        result = acc
+    return result
+
+
 @aggregate
 class TileScheduler:
     """

--- a/third_party/amd/python/examples/gluon/f16_gemm_gfx1250.py
+++ b/third_party/amd/python/examples/gluon/f16_gemm_gfx1250.py
@@ -12,6 +12,7 @@ from triton._C.libtriton.gluon_ir import make_cga_layout
 try:
     from .gfx1250_utils import static_profile
     from .f16_gemm_common_gfx1250 import (
+        apply_activation_epilogue,
         create_shared_layouts,
         create_tensor_descriptors,
         issue_loads,
@@ -24,6 +25,7 @@ try:
 except ImportError:
     from gfx1250_utils import static_profile
     from f16_gemm_common_gfx1250 import (
+        apply_activation_epilogue,
         create_shared_layouts,
         create_tensor_descriptors,
         issue_loads,
@@ -47,7 +49,9 @@ def persistent_gemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
                                          SHARED_LAYOUT_A: ttgl.constexpr,  #
                                          SHARED_LAYOUT_B: ttgl.constexpr,  #
                                          ACCUMULATOR_LAYOUT: ttgl.constexpr,  #
-                                         L2_PREFETCH_DISTANCE: ttgl.constexpr):
+                                         L2_PREFETCH_DISTANCE: ttgl.constexpr, ACTIVATION: ttgl.constexpr = ""):
+    ACTIVATION_REDUCTION_N: ttgl.constexpr = 2 if ACTIVATION == "swiglu" else 1
+    BLOCK_N_PACKED: ttgl.constexpr = BLOCK_N * ACTIVATION_REDUCTION_N
 
     OPERAND_LAYOUT_A: ttgl.constexpr = ttgl.DotOperandLayout(0, ACCUMULATOR_LAYOUT, 8)
     OPERAND_LAYOUT_B: ttgl.constexpr = ttgl.DotOperandLayout(1, ACCUMULATOR_LAYOUT, 8)
@@ -58,9 +62,10 @@ def persistent_gemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
     ttgl.static_assert(b_dtype.is_fp16() or b_dtype.is_bf16(), "Only fp16/bf16 supported for B")
     ttgl.static_assert(NUM_BUFFERS >= 2, "NUM_BUFFERS must be at least 2")
 
+    N_PACKED = N * ACTIVATION_REDUCTION_N
     a_desc, b_desc = create_tensor_descriptors(a_ptr, b_ptr, 0, 0, stride_am, stride_ak, stride_bn, stride_bk,
-                                               SHARED_LAYOUT_A, SHARED_LAYOUT_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
-                                               TRANSPOSE_B)
+                                               SHARED_LAYOUT_A, SHARED_LAYOUT_B, M, N_PACKED, K, BLOCK_M,
+                                               BLOCK_N_PACKED, BLOCK_K, TRANSPOSE_B)
     a_buffer = ttgl.allocate_shared_memory(a_desc.dtype, shape=[NUM_BUFFERS] + a_desc.block_shape, layout=a_desc.layout)
     b_buffer = ttgl.allocate_shared_memory(b_desc.dtype, shape=[NUM_BUFFERS] + b_desc.block_shape, layout=b_desc.layout)
 
@@ -73,11 +78,11 @@ def persistent_gemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
     for tile_idx in range(pid, scheduler.get_num_tiles(), num_sms):
         pid_m, pid_n = scheduler.get_swizzled_tile_coords(tile_idx, GROUP_SIZE_M=8)
         off_am = pid_m * BLOCK_M
-        off_bn = pid_n * BLOCK_N
+        off_bn = pid_n * BLOCK_N_PACKED
 
         producer = 0
         consumer = 0
-        accumulator = ttgl.zeros((BLOCK_M, BLOCK_N), dtype=c_ptr.type.element_ty, layout=ACCUMULATOR_LAYOUT)
+        accumulator = ttgl.zeros((BLOCK_M, BLOCK_N_PACKED), dtype=c_ptr.type.element_ty, layout=ACCUMULATOR_LAYOUT)
 
         issue_l2_prefetches_prologue(L2_PREFETCH_DISTANCE, producer, a_desc, b_desc, off_am, off_bn, BLOCK_K,
                                      NUM_BUFFERS, TRANSPOSE_B)
@@ -99,11 +104,13 @@ def persistent_gemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
             consumer, accumulator = issue_wmma(consumer, a_buffer, OPERAND_LAYOUT_A, b_buffer, OPERAND_LAYOUT_B,
                                                accumulator, (NUM_BUFFERS - 2 - i) * 2, NUM_BUFFERS, TRANSPOSE_B)
 
+        output = apply_activation_epilogue(accumulator, ACTIVATION, ACCUMULATOR_LAYOUT)
+
         offs_cm = pid_m * BLOCK_M + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, ACCUMULATOR_LAYOUT))
         offs_cn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, ACCUMULATOR_LAYOUT))
         offs_c = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
         mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-        ttgl.store(c_ptr + offs_c, accumulator, mask=mask_c)
+        ttgl.store(c_ptr + offs_c, output, mask=mask_c)
 
 
 @gluon.jit
@@ -119,7 +126,10 @@ def persistent_gemm_tdm_pipelined_lds_prefetch_kernel(a_ptr, b_ptr, c_ptr,  #
                                                       SHARED_LAYOUT_A: ttgl.constexpr,  #
                                                       SHARED_LAYOUT_B: ttgl.constexpr,  #
                                                       ACCUMULATOR_LAYOUT: ttgl.constexpr,  #
-                                                      L2_PREFETCH_DISTANCE: ttgl.constexpr):
+                                                      L2_PREFETCH_DISTANCE: ttgl.constexpr,
+                                                      ACTIVATION: ttgl.constexpr = ""):
+    ACTIVATION_REDUCTION_N: ttgl.constexpr = 2 if ACTIVATION == "swiglu" else 1
+    BLOCK_N_PACKED: ttgl.constexpr = BLOCK_N * ACTIVATION_REDUCTION_N
 
     OPERAND_LAYOUT_A: ttgl.constexpr = ttgl.DotOperandLayout(0, ACCUMULATOR_LAYOUT, 8)
     OPERAND_LAYOUT_B: ttgl.constexpr = ttgl.DotOperandLayout(1, ACCUMULATOR_LAYOUT, 8)
@@ -130,9 +140,10 @@ def persistent_gemm_tdm_pipelined_lds_prefetch_kernel(a_ptr, b_ptr, c_ptr,  #
     ttgl.static_assert(b_dtype.is_fp16() or b_dtype.is_bf16(), "Only fp16/bf16 supported for B")
     ttgl.static_assert(NUM_BUFFERS >= 2, "NUM_BUFFERS must be at least 2")
 
+    N_PACKED = N * ACTIVATION_REDUCTION_N
     a_desc, b_desc = create_tensor_descriptors(a_ptr, b_ptr, 0, 0, stride_am, stride_ak, stride_bn, stride_bk,
-                                               SHARED_LAYOUT_A, SHARED_LAYOUT_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K,
-                                               TRANSPOSE_B)
+                                               SHARED_LAYOUT_A, SHARED_LAYOUT_B, M, N_PACKED, K, BLOCK_M,
+                                               BLOCK_N_PACKED, BLOCK_K, TRANSPOSE_B)
     a_buffer = ttgl.allocate_shared_memory(a_desc.dtype, shape=[NUM_BUFFERS] + a_desc.block_shape, layout=a_desc.layout)
     b_buffer = ttgl.allocate_shared_memory(b_desc.dtype, shape=[NUM_BUFFERS] + b_desc.block_shape, layout=b_desc.layout)
 
@@ -145,12 +156,12 @@ def persistent_gemm_tdm_pipelined_lds_prefetch_kernel(a_ptr, b_ptr, c_ptr,  #
         # Calculate current tile coordinates
         pid_m, pid_n = scheduler.get_swizzled_tile_coords(tile_idx, GROUP_SIZE_M=8)
         off_am = pid_m * BLOCK_M
-        off_bn = pid_n * BLOCK_N
+        off_bn = pid_n * BLOCK_N_PACKED
 
         # Calculate next tile coordinates for prefetching
         pid_m_next, pid_n_next = scheduler.get_swizzled_tile_coords(tile_idx + num_sms, GROUP_SIZE_M=8)
         off_am_next = pid_m_next * BLOCK_M
-        off_bn_next = pid_n_next * BLOCK_N
+        off_bn_next = pid_n_next * BLOCK_N_PACKED
 
         producer = 0
 
@@ -162,7 +173,7 @@ def persistent_gemm_tdm_pipelined_lds_prefetch_kernel(a_ptr, b_ptr, c_ptr,  #
                                    TRANSPOSE_B)
 
         consumer = 0
-        accumulator = ttgl.zeros((BLOCK_M, BLOCK_N), dtype=c_ptr.type.element_ty, layout=ACCUMULATOR_LAYOUT)
+        accumulator = ttgl.zeros((BLOCK_M, BLOCK_N_PACKED), dtype=c_ptr.type.element_ty, layout=ACCUMULATOR_LAYOUT)
 
         for _ in range(0, ttgl.cdiv(K, BLOCK_K) - NUM_BUFFERS):
             producer = issue_loads(producer, a_desc, b_desc, off_am, off_bn, a_buffer, b_buffer, BLOCK_K, NUM_BUFFERS,
@@ -183,11 +194,13 @@ def persistent_gemm_tdm_pipelined_lds_prefetch_kernel(a_ptr, b_ptr, c_ptr,  #
             consumer, accumulator = issue_wmma(consumer, a_buffer, OPERAND_LAYOUT_A, b_buffer, OPERAND_LAYOUT_B,
                                                accumulator, (NUM_BUFFERS - 1 - i) * 2, NUM_BUFFERS, TRANSPOSE_B)
 
+        output = apply_activation_epilogue(accumulator, ACTIVATION, ACCUMULATOR_LAYOUT)
+
         offs_cm = pid_m * BLOCK_M + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, ACCUMULATOR_LAYOUT))
         offs_cn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, ACCUMULATOR_LAYOUT))
         offs_c = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
         mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-        ttgl.store(c_ptr + offs_c, accumulator, mask=mask_c)
+        ttgl.store(c_ptr + offs_c, output, mask=mask_c)
 
 
 def _build_gemm_layouts(BLOCK_M, BLOCK_N, BLOCK_K, cga_layout_c, WARP_BASES, TRANSPOSE_B):
@@ -233,7 +246,11 @@ def gemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
                               NUM_BUFFERS: ttgl.constexpr,  #
                               TRANSPOSE_B: ttgl.constexpr,  #
                               SHARED_LAYOUT_A: ttgl.constexpr, SHARED_LAYOUT_B: ttgl.constexpr,
-                              ACCUMULATOR_LAYOUT: ttgl.constexpr, L2_PREFETCH_DISTANCE: ttgl.constexpr):
+                              ACCUMULATOR_LAYOUT: ttgl.constexpr, L2_PREFETCH_DISTANCE: ttgl.constexpr,
+                              ACTIVATION: ttgl.constexpr = ""):
+    ACTIVATION_REDUCTION_N: ttgl.constexpr = 2 if ACTIVATION == "swiglu" else 1
+    BLOCK_N_PACKED: ttgl.constexpr = BLOCK_N * ACTIVATION_REDUCTION_N
+
     a_dtype: ttgl.constexpr = a_ptr.type.element_ty
     b_dtype: ttgl.constexpr = b_ptr.type.element_ty
     ttgl.static_assert(a_dtype.is_fp16() or a_dtype.is_bf16(), "Only fp16/bf16 supported for A")
@@ -248,15 +265,17 @@ def gemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
     pid_m = pid % num_pid_m
     pid_n = pid // num_pid_m
 
-    a_desc, b_desc = create_tensor_descriptors(a_ptr, b_ptr, pid_m * BLOCK_M * stride_am, pid_n * BLOCK_N * stride_bn,
-                                               stride_am, stride_ak, stride_bn, stride_bk, SHARED_LAYOUT_A,
-                                               SHARED_LAYOUT_B, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, TRANSPOSE_B)
+    N_PACKED = N * ACTIVATION_REDUCTION_N
+    a_desc, b_desc = create_tensor_descriptors(a_ptr, b_ptr, pid_m * BLOCK_M * stride_am,
+                                               pid_n * BLOCK_N_PACKED * stride_bn, stride_am, stride_ak, stride_bn,
+                                               stride_bk, SHARED_LAYOUT_A, SHARED_LAYOUT_B, M, N_PACKED, K, BLOCK_M,
+                                               BLOCK_N_PACKED, BLOCK_K, TRANSPOSE_B)
     a_buffer = ttgl.allocate_shared_memory(a_desc.dtype, shape=[NUM_BUFFERS] + a_desc.block_shape, layout=a_desc.layout)
     b_buffer = ttgl.allocate_shared_memory(b_desc.dtype, shape=[NUM_BUFFERS] + b_desc.block_shape, layout=b_desc.layout)
 
     producer = 0
     consumer = 0
-    accumulator = ttgl.zeros((BLOCK_M, BLOCK_N), dtype=c_ptr.type.element_ty, layout=ACCUMULATOR_LAYOUT)
+    accumulator = ttgl.zeros((BLOCK_M, BLOCK_N_PACKED), dtype=c_ptr.type.element_ty, layout=ACCUMULATOR_LAYOUT)
 
     # Prefetching buffers we load in the prologue does not make sense
     issue_l2_prefetches_prologue(L2_PREFETCH_DISTANCE, producer, a_desc, b_desc, 0, 0, BLOCK_K, NUM_BUFFERS,
@@ -276,11 +295,13 @@ def gemm_tdm_pipelined_kernel(a_ptr, b_ptr, c_ptr,  #
         consumer, accumulator = issue_wmma(consumer, a_buffer, OPERAND_LAYOUT_A, b_buffer, OPERAND_LAYOUT_B,
                                            accumulator, (NUM_BUFFERS - 2 - i) * 2, NUM_BUFFERS, TRANSPOSE_B)
 
+    output = apply_activation_epilogue(accumulator, ACTIVATION, ACCUMULATOR_LAYOUT)
+
     offs_cm = pid_m * BLOCK_M + ttgl.arange(0, BLOCK_M, layout=ttgl.SliceLayout(1, ACCUMULATOR_LAYOUT))
     offs_cn = pid_n * BLOCK_N + ttgl.arange(0, BLOCK_N, layout=ttgl.SliceLayout(0, ACCUMULATOR_LAYOUT))
     offs_c = stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
     mask_c = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    ttgl.store(c_ptr + offs_c, accumulator, mask=mask_c)
+    ttgl.store(c_ptr + offs_c, output, mask=mask_c)
 
 
 @gluon.jit
@@ -395,13 +416,15 @@ def gemm_tdm_pipelined_single_warp_per_simd_schedule_kernel(a_ptr, b_ptr, c_ptr,
 
 
 def _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, PERSISTENT, PREFETCH,
-                                    L2_PREFETCH_DISTANCE, M, N, K, num_warps, ctas_per_cga):
+                                    L2_PREFETCH_DISTANCE, M, N, K, num_warps, ctas_per_cga, ACTIVATION=""):
     if triton.cdiv(K, BLOCK_K) < NUM_BUFFERS:
         pytest.skip("Skip tests where K/BLOCK_K < NUM_BUFFERS")
 
     num_ctas = ctas_per_cga[0] * ctas_per_cga[1]
     if num_ctas > 1 and PERSISTENT:
         pytest.skip("Skip tests with multiple CTAs and persistent or prefetch")
+    if num_ctas > 1 and ACTIVATION != "":
+        pytest.skip("Skip tests with multiple CTAs and fused activation")
 
     # We scale the problem size and block dims by ctas_per_cga so each CTA works on BLOCK_M/BLOCK_N sized tile
     M *= ctas_per_cga[0]
@@ -409,10 +432,20 @@ def _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRAN
     BLOCK_M *= ctas_per_cga[0]
     BLOCK_N *= ctas_per_cga[1]
 
+    ACTIVATION_REDUCTION_N = 2 if ACTIVATION == "swiglu" else 1
+    BLOCK_N_PACKED = BLOCK_N * ACTIVATION_REDUCTION_N
+
     torch.manual_seed(42)
 
     a = torch.randn((M, K), dtype=torch.float16)
-    b = torch.randn((K, N), dtype=torch.float16)
+
+    if ACTIVATION == "swiglu":
+        w_gate = torch.randn((K, N), dtype=torch.float16)
+        w_up = torch.randn((K, N), dtype=torch.float16)
+        # Interleave gate/up columns: [gate_col0, up_col0, gate_col1, up_col1, ...]
+        b = torch.stack([w_gate, w_up], dim=-1).reshape(K, 2 * N)
+    else:
+        b = torch.randn((K, N), dtype=torch.float16)
     if TRANSPOSE_B:
         b = b.T.contiguous()
     c = torch.zeros((M, N), dtype=torch.float32)
@@ -431,9 +464,8 @@ def _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRAN
 
     cga_layout_c = make_cga_layout(ctas_per_cga, [ctas_per_cga[0], ctas_per_cga[1]], [0, 1])
 
-    # Build all layouts in wrapper function (outside kernel)
-    SHARED_LAYOUT_A, SHARED_LAYOUT_B, ACCUMULATOR_LAYOUT = _build_gemm_layouts(BLOCK_M, BLOCK_N, BLOCK_K, cga_layout_c,
-                                                                               warp_bases, TRANSPOSE_B)
+    SHARED_LAYOUT_A, SHARED_LAYOUT_B, ACCUMULATOR_LAYOUT = _build_gemm_layouts(BLOCK_M, BLOCK_N_PACKED, BLOCK_K,
+                                                                               cga_layout_c, warp_bases, TRANSPOSE_B)
 
     if not PERSISTENT:
 
@@ -448,7 +480,7 @@ def _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRAN
             NUM_BUFFERS=NUM_BUFFERS, TRANSPOSE_B=TRANSPOSE_B,  #
             SHARED_LAYOUT_A=SHARED_LAYOUT_A, SHARED_LAYOUT_B=SHARED_LAYOUT_B, ACCUMULATOR_LAYOUT=ACCUMULATOR_LAYOUT,
             num_warps=num_warps, waves_per_eu=num_warps // 4, num_ctas=num_ctas,
-            L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE)
+            L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, ACTIVATION=ACTIVATION)
         static_profile(kernel)
     else:
         # num_sms = torch.cuda.get_device_properties("cuda").multi_processor_count
@@ -466,7 +498,7 @@ def _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRAN
                 NUM_BUFFERS=NUM_BUFFERS, TRANSPOSE_B=TRANSPOSE_B,  #
                 SHARED_LAYOUT_A=SHARED_LAYOUT_A, SHARED_LAYOUT_B=SHARED_LAYOUT_B, ACCUMULATOR_LAYOUT=ACCUMULATOR_LAYOUT,
                 num_warps=num_warps, num_ctas=num_ctas, waves_per_eu=num_warps // 4,
-                L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE)
+                L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, ACTIVATION=ACTIVATION)
             static_profile(kernel)
         else:
             kernel = persistent_gemm_tdm_pipelined_kernel[grid](
@@ -479,12 +511,19 @@ def _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRAN
                 NUM_BUFFERS=NUM_BUFFERS, TRANSPOSE_B=TRANSPOSE_B,  #
                 SHARED_LAYOUT_A=SHARED_LAYOUT_A, SHARED_LAYOUT_B=SHARED_LAYOUT_B, ACCUMULATOR_LAYOUT=ACCUMULATOR_LAYOUT,
                 num_warps=num_warps, num_ctas=num_ctas, waves_per_eu=num_warps // 4,
-                L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE)
+                L2_PREFETCH_DISTANCE=L2_PREFETCH_DISTANCE, ACTIVATION=ACTIVATION)
             static_profile(kernel)
 
     c_triton = c_device.cpu()
-    c_torch = a.to(torch.float32) @ (b.to(torch.float32) if not TRANSPOSE_B else b.T.to(torch.float32))
-    torch.testing.assert_close(c_triton, c_torch, rtol=1e-4, atol=1e-4)
+
+    if ACTIVATION == "swiglu":
+        gate = a.to(torch.float32) @ w_gate.to(torch.float32)
+        up = a.to(torch.float32) @ w_up.to(torch.float32)
+        c_ref = gate * torch.sigmoid(gate) * up
+        torch.testing.assert_close(c_triton, c_ref, rtol=1e-2, atol=1e-2)
+    else:
+        c_ref = a.to(torch.float32) @ (b.to(torch.float32) if not TRANSPOSE_B else b.T.to(torch.float32))
+        torch.testing.assert_close(c_triton, c_ref, rtol=1e-4, atol=1e-4)
 
 
 def _build_multi_cta_gemm_cases():
@@ -529,6 +568,20 @@ def test_runtime_gemm_tdm_pipelined_multi_cta(M, N, K, BLOCK_M, BLOCK_N, BLOCK_K
                                               TRANSPOSE_B, PERSISTENT, PREFETCH, L2_PREFETCH_DISTANCE, num_warps):
     _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, PERSISTENT, PREFETCH,
                                     L2_PREFETCH_DISTANCE, M, N, K, num_warps, ctas_per_cga)
+
+
+@pytest.mark.parametrize("BLOCK_M,BLOCK_N,BLOCK_K", [(32, 32, 64)])
+@pytest.mark.parametrize("NUM_BUFFERS", [2, 3, 4])
+@pytest.mark.parametrize("TRANSPOSE_B", [False, True])
+@pytest.mark.parametrize("PERSISTENT", [False, True])
+@pytest.mark.parametrize("PREFETCH", [False, True])
+@pytest.mark.parametrize("L2_PREFETCH_DISTANCE", [0, 2])
+@pytest.mark.parametrize("M,N,K", [(256, 256, 512), (250, 250, 510)])
+@pytest.mark.parametrize("num_warps", [4, 8])
+def test_runtime_swiglu_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, PERSISTENT, PREFETCH,
+                                           L2_PREFETCH_DISTANCE, M, N, K, num_warps):
+    _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K, NUM_BUFFERS, TRANSPOSE_B, PERSISTENT, PREFETCH,
+                                    L2_PREFETCH_DISTANCE, M, N, K, num_warps, [1, 1], ACTIVATION="swiglu")
 
 
 @pytest.mark.parametrize("BLOCK_M,BLOCK_N", [(32, 32)])
@@ -1542,6 +1595,7 @@ if __name__ == "__main__":
     parser.add_argument("--single-warp-schedule", action="store_true", help="Use single warp per SIMD schedule variant")
     parser.add_argument("--warp-specialized", action="store_true", help="Use warp specialized variant")
     parser.add_argument("--subtiled", action="store_true", help="Use subtiled quadrant processing")
+    parser.add_argument("--activation", type=str, default="", choices=["", "swiglu"], help="Fused activation epilogue")
     args = parser.parse_args()
 
     assert not (args.persistent and args.single_warp_schedule)
@@ -1566,9 +1620,15 @@ if __name__ == "__main__":
     PERSISTENT = args.persistent
     PREFETCH = args.prefetch_lds
     L2_PREFETCH_DISTANCE = args.prefetch_l2_distance
+    ACTIVATION = args.activation
 
     if NUM_CTAS not in [1, 2, 4, 8, 16]:
         raise ValueError(f"NUM_CTAS (product of CTAS_PER_CGA) {NUM_CTAS} not supported")
+
+    if ACTIVATION != "":
+        assert not args.warp_specialized, "Fused activation not supported for warp specialized kernels"
+        assert not args.single_warp_schedule, "Fused activation not supported for single-warp schedule kernel"
+        assert NUM_CTAS == 1, "Fused activation not supported with multi-CTA"
 
     if args.warp_specialized:
         assert NUM_CTAS == 1, "NUM_CTAS > 1 not supported for warp specialized gemm"
@@ -1606,8 +1666,8 @@ if __name__ == "__main__":
                                                                       M, N, K)
     else:
         print(
-            f"({M=}, {N=}, {K=}), ({BLOCK_M=}, {BLOCK_N=}, {BLOCK_K=}), {TRANSPOSE_B=}, {NUM_WARPS=}, {NUM_BUFFERS=}, {PERSISTENT=}, {PREFETCH=}, {L2_PREFETCH_DISTANCE=}, {CTAS_PER_CGA=}"
+            f"({M=}, {N=}, {K=}), ({BLOCK_M=}, {BLOCK_N=}, {BLOCK_K=}), {TRANSPOSE_B=}, {NUM_WARPS=}, {NUM_BUFFERS=}, {PERSISTENT=}, {PREFETCH=}, {L2_PREFETCH_DISTANCE=}, {CTAS_PER_CGA=}, {ACTIVATION=}"
         )
         _run_runtime_gemm_tdm_pipelined(BLOCK_M, BLOCK_N, BLOCK_K,  #
                                         NUM_BUFFERS, TRANSPOSE_B, PERSISTENT, PREFETCH, L2_PREFETCH_DISTANCE,  #
-                                        M, N, K, NUM_WARPS, CTAS_PER_CGA)
+                                        M, N, K, NUM_WARPS, CTAS_PER_CGA, ACTIVATION=ACTIVATION)


### PR DESCRIPTION
Add an optional `ACTIVATION` constexpr to the TDM-pipelined f16 GEMM kernels. When `ACTIVATION` is `swiglu`, `B` is treated as a packed matrix with `2 * N` columns, and the epilogue computes `swish(gate) * up` before storing a `BLOCK_M x BLOCK_N` tile.