### PR TITLE
[AMD][CI] Continue on error if on gfx942

### DIFF
--- a/.github/workflows/integration-tests-amd.yml
+++ b/.github/workflows/integration-tests-amd.yml
@@ -11,7 +11,7 @@ jobs:
   integration-tests-amd:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
-    continue-on-error: ${{ matrix.runner[1] == 'gfx90a' || matrix.runner[0] == 'amd-gfx950' }}
+    continue-on-error: ${{ matrix.runner[1] == 'gfx90a' || matrix.runner[0] == 'amd-gfx942' }}
     strategy:
       matrix:
         runner: ${{ fromJson(inputs.matrix) }}


### PR DESCRIPTION
The machines are being migrated right now. So allow failing to avoid blocking progress.